### PR TITLE
Several minor improvements

### DIFF
--- a/libvips/foreign/foreign.c
+++ b/libvips/foreign/foreign.c
@@ -523,12 +523,6 @@ vips_foreign_find_load( const char *name )
 
 	vips__filename_split8( name, filename, option_string );
 
-	if( !vips_existsf( "%s", filename ) ) {
-		vips_error( "VipsForeignLoad", 
-			_( "file \"%s\" not found" ), name );
-		return( NULL );
-	}
-
 	if( !(load_class = (VipsForeignLoadClass *) vips_foreign_map( 
 		"VipsForeignLoad",
 		(VipsSListMap2Fn) vips_foreign_find_load_sub, 

--- a/libvips/include/vips/vips.h
+++ b/libvips/include/vips/vips.h
@@ -82,6 +82,13 @@
 extern "C" {
 #endif /*__cplusplus*/
 
+#define VIPS_EINTR_RETRY(expression) \
+  (__extension__                                                              \
+    ({ long int __result;                                                     \
+       do __result = (long int) (expression);                                 \
+       while (__result == -1L && errno == EINTR);                             \
+       __result; }))
+
 #include <glib.h>
 #include <glib/gstdio.h>
 #include <gmodule.h>


### PR DESCRIPTION
This PR resolves some issues, discussed in #921 and #922 

Namely, it implements file descriptors as source and destination and allows using `O_TMPFILE` for creating temporary files. The implementation is ugly (as expected from C code I wrote) and does not really accounts for user's best interests. In particular, there probably should be a fallback for case when filesystem does not support `O_TMPFILE`. The robustness of syntax, used for implementing file descriptor source, is also of some concern.

This PR was tested only with single thread (I don't actually need threads for my purposes). Feel free to ignore it — I don't really care about upstreaming these changes, although that'd be nice from maintenance standpoint.