### PR TITLE
Verify first 4 bytes of TIFF file

### DIFF
--- a/libvips/foreign/tiff2vips.c
+++ b/libvips/foreign/tiff2vips.c
@@ -1905,8 +1905,10 @@ vips__istiff_buffer( void *buf, size_t len )
 	char *str = (char *) buf; 
 
 	if( len >= 4 &&
-		((str[0] == 'M' && str[1] == 'M' && str[2] == '\0' && str[3] == '*') ||
-		 (str[0] == 'I' && str[1] == 'I' && str[2] == '*' && str[3] == '\0')) )
+		((str[0] == 'M' && str[1] == 'M' &&
+			str[2] == '\0' && (str[3] == '*' || str[3] == '+')) ||
+		(str[0] == 'I' && str[1] == 'I' &&
+			(str[2] == '*' || str[2] == '+') && str[3] == '\0')) )
 		return( TRUE );
 
 	return( FALSE );


### PR DESCRIPTION
This change prevents libvips' TIFF loader attempting to handle files in the `.orf` Olympus Raw format, which happen to share their first two bytes with the TIFF format. I suspect there may be other formats guilty of this orf-ul crime.

Before:

```
curl -O http://sample-images.metadata-extractor.googlecode.com/git/Olympus%20Pen%20E-PL1.orf
$ vips im_copy Olympus%20Pen%20E-PL1.orf test.jpg
Olympus%20Pen%20E-PL1.orf: Not a TIFF file, bad version number 20306 (0x4f52)
tiff2vips: unable to open "Olympus%20Pen%20E-PL1.orf" for input
```

After:

```
$ vips im_copy Olympus%20Pen%20E-PL1.orf test.jpg
VipsFormat: file "Olympus%20Pen%20E-PL1.orf" not a known format
```

The version of libmagick I'm using doesn't seem to recognise this sample `.orf` file either, but at least it's now given the chance.
