### PR TITLE
Add undefined sanitizer

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -41,11 +41,10 @@ matrix:
         - PYVIPS_VERSION=master
         - JPEG=/usr
         - JOBS=`nproc`
-        - CFLAGS="-fsanitize=address -fno-omit-frame-pointer -fopenmp"
+        - CFLAGS="-fsanitize=address -fno-omit-frame-pointer -fopenmp -DFUZZING_BUILD_MODE_UNSAFE_FOR_PRODUCTION"
         - LDFLAGS="-fsanitize=address -dynamic-asan -fopenmp=libiomp5"
         - ASAN_DSO=/usr/local/clang-7.0.0/lib/clang/7.0.0/lib/linux/libclang_rt.asan-x86_64.so
         - LSAN_OPTIONS="suppressions=$TRAVIS_BUILD_DIR/lsan.supp"
-        - FUZZING_BUILD_MODE_UNSAFE_FOR_PRODUCTION=1
       install:
         # add support for WebP
         - wget http://archive.ubuntu.com/ubuntu/pool/main/libw/libwebp/libwebp-dev_0.6.1-2_amd64.deb

--- a/.travis.yml
+++ b/.travis.yml
@@ -41,8 +41,8 @@ matrix:
         - PYVIPS_VERSION=master
         - JPEG=/usr
         - JOBS=`nproc`
-        - CFLAGS="-fsanitize=address -fno-omit-frame-pointer -fopenmp -DFUZZING_BUILD_MODE_UNSAFE_FOR_PRODUCTION"
-        - LDFLAGS="-fsanitize=address -dynamic-asan -fopenmp=libiomp5"
+        - CFLAGS="-fsanitize=address,undefined -fno-omit-frame-pointer -fopenmp -DFUZZING_BUILD_MODE_UNSAFE_FOR_PRODUCTION"
+        - LDFLAGS="-fsanitize=address,undefined -dynamic-asan -fopenmp=libiomp5"
         - ASAN_DSO=/usr/local/clang-7.0.0/lib/clang/7.0.0/lib/linux/libclang_rt.asan-x86_64.so
         - LSAN_OPTIONS="suppressions=$TRAVIS_BUILD_DIR/lsan.supp"
       install:

--- a/fuzz/test_fuzz.sh
+++ b/fuzz/test_fuzz.sh
@@ -6,6 +6,7 @@ set -e
 # Glib is build without -fno-omit-frame-pointer. We need
 # to disable the fast unwinder to get full stacktraces.
 export ASAN_OPTIONS="fast_unwind_on_malloc=0:allocator_may_return_null=1"
+export UBSAN_OPTIONS="print_stacktrace=1"
 
 # Hide all warning messages from vips.
 export VIPS_WARNING=0


### PR DESCRIPTION
This adds the undefined sanitizer [UBSAN](https://clang.llvm.org/docs/UndefinedBehaviorSanitizer.html) to the fuzzing build in travis. Currently, [ClusterFuzz](https://github.com/google/oss-fuzz/blob/master/docs/clusterfuzz.md) is fuzzing libvips with both ASAN and UBSAN sanitizers enabled by default. But in travis only ASAN was specified.

This PR also fix the declaration of FUZZING_BUILD_MODE_UNSAFE_FOR_PRODUCTION (see https://llvm.org/docs/LibFuzzer.html#fuzzer-friendly-build-mode). This must be a C macro instead of a env variable. This works in the oss-fuzz environemnt because they set CFLAGS correctly, but in travis we were missing this macro.