### PR TITLE
Add is_null check to VImage

### DIFF
--- a/cplusplus/include/vips/VImage8.h
+++ b/cplusplus/include/vips/VImage8.h
@@ -162,7 +162,7 @@ public:
 
 	bool is_null() const
 	{
-		return vobject == nullptr;
+		return vobject == 0;
 	}
 
 };

--- a/cplusplus/include/vips/VImage8.h
+++ b/cplusplus/include/vips/VImage8.h
@@ -160,6 +160,11 @@ public:
 		return( vobject ); 
 	}
 
+	bool is_null() const
+	{
+		return vobject == nullptr;
+	}
+
 };
 
 class VIPS_CPLUSPLUS_API VImage;
@@ -237,6 +242,8 @@ public:
 class VImage : VObject
 {
 public:
+	using VObject::is_null;
+
 	VImage( VipsImage *image, VSteal steal = STEAL ) : 
 		VObject( (VipsObject *) image, steal )
 	{


### PR DESCRIPTION
This pull request adds an is_null check, which is then used in VImage.
The usefulness is described in #1132.