### PR TITLE
Use directory-exists check rather than file-exists check

### DIFF
--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -22,7 +22,7 @@ ACDIR=`aclocal --print-ac-dir`
 # OS X with brew sets ACDIR to
 # /usr/local/Cellar/automake/1.13.1/share/aclocal, the staging area, which is
 # totally wrong argh
-if [ ! -f $ACDIR ]; then
+if [ ! -d $ACDIR ]; then
 	ACDIR=/usr/local/share/aclocal
 fi
 


### PR DESCRIPTION
Hi John,

The `aclocal --print-ac-dir` command in `bootstrap.sh` returns a directory so I believe the existence check a couple of lines later needs to be against a directory rather than a file.

This was preventing compilation from source on an Ubuntu 13.04 box. I was seeing errors like:

cp: cannot stat /usr/local/share/aclocal/codeset.m4: No such file or directory
cp: cannot stat /usr/local/share/aclocal/gettext.m4: No such file or directory
cp: cannot stat /usr/local/share/aclocal/glibc21.m4: No such file or directory
cp: cannot stat /usr/local/share/aclocal/iconv.m4: No such file or directory

This change fixed it.
