### PR TITLE
provide an option to set the default stack size on linux

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -455,6 +455,7 @@ AC_CHECK_FUNCS([getcwd gettimeofday getwd memset munmap putenv realpath strcasec
 AC_CHECK_LIB(m,cbrt,[AC_DEFINE(HAVE_CBRT,1,[have cbrt() in libm.])])
 AC_CHECK_LIB(m,hypot,[AC_DEFINE(HAVE_HYPOT,1,[have hypot() in libm.])])
 AC_CHECK_LIB(m,atan2,[AC_DEFINE(HAVE_ATAN2,1,[have atan2() in libm.])])
+AC_CHECK_LIB([pthread], [pthread_setattr_default_np], [AC_DEFINE(HAVE_PTHREAD_DEFAULT_NP,1,[have pthread_setattr_default_np() in pthread.])])
 
 # have to have these
 # need glib 2.6 for GOption


### PR DESCRIPTION
- Added a new environment variable called VIPS_MIN_STACK_SIZE, so that we can set the default stack size on some linux platforms e.g alpine, which uses musl and assumes a lower default stack size for embedded systems and containers. Some libraries are heavy users of a larger stack size such as poppler for PDF conversion.
- This is only set on linux and only if the environment variable "VIPS_MIN_STACK_SIZE" is set and is higher than the current stack size.
- We default to 2MB if we cannot parse this value.
- Added an error message with the current stack size.
- Tested on a PDF to png conversion that used around 90k stack for a recursive call, which is in connection to issue #1287

e.g it can be used like so, if you pass a string it defaults to 2MB otherwise the value passed.

```
VIPS_MIN_STACK_SIZE=default vips copy stackheavy.pdf x.png
```

```
VIPS_MIN_STACK_SIZE=2m vips copy stackheavy.pdf x.png
```

If you try to set it too low you see the following warning
```
process:60882): VIPS-WARNING **: 05:32:00.857: Could not set minimum pthread stack size of 2k, current size is 80k
```