### PR TITLE
pngsave: expose control over output IDAT chunk size

### DIFF
--- a/libvips/foreign/pforeign.h
+++ b/libvips/foreign/pforeign.h
@@ -204,11 +204,13 @@ int vips__png_header_buffer( const void *buffer, size_t length, VipsImage *out )
 int vips__png_write( VipsImage *in, const char *filename, 
 	int compress, int interlace, const char *profile,
 	VipsForeignPngFilter filter, gboolean strip,
-	gboolean palette, int colours, int Q, double dither );
+	gboolean palette, int colours, int Q, double dither,
+	size_t buffer_size );
 int vips__png_write_buf( VipsImage *in, 
 	void **obuf, size_t *olen, int compression, int interlace, 
 	const char *profile, VipsForeignPngFilter filter, gboolean strip,
-	gboolean palette, int colours, int Q, double dither );
+	gboolean palette, int colours, int Q, double dither,
+	size_t buffer_size );
 
 /* Map WEBP metadata names to vips names.
  */

--- a/libvips/foreign/pngsave.c
+++ b/libvips/foreign/pngsave.c
@@ -66,6 +66,7 @@ typedef struct _VipsForeignSavePng {
 	int colours;
 	int Q;
 	double dither;
+	size_t buffer_size;
 } VipsForeignSavePng;
 
 typedef VipsForeignSaveClass VipsForeignSavePngClass;
@@ -167,6 +168,13 @@ vips_foreign_save_png_class_init( VipsForeignSavePngClass *class )
 		G_STRUCT_OFFSET( VipsForeignSavePng, dither ),
 		0.0, 1.0, 1.0 );
 
+	VIPS_ARG_INT( class, "buffer_size", 17,
+		_( "Buffer size" ),
+		_( "Size of each IDAT chunk" ),
+		VIPS_ARGUMENT_OPTIONAL_INPUT,
+		G_STRUCT_OFFSET( VipsForeignSavePng, buffer_size ),
+		6, INT_MAX, 8192 );
+
 }
 
 static void
@@ -177,6 +185,7 @@ vips_foreign_save_png_init( VipsForeignSavePng *png )
 	png->colours = 256;
 	png->Q = 100;
 	png->dither = 1.0;
+	png->buffer_size = 8192;
 }
 
 typedef struct _VipsForeignSavePngFile {
@@ -204,7 +213,7 @@ vips_foreign_save_png_file_build( VipsObject *object )
 	if( vips__png_write( save->ready, 
 		png_file->filename, png->compression, png->interlace, 
 		png->profile, png->filter, save->strip, png->palette,
-		png->colours, png->Q, png->dither ) )
+		png->colours, png->Q, png->dither, png->buffer_size ) )
 		return( -1 );
 
 	return( 0 );
@@ -263,7 +272,8 @@ vips_foreign_save_png_buffer_build( VipsObject *object )
 
 	if( vips__png_write_buf( save->ready, &obuf, &olen,
 		png->compression, png->interlace, png->profile, png->filter,
-		save->strip, png->palette, png->colours, png->Q, png->dither ) )
+		save->strip, png->palette, png->colours, png->Q, png->dither,
+		png->buffer_size ) )
 		return( -1 );
 
 	/* vips__png_write_buf() makes a buffer that needs g_free(), not

--- a/libvips/foreign/vipspng.c
+++ b/libvips/foreign/vipspng.c
@@ -993,7 +993,8 @@ static int
 write_vips( Write *write, 
 	int compress, int interlace, const char *profile,
 	VipsForeignPngFilter filter, gboolean strip,
-	gboolean palette, int colours, int Q, double dither )
+	gboolean palette, int colours, int Q, double dither,
+	size_t buffer_size )
 {
 	VipsImage *in = write->in;
 
@@ -1034,6 +1035,7 @@ write_vips( Write *write,
 	/* Set compression parameters.
 	 */
 	png_set_compression_level( write->pPng, compress );
+	png_set_compression_buffer_size( write->pPng, buffer_size );
 
 	/* Set row filter.
 	 */
@@ -1247,7 +1249,8 @@ int
 vips__png_write( VipsImage *in, const char *filename, 
 	int compress, int interlace, const char *profile,
 	VipsForeignPngFilter filter, gboolean strip,
-	gboolean palette, int colours, int Q, double dither )
+	gboolean palette, int colours, int Q, double dither,
+	size_t buffer_size )
 {
 	Write *write;
 
@@ -1268,7 +1271,7 @@ vips__png_write( VipsImage *in, const char *filename,
 	 */
 	if( write_vips( write, 
 		compress, interlace, profile, filter, strip, palette,
-		colours, Q, dither ) ) {
+		colours, Q, dither, buffer_size ) ) {
 		vips_error( "vips2png", 
 			_( "unable to write \"%s\"" ), filename );
 
@@ -1296,7 +1299,8 @@ int
 vips__png_write_buf( VipsImage *in, 
 	void **obuf, size_t *olen, int compression, int interlace,
 	const char *profile, VipsForeignPngFilter filter, gboolean strip,
-	gboolean palette, int colours, int Q, double dither )
+	gboolean palette, int colours, int Q, double dither,
+	size_t buffer_size )
 {
 	Write *write;
 
@@ -1309,7 +1313,7 @@ vips__png_write_buf( VipsImage *in,
 	 */
 	if( write_vips( write, 
 		compression, interlace, profile, filter, strip, palette,
-		colours, Q, dither ) ) {
+		colours, Q, dither, buffer_size ) ) {
 		vips_error( "vips2png", 
 			"%s", _( "unable to write to buffer" ) );
 


### PR DESCRIPTION
Using `png_set_compression_buffer_size` and the sample image discussed in #1336
 
```sh
$ vips copy fish.png fish-a.png[compression=9,filter=all,strip]
$ vips copy fish.png fish-b.png[compression=9,filter=all,strip,buffer_size=10000000]
```
This results in only one IDAT chunk:
```sh
$ pngchunks fish-a.png | grep "IDAT contains" | wc -l
61
$ pngchunks fish-b.png | grep "IDAT contains" | wc -l
1
```
...and therefore a slightly smaller file size:
```
495910 fish-a.png
495190 fish-b.png
```
