### PR TITLE
Fix UBSan errors

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -110,7 +110,7 @@ jobs:
           echo "ASAN_OPTIONS=suppressions=${{ github.workspace }}/suppressions/asan.supp" >> $GITHUB_ENV
           echo "LSAN_OPTIONS=suppressions=${{ github.workspace }}/suppressions/lsan.supp" >> $GITHUB_ENV
           echo "TSAN_OPTIONS=suppressions=${{ github.workspace }}/suppressions/tsan.supp" >> $GITHUB_ENV
-          echo "UBSAN_OPTIONS=suppressions=${{ github.workspace }}/suppressions/ubsan.supp:print_stacktrace=1" >> $GITHUB_ENV
+          echo "UBSAN_OPTIONS=suppressions=${{ github.workspace }}/suppressions/ubsan.supp:halt_on_error=1:abort_on_error=1" >> $GITHUB_ENV
           echo "LD_LIBRARY_PATH=$LLVM_PREFIX/lib:`dirname $ASAN_DSO`" >> $GITHUB_ENV
           echo "$LLVM_PREFIX/bin" >> $GITHUB_PATH
           # workaround for https://github.com/google/sanitizers/issues/89

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -128,7 +128,7 @@ jobs:
         run: make V=0 -j$JOBS
 
       - name: Check libvips
-        run: make V=0 check || (cat test/test-suite.log && exit 1)
+        run: make V=0 VERBOSE=1 check
 
       - name: Install libvips
         run: sudo make V=0 install

--- a/fuzz/test_fuzz.sh
+++ b/fuzz/test_fuzz.sh
@@ -7,8 +7,8 @@ set -e
 
 # Glib is built without -fno-omit-frame-pointer. We need
 # to disable the fast unwinder to get full stacktraces.
-export ASAN_OPTIONS="fast_unwind_on_malloc=0:allocator_may_return_null=1"
-export UBSAN_OPTIONS="print_stacktrace=1"
+export ASAN_OPTIONS="$ASAN_OPTIONS:fast_unwind_on_malloc=0:allocator_may_return_null=1"
+export UBSAN_OPTIONS="$UBSAN_OPTIONS:print_stacktrace=1"
 
 # Hide all warning messages from vips.
 export VIPS_WARNING=0
@@ -17,7 +17,9 @@ ret=0
 
 for fuzzer in *_fuzzer; do
   for file in $top_srcdir/fuzz/common_fuzzer_corpus/*; do
-    if ! ./$fuzzer $file; then
+    exit_code=0
+    ./$fuzzer $file || exit_code=$?
+    if [ $exit_code -ne 0 ]; then
       echo FAIL $fuzzer $file
       ret=1
     fi

--- a/libvips/colour/scRGB2BW.c
+++ b/libvips/colour/scRGB2BW.c
@@ -84,7 +84,7 @@ vips_scRGB2BW_line_8( VipsPel * restrict q, float * restrict p,
 		q += 1;
 
 		for( j = 0; j < extra_bands; j++ ) 
-			q[j] = p[j];
+			q[j] = VIPS_CLIP( 0, p[j], UCHAR_MAX );
 		p += extra_bands;
 		q += extra_bands;
 	}

--- a/libvips/colour/scRGB2sRGB.c
+++ b/libvips/colour/scRGB2sRGB.c
@@ -110,7 +110,7 @@ vips_scRGB2sRGB_line_8( VipsPel * restrict q, float * restrict p,
 		q += 3;
 
 		for( j = 0; j < extra_bands; j++ ) 
-			q[j] = p[j];
+			q[j] = VIPS_CLIP( 0, p[j], UCHAR_MAX );
 		p += extra_bands;
 		q += extra_bands;
 	}

--- a/libvips/conversion/flatten.c
+++ b/libvips/conversion/flatten.c
@@ -81,7 +81,6 @@ typedef VipsConversionClass VipsFlattenClass;
 
 G_DEFINE_TYPE( VipsFlatten, vips_flatten, VIPS_TYPE_CONVERSION );
 
-
 /* Flatten with black background.
  */
 #define VIPS_FLATTEN_BLACK_INT( TYPE ) { \
@@ -188,19 +187,19 @@ vips_flatten_black_gen( VipsRegion *or, void *vseq, void *a, void *b,
 			break; 
 
 		case VIPS_FORMAT_USHORT: 
-      VIPS_FLATTEN_BLACK_FLOAT( unsigned short ); 
+			VIPS_FLATTEN_BLACK_FLOAT( unsigned short ); 
 			break; 
 
 		case VIPS_FORMAT_SHORT: 
-      VIPS_FLATTEN_BLACK_FLOAT( signed short ); 
+			VIPS_FLATTEN_BLACK_FLOAT( signed short ); 
 			break; 
 
 		case VIPS_FORMAT_UINT: 
-      VIPS_FLATTEN_BLACK_FLOAT( unsigned int ); 
+			VIPS_FLATTEN_BLACK_FLOAT( unsigned int ); 
 			break; 
 
 		case VIPS_FORMAT_INT: 
-      VIPS_FLATTEN_BLACK_FLOAT( signed int ); 
+			VIPS_FLATTEN_BLACK_FLOAT( signed int ); 
 			break; 
 
 		case VIPS_FORMAT_FLOAT: 
@@ -253,19 +252,19 @@ vips_flatten_gen( VipsRegion *or, void *vseq, void *a, void *b,
 			break; 
 
 		case VIPS_FORMAT_USHORT: 
-      VIPS_FLATTEN_FLOAT( unsigned short ); 
+			VIPS_FLATTEN_FLOAT( unsigned short ); 
 			break; 
 
 		case VIPS_FORMAT_SHORT: 
-      VIPS_FLATTEN_FLOAT( signed short ); 
+			VIPS_FLATTEN_FLOAT( signed short ); 
 			break; 
 
 		case VIPS_FORMAT_UINT: 
-      VIPS_FLATTEN_FLOAT( unsigned int ); 
+			VIPS_FLATTEN_FLOAT( unsigned int ); 
 			break; 
 
 		case VIPS_FORMAT_INT: 
-      VIPS_FLATTEN_FLOAT( signed int ); 
+			VIPS_FLATTEN_FLOAT( signed int ); 
 			break; 
 
 		case VIPS_FORMAT_FLOAT: 

--- a/libvips/conversion/flatten.c
+++ b/libvips/conversion/flatten.c
@@ -81,9 +81,21 @@ typedef VipsConversionClass VipsFlattenClass;
 
 G_DEFINE_TYPE( VipsFlatten, vips_flatten, VIPS_TYPE_CONVERSION );
 
+/* Cast down from an int.
+ */
+#define CAST_UCHAR( X ) VIPS_CLIP( 0, (X), UCHAR_MAX )
+#define CAST_CHAR( X ) VIPS_CLIP( SCHAR_MIN, (X), SCHAR_MAX )
+#define CAST_USHORT( X ) VIPS_CLIP( 0, (X), USHRT_MAX )
+#define CAST_SHORT( X ) VIPS_CLIP( SHRT_MIN, (X), SHRT_MAX )
+
+/* These cast down from gint64 to uint32 or int32. 
+ */
+#define CAST_UINT( X ) VIPS_CLIP( 0, (X), UINT_MAX )
+#define CAST_INT( X ) VIPS_CLIP( INT_MIN, (X), INT_MAX )
+
 /* Flatten with black background.
  */
-#define VIPS_FLATTEN_BLACK( TYPE ) { \
+#define VIPS_FLATTEN_BLACK_INT( TYPE, CAST ) { \
 	TYPE * restrict p = (TYPE *) in; \
 	TYPE * restrict q = (TYPE *) out; \
 	\
@@ -92,15 +104,14 @@ G_DEFINE_TYPE( VipsFlatten, vips_flatten, VIPS_TYPE_CONVERSION );
 		int b; \
 		\
 		for( b = 0; b < bands - 1; b++ ) \
-			q[b] = (p[b] * alpha) / max_alpha; \
+			q[b] = CAST( ((double) p[b] * alpha) / max_alpha ); \
 		\
 		p += bands; \
 		q += bands - 1; \
 	} \
 }
 
-/* Same, but with float arithmetic. Necessary for short/int to prevent
- * overflow.
+/* Same, but with float arithmetic.
  */
 #define VIPS_FLATTEN_BLACK_FLOAT( TYPE ) { \
 	TYPE * restrict p = (TYPE *) in; \
@@ -120,7 +131,7 @@ G_DEFINE_TYPE( VipsFlatten, vips_flatten, VIPS_TYPE_CONVERSION );
 
 /* Flatten with any background.
  */
-#define VIPS_FLATTEN( TYPE ) { \
+#define VIPS_FLATTEN_INT( TYPE, CAST ) { \
 	TYPE * restrict p = (TYPE *) in; \
 	TYPE * restrict q = (TYPE *) out; \
 	\
@@ -131,7 +142,8 @@ G_DEFINE_TYPE( VipsFlatten, vips_flatten, VIPS_TYPE_CONVERSION );
 		int b; \
 		\
 		for( b = 0; b < bands - 1; b++ ) \
-			q[b] = (p[b] * alpha + bg[b] * nalpha) / max_alpha; \
+			q[b] = CAST( ((double) p[b] * alpha + \
+				(double) bg[b] * nalpha) / max_alpha ); \
 		\
 		p += bands; \
 		q += bands - 1; \
@@ -179,27 +191,27 @@ vips_flatten_black_gen( VipsRegion *or, void *vseq, void *a, void *b,
 
 		switch( flatten->in->BandFmt ) { 
 		case VIPS_FORMAT_UCHAR: 
-			VIPS_FLATTEN_BLACK( unsigned char ); 
+			VIPS_FLATTEN_BLACK_INT( unsigned char, CAST_UCHAR ); 
 			break; 
 
 		case VIPS_FORMAT_CHAR: 
-			VIPS_FLATTEN_BLACK( signed char ); 
+			VIPS_FLATTEN_BLACK_INT( signed char, CAST_CHAR ); 
 			break; 
 
 		case VIPS_FORMAT_USHORT: 
-			VIPS_FLATTEN_BLACK_FLOAT( unsigned short ); 
+			VIPS_FLATTEN_BLACK_INT( unsigned short, CAST_USHORT ); 
 			break; 
 
 		case VIPS_FORMAT_SHORT: 
-			VIPS_FLATTEN_BLACK_FLOAT( signed short ); 
+			VIPS_FLATTEN_BLACK_INT( signed short, CAST_SHORT ); 
 			break; 
 
 		case VIPS_FORMAT_UINT: 
-			VIPS_FLATTEN_BLACK_FLOAT( unsigned int ); 
+			VIPS_FLATTEN_BLACK_INT( unsigned int, CAST_UINT ); 
 			break; 
 
 		case VIPS_FORMAT_INT: 
-			VIPS_FLATTEN_BLACK_FLOAT( signed int ); 
+			VIPS_FLATTEN_BLACK_INT( signed int, CAST_INT ); 
 			break; 
 
 		case VIPS_FORMAT_FLOAT: 
@@ -244,27 +256,27 @@ vips_flatten_gen( VipsRegion *or, void *vseq, void *a, void *b,
 
 		switch( flatten->in->BandFmt ) { 
 		case VIPS_FORMAT_UCHAR: 
-			VIPS_FLATTEN( unsigned char ); 
+			VIPS_FLATTEN_INT( unsigned char, CAST_UCHAR ); 
 			break; 
 
 		case VIPS_FORMAT_CHAR: 
-			VIPS_FLATTEN( signed char ); 
+			VIPS_FLATTEN_INT( signed char, CAST_CHAR ); 
 			break; 
 
 		case VIPS_FORMAT_USHORT: 
-			VIPS_FLATTEN_FLOAT( unsigned short ); 
+			VIPS_FLATTEN_INT( unsigned short, CAST_USHORT ); 
 			break; 
 
 		case VIPS_FORMAT_SHORT: 
-			VIPS_FLATTEN_FLOAT( signed short ); 
+			VIPS_FLATTEN_INT( signed short, CAST_SHORT ); 
 			break; 
 
 		case VIPS_FORMAT_UINT: 
-			VIPS_FLATTEN_FLOAT( unsigned int ); 
+			VIPS_FLATTEN_INT( unsigned int, CAST_UINT ); 
 			break; 
 
 		case VIPS_FORMAT_INT: 
-			VIPS_FLATTEN_FLOAT( signed int ); 
+			VIPS_FLATTEN_INT( signed int, CAST_INT ); 
 			break; 
 
 		case VIPS_FORMAT_FLOAT: 

--- a/libvips/foreign/heifload.c
+++ b/libvips/foreign/heifload.c
@@ -279,7 +279,11 @@ static int
 vips_foreign_load_heif_is_a( const char *buf, int len )
 {
 	if( len >= 12 ) {
-		const guint chunk_len = GUINT_FROM_BE( *((guint32 *) buf) );
+		const guint32 chunk_len = 
+			(guint32) buf[0] << 24 |
+			(guint32) buf[1] << 16 |
+			(guint32) buf[2] << 8 |
+			(guint32) buf[3];
 
 		int i;
 


### PR DESCRIPTION
As discussed in https://github.com/libvips/libvips/pull/1727#issuecomment-660932493. Commit 81132311674ea54061bb5c2e36db9a2fe8fee19d fixes this error<sup>1</sup>:
```
Running: common_fuzzer_corpus/smartcrop_fuzzer-5687924892368896
mosaic_fuzzer.cc:47:56: runtime error: member access within misaligned address 0x60b0000004c3 for type 'struct mosaic_opt', which requires 2 byte alignment
```
https://travis-ci.org/github/kleisauke/libvips/jobs/709752013#L2599

Commit 1dd6698464584893e0da5e83378799a8b3f58caf fixes this error:
```
Running: common_fuzzer_corpus/sharpen_fuzzer-5678720198639616
scRGB2sRGB.c:114:11: runtime error: 8224 is outside the range of representable values of type 'unsigned char'
```
https://travis-ci.org/github/kleisauke/libvips/jobs/709752013#L2315

Commit 1a6854a6d3678b033c37bfb2b60db876e7022d4b fixes this error<sup>2</sup>: 
```
Running: common_fuzzer_corpus/jpegsave_buffer_fuzzer-5658586599915520
flatten.c:190:4: runtime error: 1.64485e+07 is outside the range of representable values of type 'unsigned short'
```
https://travis-ci.org/github/kleisauke/libvips/jobs/709752013#L2270

And the last commit (b8f18e119cc4b85c2b7749ae9aaa8a36cc457f44) fixes this error: 
```
Running: common_fuzzer_corpus/jpegsave_buffer_fuzzer-5658586599915520
heifload.c:282:27: runtime error: load of misaligned address 0x60f000000229 for type 'guint32' (aka 'unsigned int'), which requires 4 byte alignment
```
https://github.com/libvips/libvips/runs/3554490177#step:13:366

Marked this PR as draft due to these endnotes:
- [x] <sup>1</sup>: but also changes the way how `vips_mosaic` is fuzzed (i.e. by separating the fuzzer parameters from the image), so perhaps we need to regenerate the existing corpus?
- [x] <sup>2</sup>: this was copied-pasted from `vips_cast`, I'm not sure if there's a better way to fix this?