### PR TITLE
Switch VIPS_FCLIP to VIPS_CLIP in vips_scRGB2{BW,sRGB}

### DIFF
--- a/libvips/colour/scRGB2BW.c
+++ b/libvips/colour/scRGB2BW.c
@@ -113,7 +113,7 @@ vips_scRGB2BW_line_16( unsigned short * restrict q, float * restrict p,
 		q += 1;
 
 		for( j = 0; j < extra_bands; j++ ) 
-			q[j] = VIPS_FCLIP( 0, p[j] * 256.0, USHRT_MAX ); 
+			q[j] = VIPS_CLIP( 0, (int) (p[j] * 256.0), USHRT_MAX );
 		p += extra_bands;
 		q += extra_bands;
 	}

--- a/libvips/colour/scRGB2sRGB.c
+++ b/libvips/colour/scRGB2sRGB.c
@@ -140,7 +140,7 @@ vips_scRGB2sRGB_line_16( unsigned short * restrict q, float * restrict p,
 		q += 3;
 
 		for( j = 0; j < extra_bands; j++ ) 
-			q[j] = VIPS_FCLIP( 0, p[j] * 256.0, USHRT_MAX ); 
+			q[j] = VIPS_CLIP( 0, (int) (p[j] * 256.0), USHRT_MAX );
 		p += extra_bands;
 		q += extra_bands;
 	}


### PR DESCRIPTION
As discussed in https://github.com/libvips/libvips/pull/1735#issuecomment-662439737. I didn't actually benchmark this, but it seems like a straightforward change (hence targeting the [`8.10`](https://github.com/libvips/libvips/tree/8.10) branch).