### PR TITLE
OpenSlide: convert "layer" to "level" where externally visible

### DIFF
--- a/libvips/foreign/openslide2vips.c
+++ b/libvips/foreign/openslide2vips.c
@@ -24,6 +24,8 @@
  * 11/12/11
  * 	- move argb->rgba into conversion
  * 	- turn into a set of read fns ready to be called from a class
+ * 28/2/12
+ * 	- convert "layer" to "level" where externally visible
  */
 
 /*
@@ -161,7 +163,7 @@ readslide_new( const char *filename, VipsImage *out,
 	if( layer < 0 || 
 		layer >= openslide_get_layer_count( rslide->osr ) ) {
 		vips_error( "openslide2vips",
-			"%s", _( "invalid slide layer" ) );
+			"%s", _( "invalid slide level" ) );
 		return( NULL );
 	}
 
@@ -181,7 +183,7 @@ readslide_new( const char *filename, VipsImage *out,
 			layer, &w, &h );
 		rslide->downsample = openslide_get_layer_downsample(
 			rslide->osr, layer );
-		vips_image_set_int( out, "slide-layer", layer );
+		vips_image_set_int( out, "slide-level", layer );
 		vips_demand_hint( out, VIPS_DEMAND_STYLE_SMALLTILE, NULL );
 	}
 

--- a/libvips/foreign/openslideload.c
+++ b/libvips/foreign/openslideload.c
@@ -2,6 +2,8 @@
  *
  * 5/12/11
  * 	- from openslideload.c
+ * 28/2/12
+ * 	- convert "layer" to "level" where externally visible
  */
 
 /*
@@ -177,9 +179,9 @@ vips_foreign_load_openslide_class_init( VipsForeignLoadOpenslideClass *class )
 		G_STRUCT_OFFSET( VipsForeignLoadOpenslide, filename ),
 		NULL );
 
-	VIPS_ARG_INT( class, "layer", 10, 
-		_( "Layer" ), 
-		_( "Load this layer from the file" ),
+	VIPS_ARG_INT( class, "level", 10,
+		_( "Level" ),
+		_( "Load this level from the file" ),
 		VIPS_ARGUMENT_OPTIONAL_INPUT,
 		G_STRUCT_OFFSET( VipsForeignLoadOpenslide, layer ),
 		0, 100000, 0 );


### PR DESCRIPTION
OpenSlide >= 3.3.0 will use the term "level" instead of "layer".  To avoid gratuitous incompatibility between libvips 7.28 and later versions, change this now in the openslideload argument, the "slide-layer" metadata item, and error messages.
