### PR TITLE
Prevent the version of autotools in Redhat/Centos 6 generating empty else statements

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -365,7 +365,7 @@ PACKAGES_USED="$PACKAGES_USED glib-2.0 libxml-2.0 gmodule-2.0 gobject-2.0"
 # after 2.28 we have a monotonic timer
 PKG_CHECK_MODULES(MONOTONIC, glib-2.0 >= 2.28,[
   AC_DEFINE(HAVE_MONOTONIC_TIME,1,[define if your glib has g_get_monotonic_time().])
-  ],[
+  ],[:
   ]
 )
 
@@ -386,7 +386,7 @@ PKG_CHECK_MODULES(THREADS, glib-2.0 >= 2.32,[
 # with 2.36 and after the type system inits itself
 PKG_CHECK_MODULES(TYPE_INIT, glib-2.0 < 2.36,[
   AC_DEFINE(NEED_TYPE_INIT,1,[define if your glib needs g_type_init().])
-  ],[
+  ],[:
   ]
 )
 


### PR DESCRIPTION
Even the venerable _bitcoin_ project has run into this one - see https://github.com/bitcoin/bitcoin/commit/5d5b0d284a787fc9a3c53c59232ebc2c09dffaeb - their commit message suggests this may have affected _MinGW_ also.
