### PR TITLE
Fix two compiler warnings

### DIFF
--- a/libvips/conversion/cast.c
+++ b/libvips/conversion/cast.c
@@ -222,7 +222,7 @@ G_DEFINE_TYPE( VipsCast, vips_cast, VIPS_TYPE_CONVERSION );
 	OTYPE * restrict q = (OTYPE *) out; \
 	\
 	for( x = 0; x < sz; x++ ) \
-		q[x] = CAST( p[x] ); \
+		q[x] = p[x]; \
 }
 
 /* Cast complex types to an int type. Just take the real part.
@@ -232,7 +232,7 @@ G_DEFINE_TYPE( VipsCast, vips_cast, VIPS_TYPE_CONVERSION );
 	OTYPE * restrict q = (OTYPE *) out; \
 	\
 	for( x = 0; x < sz; x++ ) { \
-		q[x] = CAST( p[0] ); \
+		q[x] = p[0]; \
 		p += 2; \
 	} \
 }

--- a/libvips/foreign/heifload.c
+++ b/libvips/foreign/heifload.c
@@ -957,7 +957,7 @@ vips_foreign_load_heif_init( VipsForeignLoadHeif *heif )
 
 	/* The first version to support heif_reader.
 	 */
-	heif->reader->reader_api_version = 1.3;
+	heif->reader->reader_api_version = 1;
 	heif->reader->get_position = vips_foreign_load_heif_get_position;
 	heif->reader->read = vips_foreign_load_heif_read;
 	heif->reader->seek = vips_foreign_load_heif_seek;


### PR DESCRIPTION
```
cast.c:400:4: warning: implicit conversion from 'int' to 'float' changes value from 2147483647 to 2147483648 [-Wimplicit-int-float-conversion]
                        BAND_SWITCH_INNER( float,
                        ^~~~~~~~~~~~~~~~~~~~~~~~~
cast.c:312:32: note: expanded from macro 'BAND_SWITCH_INNER'
                INT( ITYPE, signed int, int, CAST_INT ); \
                ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^~~~~~~~~~
cast.c:225:10: note: expanded from macro 'CAST_FLOAT_INT'
                q[x] = CAST( p[x] ); \
                       ^~~~~~~~~~~~
cast.c:132:38: note: expanded from macro 'CAST_INT'
#define CAST_INT( X ) VIPS_MIN( (X), INT_MAX )
                      ~~~~~~~~~~~~~~~^~~~~~~~~
/emsdk/upstream/emscripten/system/include/libc/limits.h:30:18: note: expanded from macro 'INT_MAX'
#define INT_MAX  0x7fffffff
                 ^~~~~~~~~~
../../libvips/include/vips/util.h:55:34: note: expanded from macro 'VIPS_MIN'
#define VIPS_MIN( A, B ) ((A) < (B) ? (A) : (B))
                              ~  ^
cast.c:414:4: warning: implicit conversion from 'int' to 'float' changes value from 2147483647 to 2147483648 [-Wimplicit-int-float-conversion]
                        BAND_SWITCH_INNER( float,
                        ^~~~~~~~~~~~~~~~~~~~~~~~~
cast.c:312:32: note: expanded from macro 'BAND_SWITCH_INNER'
                INT( ITYPE, signed int, int, CAST_INT ); \
                ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^~~~~~~~~~
cast.c:235:10: note: expanded from macro 'CAST_COMPLEX_INT'
                q[x] = CAST( p[0] ); \
                       ^~~~~~~~~~~~
cast.c:132:38: note: expanded from macro 'CAST_INT'
#define CAST_INT( X ) VIPS_MIN( (X), INT_MAX )
                      ~~~~~~~~~~~~~~~^~~~~~~~~
/emsdk/upstream/emscripten/system/include/libc/limits.h:30:18: note: expanded from macro 'INT_MAX'
#define INT_MAX  0x7fffffff
                 ^~~~~~~~~~
../../libvips/include/vips/util.h:55:34: note: expanded from macro 'VIPS_MIN'
#define VIPS_MIN( A, B ) ((A) < (B) ? (A) : (B))
                              ~  ^

heifload.c:960:37: warning: implicit conversion from 'double' to 'int' changes
      value from 1.3 to 1 [-Wliteral-conversion]
        heif->reader->reader_api_version = 1.3;
                                         ~ ^~~
```

The `-Wimplicit-int-float-conversion` issue could be a false-positive, as I couldn't reproduce this with Clang 10.