### PR TITLE
Support std::vector within the image_get/set_array_int functions

### DIFF
--- a/cplusplus/include/vips/VImage8.h
+++ b/cplusplus/include/vips/VImage8.h
@@ -358,6 +358,13 @@ public:
 	}
 
 	void 
+	set( const char *field, std::vector<int> value )
+	{
+		vips_image_set_array_int( this->get_image(), field, &value[0],
+			static_cast<int>( value.size() ) );
+	}
+
+	void 
 	set( const char *field, double value )
 	{
 		vips_image_set_double( this->get_image(), field, value ); 
@@ -399,6 +406,20 @@ public:
 	{
 		if( vips_image_get_array_int( this->get_image(), field, out, n ) )
 			throw( VError() ); 
+	}
+
+	std::vector<int> 
+	get_array_int( const char *field ) const
+	{
+		int length;
+		int *array;
+
+		if( vips_image_get_array_int( this->get_image(), field, &array, &length ) )
+			throw( VError() ); 
+
+		std::vector<int> vector( array, array + length );
+
+		return( vector );
 	}
 
 	double 


### PR DESCRIPTION
Can be useful, for example:
```c++
std::vector<int> delays = image.get_array_int("delay");
for (int i : delays) {
    std::cout << i << std::endl;
}

delays = {100, 200, 300, 400, 500};
image.set("delay", delays);
```