### PR TITLE
revise kernel mask calculations

### DIFF
--- a/libvips/resample/reduceh.cpp
+++ b/libvips/resample/reduceh.cpp
@@ -101,19 +101,19 @@ vips_reduce_get_points( VipsKernel kernel, double shrink )
 		return( 1 ); 
 
 	case VIPS_KERNEL_LINEAR:
-		return( rint( 2 * shrink ) + 1 ); 
+		return( 2 * rint( shrink ) + 1 ); 
 
 	case VIPS_KERNEL_CUBIC:
 	case VIPS_KERNEL_MITCHELL:
-		return( rint( 4 * shrink ) + 1 ); 
+		return( 2 * rint( 2 * shrink ) + 1 ); 
 
 	case VIPS_KERNEL_LANCZOS2:
 		/* Needs to be in sync with calculate_coefficients_lanczos().
 		 */
-		return( rint( 2 * 2 * shrink ) + 1 ); 
+		return( 2 * rint( 2 * shrink ) + 1 ); 
 
 	case VIPS_KERNEL_LANCZOS3:
-		return( rint( 2 * 3 * shrink ) + 1 ); 
+		return( 2 * rint( 3 * shrink ) + 1 ); 
 
 	default:
 		g_assert_not_reached();

--- a/libvips/resample/templates.h
+++ b/libvips/resample/templates.h
@@ -321,14 +321,15 @@ calculate_coefficients_triangle( double *c,
 {
 	/* Needs to be in sync with vips_reduce_get_points().
 	 */
-	const int n_points = rint( 2 * shrink ) + 1;
+	const int n_points = 2 * rint( shrink ) + 1;
+        const double half = x + n_points / 2.0 - 1;
 
 	int i;
 	double sum; 
 
 	sum = 0;
 	for( i = 0; i < n_points; i++ ) {
-		double xp = (i - (shrink - 0.5) - x) / shrink;
+		const double xp = (i - half) / shrink;
 
 		double l;
 
@@ -358,14 +359,15 @@ calculate_coefficients_cubic( double *c,
 {
 	/* Needs to be in sync with vips_reduce_get_points().
 	 */
-	const int n_points = rint( 4 * shrink ) + 1; 
+	const int n_points = 2 * rint( 2 * shrink ) + 1; 
+        const double half = x + n_points / 2.0 - 1;
 
 	int i;
 	double sum; 
 
 	sum = 0;
 	for( i = 0; i < n_points; i++ ) {
-		const double xp = (i - (2 * shrink - 1) - x) / shrink;
+		const double xp = (i - half) / shrink;
 		const double axp = VIPS_FABS( xp ); 
 		const double axp2 = axp * axp;
 		const double axp3 = axp2 * axp;
@@ -406,14 +408,15 @@ calculate_coefficients_lanczos( double *c,
 {
 	/* Needs to be in sync with vips_reduce_get_points().
 	 */
-	const int n_points = rint( 2 * a * shrink ) + 1; 
+	const int n_points = 2 * rint( a * shrink ) + 1; 
+        const double half = x + n_points / 2.0 - 1;
 
 	int i;
 	double sum; 
 
 	sum = 0;
 	for( i = 0; i < n_points; i++ ) {
-		double xp = (i - (n_points - 2) / 2 - x) / shrink;
+		double xp = (i - half) / shrink;
 
 		double l;
 


### PR DESCRIPTION
We were seeing small displacements at some shrink factors because of
rounding in the mask size calcualation. This PR takes the rounding into
account when positioning the mask.

See https://github.com/libvips/libvips/pull/1592#issuecomment-626363031