### PR TITLE
Fix out-of-source build issues

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -52,6 +52,8 @@ libtool
 libvips/include/vips/version.h
 fred
 ltmain.sh
+m4/glib-gettext.m4
+m4/pkg.m4
 m4/gtk-doc.m4
 m4/intltool.m4
 m4/libtool.m4

--- a/configure.ac
+++ b/configure.ac
@@ -56,6 +56,12 @@ AC_SUBST(LIBRARY_AGE)
 # init introspection support
 GOBJECT_INTROSPECTION_CHECK([1.30.0])
 
+# remove the '(disabled, use --enable-introspection to enable)'
+# suffix from the found_introspection variable
+if test "x$found_introspection" != x"yes"; then
+  found_introspection=no
+fi
+
 # gir needs a list of source files to scan for introspection
 #
 # build with a glob and a list of files to exclude from scanning
@@ -1298,7 +1304,7 @@ VIPS_LIBS="$ZLIB_LIBS $HEIF_LIBS $MAGICK_LIBS $SPNG_LIBS $PNG_LIBS $IMAGEQUANT_L
 
 # autoconf hates multi-line AC_SUBST so we have to have another copy of this
 # thing
-VIPS_CONFIG="native win32: $vips_os_win32, native OS X: $vips_os_darwin, open files in binary mode: $vips_binary_open, enable debug: $enable_debug, enable deprecated library components: $enable_deprecated, enable docs with gtkdoc: $enable_gtk_doc, gobject introspection: $found_introspection, enable radiance support: $with_radiance, enable analyze support: $with_analyze, enable PPM support: $with_ppm, use fftw3 for FFT: $with_fftw, Magick package: $with_magickpackage, Magick API version: $magick_version, load with libMagick: $enable_magickload, save with libMagick: $enable_magicksave, accelerate loops with orc: $with_orc, ICC profile support with lcms: $with_lcms, file import with niftiio: $with_nifti, file import with libheif: $with_heif, file import with OpenEXR: $with_OpenEXR, file import with OpenSlide: $with_openslide, file import with matio: $with_matio, PDF import with PDFium: $with_pdfium, PDF import with poppler-glib: $with_poppler, SVG import with librsvg-2.0: $with_rsvg, zlib: $with_zlib, file import with cfitsio: $with_cfitsio, file import/export with libwebp: $with_libwebp, text rendering with pangoft2: $with_pangoft2, file import/export with libpng: $with_png, support 8bpp PNG quantisation: $with_imagequant, file import/export with libtiff: $with_tiff, file import/export with giflib: $with_giflib, file import/export with libjpeg: $with_jpeg, image pyramid export: $with_gsf, use libexif to load/save JPEG metadata: $with_libexif, file import/export with libspng: $with_libspng"
+VIPS_CONFIG="native win32: $vips_os_win32, native OS X: $vips_os_darwin, open files in binary mode: $vips_binary_open, enable debug: $enable_debug, enable deprecated library components: $enable_deprecated, enable docs with gtkdoc: $enable_gtk_doc, gobject introspection: $found_introspection, enable radiance support: $with_radiance, enable analyze support: $with_analyze, enable PPM support: $with_ppm, use fftw3 for FFT: $with_fftw, Magick package: $with_magickpackage, Magick API version: $magick_version, load with libMagick: $enable_magickload, save with libMagick: $enable_magicksave, accelerate loops with orc: $with_orc, ICC profile support with lcms: $with_lcms, file import with niftiio: $with_nifti, file import with libheif: $with_heif, file import with OpenEXR: $with_OpenEXR, file import with OpenSlide: $with_openslide, file import with matio: $with_matio, PDF import with PDFium: $with_pdfium, PDF import with poppler-glib: $with_poppler, SVG import with librsvg-2.0: $with_rsvg, zlib: $with_zlib, file import with cfitsio: $with_cfitsio, file import/export with libwebp: $with_libwebp, text rendering with pangoft2: $with_pangoft2, file import/export with libspng: $with_libspng, file import/export with libpng: $with_png, support 8bpp PNG quantisation: $with_imagequant, file import/export with libtiff: $with_tiff, file import/export with giflib: $with_giflib, file import/export with libjpeg: $with_jpeg, image pyramid export: $with_gsf, use libexif to load/save JPEG metadata: $with_libexif"
 
 AC_SUBST(VIPS_LIBDIR)
 

--- a/configure.ac
+++ b/configure.ac
@@ -12,7 +12,7 @@ AC_PREREQ(2.62)
 # subdir-objects lets us have dumy.cc in a subdir
 AM_INIT_AUTOMAKE([-Wno-portability foreign subdir-objects])
 
-AC_CONFIG_HEADERS(config.h)
+AC_CONFIG_HEADERS([config.h])
 AC_CONFIG_MACRO_DIR([m4])
 
 # user-visible library versioning
@@ -1340,39 +1340,39 @@ AC_SUBST(EXTRA_LIBS_USED)
 TOP_SRCDIR=$ac_pwd
 AC_SUBST(TOP_SRCDIR)
 
-AC_OUTPUT([
+AC_CONFIG_FILES([
 	vips.pc
 	vips-cpp.pc
-	Makefile 
-	libvips/include/vips/version.h 
-	libvips/include/Makefile 
-	libvips/include/vips/Makefile 
-	libvips/Makefile 
-	libvips/arithmetic/Makefile 
-	libvips/colour/Makefile 
-	libvips/colour/profiles/Makefile 
-	libvips/conversion/Makefile 
-	libvips/convolution/Makefile 
-	libvips/deprecated/Makefile 
-	libvips/foreign/Makefile 
-	libvips/freqfilt/Makefile 
-	libvips/histogram/Makefile 
-	libvips/draw/Makefile 
-	libvips/iofuncs/Makefile 
-	libvips/morphology/Makefile 
-	libvips/mosaicing/Makefile 
-	libvips/create/Makefile 
-	libvips/resample/Makefile 
-	cplusplus/include/Makefile 
-	cplusplus/include/vips/Makefile 
-	cplusplus/Makefile 
-	tools/Makefile 
-	tools/batch_crop 
-	tools/batch_image_convert 
-	tools/batch_rubber_sheet 
-	tools/light_correct 
-	tools/shrink_width 
-	test/Makefile 
+	Makefile
+	libvips/include/vips/version.h
+	libvips/include/Makefile
+	libvips/include/vips/Makefile
+	libvips/Makefile
+	libvips/arithmetic/Makefile
+	libvips/colour/Makefile
+	libvips/colour/profiles/Makefile
+	libvips/conversion/Makefile
+	libvips/convolution/Makefile
+	libvips/deprecated/Makefile
+	libvips/foreign/Makefile
+	libvips/freqfilt/Makefile
+	libvips/histogram/Makefile
+	libvips/draw/Makefile
+	libvips/iofuncs/Makefile
+	libvips/morphology/Makefile
+	libvips/mosaicing/Makefile
+	libvips/create/Makefile
+	libvips/resample/Makefile
+	cplusplus/include/Makefile
+	cplusplus/include/vips/Makefile
+	cplusplus/Makefile
+	tools/Makefile
+	tools/batch_crop
+	tools/batch_image_convert
+	tools/batch_rubber_sheet
+	tools/light_correct
+	tools/shrink_width
+	test/Makefile
 	test/variables.sh
 	test/test-suite/Makefile
 	test/test-suite/helpers/Makefile
@@ -1382,6 +1382,7 @@ AC_OUTPUT([
 	po/Makefile.in
 	fuzz/Makefile
 ])
+AC_OUTPUT
 
 # also add any new items to VIPS_CONFIG above
 AC_MSG_RESULT([dnl

--- a/configure.ac
+++ b/configure.ac
@@ -9,7 +9,7 @@ AC_PREREQ(2.62)
 # gobject-introspection recommends -Wno-portability
 # foreign stops complaints about a missing README (we use README.md instead)
 # and missing INSTALL (the standard Gnu INSTALL is not very useful)
-# subdir-objects lets us have dumy.cc in a subdir
+# subdir-objects lets us have dummy.cc in a subdir
 AM_INIT_AUTOMAKE([-Wno-portability foreign subdir-objects])
 
 AC_CONFIG_HEADERS([config.h])
@@ -26,7 +26,7 @@ VIPS_MAJOR_VERSION=vips_major_version()
 VIPS_MINOR_VERSION=vips_minor_version()
 VIPS_MICRO_VERSION=vips_micro_version()
 VIPS_VERSION=vips_version()
-VIPS_VERSION_STRING=$VIPS_VERSION-`date -u -r ChangeLog`
+VIPS_VERSION_STRING=$VIPS_VERSION-`date -u -r $srcdir/ChangeLog`
 
 # libtool library versioning ... not user-visible (except as part of the
 # library file name) and does not correspond to major/minor/micro above
@@ -60,37 +60,10 @@ GOBJECT_INTROSPECTION_CHECK([1.30.0])
 #
 # build with a glob and a list of files to exclude from scanning
 # see also IGNORE_HFILES in doc/Makefile.am
-introspection_sources=$(cd libvips ; find . -name "*.c"; find . -name "*.cpp")
-filter_list="deprecated introspect.c dummy.c fuzz "
-
-# contains(string, substring)
-#
-# Returns 0 if the specified string contains the specified substring,
-# otherwise returns 1.
-contains() {
-  string="$1"
-  substring="$2"
-  if test x"${string#*$substring}" != x"$string"; then
-    return 0    # $substring is in $string
-  else
-    return 1 	# $substring is not in $string
-  fi
-}
-
-introspection_sources2=
+introspection_sources=$(cd $srcdir/libvips ; find . -path ./deprecated -prune -o -name dummy.c -prune -o -name introspect.c -prune -o \( -name "*.c" -o -name "*.cpp" \) -print)
 for name in $introspection_sources; do
-  found=0
-  for filter in $filter_list; do
-    if contains $name ${filter}; then
-      found=1
-    fi
-  done    
-
-  if [[ $found -eq 0 ]]; then
-    introspection_sources2="$introspection_sources2 $name"
-  fi      
-done    
-vips_introspection_sources="$introspection_sources2"
+  vips_introspection_sources="$vips_introspection_sources $name"
+done
 
 # add headers that form the public vips8 API .. don't do a find and exclude,
 # we end up excluding almost everything argh
@@ -1344,7 +1317,7 @@ AC_CONFIG_FILES([
 	vips.pc
 	vips-cpp.pc
 	Makefile
-	libvips/include/vips/version.h
+	$srcdir/libvips/include/vips/version.h
 	libvips/include/Makefile
 	libvips/include/vips/Makefile
 	libvips/Makefile

--- a/configure.ac
+++ b/configure.ac
@@ -129,6 +129,7 @@ if test x"$enable_deprecated" != x"no"; then
   VIPS_ENABLE_DEPRECATED=1
   enable_deprecated=yes
 fi
+AC_DEFINE_UNQUOTED(ENABLE_DEPRECATED,$VIPS_ENABLE_DEPRECATED,[define to build deprecated components])
 AM_CONDITIONAL(ENABLE_DEPRECATED, [test x"$enable_deprecated" = x"yes"])
 
 # this gets pasted into version.h as a #define

--- a/doc/Makefile.am
+++ b/doc/Makefile.am
@@ -81,10 +81,10 @@ IGNORE_VIPS_C = \
 	nary.h \
 	parithmetic.h \
 	statistic.h \
-	unaryconst.h \
 	unary.h \
-	CImg.h \
+	unaryconst.h \
 	pcolour.h \
+	profiles.h \
 	bandary.h \
 	pconversion.h \
 	correlation.h \
@@ -94,25 +94,14 @@ IGNORE_VIPS_C = \
 	point.h \
 	drawink.h \
 	pdraw.h \
-	analyze2vips.h \
-	csv.h \
 	dbh.h \
-	fits.h \
 	jpeg.h \
 	magick.h \
-	matlab.h \
-	openexr2vips.h \
-	openslide2vips.h \
-	ppm.h \
-	radiance.h \
+	pforeign.h \
 	tiff.h \
-	vipsjpeg.h \
-	vipspng.h \
-	webp.h \
 	pfreqfilt.h \
 	hist_unary.h \
 	phistogram.h \
-	base64.h \
 	sink.h \
 	vipsmarshal.h \
 	pmorphology.h \

--- a/libvips/include/vips/Makefile.am
+++ b/libvips/include/vips/Makefile.am
@@ -45,10 +45,11 @@ pkginclude_HEADERS = \
 	thread.h \
 	transform.h \
 	util.h \
-	version.h \
 	vector.h \
 	vips7compat.h \
-	vips.h 
+	vips.h
+
+nodist_pkginclude_HEADERS = version.h
 
 EXTRA_DIST = version.h.in internal.h enumtemplate
 

--- a/libvips/include/vips/Makefile.am
+++ b/libvips/include/vips/Makefile.am
@@ -76,4 +76,4 @@ vips_scan_headers = \
 	${top_srcdir}/libvips/include/vips/region.h
 
 enumtypes.h: $(vips_scan_headers) Makefile.am
-	glib-mkenums --template enumtemplate $(vips_scan_headers) > enumtypes.h
+	glib-mkenums --template ${top_srcdir}/libvips/include/vips/enumtemplate $(vips_scan_headers) > enumtypes.h

--- a/libvips/iofuncs/Makefile.am
+++ b/libvips/iofuncs/Makefile.am
@@ -79,4 +79,4 @@ vips_scan_headers = \
 	${top_srcdir}/libvips/include/vips/region.h
 
 enumtypes.c: $(vips_scan_headers) Makefile.am
-	glib-mkenums --template enumtemplate $(vips_scan_headers) > enumtypes.c
+	glib-mkenums --template ${top_srcdir}/libvips/iofuncs/enumtemplate $(vips_scan_headers) > enumtypes.c

--- a/libvips/iofuncs/image.c
+++ b/libvips/iofuncs/image.c
@@ -801,7 +801,7 @@ static void
 vips_image_add_progress( VipsImage *image )
 {
 	if( vips__progress || 
-#if VIPS_ENABLE_DEPRECATED
+#if ENABLE_DEPRECATED
 		g_getenv( "VIPS_PROGRESS" ) ||
 		g_getenv( "IM_PROGRESS" ) ) {
 #else
@@ -2517,7 +2517,7 @@ vips_get_disc_threshold( void )
 		 */
 		threshold = 100 * 1024 * 1024;
 
-#if VIPS_ENABLE_DEPRECATED
+#if ENABLE_DEPRECATED
 		if( (env = g_getenv( "VIPS_DISC_THRESHOLD" )) || 
 			(env = g_getenv( "IM_DISC_THRESHOLD" )) ) 
 #else

--- a/libvips/iofuncs/init.c
+++ b/libvips/iofuncs/init.c
@@ -99,7 +99,7 @@
 #include <vips/internal.h>
 #include <vips/vector.h>
 
-#if VIPS_ENABLE_DEPRECATED
+#if ENABLE_DEPRECATED
 #include <vips/vips7compat.h>
 #endif
 
@@ -463,7 +463,7 @@ vips_init( const char *argv0 )
 	g_free( locale );
 	bind_textdomain_codeset( GETTEXT_PACKAGE, "UTF-8" );
 
-#if VIPS_ENABLE_DEPRECATED
+#if ENABLE_DEPRECATED
 	if( g_getenv( "VIPS_INFO" ) || 
 		g_getenv( "IM_INFO" ) ) 
 #else
@@ -496,7 +496,7 @@ vips_init( const char *argv0 )
 	vips__meta_init_types();
 	vips__interpolate_init();
 
-#if VIPS_ENABLE_DEPRECATED
+#if ENABLE_DEPRECATED
 	im__format_init();
 #endif
 
@@ -531,7 +531,7 @@ vips_init( const char *argv0 )
 	(void) vips_load_plugins( "%s/vips-plugins-%d.%d", 
 		libdir, VIPS_MAJOR_VERSION, VIPS_MINOR_VERSION );
 
-#if VIPS_ENABLE_DEPRECATED
+#if ENABLE_DEPRECATED
 	/* Load up any vips7 plugins in the vips libdir. We don't error on 
 	 * failure, it's too annoying to have VIPS refuse to start because of 
 	 * a broken plugin.
@@ -582,7 +582,7 @@ vips_init( const char *argv0 )
 	 * set up if you are using libvips from something like Ruby. Allow this
 	 * env var hack as a workaround. 
 	 */
-#if VIPS_ENABLE_DEPRECATED
+#if ENABLE_DEPRECATED
 	if( g_getenv( "VIPS_WARNING" ) ||
 		g_getenv( "IM_WARNING" ) ) 
 #else
@@ -693,7 +693,7 @@ vips_shutdown( void )
 
 	vips_cache_drop_all();
 
-#if VIPS_ENABLE_DEPRECATED
+#if ENABLE_DEPRECATED
 	im_close_plugins();
 #endif
 

--- a/libvips/iofuncs/init.c
+++ b/libvips/iofuncs/init.c
@@ -789,7 +789,16 @@ static gboolean
 vips_lib_config_cb( const gchar *option_name, const gchar *value, 
 	gpointer data, GError **error )
 {
-	printf( "%s\n", VIPS_CONFIG );
+	char **split;
+	char *config;
+
+	split = g_strsplit( VIPS_CONFIG, ", ", -1 );
+	config = g_strjoinv( "\n", split );
+
+	printf( "%s\n", config );
+	g_strfreev( split );
+	g_free( config );
+
 	vips_shutdown();
 	exit( 0 );
 }

--- a/libvips/iofuncs/threadpool.c
+++ b/libvips/iofuncs/threadpool.c
@@ -426,7 +426,7 @@ vips_concurrency_get( void )
 	 */
 	if( vips__concurrency > 0 )
 		nthr = vips__concurrency;
-#if VIPS_ENABLE_DEPRECATED
+#if ENABLE_DEPRECATED
 	else if( ((str = g_getenv( "VIPS_CONCURRENCY" )) ||
 		(str = g_getenv( "IM_CONCURRENCY" ))) && 
 #else

--- a/libvips/iofuncs/vector.c
+++ b/libvips/iofuncs/vector.c
@@ -102,7 +102,7 @@ vips_vector_init( void )
 	/* Look for the environment variable VIPS_NOVECTOR and use that to turn
 	 * off as well.
 	 */
-#if VIPS_ENABLE_DEPRECATED
+#if ENABLE_DEPRECATED
 	if( g_getenv( "VIPS_NOVECTOR" ) || 
 		g_getenv( "IM_NOVECTOR" ) ) 
 #else

--- a/tools/vips.c
+++ b/tools/vips.c
@@ -97,7 +97,7 @@
 #include <vips/vips.h>
 #include <vips/internal.h>
 
-#if VIPS_ENABLE_DEPRECATED
+#if ENABLE_DEPRECATED
 #include <vips/vips7compat.h>
 #endif
 
@@ -186,7 +186,7 @@ static GOptionEntry main_option[] = {
 	{ NULL }
 };
 
-#if VIPS_ENABLE_DEPRECATED
+#if ENABLE_DEPRECATED
 typedef void *(*map_name_fn)( im_function * );
 
 /* Loop over a package.
@@ -253,7 +253,7 @@ list_function( im_function *func )
 static int
 print_list( int argc, char **argv )
 {
-#if VIPS_ENABLE_DEPRECATED
+#if ENABLE_DEPRECATED
 	if( !argv[0] || strcmp( argv[0], "packages" ) == 0 ) 
 		im_map_packages( (VSListMap2Fn) list_package, NULL );
 	else if( strcmp( argv[0], "classes" ) == 0 ) 
@@ -268,7 +268,7 @@ print_list( int argc, char **argv )
 			(VipsTypeMapFn) list_class, NULL );
 	}
 	else {
-#if VIPS_ENABLE_DEPRECATED
+#if ENABLE_DEPRECATED
 		if( map_name( argv[0], list_function ) )
 			vips_error_exit( "unknown package \"%s\"", argv[0] ); 
 #else
@@ -279,7 +279,7 @@ print_list( int argc, char **argv )
 	return( 0 );
 }
 
-#if VIPS_ENABLE_DEPRECATED
+#if ENABLE_DEPRECATED
 /* Print "ln -s" lines for this package.
  */
 static void *
@@ -331,7 +331,7 @@ isvips( const char *name )
 	return( vips_isprefix( "vips", name ) );
 }
 
-#if VIPS_ENABLE_DEPRECATED
+#if ENABLE_DEPRECATED
 /* Print a usage string from an im_function descriptor.
  */
 static void
@@ -426,13 +426,13 @@ static GOptionEntry empty_options[] = {
 };
 
 static ActionEntry actions[] = {
-#if VIPS_ENABLE_DEPRECATED
+#if ENABLE_DEPRECATED
 	{ "list", N_( "list classes|packages|all|package-name|operation-name" ),
 #else
 	{ "list", N_( "list classes|all|operation-name" ),
 #endif
 		&empty_options[0], print_list },
-#if VIPS_ENABLE_DEPRECATED
+#if ENABLE_DEPRECATED
 	{ "links", N_( "generate links for vips/bin" ),
 		&empty_options[0], print_links },
 #endif
@@ -515,7 +515,7 @@ main( int argc, char **argv )
 	GOptionGroup *main_group;
 	GOptionGroup *group;
 	VipsOperation *operation;
-#if VIPS_ENABLE_DEPRECATED
+#if ENABLE_DEPRECATED
 	im_function *fn;
 #endif
 	int i, j;
@@ -603,10 +603,10 @@ main( int argc, char **argv )
 		;
 
 	if( main_option_plugin ) {
-#if VIPS_ENABLE_DEPRECATED
+#if ENABLE_DEPRECATED
 		if( !im_load_plugin( main_option_plugin ) )
 			vips_error_exit( NULL );
-#else /*!VIPS_ENABLE_DEPRECATED*/
+#else /*!ENABLE_DEPRECATED*/
 		GModule *module;
 
 		module = g_module_open( main_option_plugin, G_MODULE_BIND_LAZY );
@@ -672,7 +672,7 @@ main( int argc, char **argv )
 				break;
 			}
 
-#if VIPS_ENABLE_DEPRECATED
+#if ENABLE_DEPRECATED
 	/* Could be a vips7 im_function. We need to test for vips7 first,
 	 * since we don't want to use the vips7 compat wrappers in vips8
 	 * unless we have to. They don't support all args types.


### PR DESCRIPTION
This PR fixes a few out-of-source build issues as mentioned in https://github.com/libvips/libvips/issues/1704#issuecomment-653933150. Here's a test script that I used to find these issues:
<details>
   <summary>Test script</summary>

```bash
mkdir vips
curl -Ls https://github.com/libvips/libvips/releases/download/v8.10.0-beta1/vips-8.10.0-beta1.tar.gz | tar xzC vips --strip-components=1
#curl -Ls https://kleisauke.nl/vips-8.10.0-beta1.tar.gz | tar xzC vips --strip-components=1
cd vips

[ -f "libvips/include/vips/version.h" ] && echo "WARNING: version.h exists in tarball" 

srcdir=$PWD

# Try a out-of-source debug build
mkdir build && cd build
../configure --prefix=$srcdir/inst/ --enable-debug

[ -f "$srcdir/libvips/include/vips/version.h" ] && [ -f "libvips/include/vips/version.h" ] && echo "WARNING: two version.h files detected, --vips-config may contain incorrect information"
[ ! -f "$srcdir/libvips/include/vips/version.h" ] && echo "WARNING: version.h does not exist in the source directory"
[ -f "libvips/include/vips/version.h" ] && echo "WARNING: version.h should not appear in the build directory"

make install && make distclean

( set -o pipefail; $srcdir/inst/bin/vips --vips-config | grep -q "enable debug: yes" )
if [[ "$?" -eq "1" ]]; then echo "WARNING: compiled version.h does not seem to originate from the debug build"; fi

cd $srcdir

# Regular in-source build
./configure --prefix=$srcdir/inst/

make install && make distclean

# Try a out-of-source --disable-deprecated build
cd build
../configure --prefix=$srcdir/inst/ --disable-deprecated

make || echo "WARNING: a wrong version.h is included during complication"
```
</details>

Commit https://github.com/kleisauke/libvips/commit/cd948d86f64cbbf7897c56352ea7105aae813585, https://github.com/kleisauke/libvips/commit/42a7c9736b933a7422ec2e900eab173fa1558150 and https://github.com/kleisauke/libvips/commit/b84e87b6d2b84d1b93d581d6baed44ec64341a20 are not strictly relevant to this PR, but could be useful.