### PR TITLE
Remove use of varargs in vips_*_open

### DIFF
--- a/libvips/include/vips/memory.h
+++ b/libvips/include/vips/memory.h
@@ -74,7 +74,7 @@ size_t vips_tracked_get_mem( void );
 size_t vips_tracked_get_mem_highwater( void );
 int vips_tracked_get_allocs( void );
 
-int vips_tracked_open( const char *pathname, int flags, ... );
+int vips_tracked_open( const char *pathname, int flags, mode_t mode );
 int vips_tracked_close( int fd );
 int vips_tracked_get_files( void );
 

--- a/libvips/include/vips/util.h
+++ b/libvips/include/vips/util.h
@@ -254,7 +254,7 @@ int vips_filename_suffix_match( const char *path, const char *suffixes[] );
 gint64 vips_file_length( int fd );
 int vips__write( int fd, const void *buf, size_t count );
 
-int vips__open( const char *filename, int flags, ... );
+int vips__open( const char *filename, int flags, mode_t mode );
 int vips__open_read( const char *filename );
 FILE *vips__fopen( const char *filename, const char *mode );
 

--- a/libvips/iofuncs/memory.c
+++ b/libvips/iofuncs/memory.c
@@ -356,7 +356,7 @@ vips_tracked_malloc( size_t size )
  * vips_tracked_open:
  * @pathname: name of file to open
  * @flags: flags for open()
- * @...: open mode
+ * @mode: open mode
  *
  * Exactly as open(2), but the number of files currently open via
  * vips_tracked_open() is available via vips_tracked_get_files(). This is used
@@ -372,18 +372,9 @@ vips_tracked_malloc( size_t size )
  * Returns: a file descriptor, or -1 on error.
  */
 int
-vips_tracked_open( const char *pathname, int flags, ... )
+vips_tracked_open( const char *pathname, int flags, mode_t mode )
 {
 	int fd;
-	mode_t mode;
-	va_list ap;
-
-	/* mode_t is promoted to int in ..., so we have to pull it out as an
-	 * int.
-	 */
-	va_start( ap, flags );
-	mode = va_arg( ap, int );
-	va_end( ap );
 
 	if( (fd = vips__open( pathname, flags, mode )) == -1 )
 		return( -1 );

--- a/libvips/iofuncs/source.c
+++ b/libvips/iofuncs/source.c
@@ -596,7 +596,7 @@ vips_source_unminimise( VipsSource *source )
 		int fd;
 
 		if( (fd = vips_tracked_open( connection->filename, 
-			MODE_READ )) == -1 ) {
+			MODE_READ, 0 )) == -1 ) {
 			vips_error_system( errno, 
 				vips_connection_nick( connection ),
 				"%s", _( "unable to open for read" ) );

--- a/libvips/iofuncs/util.c
+++ b/libvips/iofuncs/util.c
@@ -624,15 +624,9 @@ vips__set_create_time( int fd )
 /* open() with a utf8 filename, setting errno.
  */
 int
-vips__open( const char *filename, int flags, ... )
+vips__open( const char *filename, int flags, mode_t mode )
 {
 	int fd;
-	mode_t mode;
-	va_list ap;
-
-	va_start( ap, flags );
-	mode = va_arg( ap, int );
-	va_end( ap );
 
 	/* Various bad things happen if you accidentally open a directory as a
 	 * file.
@@ -655,7 +649,7 @@ vips__open( const char *filename, int flags, ... )
 int 
 vips__open_read( const char *filename )
 {
-	return( vips__open( filename, MODE_READONLY ) );
+	return( vips__open( filename, MODE_READONLY, 0 ) );
 }
 
 /* fopen() with utf8 filename and mode, setting errno.

--- a/libvips/iofuncs/vips.c
+++ b/libvips/iofuncs/vips.c
@@ -165,11 +165,11 @@ vips__open_image_read( const char *filename )
 	 * work. When we later mmap this file, we set read-only, so there 
 	 * is little danger of scrubbing over files we own.
 	 */
-	fd = vips_tracked_open( filename, MODE_READWRITE );
+	fd = vips_tracked_open( filename, MODE_READWRITE, 0 );
 	if( fd == -1 ) 
 		/* Open read-write failed. Fall back to open read-only.
 		 */
-		fd = vips_tracked_open( filename, MODE_READONLY );
+		fd = vips_tracked_open( filename, MODE_READONLY, 0 );
 	
 	if( fd == -1 ) {
 		vips_error_system( errno, "VipsImage", 


### PR DESCRIPTION
This PR replaces the varargs in `vips_tracked_open` and `vips__open` with direct arguments.

Reading non-existent arguments may work on most native platforms, however on WASM it can fail. See for example:

<details>
  <summary>Details</summary>

```
=================================================================
==42==ERROR: AddressSanitizer: null-pointer-dereference on address 0x00000000 at pc 0x0042db9a bp 0x035acc30 sp 0x035acc3c
READ of size 4 at 0x00000000 thread T0
    #0 0x42db9a in vips_tracked_open ../../vips/libvips/iofuncs/memory.c:385:9
    #1 0x47a73d in vips_source_unminimise ../../vips/libvips/iofuncs/source.c:598:44
Address 0x00000000 is located in the shadow gap area.
SUMMARY: AddressSanitizer: null-pointer-dereference ../../vips/libvips/iofuncs/memory.c:386:9 in vips_tracked_open
==42==ABORTING
```

```
=================================================================
==42==ERROR: AddressSanitizer: null-pointer-dereference on address 0x00000000 at pc 0x0048c38a bp 0x035a8cb0 sp 0x035a8cbc
READ of size 4 at 0x00000000 thread T0
    #0 0x48c38a in vips__open ../../vips/libvips/iofuncs/util.c:634:9
    #1 0x48c39e in vips__open_read ../../vips/libvips/iofuncs/util.c:658:10
Address 0x00000000 is located in the shadow gap area.
SUMMARY: AddressSanitizer: null-pointer-dereference ../../vips/libvips/iofuncs/util.c:634:9 in vips__open
==42==ABORTING
```
</details>

Marked this PR as draft, because I'm not sure if this preserves ABI compatibility.