### PR TITLE
Ensure SVG dimensions are rounded correctly when scaling or setting density via cairo

### DIFF
--- a/libvips/foreign/svgload.c
+++ b/libvips/foreign/svgload.c
@@ -280,8 +280,8 @@ vips_foreign_load_svg_parse( VipsForeignLoadSvg *svg, VipsImage *out )
 			 * cairo instead.
 			 */
 			svg->cairo_scale = scale;
-			width = width * scale;
-			height = height * scale;
+			width = VIPS_ROUND_UINT( width * scale );
+			height = VIPS_ROUND_UINT( height * scale );
 		} else {
 			/* SVG with width and height reports correctly scaled 
 			 * dimensions.


### PR DESCRIPTION
See the example in https://github.com/lovell/sharp/issues/1947, which at a density of 220 (scale = 3.055556) is currently incorrectly rendered at 64x42. With the change in this PR it correctly renders at 64x43.