### PR TITLE
autogen.sh: Honor NOCONFIGURE

### DIFF
--- a/autogen.sh
+++ b/autogen.sh
@@ -61,4 +61,6 @@ autoheader
 $LIBTOOLIZE --copy --force --automake
 automake --add-missing --copy
 
-./configure $*
+if test -z "$NOCONFIGURE"; then
+  ./configure $*
+fi


### PR DESCRIPTION
Linux distros will usually want to run configure separately so the script should respect their wishes. See also https://people.gnome.org/~walters/docs/build-api.txt