### PR TITLE
Revise spngloader

### DIFF
--- a/libvips/foreign/spngload.c
+++ b/libvips/foreign/spngload.c
@@ -382,8 +382,8 @@ vips_foreign_load_png_header( VipsForeignLoad *load )
 				png->fmt = SPNG_FMT_GA8;
 		}
 	}
-	else if( png->ihdr.color_type == PNG_COLOR_TYPE_GRAY_ALPHA || 
-		     png->ihdr.color_type == PNG_COLOR_TYPE_RGB_ALPHA ) {
+	else if( png->ihdr.color_type == SPNG_COLOR_TYPE_GRAYSCALE_ALPHA || 
+		     png->ihdr.color_type == SPNG_COLOR_TYPE_TRUECOLOR_ALPHA ) {
 		/* Some images have their own alpha channel,
 		 * not just a transparent color.
 		 */


### PR DESCRIPTION
Revised spngloader to be structurally similar to the libpng loader and the [test case](https://github.com/randy408/libspng/blob/master/tests/test_spng.h#L93) which guarantees the outputs will be identical for all possible color and bit depth combinations.

There might be some minor syntax errors, I haven't tried to build it.