### PR TITLE
master: fix interlaced PNG input handling with newer libpng versions

### DIFF
--- a/libvips/foreign/vipspng.c
+++ b/libvips/foreign/vipspng.c
@@ -471,6 +471,15 @@ png2vips_header( Read *read, VipsImage *out )
 			VIPS_META_ICC_NAME, profile, proflen );
 	}
 
+	/* Some libpng warn you to call png_set_interlace_handling(); here, but
+	 * that can actually break interlace on older libpngs.
+	 *
+	 * Only set this for libpng 1.6+.
+	 */
+#if PNG_LIBPNG_VER > 10600
+	(void) png_set_interlace_handling( read->pPng );
+#endif
+
 	/* Sanity-check line size.
 	 */
 	png_read_update_info( read->pPng, read->pInfo );
@@ -540,15 +549,6 @@ png2vips_interlace( Read *read, VipsImage *out )
 
 	if( setjmp( png_jmpbuf( read->pPng ) ) ) 
 		return( -1 );
-
-	/* Some libpng warn you to call png_set_interlace_handling(); here, but
-	 * that can actually break interlace on older libpngs.
-	 *
-	 * Only set this for libpng 1.6+.
-	 */
-#if PNG_LIBPNG_VER > 10600
-	(void) png_set_interlace_handling( read->pPng );
-#endif
 
 	if( !(read->row_pointer = VIPS_ARRAY( NULL, out->Ysize, png_bytep )) )
 		return( -1 );


### PR DESCRIPTION
It looks like commit 57ce5a3 prevents interlaced PNG handling working with newer libpng versions.

```sh
$ vipsthumbnail interlaced.png

(vipsthumbnail:31018): VIPS-WARNING **: 22:37:46.939: bad adaptive filter value
vipsthumbnail: unable to thumbnail interlaced.png
```

This PR ensures the new call to `png_set_interlace_handling` occurs before the first call to `png_read_update_info`.

(Calling `png_set_interlace_handling` for non-interlaced PNG images appears to be OK, or at least is sensibly ignored internally by libpng.)