### PR TITLE
Avoid artefacts when casting from float to int (master)

### DIFF
--- a/libvips/conversion/cast.c
+++ b/libvips/conversion/cast.c
@@ -195,9 +195,7 @@ G_DEFINE_TYPE( VipsCast, vips_cast, VIPS_TYPE_CONVERSION );
 	OTYPE * restrict q = (OTYPE *) out; \
 	\
 	for( x = 0; x < sz; x++ ) { \
-		TEMP v = VIPS_FLOOR( p[x] ); \
-		\
-		q[x] = CAST( v ); \
+		q[x] = CAST( p[x] ); \
 	} \
 }
 


### PR DESCRIPTION
Commit https://github.com/libvips/libvips/commit/07d58f81b3c6e6f034e5bb84f6023d1d08ac0061 on the `master` branch changed the way floats are cast to ints.

Using the following test image:
```sh
$ curl -O https://raw.githubusercontent.com/lovell/sharp/master/docs/image/sharp-logo.svg
```

The following resize operation works as expected:
```sh
$ vips resize sharp-logo.svg sharp-logo.png 0.9
```

However the following, casting to and from float values, results in what appear to be rounding-error artefacts:
```sh
$ vips cast sharp-logo.svg sharp-logo.v float
$ vips resize sharp-logo.v sharp-logo.png 0.9
```
![](https://user-images.githubusercontent.com/210965/51051845-e28e5080-15cc-11e9-8c08-3a1ce0f5d13d.png)

My best guess is that this relates to the introduction of logic to floor the (possibly negative) float value in the `CAST_FLOAT_INT` macro before an implicit truncate. When I remove the use of floor, as in the proposed change in this PR, the artefacts are gone.

![](https://user-images.githubusercontent.com/210965/51052158-c2ab5c80-15cd-11e9-86ad-250ff84b6266.png)
