### PR TITLE
Default height to VIPS_MAX_COORD for vips_thumbnail

### DIFF
--- a/libvips/resample/thumbnail.c
+++ b/libvips/resample/thumbnail.c
@@ -28,6 +28,8 @@
  * 	- smarter heif thumbnail selection
  * 12/10/19
  * 	- add thumbnail_source
+ * 3/5/20 kleisauke
+ *	- prevent reduction in the vertical axis when the height is omitted
  */
 
 /*
@@ -560,9 +562,6 @@ vips_thumbnail_build( VipsObject *object )
 	if( vips_object_argument_isset( object, "no_rotate" ) ) 
 		thumbnail->auto_rotate = !thumbnail->no_rotate;
 
-	if( !vips_object_argument_isset( object, "height" ) )
-		thumbnail->height = thumbnail->width;
-
 	/* Open and do any pre-shrinking.
 	 */
 	if( !(t[0] = vips_thumbnail_open( thumbnail )) )
@@ -825,7 +824,7 @@ vips_thumbnail_class_init( VipsThumbnailClass *class )
 		_( "Size to this height" ),
 		VIPS_ARGUMENT_OPTIONAL_INPUT,
 		G_STRUCT_OFFSET( VipsThumbnail, height ),
-		1, VIPS_MAX_COORD, 1 );
+		1, VIPS_MAX_COORD, VIPS_MAX_COORD );
 
 	VIPS_ARG_ENUM( class, "size", 114, 
 		_( "size" ), 
@@ -895,7 +894,7 @@ static void
 vips_thumbnail_init( VipsThumbnail *thumbnail )
 {
 	thumbnail->width = 1;
-	thumbnail->height = 1;
+	thumbnail->height = VIPS_MAX_COORD;
 	thumbnail->auto_rotate = TRUE;
 	thumbnail->intent = VIPS_INTENT_RELATIVE;
 }

--- a/test/test-suite/test_resample.py
+++ b/test/test-suite/test_resample.py
@@ -133,7 +133,7 @@ class TestResample:
     def test_thumbnail(self):
         im = pyvips.Image.thumbnail(JPEG_FILE, 100)
 
-        assert im.height == 100
+        assert im.width == 100
         assert im.bands == 3
         assert im.bands == 3
 
@@ -142,9 +142,9 @@ class TestResample:
         assert abs(im_orig.avg() - im.avg()) < 1
 
         # make sure we always get the right width
-        for height in range(440, 1, -13):
-            im = pyvips.Image.thumbnail(JPEG_FILE, height)
-            assert im.height == height
+        for width in range(440, 1, -13):
+            im = pyvips.Image.thumbnail(JPEG_FILE, width)
+            assert im.width == width
 
         # should fit one of width or height
         im = pyvips.Image.thumbnail(JPEG_FILE, 100, height=300)
@@ -176,7 +176,7 @@ class TestResample:
 
             # thumb should be portrait 
             assert thumb.width < thumb.height
-            assert thumb.height == 100
+            assert thumb.width == 100
 
     def test_similarity(self):
         im = pyvips.Image.new_from_file(JPEG_FILE)


### PR DESCRIPTION
This to prevent reduction in the vertical axis when the height is omitted. Marked this PR as draft since it changes the behavior of `vips_thumbnail` into a resize based on a specific axis (which is more common, I think) instead than a resize based on a square bounding box.

This PR resolves (partially) #709, but a better way to address that issue is to make `width` an optional parameter. This allows users to do this, for example:
```c
// Resize to a width of 200 pixels, no matter what the height of the input image is
if( vips_thumbnail( filename, &image,
	"width", 200,
	NULL ) )
	return( -1 );

// Resize to a height of 200 pixels, no matter what the width of the input image is
if( vips_thumbnail( filename, &image,
	"height", 200, 
	NULL ) )
	return( -1 );

// Identity transform
if( vips_thumbnail( filename, &image, NULL ) )
	return( -1 );
```

Instead of the current behavior:
```c
// Resize to a width of 200 pixels, no matter what the height of the input image is
if( vips_thumbnail( filename, &image, 200,
	"height", VIPS_MAX_COORD,
	NULL ) )
	return( -1 );

// Resize to a height of 200 pixels, no matter what the width of the input image is
if( vips_thumbnail( filename, &image, VIPS_MAX_COORD,
	"height", 200,
	NULL ) )
	return( -1 );

// Identity transform
if( vips_thumbnail( filename, &image, VIPS_MAX_COORD,
	"height", VIPS_MAX_COORD, 
	"size", VIPS_SIZE_DOWN,
	NULL ) )
	return( -1 );
```

This PR resolves kleisauke/net-vips#71 when merged.