### PR TITLE
Tile cache improvements (tiff load performance increase)

### DIFF
--- a/libvips/deprecated/im_tiff2vips.c
+++ b/libvips/deprecated/im_tiff2vips.c
@@ -69,14 +69,14 @@ im_istifftiled( const char *filename )
 
 static int
 im_tiff_read_header( const char *filename, VipsImage *out, 
-	int page, int n, gboolean autorotate )
+	int page, int n, gboolean autorotate, int max_tile_cache_memory )
 {
 	VipsSource *source;
 
 	if( !(source = vips_source_new_from_file( filename )) )
 		return( -1 );
 	if( vips__tiff_read_header_source( source, 
-		out, page, n, autorotate ) ) {
+		out, page, n, autorotate, max_tile_cache_memory) ) {
 		VIPS_UNREF( source );
 		return( -1 );
 	}
@@ -87,13 +87,13 @@ im_tiff_read_header( const char *filename, VipsImage *out,
 
 static int
 im_tiff_read( const char *filename, VipsImage *out, 
-	int page, int n, gboolean autorotate )
+	int page, int n, gboolean autorotate, int max_tile_cache_memory)
 {
 	VipsSource *source;
 
 	if( !(source = vips_source_new_from_file( filename )) )
 		return( -1 );
-	if( vips__tiff_read_source( source, out, page, n, autorotate ) ) {
+	if( vips__tiff_read_source( source, out, page, n, autorotate, max_tile_cache_memory) ) {
 		VIPS_UNREF( source );
 		return( -1 );
 	}

--- a/libvips/deprecated/im_tiff2vips.c
+++ b/libvips/deprecated/im_tiff2vips.c
@@ -112,11 +112,13 @@ tiff2vips( const char *name, IMAGE *out, gboolean header_only )
 	char *p, *q;
 	int page;
 	int seq;
+    int max_tile_cache_memory;
 
 	im_filename_split( name, filename, mode );
 
 	page = 0;
 	seq = 0;
+    max_tile_cache_memory = 0;
 	p = &mode[0];
 	if( (q = im_getnextoption( &p )) ) {
 		page = atoi( q );
@@ -125,6 +127,11 @@ tiff2vips( const char *name, IMAGE *out, gboolean header_only )
 		if( im_isprefix( "seq", q ) )
 			seq = 1;
 	}
+    if( (q = im_getnextoption( &p )) ) {
+    }
+    if( (q = im_getnextoption( &p )) ) {
+        max_tile_cache_memory = atoi( q );
+    }
 
 	/* We need to be compatible with the pre-sequential mode 
 	 * im_tiff2vips(). This returned a "t" if given a "p" image, since it
@@ -146,11 +153,11 @@ tiff2vips( const char *name, IMAGE *out, gboolean header_only )
 	}
 
 	if( header_only ) {
-		if( im_tiff_read_header( filename, out, page, 1, FALSE ) )
+		if( im_tiff_read_header( filename, out, page, 1, FALSE, max_tile_cache_memory ) )
 			return( -1 );
 	}
 	else {
-		if( im_tiff_read( filename, out, page, 1, FALSE ) )
+		if( im_tiff_read( filename, out, page, 1, FALSE, max_tile_cache_memory ) )
 			return( -1 );
 	}
 #else

--- a/libvips/foreign/pforeign.h
+++ b/libvips/foreign/pforeign.h
@@ -86,9 +86,9 @@ int vips__tiff_write_buf( VipsImage *in,
 gboolean vips__istiff_source( VipsSource *source );
 gboolean vips__istifftiled_source( VipsSource *source );
 int vips__tiff_read_header_source( VipsSource *source, VipsImage *out, 
-	int page, int n, gboolean autorotate );
+	int page, int n, gboolean autorotate, int max_tile_cache_memory );
 int vips__tiff_read_source( VipsSource *source, VipsImage *out,
-	int page, int n, gboolean autorotate );
+	int page, int n, gboolean autorotate, int max_tile_cache_memory);
 
 extern const char *vips__foreign_tiff_suffs[];
 

--- a/libvips/foreign/ppmload.c
+++ b/libvips/foreign/ppmload.c
@@ -403,7 +403,7 @@ vips_foreign_load_ppm_map( VipsForeignLoadPpm *ppm, VipsImage *image )
 
 	gint64 header_offset;
 	size_t length;
-	const void *data;
+	const VipsPel *data;
 
 	vips_sbuf_unbuffer( ppm->sbuf );
 	header_offset = vips_source_seek( ppm->source, 0, SEEK_CUR );

--- a/libvips/foreign/tiffload.c
+++ b/libvips/foreign/tiffload.c
@@ -73,6 +73,10 @@ typedef struct _VipsForeignLoadTiff {
 	 */
 	gboolean autorotate;
 
+	/* Max memory to use for the tile cache
+	 */
+	int max_tile_cache_memory;
+
 } VipsForeignLoadTiff;
 
 typedef VipsForeignLoadClass VipsForeignLoadTiffClass;
@@ -203,6 +207,13 @@ vips_foreign_load_tiff_class_init( VipsForeignLoadTiffClass *class )
 		VIPS_ARGUMENT_OPTIONAL_INPUT,
 		G_STRUCT_OFFSET( VipsForeignLoadTiff, autorotate ),
 		FALSE );
+
+	VIPS_ARG_INT( class, "max_tile_cache_memory", 23,
+		_( "max_tile_cache_memory" ),
+		_( "Use this maximum memory for tile cache" ),
+		VIPS_ARGUMENT_OPTIONAL_INPUT,
+		G_STRUCT_OFFSET( VipsForeignLoadTiff, max_tile_cache_memory),
+		0, 734003200, 0);
 }
 
 static void

--- a/libvips/foreign/tiffload.c
+++ b/libvips/foreign/tiffload.c
@@ -137,7 +137,7 @@ vips_foreign_load_tiff_header( VipsForeignLoad *load )
 	VipsForeignLoadTiff *tiff = (VipsForeignLoadTiff *) load;
 
 	if( vips__tiff_read_header_source( tiff->source, load->out, 
-		tiff->page, tiff->n, tiff->autorotate ) ) 
+		tiff->page, tiff->n, tiff->autorotate, tiff->max_tile_cache_memory ) ) 
 		return( -1 );
 
 	return( 0 );
@@ -149,7 +149,7 @@ vips_foreign_load_tiff_load( VipsForeignLoad *load )
 	VipsForeignLoadTiff *tiff = (VipsForeignLoadTiff *) load;
 
 	if( vips__tiff_read_source( tiff->source, load->real, 
-		tiff->page, tiff->n,  tiff->autorotate ) ) 
+		tiff->page, tiff->n,  tiff->autorotate, tiff->max_tile_cache_memory ) ) 
 		return( -1 );
 
 	return( 0 );

--- a/libvips/include/vips/connection.h
+++ b/libvips/include/vips/connection.h
@@ -153,7 +153,7 @@ typedef struct _VipsSource {
 	 * buffer, from mmaping the file, from reading the pipe into memory), 
 	 * a pointer to the start.
 	 */
-	const void *data;
+	const VipsPel *data;
 
 	/* For is_pipe sources, save data read during header phase here. If 
 	 * we rewind and try again, serve data from this until it runs out.

--- a/libvips/include/vips/connection.h
+++ b/libvips/include/vips/connection.h
@@ -216,7 +216,7 @@ VipsSource *vips_source_new_from_options( const char *options );
 void vips_source_minimise( VipsSource *source );
 int vips_source_unminimise( VipsSource *source );
 int vips_source_decode( VipsSource *source );
-gint64 vips_source_read( VipsSource *source, void *data, size_t length );
+gint64 vips_source_read( VipsSource *source, VipsPel *data, size_t length );
 gboolean vips_source_is_mappable( VipsSource *source );
 const void *vips_source_map( VipsSource *source, size_t *length );
 VipsBlob *vips_source_map_blob( VipsSource *source );

--- a/libvips/iofuncs/connection.c
+++ b/libvips/iofuncs/connection.c
@@ -50,7 +50,9 @@
 #include <sys/types.h>
 #include <sys/stat.h>
 #include <fcntl.h>
-#include <unistd.h>
+#ifdef HAVE_IO_H
+#include <io.h>
+#endif /*HAVE_IO_H*/
 
 #include <vips/vips.h>
 #include <vips/internal.h>

--- a/libvips/iofuncs/sbuf.c
+++ b/libvips/iofuncs/sbuf.c
@@ -50,7 +50,9 @@
 #include <sys/types.h>
 #include <sys/stat.h>
 #include <fcntl.h>
-#include <unistd.h>
+#ifdef HAVE_IO_H
+#include <io.h>
+#endif /*HAVE_IO_H*/
 
 #include <vips/vips.h>
 #include <vips/internal.h>

--- a/libvips/iofuncs/source.c
+++ b/libvips/iofuncs/source.c
@@ -59,7 +59,9 @@
 #include <sys/types.h>
 #include <sys/stat.h>
 #include <fcntl.h>
-#include <unistd.h>
+#ifdef HAVE_IO_H
+#include <io.h>
+#endif /*HAVE_IO_H*/
 
 #include <vips/vips.h>
 #include <vips/internal.h>
@@ -668,7 +670,7 @@ vips_source_decode( VipsSource *source )
  * Returns: the number of bytes read, 0 on end of file, -1 on error.
  */
 gint64
-vips_source_read( VipsSource *source, void *buffer, size_t length )
+vips_source_read( VipsSource *source, VipsPel *buffer, size_t length )
 {
 	VipsSourceClass *class = VIPS_SOURCE_GET_CLASS( source );
 

--- a/libvips/iofuncs/sourcecustom.c
+++ b/libvips/iofuncs/sourcecustom.c
@@ -50,7 +50,9 @@
 #include <sys/types.h>
 #include <sys/stat.h>
 #include <fcntl.h>
-#include <unistd.h>
+#ifdef HAVE_IO_H
+#include <io.h>
+#endif /*HAVE_IO_H*/
 
 #include <vips/vips.h>
 #include <vips/internal.h>

--- a/libvips/iofuncs/target.c
+++ b/libvips/iofuncs/target.c
@@ -50,7 +50,9 @@
 #include <sys/types.h>
 #include <sys/stat.h>
 #include <fcntl.h>
-#include <unistd.h>
+#ifdef HAVE_IO_H
+#include <io.h>
+#endif /*HAVE_IO_H*/
 
 #include <vips/vips.h>
 #include <vips/internal.h>
@@ -293,7 +295,7 @@ vips_target_new_to_memory( void )
 
 static int
 vips_target_write_unbuffered( VipsTarget *target, 
-	const void *data, size_t length )
+	const VipsPel *data, size_t length )
 {
 	VipsTargetClass *class = VIPS_TARGET_GET_CLASS( target );
 

--- a/libvips/iofuncs/targetcustom.c
+++ b/libvips/iofuncs/targetcustom.c
@@ -50,7 +50,9 @@
 #include <sys/types.h>
 #include <sys/stat.h>
 #include <fcntl.h>
-#include <unistd.h>
+#ifdef HAVE_IO_H
+#include <io.h>
+#endif /*HAVE_IO_H*/
 
 #include <vips/vips.h>
 #include <vips/internal.h>


### PR DESCRIPTION
Hi!

At my job we had an issue with slow tiff load times on certain files.
We took a look and after some testing we saw that increasing the tile cache improve the process time from 22 seconds to 2 seconds.

I made a parameter when loading tiff file for specifying the maximum memory when using the tile cache.
It then converts the maximum memory to the maximum number of tiles when using vips_tile_cache.

I don't know if this is a good way of doing it, or maybe there would be a more generic way (across other file formats) for using this variable.

What do you think?

BTW, as in master branch on Visual Studio 2019 is not building, I provided some fixes.