### PR TITLE
Allow op-cache winner in non-critical race condition

### DIFF
--- a/libvips/iofuncs/cache.c
+++ b/libvips/iofuncs/cache.c
@@ -599,12 +599,12 @@ vips_cache_ref( VipsOperation *operation )
 static void
 vips_cache_insert( VipsOperation *operation )
 {
-	VipsOperationCacheEntry *entry = g_new( VipsOperationCacheEntry, 1 ); 
-
 	/* It must not be in cache.
 	 */
-	g_assert( !g_hash_table_lookup( vips_cache_table, operation ) );
+	if( g_hash_table_lookup( vips_cache_table, operation ) )
+		return;
 
+	VipsOperationCacheEntry *entry = g_new( VipsOperationCacheEntry, 1 );
 	entry->operation = operation;
 	entry->time = 0;
 	entry->invalidate_id = 0;


### PR DESCRIPTION
Hi John, I'm experiencing a situation where two or more threads attempt to add objects with the same hash value to the operation cache.

> VIPS:ERROR:cache.c:606:vips_cache_insert: assertion failed: (!g_hash_table_lookup( vips_cache_table, operation ))

I think it's due to the (deadlock-prevention?) gap between an unlock/lock pair in `vips_cache_operation_buildp` - https://github.com/jcupitt/libvips/blob/master/libvips/iofuncs/cache.c#L762-L779

As operation objects with the same hash value are effectively equal, this PR changes the situation from a critical to non-critical race condition, allowing the first thread to add a given operation to "win".

(`g_new` is moved below `g_hash_table_lookup` to prevent a memory leak.)
