### PR TITLE
 WebP loader: verify upper limit on dimensions in header

### DIFF
--- a/libvips/foreign/webp2vips.c
+++ b/libvips/foreign/webp2vips.c
@@ -547,7 +547,9 @@ read_header( Read *read, VipsImage *out )
 	}
 
 	if( read->width <= 0 ||
-		read->height <= 0 ) {
+		read->height <= 0 ||
+		read->width > 0x3FFF ||
+		read->height > 0x3FFF ) {
 		vips_error( "webp", "%s", _( "bad image dimensions" ) ); 
 		return( -1 ); 
 	}


### PR DESCRIPTION
Before:

```sh
$ vips copy image-with-fake-header.webp out.jpg

(vips:27665): VIPS-WARNING **: 19:06:10.312: error in tile 0 x 0
webp2vips: unable to read pixels
```

After:

```sh
$ vips copy image-with-fake-header.webp out.jpg
webp: bad image dimensions
```

https://developers.google.com/speed/webp/faq#what_is_the_maximum_size_a_webp_image_can_be