### PR TITLE
webpload: ensure first frame is not blended

### DIFF
--- a/libvips/foreign/webp2vips.c
+++ b/libvips/foreign/webp2vips.c
@@ -692,6 +692,7 @@ read_next_frame( Read *read )
 	 */
 	vips_image_paint_image( read->frame, frame, 
 		area.left, area.top, 
+		read->iter.frame_num > 1 &&
 		read->iter.blend_method == WEBP_MUX_BLEND );
 
 	g_object_unref( frame );


### PR DESCRIPTION
A possible fix for https://github.com/lovell/sharp/issues/2341#issuecomment-738726237