### PR TITLE
Improve compile-time libheif and runtime AVIF detection

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -855,14 +855,16 @@ if test x"$with_heif" != x"no"; then
   PKG_CHECK_MODULES(HEIF, libheif,
     [with_heif=yes
      have_h265_decoder=`$PKG_CONFIG libheif --variable builtin_h265_decoder`
+     have_avif_decoder=`$PKG_CONFIG libheif --variable builtin_avif_decoder`
      # test for !=no so that we work for older libheif which does not have
      # this variable
-     if test x"$have_h265_decoder" != x"no"; then
+     if test x"$have_h265_decoder" != x"no" -o x"$have_avif_decoder" = x"yes"; then
         AC_DEFINE(HAVE_HEIF_DECODER,1,
 	     [define if your libheif has decode support.])
      fi
      have_h265_encoder=`$PKG_CONFIG libheif --variable builtin_h265_encoder`
-     if test x"$have_h265_encoder" != x"no"; then
+     have_avif_encoder=`$PKG_CONFIG libheif --variable builtin_avif_encoder`
+     if test x"$have_h265_encoder" != x"no" -o x"$have_avif_encoder" = x"yes"; then
         AC_DEFINE(HAVE_HEIF_ENCODER,1,
 	     [define if your libheif has encode support.])
      fi
@@ -872,6 +874,8 @@ if test x"$with_heif" != x"no"; then
      with_heif=no
      have_h265_decoder=
      have_h265_encoder=
+     have_avif_decoder=
+     have_avif_encoder=
     ]
   )
 fi

--- a/libvips/foreign/heifload.c
+++ b/libvips/foreign/heifload.c
@@ -237,7 +237,8 @@ static const char *heif_magic[] = {
 	"ftyphevm",	/* Multiview sequence */
 	"ftyphevs",	/* Scaleable sequence */
 	"ftypmif1",	/* Nokia alpha_ image */
-	"ftypmsf1"	/* Nokia animation image */
+	"ftypmsf1",	/* Nokia animation image */
+	"ftypavif"	/* AV1 image format */
 };
 
 /* THe API has:


### PR DESCRIPTION
libheif will soon support h265 and/or AVIF (using the same API) so this PR allows libvips to look for either at compile time (see https://github.com/strukturag/libheif/pull/222 for the upstream change).

It also adds the newer `ftypavif` magic bytes (older AVIF images recycled the use of `ftypmif1`, but that is no longer recommended).