### PR TITLE
skip large images in the fuzzers not in the lib

### DIFF
--- a/fuzz/jpegsave_buffer_fuzzer.cc
+++ b/fuzz/jpegsave_buffer_fuzzer.cc
@@ -11,10 +11,21 @@ extern "C" int
 LLVMFuzzerTestOneInput( const guint8 *data, size_t size )
 {
 	VipsImage *image;
-	size_t len;
 	void *buf;
+	size_t len, width, height, bands;
 
 	if( !(image = vips_image_new_from_buffer( data, size, "", NULL )) ) {
+		return( 0 );
+	}
+
+	width = image->Xsize;
+	height = image->Ysize;
+	bands = image->Bands;
+
+	/* Skip big images. It is likely to timeout.
+	 */
+	if ( width * height * bands > 256 * 256 * 16 ) {
+		g_object_unref( image );
 		return( 0 );
 	}
 

--- a/fuzz/pngsave_buffer_fuzzer.cc
+++ b/fuzz/pngsave_buffer_fuzzer.cc
@@ -12,9 +12,20 @@ LLVMFuzzerTestOneInput( const guint8 *data, size_t size )
 {
 	VipsImage *image;
 	void *buf;
-	size_t len;
+	size_t len, width, height, bands;
 
 	if( !(image = vips_image_new_from_buffer( data, size, "", NULL )) ) {
+		return( 0 );
+	}
+
+	width = image->Xsize;
+	height = image->Ysize;
+	bands = image->Bands;
+
+	/* Skip big images. It is likely to timeout.
+	 */
+	if ( width * height * bands > 256 * 256 * 16 ) {
+		g_object_unref( image );
 		return( 0 );
 	}
 

--- a/fuzz/sharpen_fuzzer.cc
+++ b/fuzz/sharpen_fuzzer.cc
@@ -11,9 +11,21 @@ extern "C" int
 LLVMFuzzerTestOneInput( const guint8 *data, size_t size )
 {
 	VipsImage *in, *out;
+	size_t width, height, bands;
 	double d;
 
 	if( !(in = vips_image_new_from_buffer( data, size, "", NULL )) ) {
+		return( 0 );
+	}
+
+	width = in->Xsize;
+	height = in->Ysize;
+	bands = in->Bands;
+
+	/* Skip big images. It is likely to timeout.
+	 */
+	if ( width * height * bands > 256 * 256 * 16 ) {
+		g_object_unref( in );
 		return( 0 );
 	}
 

--- a/fuzz/thumbnail_fuzzer.cc
+++ b/fuzz/thumbnail_fuzzer.cc
@@ -11,7 +11,7 @@ extern "C" int
 LLVMFuzzerTestOneInput( const guint8 *data, size_t size )
 {
 	VipsImage *in, *out;
-	size_t width, height;
+	size_t width, height, bands;
 	double d;
 
 	if( !(in = vips_image_new_from_buffer( data, size, "", NULL )) ) {
@@ -20,10 +20,11 @@ LLVMFuzzerTestOneInput( const guint8 *data, size_t size )
 
 	width = in->Xsize;
 	height = in->Ysize;
+	bands = in->Bands;
 
 	/* Skip big images. It is likely to timeout.
 	 */
-	if ( width * height > 256 * 256 ) {
+	if ( width * height * bands > 256 * 256 * 16 ) {
 		g_object_unref( in );
 		return( 0 );
 	}

--- a/fuzz/webpsave_buffer_fuzzer.cc
+++ b/fuzz/webpsave_buffer_fuzzer.cc
@@ -12,9 +12,20 @@ LLVMFuzzerTestOneInput( const guint8 *data, size_t size )
 {
 	VipsImage *image;
 	void *buf;
-	size_t len;
+	size_t len, width, height, bands;
 
 	if( !(image = vips_image_new_from_buffer( data, size, "", NULL )) ) {
+		return( 0 );
+	}
+
+	width = image->Xsize;
+	height = image->Ysize;
+	bands = image->Bands;
+
+	/* Skip big images. It is likely to timeout.
+	 */
+	if ( width * height * bands > 256 * 256 * 16 ) {
+		g_object_unref( image );
 		return( 0 );
 	}
 

--- a/libvips/iofuncs/generate.c
+++ b/libvips/iofuncs/generate.c
@@ -382,17 +382,6 @@ int
 vips_image_pipeline_array( VipsImage *image, 
 	VipsDemandStyle hint, VipsImage **in )
 {
-	/* Ban large images while we are fuzzing. They cause unintersting 
-	 * timeouts and OOMs.
-	 */
-#ifdef FUZZING_BUILD_MODE_UNSAFE_FOR_PRODUCTION
-	if( (size_t) image->Xsize * image->Ysize * image->Bands > 1000000 ) {
-		vips_error( "vips_image_pipeline_array", 
-			"%s", _( "no large images during fuzzing" ) );
-		return( -1 );
-	}
-#endif /*FUZZING_BUILD_MODE_UNSAFE_FOR_PRODUCTION*/
-
 	/* This function can be called more than once per output image. For
 	 * example, jpeg header load will call this once on ->out to set the
 	 * default hint, then later call it again to connect the output image


### PR DESCRIPTION
Hi. I have been tracking the project since the fuzzers are running in oss-fuzz.com to check if they are going well and I see you have already fixed several issues. Congrats.

You pushed a commit to skip large images using the macro FUZZING_BUILD_MODE_UNSAFE_FOR_PRODUCTION. This macro should be used to make code "friendly" to fuzzers, but only in very specific cases. For instance:
- to ignore failed checksums
- to make code deterministic (e.g. feed a random generator with the same seed value)

Any other issue with the fuzzers should be handled in the fuzzing functions themselves, rather than in the library. Otherwise, you will end up testing different execution paths when fuzzing than when using the library regularly, which is like testing two diverging versions of the same library.

This PR reverts your commit https://github.com/libvips/libvips/commit/0accdf858bbe32f07aeb6d79de860ad759b91f65 and move the checks to the fuzzers. It will also fix the build of https://github.com/libvips/libvips/pull/1379, which is failing now in travis: the test suite has some big images, and the library returns an error for big images because of the above commit.

I set the threshold for all the fuzzers to the same arbitrary value (1048576). It could make sense to review these values in the future analyzing the performance metrics of each fuzzers individually.


