### PR TITLE
Fix calculation of scaled SVG dimensions

### DIFF
--- a/libvips/foreign/svgload.c
+++ b/libvips/foreign/svgload.c
@@ -273,8 +273,8 @@ vips_foreign_load_svg_parse( VipsForeignLoadSvg *svg, VipsImage *out )
 			 * cairo instead.
 			 */
 			svg->cairo_scale = scale;
-			width = width * scale;
-			height = height * scale;
+			width = VIPS_CEIL(width * scale);
+			height = VIPS_CEIL(height * scale);
 		} else {
 			/* SVG with width and height reports correctly scaled 
 			 * dimensions.


### PR DESCRIPTION
Currently, libvips incorrectly scales the width/height of SVG when `rsvg_handle_get_dimensions` doesn't return scaled ones. It floors scaled values while it should ceil them. As a result, the edge pixels can be lost.

Example:

We have the following SVG: https://jsfiddle.net/5crw3h70/1/

When I do `vipsthumbnail utkonos.svg --size 234x90`, it produces 234x59 image, while it should be 234x60. As you can see, the bottom pixels are cut:

![img](https://user-images.githubusercontent.com/380856/65055715-823c8380-d991-11e9-9ca5-fd47370728fa.png)

Here is the result after my patch:

![img](https://user-images.githubusercontent.com/380856/65055835-b44de580-d991-11e9-8758-337ac90d01f0.png)
