### PR TITLE
cplusplus: ensure VOption::set for VObject uses class to determine type

### DIFF
--- a/cplusplus/VImage.cpp
+++ b/cplusplus/VImage.cpp
@@ -193,7 +193,7 @@ VOption::set( const char *name, const VObject value )
 {
 	Pair *pair = new Pair( name );
 	VipsObject *object = value.get_object();
-	GType type = G_VALUE_TYPE( object );
+	GType type = G_VALUE_TYPE( VIPS_OBJECT_GET_CLASS( object ) );
 
 	pair->input = true;
 	g_value_init( &pair->value, type );


### PR DESCRIPTION
I'm unsure if this is the _right_ way to solve this problem, but it does at least appear to prevent GType from being null and therefore triggering a segfault.

Example backtrace when the error occurs:

```
#0  0x00007ffff4c7b23a in g_type_value_table_peek () at /lib/x86_64-linux-gnu/libgobject-2.0.so.0
#1  0x00007ffff4c7d28f in g_value_init () at /lib/x86_64-linux-gnu/libgobject-2.0.so.0
#2  0x00007ffff51adbf7 in vips::VOption::set(char const*, vips::VObject) (this=this@entry=0x7fffd400a990, name=name@entry=0x7ffff51cd667 "in", value=...) at VImage.cpp:199
#3  0x00007ffff51af40d in vips::VImage::jpegsave(char const*, vips::VOption*) const (this=0x7fffdc90f8a8, filename=0x456f038 "out.jpg", options=<optimised out>) at ../cplusplus/include/vips/VImage8.h:122
#4  0x00007ffff522f5d1 in PipelineWorker::Execute() () at sharp/build/Release/sharp.node
#5  0x00007ffff5215858 in Napi::AsyncWorker::OnAsyncWorkExecute(napi_env__*, void*) () at sharp/build/Release/sharp.node
#6  0x000000000136aa74 in worker (arg=0x0) at ../deps/uv/src/threadpool.c:122
#7  0x00007ffff7c47609 in start_thread (arg=<optimised out>) at pthread_create.c:477
#8  0x00007ffff7b6e103 in clone () at ../sysdeps/unix/sysv/linux/x86_64/clone.S:95
```