### PR TITLE
fix build on older glibs

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,5 +1,6 @@
 23/9/18 started 8.7.1
 - update function list in docs [janko-m] 
+- test for g_str_to_ascii() [jcupitt]
 
 23/12/17 started 8.7.0
 - add magicksave, save image with libMagick [dlemstra]

--- a/configure.ac
+++ b/configure.ac
@@ -505,12 +505,20 @@ PKG_CHECK_MODULES(TYPE_INIT, glib-2.0 < 2.36,
   ]
 )
 
-# from 2.40 we have g_win32_get_command_line() on win
+# from 2.40, on win32 we have g_win32_get_command_line() 
 PKG_CHECK_MODULES(WIN32_GET_COMMAND_LINE, glib-2.0 >= 2.40,
   [if test x"$vips_os_win32" = x"yes"; then
      AC_DEFINE(HAVE_G_WIN32_GET_COMMAND_LINE,1,[define if your glib has g_win32_get_command_line().])
      have_g_win32_get_command_line=yes
    fi
+  ],
+  [:
+  ]
+)
+
+# from 2.40, have g_str_to_ascii()
+PKG_CHECK_MODULES(STR_TO_ASCII, glib-2.0 >= 2.40,
+  [AC_DEFINE(HAVE_G_STR_TO_ASCII,1,[define if your glib has g_str_to_ascii().])
   ],
   [:
   ]

--- a/libvips/foreign/exif.c
+++ b/libvips/foreign/exif.c
@@ -832,24 +832,30 @@ vips_exif_set_string_encoding( ExifData *ed,
 	ExifEntry *entry, unsigned long component, const char *data )
 {
 	char *str;
-	char *ascii;
 	int len;
 
 	str = drop_tail( data );
 
 	/* libexif can only really save ASCII to things like UserComment.
 	 */
+#ifdef HAVE_G_STR_TO_ASCII
+{
+	char *ascii;
+
 	ascii = g_str_to_ascii( str, NULL );
+	g_free( str );
+	str = ascii;
+}
+#endif /*HAVE_G_STR_TO_ASCII*/
 
 	/* libexif comment strings are not NULL-terminated, and have an 
 	 * encoding tag (always ASCII) in the first 8 bytes.
 	 */
-	len = strlen( ascii );
+	len = strlen( str );
 	vips_exif_alloc_string( entry, sizeof( ASCII_COMMENT ) - 1 + len );
 	memcpy( entry->data, ASCII_COMMENT, sizeof( ASCII_COMMENT ) - 1 );
-        memcpy( entry->data + sizeof( ASCII_COMMENT ) - 1, ascii, len );
+        memcpy( entry->data + sizeof( ASCII_COMMENT ) - 1, str, len );
 
-	g_free( ascii ); 
 	g_free( str );
 }
 
@@ -861,20 +867,29 @@ vips_exif_set_string_ascii( ExifData *ed,
 	ExifEntry *entry, unsigned long component, const char *data )
 {
 	char *str;
-	char *ascii;
 	int len;
 
 	str = drop_tail( data );
+
+	/* libexif can only really save ASCII to things like UserComment.
+	 */
+#ifdef HAVE_G_STR_TO_ASCII
+{
+	char *ascii;
+
 	ascii = g_str_to_ascii( str, NULL );
+	g_free( str );
+	str = ascii;
+}
+#endif /*HAVE_G_STR_TO_ASCII*/
 
 	/* ASCII strings are NULL-terminated.
 	 */
-	len = strlen( ascii );
+	len = strlen( str );
 	vips_exif_alloc_string( entry, len + 1 );
-        memcpy( entry->data, ascii, len + 1 );
+        memcpy( entry->data, str, len + 1 );
         entry->format = EXIF_FORMAT_ASCII;
 
-	g_free( ascii ); 
 	g_free( str );
 }
 


### PR DESCRIPTION
we were using g_str_to_ascii(), but it was only added in glib 2.40

see https://github.com/libvips/libvips/issues/1117