### PR TITLE
heifload: expose heif-compression metadata

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -888,6 +888,18 @@ if test x"$with_heif" = x"yes"; then
   LIBS="$save_LIBS"
 fi
 
+# heif_main_brand added in 1.4.0
+if test x"$with_heif" = x"yes"; then
+  save_LIBS="$LIBS"
+  LIBS="$LIBS $HEIF_LIBS"
+  AC_CHECK_FUNCS(heif_main_brand,[
+     AC_DEFINE(HAVE_HEIF_MAIN_BRAND,1,
+	       [define if you have heif_main_brand.])
+   ],[]
+  )
+  LIBS="$save_LIBS"
+fi
+
 # heif_decoding_options.convert_hdr_to_8bit added in 1.7.0
 if test x"$with_heif" = x"yes"; then
   save_CFLAGS="$CFLAGS"


### PR DESCRIPTION
Requires libheif 1.4.0 for `heif_main_brand` but versions prior to that didn't support AV1. The approach in this PR should hopefully provide useful information for newer versions whilst degrading gracefully for older versions.

```sh
$ vipsheader -a test.heic | grep heif
vips-loader: heifload
heif-primary: 0
heif-compression: hevc
```
```sh
$ vipsheader -a test.avif | grep heif
vips-loader: heifload
heif-primary: 0
heif-compression: av1
```