### PR TITLE
Prevent libpng verifying sRGB profiles

### DIFF
--- a/libvips/foreign/vipspng.c
+++ b/libvips/foreign/vipspng.c
@@ -188,6 +188,12 @@ read_new( VipsImage *out, gboolean readbehind )
 		user_error_function, user_warning_function )) ) 
 		return( NULL );
 
+#ifdef PNG_SKIP_sRGB_CHECK_PROFILE
+	/* Prevent libpng (>=1.6.11) verifying sRGB profiles.
+	 */
+	png_set_option( read->pPng, PNG_SKIP_sRGB_CHECK_PROFILE, PNG_OPTION_ON );
+#endif /*PNG_SKIP_sRGB_CHECK_PROFILE*/
+
 	/* Catch PNG errors from png_create_info_struct().
 	 */
 	if( setjmp( png_jmpbuf( read->pPng ) ) ) 
@@ -716,6 +722,12 @@ write_new( VipsImage *in )
 		PNG_LIBPNG_VER_STRING, NULL,
 		user_error_function, user_warning_function )) ) 
 		return( NULL );
+
+#ifdef PNG_SKIP_sRGB_CHECK_PROFILE
+	/* Prevent libpng (>=1.6.11) verifying sRGB profiles.
+	 */
+	png_set_option( write->pPng, PNG_SKIP_sRGB_CHECK_PROFILE, PNG_OPTION_ON );
+#endif /*PNG_SKIP_sRGB_CHECK_PROFILE*/
 
 	/* Catch PNG errors from png_create_info_struct().
 	 */


### PR DESCRIPTION
Hi John,

I was alerted via https://github.com/lovell/sharp/issues/73 that _libpng_, your favourite PNG library, is more strict with its colour profile verification from v1.6.11 onwards. This means PNG images output from obscure applications such as _Photoshop_ are no longer readable by default.

Luckily the `PNG_SKIP_sRGB_CHECK_PROFILE` option has been provided and is already in use by _[Imagemagick](https://subversion.imagemagick.org/subversion/ImageMagick/trunk/coders/png.c)_.

Here's an example of the current failure:

> curl -O https://cloud.githubusercontent.com/assets/3495674/3804621/1027e86e-1c29-11e4-8bcb-fdc8032a125e.png
> $ vips im_copy 1027e86e-1c29-11e4-8bcb-fdc8032a125e.png out.png
> vipspng: iCCP: known incorrect sRGB profile
> vipspng: known incorrect sRGB profile
> vips2png: unable to write "out.png"

The patch in this Pull Request allows the image to be processed without error.

Cheers,
Lovell
