### PR TITLE
Ensure magick7 buffer+file checks use consistent min length guard

### DIFF
--- a/libvips/foreign/magick7load.c
+++ b/libvips/foreign/magick7load.c
@@ -841,7 +841,7 @@ G_DEFINE_TYPE( VipsForeignLoadMagick7Buffer, vips_foreign_load_magick7_buffer,
 static gboolean
 vips_foreign_load_magick7_buffer_is_a_buffer( const void *buf, size_t len )
 {
-	return( magick_ismagick( (const unsigned char *) buf, len ) );
+	return( len > 10 && magick_ismagick( (const unsigned char *) buf, len ) );
 }
 
 static int


### PR DESCRIPTION
This change add the same `len > 10` check to the buffer-based logic to bring it in line with the existing file-checking logic:

https://github.com/libvips/libvips/blob/a592d99bb2e8a90be00121bf81cba338232183b5/libvips/foreign/magick7load.c#L752-L760

This prevents a call to `GetImageMagick` with a zero-length buffer, which crashes on FreeBSD.