### PR TITLE
improve labpack processing

### DIFF
--- a/libvips/foreign/tiff2vips.c
+++ b/libvips/foreign/tiff2vips.c
@@ -741,7 +741,6 @@ rtiff_labpack_line( Rtiff *rtiff, VipsPel *q, VipsPel *p, int n, void *dummy )
 
 	float pf[3];
 	int x;
-	int i;
 
 	for( x = 0; x < n; x++ ) {
 		pf[0] = p[0] * 100.0f / 255.0f;
@@ -750,10 +749,7 @@ rtiff_labpack_line( Rtiff *rtiff, VipsPel *q, VipsPel *p, int n, void *dummy )
 
 		vips__Lab2LabQ_vec(q, pf, 1);
 
-		for (i = 3; i < samples_per_pixel; i++)
-			q[i+1] = p[i];
-
-		q += samples_per_pixel+1;
+		q += 4;
 		p += samples_per_pixel;
 	}
 }
@@ -768,7 +764,7 @@ rtiff_parse_labpack( Rtiff *rtiff, VipsImage *out )
 		rtiff_check_interpretation( rtiff, PHOTOMETRIC_CIELAB ) )
 		return( -1 );
 
-	out->Bands = rtiff->header.samples_per_pixel + 1;
+	out->Bands = 4; 
 	out->BandFmt = VIPS_FORMAT_UCHAR; 
 	out->Coding = VIPS_CODING_LABQ; 
 	out->Type = VIPS_INTERPRETATION_LAB; 

--- a/libvips/foreign/tiff2vips.c
+++ b/libvips/foreign/tiff2vips.c
@@ -739,13 +739,15 @@ rtiff_labpack_line( Rtiff *rtiff, VipsPel *q, VipsPel *p, int n, void *dummy )
 {
 	int samples_per_pixel = rtiff->header.samples_per_pixel;
 
+	float pf[3];
 	int x;
 
 	for( x = 0; x < n; x++ ) {
-		q[0] = p[0];
-		q[1] = p[1];
-		q[2] = p[2];
-		q[3] = 0;
+		pf[0] = p[0] * 100.0f / 255.0f;
+		pf[1] = (signed char)p[1];
+		pf[2] = (signed char)p[2];
+
+		vips__Lab2LabQ_vec(q, pf, 1);
 
 		q += 4;
 		p += samples_per_pixel;

--- a/libvips/foreign/tiff2vips.c
+++ b/libvips/foreign/tiff2vips.c
@@ -741,6 +741,7 @@ rtiff_labpack_line( Rtiff *rtiff, VipsPel *q, VipsPel *p, int n, void *dummy )
 
 	float pf[3];
 	int x;
+	int i;
 
 	for( x = 0; x < n; x++ ) {
 		pf[0] = p[0] * 100.0f / 255.0f;
@@ -749,7 +750,10 @@ rtiff_labpack_line( Rtiff *rtiff, VipsPel *q, VipsPel *p, int n, void *dummy )
 
 		vips__Lab2LabQ_vec(q, pf, 1);
 
-		q += 4;
+		for (i = 3; i < samples_per_pixel; i++)
+			q[i+1] = p[i];
+
+		q += samples_per_pixel+1;
 		p += samples_per_pixel;
 	}
 }
@@ -764,7 +768,7 @@ rtiff_parse_labpack( Rtiff *rtiff, VipsImage *out )
 		rtiff_check_interpretation( rtiff, PHOTOMETRIC_CIELAB ) )
 		return( -1 );
 
-	out->Bands = 4; 
+	out->Bands = rtiff->header.samples_per_pixel + 1;
 	out->BandFmt = VIPS_FORMAT_UCHAR; 
 	out->Coding = VIPS_CODING_LABQ; 
 	out->Type = VIPS_INTERPRETATION_LAB; 

--- a/libvips/foreign/tiff2vips.c
+++ b/libvips/foreign/tiff2vips.c
@@ -739,15 +739,13 @@ rtiff_labpack_line( Rtiff *rtiff, VipsPel *q, VipsPel *p, int n, void *dummy )
 {
 	int samples_per_pixel = rtiff->header.samples_per_pixel;
 
-	float pf[3];
 	int x;
 
 	for( x = 0; x < n; x++ ) {
-		pf[0] = p[0] * 100.0f / 255.0f;
-		pf[1] = (signed char)p[1];
-		pf[2] = (signed char)p[2];
-
-		vips__Lab2LabQ_vec(q, pf, 1);
+		q[0] = p[0];
+		q[1] = p[1];
+		q[2] = p[2];
+		q[3] = 0;
 
 		q += 4;
 		p += samples_per_pixel;

--- a/libvips/foreign/vips2tiff.c
+++ b/libvips/foreign/vips2tiff.c
@@ -594,7 +594,7 @@ wtiff_write_header( Wtiff *wtiff, Layer *layer )
 	/* And colour fields.
 	 */
 	if( wtiff->im->Coding == VIPS_CODING_LABQ ) {
-		TIFFSetField( tif, TIFFTAG_SAMPLESPERPIXEL, wtiff->im->Bands - 1 );
+		TIFFSetField( tif, TIFFTAG_SAMPLESPERPIXEL, 3 );
 		TIFFSetField( tif, TIFFTAG_BITSPERSAMPLE, 8 );
 		TIFFSetField( tif, TIFFTAG_PHOTOMETRIC, PHOTOMETRIC_CIELAB );
 	}
@@ -1027,7 +1027,7 @@ wtiff_new( VipsImage *im, const char *filename,
 	/* Sizeof a line of bytes in the TIFF tile.
 	 */
 	if( im->Coding == VIPS_CODING_LABQ )
-		wtiff->tls = wtiff->tilew * (im->Bands - 1);
+		wtiff->tls = wtiff->tilew * 3;
 	else if( wtiff->onebit )
 		wtiff->tls = VIPS_ROUND_UP( wtiff->tilew, 8 ) / 8;
 	else
@@ -1075,10 +1075,9 @@ wtiff_new( VipsImage *im, const char *filename,
 /* Convert VIPS LabQ to TIFF LAB. Just take the first three bands.
  */
 static void
-LabQ2LabC( VipsPel *q, VipsPel *p, int n, int bands )
+LabQ2LabC( VipsPel *q, VipsPel *p, int n )
 {
         int x;
-		int b;
 
         for( x = 0; x < n; x++ ) {
                 /* Get most significant 8 bits of lab.
@@ -1087,11 +1086,8 @@ LabQ2LabC( VipsPel *q, VipsPel *p, int n, int bands )
                 q[1] = p[1];
                 q[2] = p[2];
 
-				for (b = 4; b < bands; ++b)
-					q[b-1] = p[b];
-
-                p += bands;
-                q += bands - 1;
+                p += 4;
+                q += 3;
         }
 }
 
@@ -1242,7 +1238,7 @@ wtiff_pack2tiff( Wtiff *wtiff, Layer *layer,
 		VipsPel *p = (VipsPel *) VIPS_REGION_ADDR( in, area->left, y );
 
 		if( wtiff->im->Coding == VIPS_CODING_LABQ )
-			LabQ2LabC( q, p, area->width, wtiff->im->Bands );
+			LabQ2LabC( q, p, area->width );
 		else if( wtiff->onebit ) 
 			eightbit2onebit( wtiff, q, p, area->width );
 		else if( (in->im->Bands == 1 || in->im->Bands == 2) && 
@@ -1328,7 +1324,7 @@ wtiff_layer_write_strip( Wtiff *wtiff, Layer *layer, VipsRegion *strip )
 		/* Any repacking necessary.
 		 */
 		if( im->Coding == VIPS_CODING_LABQ ) {
-			LabQ2LabC( wtiff->tbuf, p, im->Xsize, wtiff->im->Bands );
+			LabQ2LabC( wtiff->tbuf, p, im->Xsize );
 			p = wtiff->tbuf;
 		}
 		else if( im->BandFmt == VIPS_FORMAT_SHORT &&

--- a/libvips/foreign/vips2tiff.c
+++ b/libvips/foreign/vips2tiff.c
@@ -594,7 +594,7 @@ wtiff_write_header( Wtiff *wtiff, Layer *layer )
 	/* And colour fields.
 	 */
 	if( wtiff->im->Coding == VIPS_CODING_LABQ ) {
-		TIFFSetField( tif, TIFFTAG_SAMPLESPERPIXEL, 3 );
+		TIFFSetField( tif, TIFFTAG_SAMPLESPERPIXEL, wtiff->im->Bands - 1 );
 		TIFFSetField( tif, TIFFTAG_BITSPERSAMPLE, 8 );
 		TIFFSetField( tif, TIFFTAG_PHOTOMETRIC, PHOTOMETRIC_CIELAB );
 	}
@@ -1027,7 +1027,7 @@ wtiff_new( VipsImage *im, const char *filename,
 	/* Sizeof a line of bytes in the TIFF tile.
 	 */
 	if( im->Coding == VIPS_CODING_LABQ )
-		wtiff->tls = wtiff->tilew * 3;
+		wtiff->tls = wtiff->tilew * (im->Bands - 1);
 	else if( wtiff->onebit )
 		wtiff->tls = VIPS_ROUND_UP( wtiff->tilew, 8 ) / 8;
 	else
@@ -1075,9 +1075,10 @@ wtiff_new( VipsImage *im, const char *filename,
 /* Convert VIPS LabQ to TIFF LAB. Just take the first three bands.
  */
 static void
-LabQ2LabC( VipsPel *q, VipsPel *p, int n )
+LabQ2LabC( VipsPel *q, VipsPel *p, int n, int bands )
 {
         int x;
+		int b;
 
         for( x = 0; x < n; x++ ) {
                 /* Get most significant 8 bits of lab.
@@ -1086,8 +1087,11 @@ LabQ2LabC( VipsPel *q, VipsPel *p, int n )
                 q[1] = p[1];
                 q[2] = p[2];
 
-                p += 4;
-                q += 3;
+				for (b = 4; b < bands; ++b)
+					q[b-1] = p[b];
+
+                p += bands;
+                q += bands - 1;
         }
 }
 
@@ -1238,7 +1242,7 @@ wtiff_pack2tiff( Wtiff *wtiff, Layer *layer,
 		VipsPel *p = (VipsPel *) VIPS_REGION_ADDR( in, area->left, y );
 
 		if( wtiff->im->Coding == VIPS_CODING_LABQ )
-			LabQ2LabC( q, p, area->width );
+			LabQ2LabC( q, p, area->width, wtiff->im->Bands );
 		else if( wtiff->onebit ) 
 			eightbit2onebit( wtiff, q, p, area->width );
 		else if( (in->im->Bands == 1 || in->im->Bands == 2) && 
@@ -1324,7 +1328,7 @@ wtiff_layer_write_strip( Wtiff *wtiff, Layer *layer, VipsRegion *strip )
 		/* Any repacking necessary.
 		 */
 		if( im->Coding == VIPS_CODING_LABQ ) {
-			LabQ2LabC( wtiff->tbuf, p, im->Xsize );
+			LabQ2LabC( wtiff->tbuf, p, im->Xsize, wtiff->im->Bands );
 			p = wtiff->tbuf;
 		}
 		else if( im->BandFmt == VIPS_FORMAT_SHORT &&


### PR DESCRIPTION
At work we are unifying our loaders with libvips (or to say, we are deprecating our loaders for using libvips ones), and I found that labpack was not being processed correctly, so I found an already existing function that properly converted the color.