### PR TITLE
#1376 - Adding base docker image for popular web formats

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,14 +20,14 @@ script:
     DYLD_LIBRARY_PATH=$PWD/libvips/.libs
     LD_PRELOAD=$ASAN_DSO
     $PYTHON -m pytest -v test/test-suite
-  - docker build --squash --build-arg VIPS_VERSION -t vips/vips-web .
-  - docker tag vips/vips-web:latest vips/vips-web:$VIPS_VERSION
+  - docker build --squash --build-arg VIPS_VERSION=$TRAVIS_TAG -t vips/vips-web .
+  - docker tag vips/vips-web:latest vips/vips-web:$TRAVIS_TAG
 
 deploy:
   provider: script
   script: 
     - docker push vips/vips-web:latest
-    - docker push vips/vips-web:$VIPS_VERSION
+    - docker push vips/vips-web:$TRAVIS_TAG
   on:
     branch: master
     tags: true

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,8 @@
 language: cpp
 
+services:
+  - docker
+
 before_script:
   - $PYTHON -m pip download --no-deps https://github.com/libvips/pyvips/archive/$PYVIPS_VERSION.tar.gz
   - tar xf $PYVIPS_VERSION.tar.gz
@@ -10,12 +13,23 @@ before_script:
     --with-jpeg-libraries=$JPEG/lib
     --with-magick=$WITH_MAGICK
   - make -j$JOBS -s 
+  - echo "$DOCKER_PASSWORD" | docker login -u "$DOCKER_USERNAME" --password-stdin
 script:
   - make -j$JOBS -s -k V=0 VERBOSE=1 check
   - LD_LIBRARY_PATH=$PWD/libvips/.libs
     DYLD_LIBRARY_PATH=$PWD/libvips/.libs
     LD_PRELOAD=$ASAN_DSO
     $PYTHON -m pytest -v test/test-suite
+  - docker build --build-arg VIPS_VERSION -t vips/vips-web .
+  - docker tag vips/vips-web:latest vips/vips-web:$VIPS_VERSION
+
+deploy:
+  provider: script
+  script: 
+    - docker push vips/vips-web:latest
+    - docker push vips/vips-web:$VIPS_VERSION
+  on:
+    branch: master
 
 matrix:
   allow_failures:

--- a/.travis.yml
+++ b/.travis.yml
@@ -20,7 +20,7 @@ script:
     DYLD_LIBRARY_PATH=$PWD/libvips/.libs
     LD_PRELOAD=$ASAN_DSO
     $PYTHON -m pytest -v test/test-suite
-  - docker build --build-arg VIPS_VERSION -t vips/vips-web .
+  - docker build --squash --build-arg VIPS_VERSION -t vips/vips-web .
   - docker tag vips/vips-web:latest vips/vips-web:$VIPS_VERSION
 
 deploy:
@@ -30,6 +30,7 @@ deploy:
     - docker push vips/vips-web:$VIPS_VERSION
   on:
     branch: master
+    tags: true
 
 matrix:
   allow_failures:

--- a/Dockerfile
+++ b/Dockerfile
@@ -15,8 +15,7 @@ RUN apk add --update --no-cache --virtual .build-deps \
             lcms2-dev \
             libpng-dev \
             orc-dev \
-            libwebp-dev \
-            libheif-dev 
+            libwebp-dev
             
 RUN wget https://github.com/libvips/libvips/releases/download/v${VIPS_VERSION}/vips-${VIPS_VERSION}.tar.gz
 
@@ -40,7 +39,7 @@ RUN rm -rf vips
 
 RUN apk del .build-deps
 
-RUN apk add --update --no-cache libgsf glib gobject-introspection expat tiff libjpeg-turbo libexif giflib librsvg lcms2 libpng orc libwebp libheif
+RUN apk add --update --no-cache libgsf glib gobject-introspection expat tiff libjpeg-turbo libexif giflib librsvg lcms2 libpng orc libwebp 
 
 ENV GI_TYPELIB_PATH /usr/local/lib/girepository-1.0
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,29 @@
+FROM alpine
+
+ARG VIPS_VERSION
+
+RUN apk update
+
+RUN apk add build-base pkgconfig glib-dev gobject-introspection-dev expat-dev tiff-dev libjpeg-turbo-dev libexif-dev giflib-dev librsvg-dev lcms2-dev libpng orc-dev libwebp-dev libheif-dev
+
+RUN apk add libimagequant-dev --repository=http://dl-cdn.alpinelinux.org/alpine/edge/testing
+
+RUN https://github.com/libvips/libvips/releases/download/v${VIPS_VERSION}/vips-${VIPS_VERSION}.tar.gz
+
+RUN mkdir vips
+
+RUN tar xvzf vips-${VIPS_VERSION}.tar.gz -C vips --strip-components 1
+
+WORKDIR /vips
+
+RUN ./configure
+
+RUN make
+
+RUN make install
+
+RUN ldconfig
+
+WORKDIR /
+
+RUN rm -rf vips

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,14 +1,25 @@
-FROM alpine
+FROM alpine:3.10
 
 ARG VIPS_VERSION
 
-RUN apk update
+RUN apk add --update --no-cache --repository=http://dl-cdn.alpinelinux.org/alpine/edge/testing --virtual .build-deps \
+            build-base \
+            pkgconfig \
+            glib-dev \
+            gobject-introspection-dev \
+            expat-dev \
+            tiff-dev \
+            libjpeg-turbo-dev \
+            libexif-dev giflib-dev \
+            librsvg-dev \
+            lcms2-dev \
+            libpng-dev \
+            orc-dev \
+            libwebp-dev \
+            libheif-dev \
+            libimagequant-dev 
 
-RUN apk add build-base pkgconfig glib-dev gobject-introspection-dev expat-dev tiff-dev libjpeg-turbo-dev libexif-dev giflib-dev librsvg-dev lcms2-dev libpng-dev orc-dev libwebp-dev libheif-dev
-
-RUN apk add libimagequant-dev --repository=http://dl-cdn.alpinelinux.org/alpine/edge/testing
-
-RUN https://github.com/libvips/libvips/releases/download/v${VIPS_VERSION}/vips-${VIPS_VERSION}.tar.gz
+RUN wget https://github.com/libvips/libvips/releases/download/v${VIPS_VERSION}/vips-${VIPS_VERSION}.tar.gz
 
 RUN mkdir vips
 
@@ -27,3 +38,13 @@ RUN ldconfig
 WORKDIR /
 
 RUN rm -rf vips
+
+RUN apk del .build-deps
+
+RUN apk add --update --no-cache libgsf glib gobject-introspection expat tiff libjpeg-turbo libexif giflib librsvg lcms2 libpng orc libwebp libheif
+
+RUN apk add --update --no-cache libimagequant --repository=http://dl-cdn.alpinelinux.org/alpine/edge/testing
+
+ENV GI_TYPELIB_PATH /usr/local/lib/girepository-1.0
+
+CMD /usr/local/bin/vips

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@ FROM alpine:3.10
 
 ARG VIPS_VERSION
 
-RUN apk add --update --no-cache --repository=http://dl-cdn.alpinelinux.org/alpine/edge/testing --virtual .build-deps \
+RUN apk add --update --no-cache --virtual .build-deps \
             build-base \
             pkgconfig \
             glib-dev \
@@ -16,9 +16,8 @@ RUN apk add --update --no-cache --repository=http://dl-cdn.alpinelinux.org/alpin
             libpng-dev \
             orc-dev \
             libwebp-dev \
-            libheif-dev \
-            libimagequant-dev 
-
+            libheif-dev 
+            
 RUN wget https://github.com/libvips/libvips/releases/download/v${VIPS_VERSION}/vips-${VIPS_VERSION}.tar.gz
 
 RUN mkdir vips
@@ -42,8 +41,6 @@ RUN rm -rf vips
 RUN apk del .build-deps
 
 RUN apk add --update --no-cache libgsf glib gobject-introspection expat tiff libjpeg-turbo libexif giflib librsvg lcms2 libpng orc libwebp libheif
-
-RUN apk add --update --no-cache libimagequant --repository=http://dl-cdn.alpinelinux.org/alpine/edge/testing
 
 ENV GI_TYPELIB_PATH /usr/local/lib/girepository-1.0
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -33,7 +33,7 @@ RUN make
 
 RUN make install
 
-RUN ldconfig
+RUN ldconfig /etc/ld.so.conf.d
 
 WORKDIR /
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,7 @@ ARG VIPS_VERSION
 
 RUN apk update
 
-RUN apk add build-base pkgconfig glib-dev gobject-introspection-dev expat-dev tiff-dev libjpeg-turbo-dev libexif-dev giflib-dev librsvg-dev lcms2-dev libpng orc-dev libwebp-dev libheif-dev
+RUN apk add build-base pkgconfig glib-dev gobject-introspection-dev expat-dev tiff-dev libjpeg-turbo-dev libexif-dev giflib-dev librsvg-dev lcms2-dev libpng-dev orc-dev libwebp-dev libheif-dev
 
 RUN apk add libimagequant-dev --repository=http://dl-cdn.alpinelinux.org/alpine/edge/testing
 
@@ -16,7 +16,7 @@ RUN tar xvzf vips-${VIPS_VERSION}.tar.gz -C vips --strip-components 1
 
 WORKDIR /vips
 
-RUN ./configure
+RUN ./configure --enable-debug=no --without-python
 
 RUN make
 


### PR DESCRIPTION
Fixes #1376 
I don't have much knowledge about Travis, but I think this should work.
You'd need to create the env vars for `DOCKER_PASSWORD`, `DOCKER_USERNAME` and `VIPS_VERSION` (I don't know if it follows the same as pyvips and it will be used to download the release tar.gz from github)