### PR TITLE
Performance: improve scRGB to sRGB conversion by ~8%

### DIFF
--- a/libvips/colour/LabQ2sRGB.c
+++ b/libvips/colour/LabQ2sRGB.c
@@ -238,7 +238,7 @@ vips_col_XYZ2scRGB( float X, float Y, float Z, float *R, float *G, float *B )
 /* Turn scRGB into sRGB. Return og=1 for out of gamut - rgb will contain an 
  * approximation of the right colour.
  *
- * Return -1 for NaN, Inf etc. 
+ * Return -1 for NaN.
  */
 static int
 vips_col_scRGB2sRGB( int range, int *lut, 
@@ -253,15 +253,13 @@ vips_col_scRGB2sRGB( int range, int *lut,
 	int Yi;
 	float v;
 
-	/* XYZ can be Nan, Inf etc. Throw those values out, they will break
+	/* XYZ can be NaN. Throw those values out, they will break
 	 * our clipping.
 	 *
 	 * Don't use isnormal(), it is false for 0.0 and for subnormal
 	 * numbers. 
 	 */
-	if( VIPS_ISNAN( R ) || VIPS_ISINF( R ) ||
-		VIPS_ISNAN( G ) || VIPS_ISINF( G ) ||
-		VIPS_ISNAN( B ) || VIPS_ISINF( B ) ) {
+	if( VIPS_ISNAN( R ) || VIPS_ISNAN( G ) || VIPS_ISNAN( B ) ) {
 		*r = 0; 
 		*g = 0; 
 		*b = 0; 
@@ -276,7 +274,7 @@ vips_col_scRGB2sRGB( int range, int *lut,
 		(V) = (L); \
 		og = 1; \
 	} \
-	if( (V) > (H) ) { \
+	else if( (V) > (H) ) { \
 		(V) = (H); \
 		og = 1; \
 	} \
@@ -336,7 +334,7 @@ vips_col_scRGB2sRGB_16( float R, float G, float B,
 /* Turn scRGB into BW. Return or=1 for out of gamut - g will contain an 
  * approximation of the right colour.
  *
- * Return -1 for NaN, Inf etc. 
+ * Return -1 for NaN.
  */
 static int
 vips_col_scRGB2BW( int range, int *lut, float R, float G, float B, 
@@ -354,10 +352,10 @@ vips_col_scRGB2BW( int range, int *lut, float R, float G, float B,
 	 */
 	Y = 0.2 * R + 0.7 * G + 0.1 * B;
 
-	/* Y can be Nan, Inf etc. Throw those values out, they will break
+	/* Y can be Nan. Throw those values out, they will break
 	 * our clipping.
 	 */
-	if( VIPS_ISNAN( Y ) || VIPS_ISINF( Y ) ) {
+	if( VIPS_ISNAN( Y ) ) {
 		*g = 0; 
 
 		return( -1 );
@@ -418,12 +416,11 @@ build_tables( void *client )
                                 float X, Y, Z;
                                 float Rf, Gf, Bf;
                                 int rb, gb, bb;
-                                int oflow;
  
                                 vips_col_Lab2XYZ( L, A, B, &X, &Y, &Z );
                                 vips_col_XYZ2scRGB( X, Y, Z, &Rf, &Gf, &Bf );
                                 vips_col_scRGB2sRGB_8( Rf, Gf, Bf,
-					&rb, &gb, &bb, &oflow );
+					&rb, &gb, &bb, NULL );
 
 				t = INDEX( l, a, b );
                                 vips_red[t] = rb;

--- a/libvips/colour/scRGB2sRGB.c
+++ b/libvips/colour/scRGB2sRGB.c
@@ -98,9 +98,8 @@ vips_scRGB2sRGB_line_8( VipsPel * restrict q, float * restrict p,
 		float B = p[2];
 
 		int r, g, b;
-		int or;
 
-		vips_col_scRGB2sRGB_8( R, G, B, &r, &g, &b, &or );
+		vips_col_scRGB2sRGB_8( R, G, B, &r, &g, &b, NULL );
 
 		p += 3;
 
@@ -129,9 +128,8 @@ vips_scRGB2sRGB_line_16( unsigned short * restrict q, float * restrict p,
 		float B = p[2];
 
 		int r, g, b;
-		int or;
 
-		vips_col_scRGB2sRGB_16( R, G, B, &r, &g, &b, &or );
+		vips_col_scRGB2sRGB_16( R, G, B, &r, &g, &b, NULL );
 
 		p += 3;
 

--- a/libvips/include/vips/util.h
+++ b/libvips/include/vips/util.h
@@ -66,7 +66,6 @@ extern "C" {
  */
 #if defined(__clang__) || (__GNUC__ >= 4)
 #define VIPS_ISNAN( V ) __builtin_isnan( V )
-#define VIPS_ISINF( V ) __builtin_isinf( V )
 #define VIPS_FLOOR( V ) __builtin_floor( V )
 #define VIPS_CEIL( V ) __builtin_ceil( V )
 #define VIPS_RINT( V ) __builtin_rint( V )
@@ -76,7 +75,6 @@ extern "C" {
 #define VIPS_FMIN( A, B ) __builtin_fmin( A, B )
 #else
 #define VIPS_ISNAN( V ) isnan( V )
-#define VIPS_ISINF( V ) isinf( V )
 #define VIPS_FLOOR( V ) floor( V )
 #define VIPS_CEIL( V ) ceil( V )
 #define VIPS_RINT( V ) rint( V )


### PR DESCRIPTION
Hello, I think we can safely remove the `isinf` checks as the values are clipped before use (this represents about half of the savings).

The `CLIP` macro was missing an `else`, which I think was preventing the compiler from detecting this as a "clip a value" operation.

Out-of-gamut tracking is optional and at a slight cost so we can remove it where the return value is ignored.

Before:
```
225,846,621  ???:vips_col_scRGB2sRGB_8 [/usr/local/lib/libvips.so.42.12.3]
 31,367,336  ???:vips_scRGB2sRGB_gen [/usr/local/lib/libvips.so.42.12.3]
```
After:
```
198,858,660  ???:vips_col_scRGB2sRGB_8 [/usr/local/lib/libvips.so.42.12.3]
 31,365,334  ???:vips_scRGB2sRGB_gen [/usr/local/lib/libvips.so.42.12.3]
```

(All these timings are using gcc v9.2.1 with the `-O3` flag.)
