### PR TITLE
Ensure ICC profile data is freed after use (master)

### DIFF
--- a/libvips/colour/profile_load.c
+++ b/libvips/colour/profile_load.c
@@ -136,7 +136,7 @@ vips_profile_load_build( VipsObject *object )
 	}
 	else if( (data = vips__file_read_name( load->name, 
 		vips__icc_dir(), &length )) ) {
-		profile = vips_blob_new( NULL, data, length );
+		profile = vips_blob_new( (VipsCallbackFn) g_free, data, length );
 	}
 	else {
 		vips_error( class->nickname, 


### PR DESCRIPTION
The recent change to the `master` branch introduced by #1194 leaks the ICC profile data:
```
==28548== 2,429 bytes in 1 blocks are definitely lost in loss record 6,423 of 6,523
==28548==    at 0x483774F: malloc (in /usr/lib/valgrind/vgpreload_memcheck-amd64-linux.so)
==28548==    by 0x9424650: g_malloc (in /usr/lib/x86_64-linux-gnu/libglib-2.0.so.0.5800.1)
==28548==    by 0x8FCD261: vips_malloc (memory.c:176)
==28548==    by 0x8FD7722: vips__file_read (util.c:754)
==28548==    by 0x8FD77D6: vips__file_read_name (util.c:787)
==28548==    by 0x8EFBA6D: vips_profile_load_build (profile_load.c:137)
==28548==    by 0x8FBEF18: vips_object_build (object.c:367)
==28548==    by 0x8FCAA57: vips_cache_operation_buildp (cache.c:866)
==28548==    by 0x8FD074C: vips_call_required_optional (operation.c:880)
==28548==    by 0x8FD0E55: vips_call_by_name (operation.c:920)
==28548==    by 0x8FD12A8: vips_call_split (operation.c:1024)
==28548==    by 0x8EFBC95: vips_profile_load (profile_load.c:221)
==28548==    by 0x8F00EED: vips_icc_transform_build (icc_transform.c:1089)
```
The proposed change in this PR seems to fix things.