### PR TITLE
heifsave: expose compression option

### DIFF
--- a/libvips/foreign/heifload.c
+++ b/libvips/foreign/heifload.c
@@ -146,7 +146,8 @@ void
 vips__heif_error( struct heif_error *error )
 {
 	if( error->code ) 
-		vips_error( "heifload", "%s", error->message ); 
+		vips_error( "heif", "%s (%d.%d)", error->message, error->code,
+			error->subcode );
 }
 
 static const char *heif_magic[] = {
@@ -814,6 +815,8 @@ vips_foreign_load_heif_file_header( VipsForeignLoad *load )
 
 const char *vips__heif_suffs[] = { 
 	".heic",
+	".heif",
+	".avif",
 	NULL 
 };
 

--- a/libvips/include/vips/enumtypes.h
+++ b/libvips/include/vips/enumtypes.h
@@ -74,6 +74,8 @@ GType vips_foreign_dz_depth_get_type (void) G_GNUC_CONST;
 #define VIPS_TYPE_FOREIGN_DZ_DEPTH (vips_foreign_dz_depth_get_type())
 GType vips_foreign_dz_container_get_type (void) G_GNUC_CONST;
 #define VIPS_TYPE_FOREIGN_DZ_CONTAINER (vips_foreign_dz_container_get_type())
+GType vips_foreign_heif_compression_get_type (void) G_GNUC_CONST;
+#define VIPS_TYPE_FOREIGN_HEIF_COMPRESSION (vips_foreign_heif_compression_get_type())
 /* enumerations from "../../../libvips/include/vips/image.h" */
 GType vips_demand_style_get_type (void) G_GNUC_CONST;
 #define VIPS_TYPE_DEMAND_STYLE (vips_demand_style_get_type())

--- a/libvips/include/vips/foreign.h
+++ b/libvips/include/vips/foreign.h
@@ -623,6 +623,23 @@ typedef enum {
 int vips_dzsave( VipsImage *in, const char *name, ... )
 	__attribute__((sentinel));
 
+/**
+ * VipsForeignHeifCompression:
+ * @VIPS_FOREIGN_HEIF_COMPRESSION_HEVC: x265
+ * @VIPS_FOREIGN_HEIF_COMPRESSION_AVC: x264
+ * @VIPS_FOREIGN_HEIF_COMPRESSION_JPEG: jpeg
+ * @VIPS_FOREIGN_HEIF_COMPRESSION_AV1: aom
+ *
+ * The compression format to use inside a HEIF container.
+ */
+typedef enum {
+	VIPS_FOREIGN_HEIF_COMPRESSION_HEVC = 1,
+	VIPS_FOREIGN_HEIF_COMPRESSION_AVC = 2,
+	VIPS_FOREIGN_HEIF_COMPRESSION_JPEG = 3,
+	VIPS_FOREIGN_HEIF_COMPRESSION_AV1 = 4,
+	VIPS_FOREIGN_HEIF_COMPRESSION_LAST
+} VipsForeignHeifCompression;
+
 #ifdef __cplusplus
 }
 #endif /*__cplusplus*/

--- a/libvips/iofuncs/enumtypes.c
+++ b/libvips/iofuncs/enumtypes.c
@@ -657,6 +657,26 @@ vips_foreign_dz_container_get_type( void )
 
 	return( etype );
 }
+GType
+vips_foreign_heif_compression_get_type( void )
+{
+	static GType etype = 0;
+
+	if( etype == 0 ) {
+		static const GEnumValue values[] = {
+			{VIPS_FOREIGN_HEIF_COMPRESSION_HEVC, "VIPS_FOREIGN_HEIF_COMPRESSION_HEVC", "hevc"},
+			{VIPS_FOREIGN_HEIF_COMPRESSION_AVC, "VIPS_FOREIGN_HEIF_COMPRESSION_AVC", "avc"},
+			{VIPS_FOREIGN_HEIF_COMPRESSION_JPEG, "VIPS_FOREIGN_HEIF_COMPRESSION_JPEG", "jpeg"},
+			{VIPS_FOREIGN_HEIF_COMPRESSION_AV1, "VIPS_FOREIGN_HEIF_COMPRESSION_AV1", "av1"},
+			{VIPS_FOREIGN_HEIF_COMPRESSION_LAST, "VIPS_FOREIGN_HEIF_COMPRESSION_LAST", "last"},
+			{0, NULL, NULL}
+		};
+		
+		etype = g_enum_register_static( "VipsForeignHeifCompression", values );
+	}
+
+	return( etype );
+}
 /* enumerations from "../../libvips/include/vips/image.h" */
 GType
 vips_demand_style_get_type( void )


### PR DESCRIPTION
This implements an existing TODO in the heifsave code. I tested against the latest libheif master and avif branches and it appears to either work or return (expected) "unsupported" messages with the various values so this change will future-proof libvips against upstream libheif changes.

It also improves libheif error messaging and adds a couple of further suffixes that libheif can load.