### PR TITLE
Performance: improve LAB to LCH conversion by ~30%

### DIFF
--- a/libvips/colour/Lab2LCh.c
+++ b/libvips/colour/Lab2LCh.c
@@ -63,11 +63,6 @@ vips_col_ab2h( double a, double b )
 {
 	double h;
 
-#ifdef HAVE_ATAN2
-	h = VIPS_DEG( atan2( b, a ) );
-	if( h < 0.0 )
-		h += 360;
-#else
 	/* We have to get the right quadrant!
 	 */
 	if( a == 0 ) {
@@ -89,7 +84,6 @@ vips_col_ab2h( double a, double b )
 		else
 			h = VIPS_DEG( t + VIPS_PI );
 	}
-#endif
 
 	return( h );
 }
@@ -97,13 +91,7 @@ vips_col_ab2h( double a, double b )
 void
 vips_col_ab2Ch( float a, float b, float *C, float *h )
 {
-#ifdef HAVE_ATAN2
-	*h = VIPS_DEG( atan2( b, a ) );
-	if( *h < 0.0 )
-		*h += 360;
-#else
 	*h = vips_col_ab2h( a, b ); 
-#endif 
 
 #ifdef HAVE_HYPOT
 	*C = hypot( a, b ); 


### PR DESCRIPTION
This is a proposal to remove the atan2 paths from the LAB to LCH conversion code as these incur a greater performance cost than the atan paths.

It's quite likely there was a good reason for using atan2 though, hence this is only a proposal.

Before:
```sh
$ time vips colourspace in.jpeg out.v lch

real	0m0.149s
user	0m0.205s
sys	0m0.032s
```

```
175,203,081  /build/glibc-5mDdLG/glibc-2.30/math/../sysdeps/ieee754/dbl-64/e_atan2.c:__ieee754_atan2_fma [/usr/lib/x86_64-linux-gnu/libm-2.30.so]
150,596,456  ???:vips_XYZ2Lab_line [/usr/local/lib/libvips.so.42.12.3]
 46,873,827  ???:vips_col_scRGB2XYZ [/usr/local/lib/libvips.so.42.12.3]
 41,210,169  ???:vips_Lab2LCh_line [/usr/local/lib/libvips.so.42.12.3]
 33,169,488  /build/glibc-5mDdLG/glibc-2.30/math/w_atan2_compat.c:atan2 [/usr/lib/x86_64-linux-gnu/libm-2.30.so]
 25,567,542  /build/glibc-5mDdLG/glibc-2.30/math/../sysdeps/x86_64/fpu/s_fmax.S:fmax [/usr/lib/x86_64-linux-gnu/libm-2.30.so]
 25,567,542  /build/glibc-5mDdLG/glibc-2.30/math/../sysdeps/x86_64/fpu/s_fmin.S:fmin [/usr/lib/x86_64-linux-gnu/libm-2.30.so]
 24,180,156  ???:vips_scRGB2XYZ_line [/usr/local/lib/libvips.so.42.12.3]
 21,563,738  /build/glibc-5mDdLG/glibc-2.30/string/../sysdeps/x86_64/multiarch/memmove-vec-unaligned-erms.S:__memcpy_avx_unaligned_erms [/usr/lib/x86_64-linux-gnu/libc-2.30.so]
 20,307,431  ???:vips_col_ab2h [/usr/local/lib/libvips.so.42.12.3]
 18,512,200  ???:vips_sRGB2scRGB_gen [/usr/local/lib/libvips.so.42.12.3]
```
After:
```sh
$ time vips colourspace in.jpeg out.v lch

real	0m0.087s
user	0m0.188s
sys	0m0.020s
```

```
150,596,456  ???:vips_XYZ2Lab_line [/usr/local/lib/libvips.so.42.12.3]
109,403,193  /build/glibc-5mDdLG/glibc-2.30/math/../sysdeps/ieee754/dbl-64/s_atan.c:__atan_fma [/usr/lib/x86_64-linux-gnu/libm-2.30.so]
 46,873,827  ???:vips_col_scRGB2XYZ [/usr/local/lib/libvips.so.42.12.3]
 41,210,169  ???:vips_Lab2LCh_line [/usr/local/lib/libvips.so.42.12.3]
 31,977,821  ???:vips_col_ab2h [/usr/local/lib/libvips.so.42.12.3]
 25,567,542  /build/glibc-5mDdLG/glibc-2.30/math/../sysdeps/x86_64/fpu/s_fmax.S:fmax [/usr/lib/x86_64-linux-gnu/libm-2.30.so]
 25,567,542  /build/glibc-5mDdLG/glibc-2.30/math/../sysdeps/x86_64/fpu/s_fmin.S:fmin [/usr/lib/x86_64-linux-gnu/libm-2.30.so]
 24,180,156  ???:vips_scRGB2XYZ_line [/usr/local/lib/libvips.so.42.12.3]
 21,565,062  /build/glibc-5mDdLG/glibc-2.30/string/../sysdeps/x86_64/multiarch/memmove-vec-unaligned-erms.S:__memcpy_avx_unaligned_erms [/usr/lib/x86_64-linux-gnu/libc-2.30.so]
 18,512,200  ???:vips_sRGB2scRGB_gen [/usr/local/lib/libvips.so.42.12.3]
