### PR TITLE
Fix thumbnailing of a WebP image (master)

### DIFF
--- a/libvips/resample/thumbnail.c
+++ b/libvips/resample/thumbnail.c
@@ -885,7 +885,8 @@ vips_thumbnail_file_open( VipsThumbnail *thumbnail, double factor )
 {
 	VipsThumbnailFile *file = (VipsThumbnailFile *) thumbnail;
 
-	if( vips_isprefix( "VipsForeignLoadJpeg", thumbnail->loader ) ) {
+	if( vips_isprefix( "VipsForeignLoadJpeg", thumbnail->loader ) ||
+		vips_isprefix( "VipsForeignLoadWebp", thumbnail->loader ) ) {
 		return( vips_image_new_from_file( file->filename, 
 			"access", VIPS_ACCESS_SEQUENTIAL,
 			"shrink", (int) factor,
@@ -899,8 +900,7 @@ vips_thumbnail_file_open( VipsThumbnail *thumbnail, double factor )
 			NULL ) );
 	}
 	else if( vips_isprefix( "VipsForeignLoadPdf", thumbnail->loader ) ||
-		vips_isprefix( "VipsForeignLoadSvg", thumbnail->loader ) ||
-		vips_isprefix( "VipsForeignLoadWebp", thumbnail->loader ) ) {
+		vips_isprefix( "VipsForeignLoadSvg", thumbnail->loader ) ) {
 		return( vips_image_new_from_file( file->filename, 
 			"access", VIPS_ACCESS_SEQUENTIAL,
 			"scale", factor,
@@ -1076,7 +1076,8 @@ vips_thumbnail_buffer_open( VipsThumbnail *thumbnail, double factor )
 {
 	VipsThumbnailBuffer *buffer = (VipsThumbnailBuffer *) thumbnail;
 
-	if( vips_isprefix( "VipsForeignLoadJpeg", thumbnail->loader ) ) {
+	if( vips_isprefix( "VipsForeignLoadJpeg", thumbnail->loader ) ||
+		vips_isprefix( "VipsForeignLoadWebp", thumbnail->loader ) ) {
 		return( vips_image_new_from_buffer( 
 			buffer->buf->data, buffer->buf->length, buffer->option_string,
 			"access", VIPS_ACCESS_SEQUENTIAL,
@@ -1092,8 +1093,7 @@ vips_thumbnail_buffer_open( VipsThumbnail *thumbnail, double factor )
 			NULL ) );
 	}
 	else if( vips_isprefix( "VipsForeignLoadPdf", thumbnail->loader ) ||
-		vips_isprefix( "VipsForeignLoadSvg", thumbnail->loader ) ||
-		vips_isprefix( "VipsForeignLoadWebp", thumbnail->loader ) ) {
+		vips_isprefix( "VipsForeignLoadSvg", thumbnail->loader ) ) {
 		return( vips_image_new_from_buffer( 
 			buffer->buf->data, buffer->buf->length, buffer->option_string,
 			"access", VIPS_ACCESS_SEQUENTIAL,


### PR DESCRIPTION
The current master does not succeed in thumbnailing a WebP image: 
```
wget https://www.gstatic.com/webp/gallery/4.webp
vipsthumbnail 4.webp \
    --size 128 \
    -o tn_%s.jpg \
    --eprofile srgb
``` 

```
vipsthumbnail: unable to thumbnail 4.webp
webpload: no property named `scale'
```

Looks like a regression from: https://github.com/libvips/libvips/commit/22ba9106b5c671765d156719ae39e2582279ad04. This PR ensures that the parameter `shrink` is used instead of `scale`.

By the way,
The same WebP image as above generates the following warnings:
```
(vipsthumbnail:3859): VIPS-WARNING **: 17:27:43.555: webp2vips: not all frames have equal duration
(vipsthumbnail:3859): VIPS-WARNING **: 17:27:43.568: webp2vips: not all frames have equal duration
```
Perhaps the frames check here:
https://github.com/libvips/libvips/blob/2968bee3fa933f08a0f0bd4686eff43ee9176c55/libvips/foreign/webp2vips.c#L644-L646
Should be disabled for non-animated WebP images.