### PR TITLE
Add Issue Templates with Auto Labeling

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,34 @@
+---
+name: Bug Report
+about: Create A Bug Report
+title: 'A concise title of what the bug is.'
+labels: 'bug'
+assignees: ''
+
+---
+
+**Describe the bug**
+A clear and concise description of what the bug is.
+
+**To Reproduce**
+Steps to reproduce the behavior:
+1. Use Image '...'
+2. Use Configuration '....'
+3. See error
+
+**Expected behavior**
+A clear and concise description of what you expected to happen.
+
+**Actual behavior**
+A clear and concise description of what actually happen.
+
+**Screenshots**
+If applicable, add screenshots to help explain your problem.
+
+**Environment**
+(please complete the following information)
+ - OS: [e.g. Ubuntu 16.04, MacOS 10.13]
+ - Vips: [e.g. 8.8, 8.9, etc]
+
+**Additional context**
+Add any other context about the problem here.

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,20 @@
+---
+name: Enhancement or Feature Request
+about: Suggest an addition to libvips
+title: ''
+labels: 'enhancement'
+assignees: ''
+
+---
+
+**Is your feature request related to a problem? Please describe.**
+A clear and concise description of what the problem is. Ex. I'm always frustrated when [...]
+
+**Describe the solution you'd like**
+A clear and concise description of what you want to happen.
+
+**Describe alternatives you've considered**
+A clear and concise description of any alternative solutions or features you've considered.
+
+**Additional context**
+Add any other context or screenshots about the feature request here.

--- a/.github/ISSUE_TEMPLATE/question.md
+++ b/.github/ISSUE_TEMPLATE/question.md
@@ -1,0 +1,11 @@
+---
+name: Question
+about: Ask a Question
+title: ''
+labels: 'question'
+assignees: ''
+
+---
+
+Ask a question...
+


### PR DESCRIPTION
Added Issue Templates to the `.github` folder, Issue templates help to organize the project issues and support auto-labeling issues upon creation, which I think will save you loads of time.

Added Issue Template for 
- Bug Report
- Enhancement
- Question

Create Issue window should be like this (Taken from one of my projects): 
![Screen Shot 2020-07-06 at 5 47 48 PM](https://user-images.githubusercontent.com/16992394/86612865-0a3b5a80-bfb1-11ea-8a2b-4de0722ee094.png)
The issue created will have the corresponding label based on the template chosen. 
