### PR TITLE
Fix .PHONY Make targets

### DIFF
--- a/doc/src/Makefile
+++ b/doc/src/Makefile
@@ -39,7 +39,7 @@ $(PDF): $(SRC)
 	pdflatex vipsmanual.tex
 	pdflatex vipsmanual.tex
 
-.PHONEY: html
+.PHONY: html
 html: 
 	-rm -rf vipsmanual 
 	mkdir vipsmanual
@@ -48,7 +48,7 @@ html:
 	-rm vipsmanual/figs/*.svg
 	-rm vipsmanual/*.png
 
-.PHONEY: clean 
+.PHONY: clean 
 clean:
 	-rm -f *.4ct
 	-rm -f *.4tc

--- a/libvipsCC/Makefile.am
+++ b/libvipsCC/Makefile.am
@@ -24,7 +24,6 @@ libvipsCC_la_LIBADD = \
 # swap the 'awk' line for this:
 # awk '{if($$1!="deprecated") print $$1}'` ; \
 # to not generate the wrappers for deprecated functions
-.PHONEY:
 vipsc++.cc:
 	packages=`vips list packages | \
 	  awk '{print $$1}'` ; \

--- a/libvipsCC/include/vips/Makefile.am
+++ b/libvipsCC/include/vips/Makefile.am
@@ -10,7 +10,6 @@ pkginclude_HEADERS = \
 # swap the 'awk' line for this:
 # awk '{if($$1!="deprecated") print $$1}'` ; \
 # to not generate the wrappers for deprecated functions
-.PHONEY:
 vipsc++.h:
 	packages=`vips list packages | \
 	  awk '{print $$1}'` ; \


### PR DESCRIPTION
GNU Make only respects the en-us spelling.
