### PR TITLE
Drop dependency on Python "future" package

### DIFF
--- a/python/README.md
+++ b/python/README.md
@@ -33,10 +33,3 @@ or
     sudo cp Vips.py /usr/lib/python3/dist-packages/gi/overrides
 
 You can optionally pre-compile this file for a small speedup.
-
-For python2.7, you need to install the "future" package. In Ubuntu, for
-example, you can do something like:
-
-    sudo apt-get install python-pip
-    sudo pip install future
-

--- a/python/Vips.py
+++ b/python/Vips.py
@@ -3,21 +3,6 @@
 
 from __future__ import division
 
-# if this is py2 and future is not found, it's the first import from builtins 
-# that fails silently, for some reason 
-
-# raise a RuntimeError, this is not caught by our importer
-
-try:
-    from builtins import map
-except Exception as e:
-    raise RuntimeError("Unable to import 'map' from 'builtins': " + str(e) + 
-                       " -- maybe try 'pip install future'")
-
-from builtins import str
-from builtins import range
-from builtins import object
-
 # overrides for pygobject gobject-introspection binding for libvips, tested 
 # with python2.7 and python3.4
 

--- a/test/test_arithmetic.py
+++ b/test/test_arithmetic.py
@@ -1,8 +1,6 @@
 #!/usr/bin/python3
 
 from __future__ import division
-from builtins import zip
-from builtins import range
 import unittest
 import math
 

--- a/test/test_colour.py
+++ b/test/test_colour.py
@@ -1,7 +1,5 @@
 #!/usr/bin/python
 
-from builtins import zip
-
 import unittest
 import math
 

--- a/test/test_conversion.py
+++ b/test/test_conversion.py
@@ -1,7 +1,6 @@
 #!/usr/bin/python
 
 from __future__ import division
-from builtins import zip
 import unittest
 import math
 

--- a/test/test_convolution.py
+++ b/test/test_convolution.py
@@ -1,8 +1,6 @@
 #!/usr/bin/python3
 
 from __future__ import division
-from builtins import zip
-from builtins import range
 from numbers import Number
 from functools import reduce
 


### PR DESCRIPTION
The `future` Python package isn't included in Debian or Fedora, so those downstreams (among others?) will have to package it before they can ship the new VIPS Python bindings.  However, VIPS' use of `future` seems to be limited: it just replaces a few builtins with versions that provide Python 3 semantics.  Since none of the call sites for those builtins appear to depend on Python 3 semantics, it seems the `future` dependency can be dropped.

Tested with `test_python.sh` with `future` uninstalled.  The only failure is `test_icc` on Python 3, which is also failing in master.
