### PR TITLE
Further reduce animated WebP image size by ~5% when min_size is set

### DIFF
--- a/libvips/foreign/vips2webp.c
+++ b/libvips/foreign/vips2webp.c
@@ -310,6 +310,7 @@ write_webp_anim( VipsWebPWrite *write, VipsImage *image, int page_height )
 	}
 
 	anim_config.minimize_size = write->min_size;
+	anim_config.allow_mixed = write->min_size;
 	anim_config.kmin = write->kmin;
 	anim_config.kmax = write->kmax;
 


### PR DESCRIPTION
When `min_size` has been explicitly set to minimise the size of an animated WebP image, also setting `allow_mixed` allows the encoder to evaluate and mix both lossy and lossless frames.

See https://github.com/webmproject/libwebp/commit/f29bf582df2349b29264e188670750b54850651e

The original claim is a 5% reduction, but I've seen anywhere from a ~2%-15% reduction depending on the input. There doesn't appear to be any increase in compression time and I've not seen any increase in file size so this seems like a safe setting.