### PR TITLE
svgload: remove was-deprecated, now-removed librsvg-features.h include

### DIFF
--- a/libvips/foreign/svgload.c
+++ b/libvips/foreign/svgload.c
@@ -80,13 +80,6 @@
  */
 #define RSVG_MAX_WIDTH (32767)
 
-/* Old librsvg versions don't include librsvg-features.h by default.
- * Newer versions deprecate direct inclusion.
- */
-#ifndef LIBRSVG_FEATURES_H
-#include <librsvg/librsvg-features.h>
-#endif
-
 /* A handy #define for we-will-handle-svgz.
  */
 #if LIBRSVG_CHECK_FEATURE(SVGZ) && defined(HAVE_ZLIB)


### PR DESCRIPTION
libvips 8.10.x requires librsvg >=2.40.3
https://github.com/libvips/libvips/blob/8.10/configure.ac#L911

librsvg >=2.40.3 <2.51.0 includes `librsvg-features.h` for you
https://github.com/GNOME/librsvg/blob/2.40.3/rsvg.h#L259

...plus displays a deprecation warning when included directly
https://github.com/GNOME/librsvg/blob/2.40.3/librsvg-features.h.in#L2

librsvg >=2.51.0 removes it entirely
https://github.com/GNOME/librsvg/commit/b8c8756a0e8148afb2752acb62f06c57c917e4b4
