### PR TITLE
Plug memory leaks in tilecache and colourspace conversion

### DIFF
--- a/libvips/conversion/tilecache.c
+++ b/libvips/conversion/tilecache.c
@@ -155,6 +155,7 @@ vips_block_cache_dispose( GObject *gobject )
 	vips_block_cache_drop_all( cache );
 	VIPS_FREEF( vips_g_mutex_free, cache->lock );
 	VIPS_FREEF( vips_g_cond_free, cache->new_tile );
+	VIPS_FREEF( g_hash_table_destroy, cache->tiles );
 
 	G_OBJECT_CLASS( vips_block_cache_parent_class )->dispose( gobject );
 }

--- a/libvips/iofuncs/type.c
+++ b/libvips/iofuncs/type.c
@@ -336,6 +336,8 @@ vips_area_free_array_object( GObject **array, VipsArea *area )
 		VIPS_FREEF( g_object_unref, array[i] );
 
 	area->n = 0;
+
+	VIPS_FREE( array );
 }
 
 /**


### PR DESCRIPTION
Hi John, a couple of goodies for you here.

The change to `tilecache.c` ensures the underlying hash table is destroyed at dispose-time.

This prevents tile caches from leaking. The effect is most noticeable for persistent tile caches as entries are never otherwise disposed.

```
==2022== 3,472 (1,232 direct, 2,240 indirect) bytes in 14 blocks are definitely lost in loss record 4,550 of 4,676
==2022==    at 0x4C2AB80: malloc (in /usr/lib/valgrind/vgpreload_memcheck-amd64-linux.so)
==2022==    by 0x829F610: g_malloc (in /lib/x86_64-linux-gnu/libglib-2.0.so.0.4000.0)
==2022==    by 0x82B522D: g_slice_alloc (in /lib/x86_64-linux-gnu/libglib-2.0.so.0.4000.0)
==2022==    by 0x828917D: g_hash_table_new_full (in /lib/x86_64-linux-gnu/libglib-2.0.so.0.4000.0)
==2022==    by 0x7AE5C1B: vips_block_cache_init (tilecache.c:493)
```

The change to `type.c` ensures the underlying array is freed when the `VipsArea` is freed.

For example, this change prevents 96 bytes leaking during each colour space conversion. [Other uses](https://github.com/jcupitt/libvips/search?q=vips_area_new_array_object) of this code may also benefit.

```
96 bytes in 4 blocks are definitely lost in loss record 3,974 of 4,698
==18888==    at 0x4C2CC70: calloc (in /usr/lib/valgrind/vgpreload_memcheck-amd64-linux.so)
==18888==    by 0x82A0668: g_malloc0 (in /lib/x86_64-linux-gnu/libglib-2.0.so.0.4000.0)
==18888==    by 0x7B9293B: vips_area_new_array_object (type.c:358)
==18888==    by 0x7AF1A52: vips_bandjoinv (bandjoin.c:195)
==18888==    by 0x7AF1BD1: vips_bandjoin (bandjoin.c:241)
==18888==    by 0x7ADCDE6: vips_BW2sRGB (colourspace.c:87)
==18888==    by 0x7ADD2E7: vips_colourspace_build (colourspace.c:464)
```

The [upstream/master CI job](https://travis-ci.org/lovell/libvips/builds/33528792) is currently failing for me with a "testing sample.mat matlab ... save / load difference is 64668 failed" message, which I think you've now [fixed on the 7.40 branch](https://github.com/jcupitt/libvips/commit/a75ddfbd5a35547a8fae7b5e10896f6ba41797d7).

The [CI failure for this PR](https://travis-ci.org/lovell/libvips/builds/33590458) is due to the same "matlab ... save / load difference" error. All other tests pass.
