### PR TITLE
Silence a couple of GCC compiler warnings

### DIFF
--- a/libvips/foreign/heifload.c
+++ b/libvips/foreign/heifload.c
@@ -330,7 +330,7 @@ vips_foreign_load_heif_set_header( VipsForeignLoadHeif *heif, VipsImage *out )
 			vips_snprintf( name, 256, VIPS_META_EXIF_NAME );
 		else if( g_ascii_strcasecmp( type, "mime" ) == 0 &&
 			vips_isprefix( "<x:xmpmeta", (const char *) data ) ) 
-			snprintf( name, 256, VIPS_META_XMP_NAME ); 
+			vips_snprintf( name, 256, VIPS_META_XMP_NAME );
 		else
 			vips_snprintf( name, 256, "heif-%s-%d", type, i );
 

--- a/libvips/iofuncs/util.c
+++ b/libvips/iofuncs/util.c
@@ -444,8 +444,8 @@ vips_vsnprintf( char *str, size_t size, const char *format, va_list ap )
 	 */
 	if( size > MAX_BUF )
 		vips_error_exit( "panic: buffer overflow "
-			"(request to write %d bytes to buffer of %d bytes)",
-			size, MAX_BUF );
+			"(request to write %lu bytes to buffer of %d bytes)",
+			(unsigned long) size, MAX_BUF );
 	n = vsprintf( buf, format, ap );
 	if( n > MAX_BUF )
 		vips_error_exit( "panic: buffer overflow "


### PR DESCRIPTION
I stumbled across these whilst investigating a unrelated compiler bug/feature on an ARM64 machine (I had enabled the "-Werror" switch).