### PR TITLE
Speed up VIPS_ARGUMENT_COLLECT_SET

### DIFF
--- a/libvips/include/vips/object.h
+++ b/libvips/include/vips/object.h
@@ -365,6 +365,25 @@ int vips_object_get_argument_priority( VipsObject *object, const char *name );
 	VIPS_ARGUMENT_COLLECT_END
  
  */
+#if GLIB_CHECK_VERSION( 2, 24, 0 )
+#define VIPS_ARGUMENT_COLLECT_SET( PSPEC, ARG_CLASS, AP ) \
+	if( (ARG_CLASS->flags & VIPS_ARGUMENT_INPUT) ) { \
+		GValue value = { 0, }; \
+		gchar *error = NULL; \
+ 		\
+		/* Input args are given inline, eg. ("factor", 12.0)  \
+		 * and must be collected. \
+		 */ \
+		G_VALUE_COLLECT_INIT( &value, \
+				G_PARAM_SPEC_VALUE_TYPE( PSPEC ), AP, 0, &error ); \
+		\
+		/* Don't bother with the error message. \
+		 */ \
+		if( error ) { \
+			VIPS_DEBUG_MSG( "VIPS_OBJECT_COLLECT_SET: err\n" ); \
+			g_free( error ); \
+		}
+#else
 #define VIPS_ARGUMENT_COLLECT_SET( PSPEC, ARG_CLASS, AP ) \
 	if( (ARG_CLASS->flags & VIPS_ARGUMENT_INPUT) ) { \
 		GValue value = { 0, }; \
@@ -382,6 +401,7 @@ int vips_object_get_argument_priority( VipsObject *object, const char *name );
 			VIPS_DEBUG_MSG( "VIPS_OBJECT_COLLECT_SET: err\n" ); \
 			g_free( error ); \
 		}
+#endif
 
 #define VIPS_ARGUMENT_COLLECT_GET( PSPEC, ARG_CLASS, AP ) \
 		g_value_unset( &value ); \


### PR DESCRIPTION
By using [`G_VALUE_COLLECT_INIT`](https://developer.gnome.org/gobject/stable/gobject-Varargs-Value-Collection.html#G-VALUE-COLLECT-INIT:CAPS), according to [this upstream bug report](https://bugzilla.gnome.org/show_bug.cgi?id=603590) this could give a speed-up varying from 15% to 30% (measured with Callgrind).