### PR TITLE
Revert "Update include path for libspng"

### DIFF
--- a/libvips/foreign/spngload.c
+++ b/libvips/foreign/spngload.c
@@ -52,7 +52,7 @@
 
 #ifdef HAVE_SPNG
 
-#include <spng/spng.h>
+#include <spng.h>
 
 typedef struct _VipsForeignLoadPng {
 	VipsForeignLoad parent_object;


### PR DESCRIPTION
The include path will stay the same for v0.6.0, sorry about that.


Reverts libvips/libvips#1694