### PR TITLE
Ensure vipsload only byte swaps if necessary

### DIFF
--- a/libvips/iofuncs/image.c
+++ b/libvips/iofuncs/image.c
@@ -859,10 +859,7 @@ vips_image_build( VipsObject *object )
 		if( (magic = vips__file_magic( filename )) ) {
 			/* We may need to byteswap.
 			 */
-			guint32 us = vips_amiMSBfirst() ? 
-				VIPS_MAGIC_INTEL : VIPS_MAGIC_SPARC;
-
-			if( magic == us ) {
+			if( GUINT_FROM_BE( magic ) == image->magic ) {
 				/* Native open.
 				 */
 				if( vips_image_open_input( image ) )

--- a/libvips/iofuncs/util.c
+++ b/libvips/iofuncs/util.c
@@ -1602,16 +1602,13 @@ vips_ispoweroftwo( int p )
 int
 vips_amiMSBfirst( void )
 {
-        int test;
-        unsigned char *p = (unsigned char *) &test;
-
-        test = 0;
-        p[0] = 255;
-
-        if( test == 255 )
-                return( 0 );
-        else
-                return( 1 );
+#if G_BYTE_ORDER == G_BIG_ENDIAN
+	return( 1 );
+#elif G_BYTE_ORDER == G_LITTLE_ENDIAN
+	return( 0 );
+#else
+#error "Byte order not recognised"
+#endif
 }
 
 /* Return the tmp dir. On Windows, GetTempPath() will also check the values of 

--- a/libvips/iofuncs/vips.c
+++ b/libvips/iofuncs/vips.c
@@ -354,7 +354,7 @@ vips__read_header_bytes( VipsImage *im, unsigned char *from )
 	/* We need to swap for other fields if the file byte order is 
 	 * different from ours.
 	 */
-	swap = vips_amiMSBfirst() != (im->magic == VIPS_MAGIC_SPARC);
+	swap = vips_amiMSBfirst() != vips_image_isMSBfirst( im );
 
 	for( i = 0; i < VIPS_NUMBER( fields ); i++ ) {
 		fields[i].copy( swap,
@@ -435,7 +435,7 @@ vips__write_header_bytes( VipsImage *im, unsigned char *to )
 	/* Swap if the byte order we are asked to write the header in is
 	 * different from ours.
 	 */
-	gboolean swap = vips_amiMSBfirst() != (im->magic == VIPS_MAGIC_SPARC);
+	gboolean swap = vips_amiMSBfirst() != vips_image_isMSBfirst( im );
 
 	int i;
 	unsigned char *q;

--- a/test/test-suite/test_foreign.py
+++ b/test/test-suite/test_foreign.py
@@ -128,6 +128,17 @@ class TestForeign:
         for i in range(len(before_exif)):
             assert before_exif[i] == after_exif[i]
 
+        # https://github.com/libvips/libvips/issues/1847
+        filename = temp_filename(self.tempdir, ".v")
+        x = pyvips.Image.black(16, 16) + 128
+        x.write_to_file(filename)
+
+        x = pyvips.Image.new_from_file(filename)
+        assert x.width == 16
+        assert x.height == 16
+        assert x.bands == 1
+        assert x.avg() == 128
+
         x = None
 
     @skip_if_no("jpegload")


### PR DESCRIPTION
MSB-ordered vips images were always byte swapped on both little- and big endian systems. And LSB-ordered vips images were loaded without a byte swap. This works correctly on little endian systems, but will not work on big endian systems where the byte swap must be done vice versa.

This PR ensures that the byte swap only takes place when needed. I also simplified the MSB-ordered image check (by using a helper) and moved the endianness check to compile time.

Resolves https://github.com/libvips/libvips/issues/1847.

(This PR targets the 8.10 branch, but I can change it to the master branch if necessary)