### PR TITLE
Ensure -interpolate flag is used with affine transformation

### DIFF
--- a/tools/vipsthumbnail.c
+++ b/tools/vipsthumbnail.c
@@ -460,7 +460,7 @@ thumbnail_shrink( VipsObject *process, VipsImage *in,
 		"access", VIPS_ACCESS_SEQUENTIAL,
 		"threaded", TRUE, 
 		NULL ) ||
-		vips_affine( t[4], &t[5], residual, 0, 0, residual, NULL, 
+		vips_affine( t[4], &t[5], residual, 0, 0, residual, 
 			"interpolate", interp,
 			NULL ) )  
 		return( NULL );


### PR DESCRIPTION
Hi John, I think the extra NULL here prevents the value of the -interpolate flag being passed to vips_affine. Does this change make sense?
