### PR TITLE
Remove redundant -lstdc++ configure check

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -141,24 +141,6 @@ AM_CONDITIONAL(ENABLE_DEPRECATED, [test x"$enable_deprecated" = x"yes"])
 # this gets pasted into version.h as a #define
 AC_SUBST(VIPS_ENABLE_DEPRECATED)
 
-# we are a C library with some optional C++ components inside it
-
-# on most platforms, but not all, we just include -lstdc++ in the link line 
-# for programs
-
-# we ought to have a proper configure test for this :( 
-
-AC_MSG_CHECKING([for needs -lstdc++])
-case "$host_os" in
-  freebsd*)
-    vips_needs_stdcpp=no
-    ;;
-  *)
-    vips_needs_stdcpp=yes
-    ;;
-esac
-AC_MSG_RESULT([$vips_needs_stdcpp])
-
 AC_MSG_CHECKING([for native Win32])
 case "$host" in
   *-*-mingw*)


### PR DESCRIPTION
This became unused after commit 346a9e7.