### PR TITLE
Add missing vips7 compat wrappers

### DIFF
--- a/libvips/deprecated/vips7compat.c
+++ b/libvips/deprecated/vips7compat.c
@@ -5310,6 +5310,32 @@ im_remosaic( IMAGE *in, IMAGE *out, const char *old_str, const char *new_str )
 }
 
 int
+im_lrmosaic( IMAGE *ref, IMAGE *sec, IMAGE *out,
+	int bandno,
+	int xref, int yref, int xsec, int ysec,
+ 	int hwindowsize, int hsearchsize,
+	int balancetype,
+	int mwidth )
+{
+	VipsImage *x;
+
+	if( vips_mosaic( ref, sec, &x, VIPS_DIRECTION_HORIZONTAL,
+		xref, yref, xsec, ysec,
+		"hwindow", hwindowsize,
+		"harea", hsearchsize,
+		"mblend", mwidth,
+		NULL ) ) 
+		return( -1 );
+	if( vips_image_write( x, out ) ) {
+		g_object_unref( x );
+		return( -1 );
+	}
+	g_object_unref( x );
+
+	return( 0 );
+}
+
+int
 im_lrmosaic1( IMAGE *ref, IMAGE *sec, IMAGE *out, 
 	int bandno,
 	int xr1, int yr1, int xs1, int ys1, 
@@ -5324,6 +5350,32 @@ im_lrmosaic1( IMAGE *ref, IMAGE *sec, IMAGE *out,
 		xr1, yr1, xs1, ys1, xr2, yr2, xs2, ys2,
 		"search", TRUE,
 		"bandno", bandno,
+		"hwindow", hwindowsize,
+		"harea", hsearchsize,
+		"mblend", mwidth,
+		NULL ) ) 
+		return( -1 );
+	if( vips_image_write( x, out ) ) {
+		g_object_unref( x );
+		return( -1 );
+	}
+	g_object_unref( x );
+
+	return( 0 );
+}
+
+int
+im_tbmosaic( IMAGE *ref, IMAGE *sec, IMAGE *out,
+	int bandno,
+	int xref, int yref, int xsec, int ysec,
+ 	int hwindowsize, int hsearchsize,
+	int balancetype,
+	int mwidth )
+{
+	VipsImage *x;
+
+	if( vips_mosaic( ref, sec, &x, VIPS_DIRECTION_VERTICAL,
+		xref, yref, xsec, ysec,
 		"hwindow", hwindowsize,
 		"harea", hsearchsize,
 		"mblend", mwidth,
@@ -5365,6 +5417,16 @@ im_tbmosaic1( IMAGE *ref, IMAGE *sec, IMAGE *out,
 	g_object_unref( x );
 
 	return( 0 );
+}
+
+int
+im_correl( VipsImage *ref, VipsImage *sec,
+	int xref, int yref, int xsec, int ysec,
+	int hwindowsize, int hsearchsize,
+	double *correlation, int *x, int *y )
+{
+	return( vips__correl( ref, sec, xref, yref, xsec, ysec,
+		hwindowsize, hsearchsize, correlation, x, y ) );
 }
 
 int

--- a/libvips/include/vips/mosaicing.h
+++ b/libvips/include/vips/mosaicing.h
@@ -31,8 +31,8 @@
 
  */
 
-#ifndef IM_MOSAICING_H
-#define IM_MOSAICING_H
+#ifndef VIPS_MOSAICING_H
+#define VIPS_MOSAICING_H
 
 #ifdef __cplusplus
 extern "C" {
@@ -70,4 +70,4 @@ int vips_matrixinvert( VipsImage *m, VipsImage **out, ... )
 }
 #endif /*__cplusplus*/
 
-#endif /*IM_MOSAICING_H*/
+#endif /*VIPS_MOSAICING_H*/

--- a/libvips/include/vips/vips7compat.h
+++ b/libvips/include/vips/vips7compat.h
@@ -1078,10 +1078,22 @@ int im_tbmerge1( VipsImage *ref, VipsImage *sec, VipsImage *out,
 	int xr2, int yr2, int xs2, int ys2,
 	int mwidth );
 
+int im_lrmosaic( VipsImage *ref, VipsImage *sec, VipsImage *out,
+	int bandno,
+	int xref, int yref, int xsec, int ysec,
+	int hwindowsize, int hsearchsize,
+	int balancetype,
+	int mwidth );
 int im_lrmosaic1( VipsImage *ref, VipsImage *sec, VipsImage *out, 
 	int bandno,
 	int xr1, int yr1, int xs1, int ys1, 
 	int xr2, int yr2, int xs2, int ys2,
+	int hwindowsize, int hsearchsize,
+	int balancetype,
+	int mwidth );
+int im_tbmosaic( VipsImage *ref, VipsImage *sec, VipsImage *out, 
+	int bandno,
+	int xref, int yref, int xsec, int ysec, 
 	int hwindowsize, int hsearchsize,
 	int balancetype,
 	int mwidth );

--- a/libvips/mosaicing/global_balance.c
+++ b/libvips/mosaicing/global_balance.c
@@ -174,8 +174,8 @@ vips__global_open_image( SymbolTable *st, char *name )
 
 	if( !(image = vips_image_new_from_file( name, NULL ))) {
 		/* TODO(kleisauke): Is this behavior the same as im_skip_dir?
-		 *					i.e. could we open a filename which came
-		 *					from a win32 (`\\`) on a *nix machine? */
+		 * i.e. could we open a filename which came
+		 * from a win32 (`\\`) on a *nix machine? */
 		basename = g_path_get_basename( name );
 
 		if( !(image = vips_image_new_from_file( basename, NULL ))) {

--- a/libvips/mosaicing/global_balance.h
+++ b/libvips/mosaicing/global_balance.h
@@ -47,8 +47,8 @@ typedef VipsImage *(*transform_fn)( JoinNode *, void * );
 /* Join type.
  */
 enum _JoinType {
-	JOIN_LR,		/* vips_lrmerge join */
-	JOIN_TB,		/* vips_tbmerge join */
+	JOIN_LR,		/* vips__lrmerge join */
+	JOIN_TB,		/* vips__tbmerge join */
 	JOIN_LRROTSCALE,	/* 1st oder lrmerge */
 	JOIN_TBROTSCALE,	/* 1st oder tbmerge */
 	JOIN_CP,		/* vips_copy operation */

--- a/libvips/mosaicing/im_avgdxdy.c
+++ b/libvips/mosaicing/im_avgdxdy.c
@@ -3,11 +3,11 @@
  * @(#)  The rounded integer result is returned into dx, dy
  * @(#) No images are involved in this function.
  * @(#)
- * @(#) int vips_avgdxdy( points, dx, dy )
+ * @(#) int vips__avgdxdy( points, dx, dy )
  * @(#) TiePoints *points;
  * @(#) int *dx, *dy;
  * @(#) 
- * @(#) Returns 0 on sucess  and -1 on error.
+ * @(#) Returns 0 on success  and -1 on error.
  *
  * Copyright: 1990, N. Dessipris.
  *
@@ -62,7 +62,7 @@ vips__avgdxdy( TiePoints *points, int *dx, int *dy )
 	int i;
 
 	if( points->nopoints == 0 ) {
-		vips_error( "vips_avgdxdy", "%s", _( "no points to average" ) );
+		vips_error( "vips__avgdxdy", "%s", _( "no points to average" ) );
 		return( -1 );
 	}
 

--- a/libvips/mosaicing/im_improve.c
+++ b/libvips/mosaicing/im_improve.c
@@ -10,7 +10,7 @@
  * @(#) int vips__improve( inpoints, outpoints )
  * @(#) TiePoints *inpoints, *outpoints;
  * @(#) 
- * @(#) Returns 0 on sucess  and -1 on error.
+ * @(#) Returns 0 on success  and -1 on error.
  *
  * Copyright: 1990, N. Dessipris.
  *

--- a/libvips/mosaicing/im_lrcalcon.c
+++ b/libvips/mosaicing/im_lrcalcon.c
@@ -8,7 +8,7 @@
  * @(#) Results are saved in the structure points
  * @(#) The function expects the following valid data in points:
  * @(#) deltax, deltay, nopoints, halfcorsize, halfareasize
- * @(#) and fills in the memebers:
+ * @(#) and fills in the members:
  * @(#) x, y_reference[], contrast and x,y_secondary[],
  * @(#) based on deltax and deltay
  * @(#) Input image should are either memory mapped or in a buffer.

--- a/libvips/mosaicing/im_tbcalcon.c
+++ b/libvips/mosaicing/im_tbcalcon.c
@@ -22,7 +22,7 @@
  * @(#) int bandno;
  * @(#) TiePoints *points; 	see mosaic.h
  * @(#) 
- * @(#) Returns 0 on sucess  and -1 on error.
+ * @(#) Returns 0 on success  and -1 on error.
  *
  * Copyright: 1990, N. Dessipris.
  *

--- a/libvips/mosaicing/lrmerge.c
+++ b/libvips/mosaicing/lrmerge.c
@@ -704,8 +704,8 @@ vips__build_mergestate( const char *domain,
 	int x;
 
 	/* TODO(kleisauke): Copied from vips_insert, perhaps we
-	 *                  need a separate function for this? 
-	 *                  (just like im__insert_base) 
+	 * need a separate function for this?
+	 * (just like im__insert_base)
 	 */
 	if( vips_image_pio_input( ref ) ||
 		vips_image_pio_input( sec ) ||

--- a/libvips/mosaicing/lrmosaic.c
+++ b/libvips/mosaicing/lrmosaic.c
@@ -119,7 +119,7 @@ vips__find_lroverlap( VipsImage *ref_in, VipsImage *sec_in, VipsImage *out,
 	 */
 	if( halfcorrelation < 0 || halfarea < 0 || 
 		halfarea < halfcorrelation ) {
-		vips_error( "vips_lrmosaic", "%s", _( "bad area parameters" ) );
+		vips_error( "vips__lrmosaic", "%s", _( "bad area parameters" ) );
 		return( -1 );
 	}
 
@@ -139,7 +139,7 @@ vips__find_lroverlap( VipsImage *ref_in, VipsImage *sec_in, VipsImage *out,
 	vips_rect_intersectrect( &left, &right, &overlap );
 	if( overlap.width < 2 * halfarea + 1 ||
 		overlap.height < 2 * halfarea + 1 ) {
-		vips_error( "vips_lrmosaic", 
+		vips_error( "vips__lrmosaic", 
 			"%s", _( "overlap too small for search" ) );
 		return( -1 );
 	}
@@ -168,7 +168,7 @@ vips__find_lroverlap( VipsImage *ref_in, VipsImage *sec_in, VipsImage *out,
 			return( -1 );
 	}
 	else {
-		vips_error( "vips_lrmosaic", "%s", _( "unknown Coding type" ) );
+		vips_error( "vips__lrmosaic", "%s", _( "unknown Coding type" ) );
 		return( -1 );
 	}
 

--- a/libvips/mosaicing/matrixinvert.c
+++ b/libvips/mosaicing/matrixinvert.c
@@ -227,7 +227,7 @@ lu_decomp( VipsImage *mat )
  *   PRESS, W. et al, 1992.  Numerical Recipies in C; The Art of Scientific 
  *   Computing, 2nd ed.  Cambridge: Cambridge University Press, pp. 43-50.
  *
- * See also: im_mattrn(), im_matinv().
+ * See also: vips__matrixtranspose(), vips__matrixmultiply().
  *
  * Returns: 0 on success, -1 on error
  */

--- a/libvips/mosaicing/pmosaicing.h
+++ b/libvips/mosaicing/pmosaicing.h
@@ -135,11 +135,6 @@ int vips__tbmerge1( VipsImage *ref, VipsImage *sec, VipsImage *out,
 	double a, double b, double dx, double dy, 
 	int mwidth );
 
-int vips_correl( VipsImage *ref, VipsImage *sec,
-	int xref, int yref, int xsec, int ysec,
-	int hwindowsize, int hsearchsize,
-	double *correlation, int *x, int *y );
-
 #define VIPS_MAXPOINTS (60)	/* VIPS_MAXPOINTS % AREAS must be zero */
 #define AREAS (3)	
 

--- a/libvips/mosaicing/tbmerge.c
+++ b/libvips/mosaicing/tbmerge.c
@@ -23,7 +23,7 @@
  *	- ANSIfied
  *	- proper freeing on errors, ready for partial
  * 8/11/93 JC
- *	- now propogates both input histories
+ *	- now propagates both input histories
  *	- adds magic lines for global mosaic optimisation
  *
  *

--- a/libvips/mosaicing/tbmosaic.c
+++ b/libvips/mosaicing/tbmosaic.c
@@ -78,7 +78,7 @@ vips__find_tboverlap( VipsImage *ref_in, VipsImage *sec_in, VipsImage *out,
 	double *scale1, double *angle1, double *dx1, double *dy1 )
 {
 	VipsImage **t = (VipsImage **)
-			vips_object_local_array( VIPS_OBJECT( out ), 6 );
+		vips_object_local_array( VIPS_OBJECT( out ), 6 );
 
 	VipsRect top, bottom, overlap;
 	TiePoints points, *p_points;		/* defined in mosaic.h */
@@ -90,7 +90,7 @@ vips__find_tboverlap( VipsImage *ref_in, VipsImage *sec_in, VipsImage *out,
 	 */
 	if( halfcorrelation < 0 || halfarea < 0 || 
 		halfarea < halfcorrelation ) {
-		vips_error( "vips_tbmosaic", "%s", _( "bad area parameters" ) );
+		vips_error( "vips__tbmosaic", "%s", _( "bad area parameters" ) );
 		return( -1 );
 	}
 
@@ -110,7 +110,7 @@ vips__find_tboverlap( VipsImage *ref_in, VipsImage *sec_in, VipsImage *out,
 	vips_rect_intersectrect( &top, &bottom, &overlap );
 	if( overlap.width < 2 * halfarea + 1 ||
 		overlap.height < 2 * halfarea + 1 ) {
-		vips_error( "vips_tbmosaic", "%s", 
+		vips_error( "vips__tbmosaic", "%s", 
 			_( "overlap too small for search" ) );
 		return( -1 );
 	}
@@ -139,7 +139,7 @@ vips__find_tboverlap( VipsImage *ref_in, VipsImage *sec_in, VipsImage *out,
 			return( -1 );
 	}
 	else {
-		vips_error( "vips_tbmosaic", "%s", _( "unknown Coding type" ) );
+		vips_error( "vips__tbmosaic", "%s", _( "unknown Coding type" ) );
 		return( -1 );
 	}
 


### PR DESCRIPTION
Here's the `abi-compliance-checker` result between v8.9.2 and this branch:
https://kleisauke.nl/compat_reports/vips/8.9.2_to_vips-7-compat/compat_report.html