### PR TITLE
Resolve rounding issues in reduce

### DIFF
--- a/libvips/resample/bicubic.cpp
+++ b/libvips/resample/bicubic.cpp
@@ -79,15 +79,16 @@ typedef VipsInterpolate VipsInterpolateBicubic;
 typedef VipsInterpolateClass VipsInterpolateBicubicClass;
 
 /* Precalculated interpolation matrices. int (used for pel
- * sizes up to short), and double (for all others).
+ * sizes up to short), and double (for all others). We go to
+ * scale + 1 so we can round-to-nearest safely.
  */
 
 /* We could keep a large set of 2d 4x4 matricies, but this actually
  * works out slower since for many resizes the thing will no longer
  * fit in L1.
  */
-static int vips_bicubic_matrixi[VIPS_TRANSFORM_SCALE][4];
-static double vips_bicubic_matrixf[VIPS_TRANSFORM_SCALE][4];
+static int vips_bicubic_matrixi[VIPS_TRANSFORM_SCALE + 1][4];
+static double vips_bicubic_matrixf[VIPS_TRANSFORM_SCALE + 1][4];
 
 /* We need C linkage for this.
  */
@@ -497,13 +498,19 @@ static void
 vips_interpolate_bicubic_interpolate( VipsInterpolate *interpolate,
 	void *out, VipsRegion *in, double x, double y )
 {
-	/* Find the mask index.
+	/* Find the mask index. We round-to-nearest, so we need to generate 
+	 * indexes in 0 to VIPS_TRANSFORM_SCALE, 2^n + 1 values. We multiply 
+	 * by 2 more than we need to, add one, mask, then shift down again to 
+	 * get the extra range.
 	 */
-	const int sx = x * VIPS_TRANSFORM_SCALE;
-	const int sy = y * VIPS_TRANSFORM_SCALE;
+	const int sx = x * VIPS_TRANSFORM_SCALE * 2;
+	const int sy = y * VIPS_TRANSFORM_SCALE * 2;
 
-	const int tx = sx & (VIPS_TRANSFORM_SCALE - 1);
-	const int ty = sy & (VIPS_TRANSFORM_SCALE - 1);
+	const int six = sx & (VIPS_TRANSFORM_SCALE * 2 - 1);
+	const int siy = sy & (VIPS_TRANSFORM_SCALE * 2 - 1);
+
+	const int tx = (six + 1) >> 1;
+	const int ty = (siy + 1) >> 1;
 
 	/* We know x/y are always positive, so we can just (int) them. 
 	 */
@@ -636,7 +643,7 @@ vips_interpolate_bicubic_class_init( VipsInterpolateBicubicClass *iclass )
 
 	/* Build the tables of pre-computed coefficients.
 	 */
-	for( int x = 0; x < VIPS_TRANSFORM_SCALE; x++ ) {
+	for( int x = 0; x < VIPS_TRANSFORM_SCALE + 1; x++ ) {
 		calculate_coefficients_catmull( vips_bicubic_matrixf[x], 
 			(float) x / VIPS_TRANSFORM_SCALE ); 
 

--- a/libvips/resample/reduceh.cpp
+++ b/libvips/resample/reduceh.cpp
@@ -281,8 +281,12 @@ reduceh_notab( VipsReduceh *reduceh,
 
 	vips_reduce_make_mask( cx, reduceh->kernel, reduceh->hshrink, x ); 
 
-	for( int z = 0; z < bands; z++ )
-		out[z] = reduce_sum<T, double>( in + z, bands, cx, n );
+	for( int z = 0; z < bands; z++ ) {
+		double sum;
+		sum = reduce_sum<T, double>( in + z, bands, cx, n );
+
+		out[z] = VIPS_ROUND_UINT( sum );
+	}
 }
 
 /* Tried a vector path (see reducev) but it was slower. The vectors for

--- a/libvips/resample/reduceh.cpp
+++ b/libvips/resample/reduceh.cpp
@@ -480,7 +480,7 @@ vips_reduceh_build( VipsObject *object )
 	 * by half that distance so that we discard pixels equally
 	 * from left and right. 
 	 */
-	reduceh->hoffset = (1 + extra_pixels) / 2.0;
+	reduceh->hoffset = (1 + extra_pixels) / 2.0 - 1;
 
 	/* Build the tables of pre-computed coefficients.
 	 */
@@ -518,7 +518,7 @@ vips_reduceh_build( VipsObject *object )
 	/* Add new pixels around the input so we can interpolate at the edges.
 	 */
 	if( vips_embed( in, &t[1], 
-		reduceh->n_point / 2 - 1, 0, 
+		VIPS_CEIL( reduceh->n_point / 2.0 ) - 1, 0, 
 		in->Xsize + reduceh->n_point, in->Ysize,
 		"extend", VIPS_EXTEND_COPY,
 		(void *) NULL ) )

--- a/libvips/resample/reducev.cpp
+++ b/libvips/resample/reducev.cpp
@@ -511,8 +511,12 @@ reducev_notab( VipsReducev *reducev,
 
 	vips_reduce_make_mask( cy, reducev->kernel, reducev->vshrink, y ); 
 
-	for( int z = 0; z < ne; z++ ) 
-		out[z] = reduce_sum<T, double>( in + z, l1, cy, n );
+	for( int z = 0; z < ne; z++ ) {
+		double sum;
+		sum = reduce_sum<T, double>( in + z, l1, cy, n );
+
+		out[z] = VIPS_ROUND_UINT( sum );
+	}
 }
 
 static int

--- a/libvips/resample/reducev.cpp
+++ b/libvips/resample/reducev.cpp
@@ -21,7 +21,6 @@
  * 	- deprecate @centre option, it's now always on
  * 	- fix pixel shift
  * 	- speed up the mask construction for uchar/ushort images
- * 	- remove unnecessary round-to-nearest behaviour
  */
 
 /*
@@ -118,14 +117,15 @@ typedef struct _VipsReducev {
 	double voffset;
 
 	/* Precalculated interpolation matrices. int (used for pel
-	 * sizes up to short), and double (for all others).
+	 * sizes up to short), and double (for all others). We go to
+	 * scale + 1 so we can round-to-nearest safely.
 	 */
-	int *matrixi[VIPS_TRANSFORM_SCALE];
-	double *matrixf[VIPS_TRANSFORM_SCALE];
+	int *matrixi[VIPS_TRANSFORM_SCALE + 1];
+	double *matrixf[VIPS_TRANSFORM_SCALE + 1];
 
 	/* And another set for orc: we want 2.6 precision.
 	 */
-	int *matrixo[VIPS_TRANSFORM_SCALE];
+	int *matrixo[VIPS_TRANSFORM_SCALE + 1];
 
 	/* The passes we generate for this mask.
 	 */
@@ -154,7 +154,7 @@ vips_reducev_finalize( GObject *gobject )
 	for( int i = 0; i < reducev->n_pass; i++ )
 		VIPS_FREEF( vips_vector_free, reducev->pass[i].vector );
 	reducev->n_pass = 0;
-	for( int i = 0; i < VIPS_TRANSFORM_SCALE; i++ ) {
+	for( int i = 0; i < VIPS_TRANSFORM_SCALE + 1; i++ ) {
 		VIPS_FREE( reducev->matrixf[i] );
 		VIPS_FREE( reducev->matrixi[i] );
 		VIPS_FREE( reducev->matrixo[i] );
@@ -555,8 +555,9 @@ vips_reducev_gen( VipsRegion *out_region, void *vseq,
 			VIPS_REGION_ADDR( out_region, r->left, r->top + y );
 		const int py = (int) Y;
 		VipsPel *p = VIPS_REGION_ADDR( ir, r->left, py );
-		const int sy = Y * VIPS_TRANSFORM_SCALE;
-		const int ty = sy & (VIPS_TRANSFORM_SCALE - 1);
+		const int sy = Y * VIPS_TRANSFORM_SCALE * 2;
+		const int siy = sy & (VIPS_TRANSFORM_SCALE * 2 - 1);
+		const int ty = (siy + 1) >> 1;
 		const int *cyi = reducev->matrixi[ty];
 		const double *cyf = reducev->matrixf[ty];
 		const int lskip = VIPS_REGION_LSKIP( ir );
@@ -677,8 +678,9 @@ vips_reducev_vector_gen( VipsRegion *out_region, void *vseq,
 		VipsPel *q = 
 			VIPS_REGION_ADDR( out_region, r->left, r->top + y );
 		const int py = (int) Y;
-		const int sy = Y * VIPS_TRANSFORM_SCALE;
-		const int ty = sy & (VIPS_TRANSFORM_SCALE - 1);
+		const int sy = Y * VIPS_TRANSFORM_SCALE * 2;
+		const int siy = sy & (VIPS_TRANSFORM_SCALE * 2 - 1);
+		const int ty = (siy + 1) >> 1;
 		const int *cyo = reducev->matrixo[ty];
 
 #ifdef DEBUG_PIXELS
@@ -739,7 +741,7 @@ vips_reducev_raw( VipsReducev *reducev, VipsImage *in, VipsImage **out )
 	 */
 	if( in->BandFmt == VIPS_FORMAT_UCHAR &&
 		vips_vector_isenabled() ) 
-		for( int y = 0; y < VIPS_TRANSFORM_SCALE; y++ ) {
+		for( int y = 0; y < VIPS_TRANSFORM_SCALE + 1; y++ ) {
 			reducev->matrixo[y] = 
 				VIPS_ARRAY( NULL, reducev->n_point, int ); 
 			if( !reducev->matrixo[y] )
@@ -851,7 +853,7 @@ vips_reducev_build( VipsObject *object )
 
 	/* Build the tables of pre-computed coefficients.
 	 */
-	for( int y = 0; y < VIPS_TRANSFORM_SCALE; y++ ) {
+	for( int y = 0; y < VIPS_TRANSFORM_SCALE + 1; y++ ) {
 		reducev->matrixf[y] = 
 			VIPS_ARRAY( NULL, reducev->n_point, double ); 
 		reducev->matrixi[y] = 

--- a/libvips/resample/reducev.cpp
+++ b/libvips/resample/reducev.cpp
@@ -853,7 +853,7 @@ vips_reducev_build( VipsObject *object )
 	 * by half that distance so that we discard pixels equally
 	 * from left and right. 
 	 */
-	reducev->voffset = (1 + extra_pixels) / 2.0;
+	reducev->voffset = (1 + extra_pixels) / 2.0 - 1;
 
 	/* Build the tables of pre-computed coefficients.
 	 */
@@ -891,7 +891,7 @@ vips_reducev_build( VipsObject *object )
 	/* Add new pixels around the input so we can interpolate at the edges.
 	 */
 	if( vips_embed( in, &t[1], 
-		0, reducev->n_point / 2 - 1, 
+		0, VIPS_CEIL( reducev->n_point / 2.0 ) - 1, 
 		in->Xsize, in->Ysize + reducev->n_point, 
 		"extend", VIPS_EXTEND_COPY,
 		(void *) NULL ) )


### PR DESCRIPTION
This PR is a split-off from https://github.com/libvips/libvips/pull/1769, targeting the [`8.10`](https://github.com/libvips/libvips/tree/8.10) branch.

It fixes two small bugs that have been found with [jsummers/resamplescope](https://github.com/jsummers/resamplescope). The first commit (https://github.com/kleisauke/libvips/commit/49d8051e22d1b06f64a7f85b2c70db2497cece54) restores the round-to-nearest behaviour in `reduce{h,v}`, that was removed with PR https://github.com/libvips/libvips/pull/1592. This change can be observed in the following graphs:

| Before | After |
| :---: |  :---: |
| ![pd_vips_lanczos3-out.png](https://raw.githubusercontent.com/kleisauke/pyvips-issue-148/438bd3c0cd5c6a859c92d9df9bde956f48ffa20e/output-patch/pd_vips_lanczos3-out.png) | ![pd_vips_lanczos3-out.png](https://raw.githubusercontent.com/kleisauke/pyvips-issue-148/0965ca1a662f461d15d9c45a24e18dcddcd549fb/output-patch/pd_vips_lanczos3-out.png) |
| Rounding error | |

The second commit (https://github.com/kleisauke/libvips/commit/fdc140e8e90ec42e1655135fadaf1479bd2c852a) rounds the sum values to the nearest integer in `*_notab` version. I'm not entirely sure why this is necessary and whether this is the right place to do it, but it seems to fix the double-precision graph:
| Before | After |
| :---: |  :---: |
| ![pd_vips_lanczos3-out.png](https://raw.githubusercontent.com/kleisauke/pyvips-issue-148/7137599aff4b9dd4e9116222aa1c5cbe6d5ca682/output-patch/pd_vips_lanczos3-out.png) | ![pd_vips_lanczos3-out.png](https://raw.githubusercontent.com/kleisauke/pyvips-issue-148/f9e7c053e8dbd260100d64cc6df476e53cee386b/output-patch/pd_vips_lanczos3-out.png) |
| Rounding / offset error | |

The last commit (https://github.com/kleisauke/libvips/commit/4533375f63a94f265feef3bc1fc4365b1b7d66f3) rounds the `x` and `y` values of the `vips_embed` call up and take this offset into account (i.e. by subtracting it from `hoffset` / `voffset`). Somehow I cannot illustrate this change within the graphs, but can confirm that this fixes the border-issues reported on sharp (https://github.com/lovell/sharp/issues/2408 and https://github.com/lovell/sharp/issues/2411). It also does not cause regressions on the [pyvips-issue-148](https://github.com/kleisauke/pyvips-issue-148) and [vips-issue-703](https://github.com/kleisauke/vips-issue-703) test repositories.