### PR TITLE
[webp] Use well documented use_sharp_yuv option instead of preprocessing

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -1160,14 +1160,14 @@ if test x"$with_cfitsio" != x"no"; then
   )
 fi
 
-# libwebp ... target 0.5+ to reduce complication
+# libwebp ... target 0.6+ to reduce complication
 # webp has the stuff for handling metadata in two separate libraries  -- we
 # insit on having all of them
 AC_ARG_WITH([libwebp], 
   AS_HELP_STRING([--without-libwebp], [build without libwebp (default: test)]))
 
 if test x"$with_libwebp" != x"no"; then
-  PKG_CHECK_MODULES(LIBWEBP, libwebp >= 0.5 libwebpmux >= 0.5 libwebpdemux >= 0.5,
+  PKG_CHECK_MODULES(LIBWEBP, libwebp >= 0.6 libwebpmux >= 0.6 libwebpdemux >= 0.6,
     [AC_DEFINE(HAVE_LIBWEBP,1,[define if you have libwebp/libwebpmux/libwebpdemux installed.])
      with_libwebp=yes
      PACKAGES_USED="$PACKAGES_USED libwebp libwebpmux libwebpdemux"
@@ -1476,7 +1476,7 @@ SVG import with librsvg-2.0: 		$with_rsvg
 zlib: 					$with_zlib
 file import with cfitsio: 		$with_cfitsio
 file import/export with libwebp:	$with_libwebp
-  (requires libwebp, libwebpmux, libwebpdemux 0.5.0 or later)
+  (requires libwebp, libwebpmux, libwebpdemux 0.6.0 or later)
 text rendering with pangoft2: 		$with_pangoft2
 file import/export with libpng: 	$with_png
   (requires libpng-1.2.9 or later)

--- a/libvips/foreign/vips2webp.c
+++ b/libvips/foreign/vips2webp.c
@@ -184,7 +184,7 @@ vips_webp_write_init( VipsWebPWrite *write, VipsImage *image,
 	if( near_lossless )
 		write->config.near_lossless = Q;
 	if( smart_subsample )
-		write->config.preprocessing |= 4;
+		write->config.use_sharp_yuv = 1;
 
 	if( !WebPValidateConfig( &write->config ) ) {
 		vips_webp_write_unset( write );


### PR DESCRIPTION
`WebPConfig.preprocessing` is not documented to have a value of 4 (https://github.com/webmproject/libwebp/blob/1.0.3/src/webp/encode.h#L130).
libwebp caller should use `WebPConfig.use_sharp_yuv` instead (introduced in 0.6.0: https://github.com/webmproject/libwebp/commit/4689ce16353fec7a7193c1ba4b6f5a9e0bce060e#diff-a602a176048dbf8f1c2da5fd9836d23dR345)

This PR replaces the usage of `WebPConfig.preprocessing` with `WebPConfig.use_sharp_yuv` and updates the minimal version of libwebp from 0.5.0 to 0.6.0.
The latter one, if necessary, can also be done by `if WEBP_ENCODER_ABI_VERSION >= 0x020e`.

To prove that those options are equivalent:
```
# without smart-subsample:
$ ./tools/vips webpsave /tmp/test.jpg /dev/stdout | md5sum
78a69451d5193430e6aadbefdebc30a1  -
# with preprocessing |= 4:
$ ./tools/vips webpsave /tmp/test.jpg /dev/stdout --smart-subsample | md5sum
3b7924917d6148570c038579be359a79  -
# with use_sharp_yuv = 1:
$ ./tools/vips webpsave /tmp/test.jpg /dev/stdout --smart-subsample | md5sum
3b7924917d6148570c038579be359a79  -
```