### PR TITLE
Update include path for libspng

### DIFF
--- a/libvips/foreign/spngload.c
+++ b/libvips/foreign/spngload.c
@@ -52,7 +52,7 @@
 
 #ifdef HAVE_SPNG
 
-#include <spng.h>
+#include <spng/spng.h>
 
 typedef struct _VipsForeignLoadPng {
 	VipsForeignLoad parent_object;


### PR DESCRIPTION
The header has been moved for v0.6.0, `#include <spng/spng.h>` is the correct way to include the header from now on.