### PR TITLE
Ensure Read struct is freed when reading WebP image data from a buffer

### DIFF
--- a/libvips/foreign/webp2vips.c
+++ b/libvips/foreign/webp2vips.c
@@ -298,6 +298,8 @@ vips__webp_read_buffer( void *buf, size_t len, VipsImage *out )
 	if( read_image( read, out ) )
 		return( -1 );
 
+	read_free( read );
+
 	return( 0 );
 }
 


### PR DESCRIPTION
Prevents 280 bytes leaking for each WebP image loaded from a buffer.

```
==22929== 3,360 bytes in 12 blocks are definitely lost in loss record 4,697 of 4,860
==22929==    at 0x4C2AB80: malloc (in /usr/lib/valgrind/vgpreload_memcheck-amd64-linux.so)
==22929==    by 0x82A0610: g_malloc (in /lib/x86_64-linux-gnu/libglib-2.0.so.0.4000.0)
==22929==    by 0x7BA3051: vips_malloc (memory.c:151)
==22929==    by 0x7B7A99E: read_new (webp2vips.c:139)
==22929==    by 0x7B7AE10: vips__webp_read_buffer (webp2vips.c:292)
==22929==    by 0x7B79DFA: vips_foreign_load_webp_buffer_load (webpload.c:219)
```
