### PR TITLE
Fix dependency to introspect program on Windows MINGW

### DIFF
--- a/libvips/Makefile.am
+++ b/libvips/Makefile.am
@@ -87,7 +87,7 @@ AM_LDFLAGS = \
 LDADD = @INTROSPECTION_LIBS@ @VIPS_CFLAGS@ libvips.la @VIPS_LIBS@ 
 
 noinst_PROGRAMS = \
-	introspect
+	introspect$(EXEEXT)
 introspect_SOURCES = \
 	introspect.c
 
@@ -96,7 +96,7 @@ introspect_SOURCES = \
 introspection_sources = @vips_introspection_sources@
 
 # we make the vips8 API
-Vips-8.0.gir: introspect
+Vips-8.0.gir: introspect$(EXEEXT)
 Vips_8_0_gir_INCLUDES = GObject-2.0
 Vips_8_0_gir_CFLAGS = $(INCLUDES) -I${top_srcdir}/libvips/include
 Vips_8_0_gir_LIBS = libvips.la


### PR DESCRIPTION
I added libvips to the official MINGW-packages here https://github.com/msys2/MINGW-packages/pull/5885 and added this patch to libvips in https://github.com/msys2/MINGW-packages/pull/5907 . So this is the upstream PR. Hope it's correct.