### PR TITLE
Expose 'density' attribute for magickload

### DIFF
--- a/libvips/deprecated/im_magick2vips.c
+++ b/libvips/deprecated/im_magick2vips.c
@@ -50,7 +50,7 @@ im_magick2vips( const char *filename, IMAGE *out )
 #ifdef HAVE_MAGICK
 	/* Old behaviour was always to read all frames.
 	 */
-	return( vips__magick_read( filename, out, TRUE ) ); 
+	return( vips__magick_read( filename, out, TRUE, NULL ) );
 #else
 	vips_error( "im_magick2vips", 
 		"%s", _( "no libMagick support in your libvips" ) ); 

--- a/libvips/foreign/foreign.c
+++ b/libvips/foreign/foreign.c
@@ -1631,6 +1631,7 @@ vips_foreign_operation_init( void )
  * Optional arguments:
  *
  * @all_frames: load all frames in sequence
+ * @density: canvas resolution for rendering vector formats like SVG
  *
  * Read in an image using libMagick, the ImageMagick library. This library can
  * read more than 80 file formats, including SVG, BMP, EPS, DICOM and many 
@@ -1644,6 +1645,9 @@ vips_foreign_operation_init( void )
  *
  * Normally it will only load the first image in a many-image sequence (such
  * as a GIF). Set @all_frames to true to read the whole image sequence. 
+ *
+ * @density is "WxH" in DPI, e.g. "600x300" or "600" (default is "72x72")
+ * http://www.imagemagick.org/script/command-line-options.php#density
  *
  * See also: vips_image_new_from_file().
  *

--- a/libvips/foreign/magick.h
+++ b/libvips/foreign/magick.h
@@ -36,9 +36,9 @@ extern "C" {
 #endif /*__cplusplus*/
 
 int vips__magick_read( const char *filename, 
-	VipsImage *out, gboolean all_frames );
+	VipsImage *out, gboolean all_frames, const char* density );
 int vips__magick_read_header( const char *filename, 
-	VipsImage *out, gboolean all_frames );
+	VipsImage *out, gboolean all_frames, const char* density );
 
 #ifdef __cplusplus
 }

--- a/libvips/foreign/magick2vips.c
+++ b/libvips/foreign/magick2vips.c
@@ -141,7 +141,8 @@ read_destroy( VipsImage *im, Read *read )
 }
 
 static Read *
-read_new( const char *filename, VipsImage *im, gboolean all_frames )
+read_new( const char *filename, VipsImage *im, gboolean all_frames,
+	const char* density )
 {
 	Read *read;
 	static int inited = 0;
@@ -174,6 +175,10 @@ read_new( const char *filename, VipsImage *im, gboolean all_frames )
 		return( NULL );
 
 	vips_strncpy( read->image_info->filename, filename, MaxTextExtent );
+
+	/* Canvas resolution for rendering vector formats like SVG
+	 */
+	VIPS_SETSTR( read->image_info->density, density );
 
 #ifdef DEBUG
 	printf( "magick2vips: read_new: %s\n", read->filename );
@@ -647,7 +652,8 @@ magick_fill_region( VipsRegion *out,
 }
 
 int
-vips__magick_read( const char *filename, VipsImage *out, gboolean all_frames )
+vips__magick_read( const char *filename, VipsImage *out, gboolean all_frames,
+	const char *density )
 {
 	Read *read;
 
@@ -655,7 +661,7 @@ vips__magick_read( const char *filename, VipsImage *out, gboolean all_frames )
 	printf( "magick2vips: vips__magick_read: %s\n", filename );
 #endif /*DEBUG*/
 
-	if( !(read = read_new( filename, out, all_frames )) )
+	if( !(read = read_new( filename, out, all_frames, density )) )
 		return( -1 );
 
 #ifdef HAVE_SETIMAGEOPTION
@@ -697,7 +703,7 @@ vips__magick_read( const char *filename, VipsImage *out, gboolean all_frames )
  */
 int
 vips__magick_read_header( const char *filename, VipsImage *im, 
-	gboolean all_frames )
+	gboolean all_frames, const char *density )
 {
 	Read *read;
 
@@ -705,7 +711,7 @@ vips__magick_read_header( const char *filename, VipsImage *im,
 	printf( "vips__magick_read_header: %s\n", filename );
 #endif /*DEBUG*/
 
-	if( !(read = read_new( filename, im, all_frames )) )
+	if( !(read = read_new( filename, im, all_frames, density )) )
 		return( -1 );
 
 #ifdef DEBUG

--- a/libvips/foreign/magickload.c
+++ b/libvips/foreign/magickload.c
@@ -61,6 +61,7 @@ typedef struct _VipsForeignLoadMagick {
 
 	char *filename; 
 	gboolean all_frames;
+	char *density;
 
 } VipsForeignLoadMagick;
 
@@ -77,7 +78,7 @@ ismagick( const char *filename )
 
 	t = vips_image_new();
 	vips_error_freeze();
-	result = vips__magick_read_header( filename, t, FALSE );
+	result = vips__magick_read_header( filename, t, FALSE, NULL );
 	g_object_unref( t );
 	vips_error_thaw();
 
@@ -113,7 +114,7 @@ vips_foreign_load_magick_header( VipsForeignLoad *load )
 	VipsForeignLoadMagick *magick = (VipsForeignLoadMagick *) load;
 
 	if( vips__magick_read( magick->filename, 
-		load->out, magick->all_frames ) ) 
+		load->out, magick->all_frames, magick->density ) )
 		return( -1 );
 
 	VIPS_SETSTR( load->out->filename, magick->filename );
@@ -160,6 +161,13 @@ vips_foreign_load_magick_class_init( VipsForeignLoadMagickClass *class )
 		VIPS_ARGUMENT_OPTIONAL_INPUT,
 		G_STRUCT_OFFSET( VipsForeignLoadMagick, all_frames ),
 		FALSE );
+
+	VIPS_ARG_STRING( class, "density", 4,
+		_( "Density" ),
+		_( "Canvas resolution for rendering vector formats like SVG" ),
+		VIPS_ARGUMENT_OPTIONAL_INPUT,
+		G_STRUCT_OFFSET( VipsForeignLoadMagick, density ),
+		NULL );
 }
 
 static void


### PR DESCRIPTION
Hi John, this change is to expose *magick's String-based `density` attribute.

If you weren't already aware (unlikely), it's used when loading vector formats to control the DPI of the "canvas" resolution prior to rasterisation.

Amongst other things, it will allow sharp and friends to provide improved support for SVG, PDF and Postscript files.

The nip2 test suite passes with this change. I had to modify one of the deprecated source files to get it to compile - not sure how to test this bit still works.
