### PR TITLE
Performance: improve XYZ to LAB conversion by ~15%

### DIFF
--- a/libvips/colour/XYZ2Lab.c
+++ b/libvips/colour/XYZ2Lab.c
@@ -133,15 +133,15 @@ vips_XYZ2Lab_line( VipsColour *colour, VipsPel *out, VipsPel **in, int width )
 		nZ = QUANT_ELEMENTS * p[2] / XYZ2Lab->Z0;
 		p += 3;
 
-		i = VIPS_FCLIP( 0, nX, QUANT_ELEMENTS - 2 );
+		i = VIPS_CLIP( 0, nX, QUANT_ELEMENTS - 2 );
 		f = nX - i;
 		cbx = cbrt_table[i] + f * (cbrt_table[i + 1] - cbrt_table[i]);
 
-		i = VIPS_FCLIP( 0, nY, QUANT_ELEMENTS - 2 );
+		i = VIPS_CLIP( 0, nY, QUANT_ELEMENTS - 2 );
 		f = nY - i;
 		cby = cbrt_table[i] + f * (cbrt_table[i + 1] - cbrt_table[i]);
 
-		i = VIPS_FCLIP( 0, nZ, QUANT_ELEMENTS - 2 );
+		i = VIPS_CLIP( 0, nZ, QUANT_ELEMENTS - 2 );
 		f = nZ - i;
 		cbz = cbrt_table[i] + f * (cbrt_table[i + 1] - cbrt_table[i]);
 


### PR DESCRIPTION
This PR switches the XYZ to LAB clipping from fmax/fmin maths library calls to instead use the simple ternary operators of `VIPS_CLIP`, which the compiler is able to heavily optimise.

Before:
```
150,596,456  ???:vips_XYZ2Lab_line [/usr/local/lib/libvips.so.42.12.3]
 46,873,827  ???:vips_col_scRGB2XYZ [/usr/local/lib/libvips.so.42.12.3]
 25,567,542  /build/glibc-5mDdLG/glibc-2.30/math/../sysdeps/x86_64/fpu/s_fmax.S:fmax [/usr/lib/x86_64-linux-gnu/libm-2.30.so]
 25,567,542  /build/glibc-5mDdLG/glibc-2.30/math/../sysdeps/x86_64/fpu/s_fmin.S:fmin [/usr/lib/x86_64-linux-gnu/libm-2.30.so]
 24,180,156  ???:vips_scRGB2XYZ_line [/usr/local/lib/libvips.so.42.12.3]
 21,563,120  /build/glibc-5mDdLG/glibc-2.30/string/../sysdeps/x86_64/multiarch/memmove-vec-unaligned-erms.S:__memcpy_avx_unaligned_erms [/usr/lib/x86_64-linux-gnu/libc-2.30.so]
 18,512,200  ???:vips_sRGB2scRGB_gen [/usr/local/lib/libvips.so.42.12.3]
```

After:
```
116,498,847  ???:vips_XYZ2Lab_line [/usr/local/lib/libvips.so.42.12.3]
 46,873,827  ???:vips_col_scRGB2XYZ [/usr/local/lib/libvips.so.42.12.3]
 24,180,156  ???:vips_scRGB2XYZ_line [/usr/local/lib/libvips.so.42.12.3]
 21,562,840  /build/glibc-5mDdLG/glibc-2.30/string/../sysdeps/x86_64/multiarch/memmove-vec-unaligned-erms.S:__memcpy_avx_unaligned_erms [/usr/lib/x86_64-linux-gnu/libc-2.30.so]
 18,512,200  ???:vips_sRGB2scRGB_gen [/usr/local/lib/libvips.so.42.12.3]
```