### PR TITLE
PNG loader: attach palette bit depth, if any, as metadata

### DIFF
--- a/libvips/foreign/vipspng.c
+++ b/libvips/foreign/vipspng.c
@@ -490,6 +490,11 @@ png2vips_header( Read *read, VipsImage *out )
 				return( -1 ); 
 	}
 
+	/* Attach original palette bit depth, if any, as metadata.
+	 */
+	if( color_type == PNG_COLOR_TYPE_PALETTE )
+		vips_image_set_int( out, "palette-bit-depth", bit_depth );
+
 	return( 0 );
 }
 


### PR DESCRIPTION
Hello, this is a small addition to the PNG header reader to attach the bit depth of the palette, if any, as metadata.

By way of example, using test images from http://www.schaik.com/pngsuite/pngsuite_bas_png.html we can now differentiate 4-bit vs 8-bit palette:

```sh
$ vipsheader -a basn3p04.png
basn3p04.png: 32x32 uchar, 3 bands, srgb, pngload
width: 32
height: 32
bands: 3
format: uchar
coding: none
interpretation: srgb
xoffset: 0
yoffset: 0
xres: 2.834
yres: 2.834
filename: basn3p04.png
vips-loader: pngload
palette-bit-depth: 4
```

```sh
$ vipsheader -a basn3p08.png
basn3p08.png: 32x32 uchar, 3 bands, srgb, pngload
width: 32
height: 32
bands: 3
format: uchar
coding: none
interpretation: srgb
xoffset: 0
yoffset: 0
xres: 2.834
yres: 2.834
filename: basn3p08.png
vips-loader: pngload
palette-bit-depth: 8
```

These two images would otherwise be indistinguishable using metadata alone.