### PR TITLE
vips_image_temp_name: Fixed race condition / heap-buffer-overflow

### DIFF
--- a/libvips/iofuncs/image.c
+++ b/libvips/iofuncs/image.c
@@ -1666,7 +1666,13 @@ vips_image_temp_name( char *name, int size )
 {
 	static int global_serial = 0;
 
-	int serial = g_atomic_int_add( &global_serial, 1);
+	int serial =
+#if GLIB_CHECK_VERSION( 2, 30, 0 )
+		g_atomic_int_add( &global_serial, 1);
+#else
+		g_atomic_exchange_and_add( &global_serial, 1);
+#endif
+
 	vips_snprintf( name, size, "temp-%d", serial );
 }
 

--- a/libvips/iofuncs/image.c
+++ b/libvips/iofuncs/image.c
@@ -1658,18 +1658,16 @@ vips_image_set_kill( VipsImage *image, gboolean kill )
 	image->kill = kill;
 }
 
-/* Make a name for a filename-less image. Use immediately, don't free the
- * result.
+/* Fills the given buffer with a temporary filename.
+ * Assuming that "int" might be 64 Bit wide a buffer size of 26 suffices.
  */
-static const char *
-vips_image_temp_name( void )
+void
+vips_image_temp_name( char *name, int size )
 {
-	static int serial = 0;
-	static char name[256];
+	static int global_serial = 0;
 
-	vips_snprintf( name, 256, "temp-%d", serial++ );
-
-	return( name );
+	int serial = g_atomic_int_add( &global_serial, 1);
+	vips_snprintf( name, size, "temp-%d", serial );
 }
 
 /**
@@ -1689,12 +1687,14 @@ VipsImage *
 vips_image_new( void )
 {
 	VipsImage *image;
+	char filename[26];
 
 	vips_check_init();
+	vips_image_temp_name( filename, sizeof(filename) );
 
 	image = VIPS_IMAGE( g_object_new( VIPS_TYPE_IMAGE, NULL ) );
 	g_object_set( image,
-		"filename", vips_image_temp_name(),
+		"filename", filename,
 		"mode", "p",
 		NULL );
 	if( vips_object_build( VIPS_OBJECT( image ) ) ) {
@@ -1741,7 +1741,9 @@ vips_image_new_mode( const char *filename, const char *mode )
 VipsImage *
 vips_image_new_memory( void )
 {
-	return( vips_image_new_mode( vips_image_temp_name(), "t" ) );
+	char filename[26];
+	vips_image_temp_name( filename, sizeof(filename) );
+	return( vips_image_new_mode( filename, "t" ) );
 }
 
 /**
@@ -2004,12 +2006,14 @@ vips_image_new_from_memory( const void *data, size_t size,
 	int width, int height, int bands, VipsBandFormat format )
 {
 	VipsImage *image;
+	char filename[26];
 
 	vips_check_init();
+	vips_image_temp_name( filename, sizeof(filename) );
 
 	image = VIPS_IMAGE( g_object_new( VIPS_TYPE_IMAGE, NULL ) );
 	g_object_set( image,
-		"filename", vips_image_temp_name(),
+		"filename", filename,
 		"mode", "m",
 		"foreign_buffer", data,
 		"width", width,


### PR DESCRIPTION
`vips_image_temp_name` can be called concurrently and thus the usage of the static `name` array is not thread safe.
`-fsanitize=address` spuriously complains about `heap-buffer-overflow` errors due to this.

---

**A different issue follows, but I thought I'd might write it up already.**

I recently upgraded all dependencies of a project I'm working on from libvips 8.6.4 to 8.7.2, as well as Alpine from 3.7 to 3.8 (i.e. an upgrade of liborc from 0.4.27 to 0.4.28).
Ever since then I'm seeing spurious, seemingly racy, segmentation faults.

This PR is the first thing that came out of the bug hunt. :smile: 

I personally suspect that this is due to liborc, as I can see the following if I compile with `-fsanitize=address`:
```
AddressSanitizer:DEADLYSIGNAL
=================================================================
==16786==ERROR: AddressSanitizer: SEGV on unknown address 0x60400f00000c (pc 0x7f8be84be206 bp 0x62a00103d8a0 sp 0x7f8bdc0d9548 T42)
==16786==The signal is caused by a READ memory access.
AddressSanitizer:DEADLYSIGNAL
    #0 0x7f8be84be205 in orc_code_chunk_merge (/usr/lib/x86_64-linux-gnu/liborc-0.4.so.0+0xd205)

AddressSanitizer can not provide additional info.
SUMMARY: AddressSanitizer: SEGV (/usr/lib/x86_64-linux-gnu/liborc-0.4.so.0+0xd205) in orc_code_chunk_merge
Thread T42 created by T41 here:
...
```

Interestingly on the production servers SIGSEGV always happens in a deep chain of recursive `vips_object_close` calls instead (600+ frames deep!).
The crash happens on `push` or `call` instructions which lead me to believe that this is a stackoverflow, but the difference between the stack pointers in the highest and lowest frames is only around 84kB.
Due to that I believe that the current libvips 8.7.2 & liborc 0.4.28 combination might silently currupt heaps/stacks and thus lead to segmentation faults for users, if libvips is used concurrently.

If you happen to be interested in that I'd be able to _privately_ provide you with 6 different backtraces. While I sadly won't be able to provide you with a proper binary and it's core dumps, I could write a small test case though, given enough time.