### PR TITLE
also set png max chunk malloc when reading buffer

### DIFF
--- a/libvips/foreign/vipspng.c
+++ b/libvips/foreign/vipspng.c
@@ -812,7 +812,13 @@ read_new_buffer( VipsImage *out, const void *buffer, size_t length,
 
 	/* Read enough of the file that png_get_interlace_type() will start
 	 * working.
+	 *
+	 * By default, libpng refuses to open files with a metadata chunk 
+	 * larger than 8mb. We've seen real files with 20mb, so set 50mb.
 	 */
+#ifdef HAVE_PNG_SET_CHUNK_MALLOC_MAX
+	png_set_chunk_malloc_max( read->pPng, 50 * 1024 * 1024 );
+#endif /*HAVE_PNG_SET_CHUNK_MALLOC_MAX*/
 	png_read_info( read->pPng, read->pInfo );
 
 	return( read );


### PR DESCRIPTION
A [previous change](https://github.com/OrderMyGear/libvips/commit/8d7e03237a264001ca3427c361bd74d2a95d4a71) increased the max malloc when reading a png from a file. This PR applies the same configuration when reading from an in-memory buffer.