### PR TITLE
Reset orientation if exif data is incorrect

### DIFF
--- a/libvips/foreign/exif.c
+++ b/libvips/foreign/exif.c
@@ -525,9 +525,8 @@ vips__exif_parse( VipsImage *image )
 		int orientation;
 
 		orientation = atoi( str );
-		if ( orientation < 0 || orientation > 8 ) {
+		if( orientation < 1 || orientation > 8 )
 			orientation = 1;
-		}
 		vips_image_set_int( image, VIPS_META_ORIENTATION, orientation );
 	}
 

--- a/libvips/foreign/exif.c
+++ b/libvips/foreign/exif.c
@@ -525,7 +525,9 @@ vips__exif_parse( VipsImage *image )
 		int orientation;
 
 		orientation = atoi( str );
-		orientation = VIPS_CLIP( 1, orientation, 8 );
+		if ( orientation < 0 || orientation > 8 ) {
+			orientation = 1;
+		}
 		vips_image_set_int( image, VIPS_META_ORIENTATION, orientation );
 	}
 

--- a/test/test-suite/test_foreign.py
+++ b/test/test-suite/test_foreign.py
@@ -189,6 +189,18 @@ class TestForeign:
             assert x1.width == x2.height
             assert x1.height == x2.width
 
+            # sets incorrect orientation, save, load again, orientation
+            # has reset to 1
+            x = x.copy()
+            x.set("orientation", 256)
+
+            filename = temp_filename(self.tempdir, '.jpg')
+            x.write_to_file(filename)
+
+            x = pyvips.Image.new_from_file(filename)
+            y = x.get("orientation")
+            assert y == 1
+
             # can set, save and reload ASCII string fields
             x = pyvips.Image.new_from_file(JPEG_FILE)
             x = x.copy()


### PR DESCRIPTION
If data in the orientation field `exif-ifd0-Orientation` is incorrect, ignore the orientation value.
Other software seems to be ignoring orientation value if it's not within an expected range, libvips was falling back to orientation 8.
