### PR TITLE
Add link to opencollective

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,0 +1,1 @@
+open_collective: libvips


### PR DESCRIPTION
Links the libvips GitHub repo to https://opencollective.com/libvips