### PR TITLE
vips_magicksave for GraphicsMagick

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -799,11 +799,13 @@ if test x"$enable_magicksave" != x"yes"; then
   AC_CHECK_FUNCS(ImportImagePixels,[
      AC_DEFINE(HAVE_IMPORTIMAGEPIXELS,1,
 	       [define if you have ImportImagePixels.])
-   ],[
-     AC_MSG_WARN([ImportImagePixels not found; disabling magicksave])
-     enable_magicksave=no
-   ]
+   ],[]
   )
+  AC_CHECK_FUNCS(ImagesToBlob,[
+     AC_DEFINE(HAVE_IMAGESTOBLOB,1,
+	       [define if you have ImagesToBlob.])
+   ],[]
+  ) 
   LIBS="$save_LIBS"
 fi
 

--- a/libvips/foreign/magick.c
+++ b/libvips/foreign/magick.c
@@ -78,6 +78,13 @@ magick_import_pixels( Image *image, const ssize_t x, const ssize_t y,
 		type, pixels, exception ) );
 }
 
+void *
+magick_images_to_blob( const ImageInfo *image_info, Image *images, size_t *length,
+	ExceptionInfo *exception )
+{
+	return( ImagesToBlob( image_info, images, length, exception ) );
+}
+
 void
 magick_set_property( Image *image, const char *property, const char *value,
 	ExceptionInfo *exception )
@@ -193,8 +200,29 @@ magick_import_pixels( Image *image, const ssize_t x, const ssize_t y,
 	return( ImportImagePixels( image, x, y, width, height, map,
 		type, pixels ) );
 #else /*!HAVE_IMPORTIMAGEPIXELS*/
+	g_assert(image != (Image *) NULL);
+	g_assert(image->signature == MagickSignature);
+
+	Image *constitute_image=
+		ConstituteImage(width,height,map,type,pixels,&image->exception);
+	if (constitute_image) {
+		(void) CompositeImage(image,CopyCompositeOp,constitute_image,x,y);
+		DestroyImage(constitute_image);
+		return (image->exception.severity == UndefinedException);
+	}
 	return( MagickFalse );
 #endif /*HAVE_IMPORTIMAGEPIXELS*/
+}
+
+void *
+magick_images_to_blob( const ImageInfo *image_info, Image *images, size_t *length,
+	ExceptionInfo *exception )
+{
+#ifdef HAVE_IMAGESTOBLOB
+	return( ImagesToBlob( image_info, images, length, exception ) );
+#else
+	return( ImageToBlob( image_info, images, length, exception ) );
+#endif /*HAVE_IMAGESTOBLOB*/
 }
 
 void

--- a/libvips/foreign/magick.h
+++ b/libvips/foreign/magick.h
@@ -51,6 +51,8 @@ int magick_set_image_size( Image *image,
 int magick_import_pixels( Image *image, const ssize_t x, const ssize_t y,
 	const size_t width, const size_t height, const char *map,
 	const StorageType type,const void *pixels, ExceptionInfo *exception );
+void *magick_images_to_blob( const ImageInfo *image_info, Image *images, size_t *length,
+	ExceptionInfo *exception );
 void magick_set_property( Image *image, const char *property, const char *value,
 	ExceptionInfo *exception );
 void magick_set_image_option( ImageInfo *image_info, 

--- a/libvips/foreign/magicksave.c
+++ b/libvips/foreign/magicksave.c
@@ -112,7 +112,7 @@ magick_write_block( VipsRegion *region, VipsRect *area, void *a )
 {
 	VipsForeignSaveMagick *magick = (VipsForeignSaveMagick *) a;
 
-	MagickBooleanType status;
+	int status;
 	void *p;
 
 	p = VIPS_REGION_ADDR( region, area->left, area->top );
@@ -221,7 +221,7 @@ vips_foreign_save_magick_build( VipsObject *object )
 	magick->exception = magick_acquire_exception();
 	magick->image_info = CloneImageInfo( NULL );
 
-	magick->storage_type = UndefinedPixel;
+	magick->storage_type = CharPixel;
 	switch( im->BandFmt ) {
 	case VIPS_FORMAT_UCHAR:
 		magick->storage_type = CharPixel;
@@ -465,8 +465,8 @@ vips_foreign_save_magick_buffer_build( VipsObject *object )
 		build( object ) )
 		return( -1 );
 
-	if( !(obuf = ImagesToBlob( magick->image_info, magick->images, 
-		&olen, magick->exception )) ) { 
+	if( !(obuf = magick_images_to_blob( magick->image_info, magick->images, 
+		&olen, magick->exception )) ) {
 		magick_inherit_exception( magick->exception, magick->images );
 		magick_vips_error( class->nickname, magick->exception );
 


### PR DESCRIPTION
Hi,

Looks like I made `vips_magicksave` working with GM. There is what I've done:

1. GraphicsMagick has [its own implementation](http://hg.code.sf.net/p/graphicsmagick/code/file/c38fc0e3e465/wand/magick_compat.c#l315) of `ImportImagePixels` in the wand part. Since it's pointlessly to link the wand part, I just borrowed the code. Using `SetImagePixels` may be a more effective solution, but the current one is better than nothing.

2. GM doesn't have `UndefinedPixel` value. Since we anyway will throw an error in `vips_foreign_save_magick_build ` if the band format is unsupported, I've decided that we can safely assign `CharPixel` to `magick->storage_type` at the start. Maybe, we even can remove this assignation, but I'm not sure about this.

3. Also, GM doesn't have `ImagesToBlob` function. From what I researched, it successfully saves multi-frame images with `ImageToBlob`, so I use one when `ImagesToBlob` is not found. Tested with GIF and TIFF, works as expected.

I didn't use C since university time, so I'm sorry if there are problems with code style and stuff :)