### PR TITLE
Fix compilation error when lcms has not been found

### DIFF
--- a/libvips/colour/CMYK2XYZ.c
+++ b/libvips/colour/CMYK2XYZ.c
@@ -37,12 +37,13 @@
 #endif /*HAVE_CONFIG_H*/
 #include <vips/intl.h>
 
+#include <vips/vips.h>
+
 #ifdef HAVE_LCMS2
 
 #include <stdio.h>
 #include <math.h>
 
-#include <vips/vips.h>
 #include <vips/internal.h>
 
 #include "pcolour.h"

--- a/libvips/colour/XYZ2CMYK.c
+++ b/libvips/colour/XYZ2CMYK.c
@@ -37,12 +37,13 @@
 #endif /*HAVE_CONFIG_H*/
 #include <vips/intl.h>
 
+#include <vips/vips.h>
+
 #ifdef HAVE_LCMS2
 
 #include <stdio.h>
 #include <math.h>
 
-#include <vips/vips.h>
 #include <vips/internal.h>
 
 #include "pcolour.h"


### PR DESCRIPTION
If HAVE_LCMS2 is not defined, VipsImage is not declared in both
CMYK2XYZ and XYZ2CMYK source files.

#1197 