### PR TITLE
tools/batch_* scripts: verify number of arguments before invoking 'shift'

### DIFF
--- a/tools/batch_crop.in
+++ b/tools/batch_crop.in
@@ -12,14 +12,9 @@
 VIPSHOME=${VIPSHOME-@prefix@}
 
 name=`basename $0`
-left=$1
-top=$2
-width=$3
-height=$4
-shift 4
 
 # check args
-if [ $# -lt 1 ]; then
+if [ $# -lt 5 ]; then
 	echo "usage: $name left top width height image1 image2 ..."
 	echo 
 	echo "$name writes a new set of images called crop_image1, "
@@ -27,6 +22,12 @@ if [ $# -lt 1 ]; then
 
 	exit 1
 fi
+
+left=$1
+top=$2
+width=$3
+height=$4
+shift 4
 
 # convert each argument
 for i in $*; do

--- a/tools/batch_image_convert.in
+++ b/tools/batch_image_convert.in
@@ -12,11 +12,9 @@
 VIPSHOME=${VIPSHOME-@prefix@}
 
 name=`basename $0`
-type=$1
-shift
 
 # check args
-if [ $# -lt 1 ]; then
+if [ $# -lt 2 ]; then
 	echo "usage: $name <new image type> image1 image2 ..."
 	echo 
 	echo "$name uses VIPS to convert a group of image files of"
@@ -26,6 +24,9 @@ if [ $# -lt 1 ]; then
 
 	exit 1
 fi
+
+type=$1
+shift
 
 # convert each argument
 for i in $*; do

--- a/tools/batch_rubber_sheet.in
+++ b/tools/batch_rubber_sheet.in
@@ -14,11 +14,9 @@ VIPSHOME=${VIPSHOME-@prefix@}
 
 # get name we were run as
 name=`basename $0`
-rec=$1
-shift
 
 # check args
-if [ $# -lt 1 ]; then
+if [ $# -lt 2 ]; then
 	echo "usage: $name matrix image1 image2 ..."
 	echo "writes rsc_image1, rsc_image2, ..."
 	echo
@@ -27,6 +25,9 @@ if [ $# -lt 1 ]; then
 
         exit 1
 fi
+
+rec=$1
+shift
 
 # transform each argument
 for i in $*; do


### PR DESCRIPTION
Currently, the `tools/batch_*` scripts will print a rather cryptic message, if the number of arguments on the command line is wrong. For instance, `batch_crop` expects at least 5 arguments, invoking the command with fewer than 5 arguments will result in:

```
$ batch_crop
`/usr/bin/batch_crop: 19: shift: can't shift that many`
```

This is because the batch scripts are invoking `shift` before making sure that enough arguments have been specified.

This pull request fixes that by moving the invocation of `shift` down, until after checking for the right number of arguments. Instead of failing on `shift`, the usage message will now be shown, if a wrong number of arguments has been given.
