### PR TITLE
Set minimum glib-2.0 dependency version of 2.40 (March 2014)

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -429,18 +429,8 @@ AC_CHECK_LIB(m,hypot,[AC_DEFINE(HAVE_HYPOT,1,[have hypot() in libm.])])
 AC_CHECK_LIB(m,atan2,[AC_DEFINE(HAVE_ATAN2,1,[have atan2() in libm.])])
 
 # have to have these parts of glib ... we need glib 2.15 for gio
-PKG_CHECK_MODULES(REQUIRED, glib-2.0 >= 2.15 gmodule-2.0 gobject-2.0 gio-2.0)
+PKG_CHECK_MODULES(REQUIRED, glib-2.0 >= 2.40 gmodule-2.0 gobject-2.0 gio-2.0)
 PACKAGES_USED="$PACKAGES_USED glib-2.0 gmodule-2.0 gobject-2.0 gio-2.0"
-
-# from 2.28 we have a monotonic timer
-PKG_CHECK_MODULES(MONOTONIC_TIME, glib-2.0 >= 2.28,
-  [AC_DEFINE(HAVE_MONOTONIC_TIME,1,
-	    [define if your glib has g_get_monotonic_time().]
-   )
-  ],
-  [:
-  ]
-)
 
 # from 2.62 we have datetime
 PKG_CHECK_MODULES(DATE_TIME_FORMAT_ISO8601, glib-2.0 >= 2.62,
@@ -449,22 +439,6 @@ PKG_CHECK_MODULES(DATE_TIME_FORMAT_ISO8601, glib-2.0 >= 2.62,
    )
   ],
   [:
-  ]
-)
-
-# from 2.32 there are a new set of thread functions, it is no longer
-# necessary to use g_thread_init() or to link against libgthread
-PKG_CHECK_MODULES(THREADS, glib-2.0 >= 2.32,
-  [AC_DEFINE(HAVE_MUTEX_INIT,1,[define if your glib has g_mutex_init().])
-   AC_DEFINE(HAVE_COND_INIT,1,[define if your glib has g_cond_init().])
-   AC_DEFINE(HAVE_THREAD_NEW,1,[define if your glib has g_thread_new().])
-   AC_DEFINE(HAVE_PRIVATE_INIT,1,[define if your glib has G_PRIVATE_INIT().])
-   AC_DEFINE(HAVE_VALUE_GET_SCHAR,1,
-	     [define if your glib has g_value_get_schar().]
-   )
-  ],
-  [PKG_CHECK_MODULES(GTHREAD, gthread-2.0)
-   PACKAGES_USED="$PACKAGES_USED gthread-2.0"
   ]
 )
 
@@ -482,32 +456,10 @@ AC_CHECK_FUNC(pthread_setattr_default_np,
 LIBS="$save_pthread_LIBS"
 CFLAGS="$save_pthread_CFLAGS"
 
-# from 2.36 the type system inits itself
-PKG_CHECK_MODULES(TYPE_INIT, glib-2.0 < 2.36,
-  [AC_DEFINE(HAVE_TYPE_INIT,1,[define if your glib needs g_type_init().])
-  ],
-  [:
-  ]
-)
-
-# from 2.40, on win32 we have g_win32_get_command_line() 
-PKG_CHECK_MODULES(WIN32_GET_COMMAND_LINE, glib-2.0 >= 2.40,
-  [if test x"$vips_os_win32" = x"yes"; then
-     AC_DEFINE(HAVE_G_WIN32_GET_COMMAND_LINE,1,[define if your glib has g_win32_get_command_line().])
-     have_g_win32_get_command_line=yes
-   fi
-  ],
-  [:
-  ]
-)
-
-# from 2.40, have g_str_to_ascii()
-PKG_CHECK_MODULES(STR_TO_ASCII, glib-2.0 >= 2.40,
-  [AC_DEFINE(HAVE_G_STR_TO_ASCII,1,[define if your glib has g_str_to_ascii().])
-  ],
-  [:
-  ]
-)
+if test x"$vips_os_win32" = x"yes"; then
+  AC_DEFINE(HAVE_G_WIN32_GET_COMMAND_LINE,1,[define if your glib has g_win32_get_command_line().])
+  have_g_win32_get_command_line=yes
+fi
 
 # from 2.48 we have g_uint_checked_mul() etc.
 PKG_CHECK_MODULES(HAVE_CHECKED_MUL, glib-2.0 >= 2.48,

--- a/libvips/foreign/exif.c
+++ b/libvips/foreign/exif.c
@@ -845,21 +845,16 @@ vips_exif_set_string_encoding( ExifData *ed,
 	ExifEntry *entry, unsigned long component, const char *data )
 {
 	char *str;
+	char *ascii;
 	int len;
 
 	str = drop_tail( data );
 
 	/* libexif can only really save ASCII to things like UserComment.
 	 */
-#ifdef HAVE_G_STR_TO_ASCII
-{
-	char *ascii;
-
 	ascii = g_str_to_ascii( str, NULL );
 	g_free( str );
 	str = ascii;
-}
-#endif /*HAVE_G_STR_TO_ASCII*/
 
 	/* libexif comment strings are not NULL-terminated, and have an 
 	 * encoding tag (always ASCII) in the first 8 bytes.
@@ -880,21 +875,16 @@ vips_exif_set_string_ascii( ExifData *ed,
 	ExifEntry *entry, unsigned long component, const char *data )
 {
 	char *str;
+	char *ascii;
 	int len;
 
 	str = drop_tail( data );
 
 	/* libexif can only really save ASCII to things like UserComment.
 	 */
-#ifdef HAVE_G_STR_TO_ASCII
-{
-	char *ascii;
-
 	ascii = g_str_to_ascii( str, NULL );
 	g_free( str );
 	str = ascii;
-}
-#endif /*HAVE_G_STR_TO_ASCII*/
 
 	/* ASCII strings are NULL-terminated.
 	 */

--- a/libvips/iofuncs/buffer.c
+++ b/libvips/iofuncs/buffer.c
@@ -658,16 +658,10 @@ buffer_thread_destroy_notify( VipsBufferThread *buffer_thread )
 void
 vips__buffer_init( void )
 {
-#ifdef HAVE_PRIVATE_INIT
 	static GPrivate private = 
 		G_PRIVATE_INIT( (GDestroyNotify) buffer_thread_destroy_notify );
 
 	buffer_thread_key = &private;
-#else
-	if( !buffer_thread_key ) 
-		buffer_thread_key = g_private_new( 
-			(GDestroyNotify) buffer_thread_destroy_notify );
-#endif
 
 	if( buffer_cache_max_reserve < 1 )
 		printf( "vips__buffer_init: buffer reserve disabled\n" );

--- a/libvips/iofuncs/cache.c
+++ b/libvips/iofuncs/cache.c
@@ -111,14 +111,6 @@ static GMutex *vips_cache_lock = NULL;
 #define INT64_HASH(X) (g_direct_hash(X))
 #define DOUBLE_HASH(X) (g_direct_hash(X))
 
-/* Old glibs use g_value_get_char(), new ones g_value_get_schar().
- */
-#ifdef HAVE_VALUE_GET_SCHAR
-#define VIPS_VALUE_GET_CHAR g_value_get_schar
-#else 
-#define VIPS_VALUE_GET_CHAR g_value_get_char
-#endif 
-
 /* A cache entry.
  */
 typedef struct _VipsOperationCacheEntry {
@@ -156,7 +148,7 @@ vips_value_hash( GParamSpec *pspec, GValue *value )
 	if( generic == G_TYPE_PARAM_BOOLEAN )
 		return( (unsigned int) g_value_get_boolean( value ) );
 	else if( generic == G_TYPE_PARAM_CHAR )
-		return( (unsigned int) VIPS_VALUE_GET_CHAR( value ) );
+		return( (unsigned int) g_value_get_schar( value ) );
 	else if( generic == G_TYPE_PARAM_UCHAR )
 		return( (unsigned int) g_value_get_uchar( value ) );
 	else if( generic == G_TYPE_PARAM_INT )
@@ -258,8 +250,8 @@ vips_value_equal( GParamSpec *pspec, GValue *v1, GValue *v2 )
 		return( g_value_get_boolean( v1 ) == 
 			g_value_get_boolean( v2 ) );
 	else if( generic == G_TYPE_PARAM_CHAR ) 
-		return( VIPS_VALUE_GET_CHAR( v1 ) ==
-			VIPS_VALUE_GET_CHAR( v2 ) );
+		return( g_value_get_schar( v1 ) ==
+			g_value_get_schar( v2 ) );
 	if( generic == G_TYPE_PARAM_UCHAR ) 
 		return( g_value_get_uchar( v1 ) ==
 			g_value_get_uchar( v2 ) );

--- a/libvips/iofuncs/gate.c
+++ b/libvips/iofuncs/gate.c
@@ -213,16 +213,10 @@ vips__thread_profile_init_cb( VipsThreadProfile *profile )
 static void *
 vips__thread_profile_init( void *data )
 {
-#ifdef HAVE_PRIVATE_INIT
 	static GPrivate private = 
 		G_PRIVATE_INIT( (GDestroyNotify) vips__thread_profile_init_cb );
 
 	vips_thread_profile_key = &private;
-#else
-	if( !vips_thread_profile_key ) 
-		vips_thread_profile_key = g_private_new( 
-			(GDestroyNotify) vips__thread_profile_init_cb );
-#endif
 
 	return( NULL );
 }
@@ -300,20 +294,6 @@ vips_thread_gate_block_add( VipsThreadGateBlock **block )
 	*block = new_block;
 }
 
-static gint64
-vips_get_time( void )
-{
-#ifdef HAVE_MONOTONIC_TIME
-	return( g_get_monotonic_time() );  
-#else
-	GTimeVal time;
-
-	g_get_current_time( &time );
-
-	return( (gint64) time.tv_usec ); 
-#endif
-}
-
 void
 vips__thread_gate_start( const char *gate_name )
 {
@@ -322,7 +302,7 @@ vips__thread_gate_start( const char *gate_name )
 	VIPS_DEBUG_MSG_RED( "vips__thread_gate_start: %s\n", gate_name ); 
 
 	if( (profile = vips_thread_profile_get()) ) { 
-		gint64 time = vips_get_time(); 
+		gint64 time = g_get_monotonic_time();
 
 		VipsThreadGate *gate;
 
@@ -350,7 +330,7 @@ vips__thread_gate_stop( const char *gate_name )
 	VIPS_DEBUG_MSG_RED( "vips__thread_gate_stop: %s\n", gate_name ); 
 
 	if( (profile = vips_thread_profile_get()) ) { 
-		gint64 time = vips_get_time(); 
+		gint64 time = g_get_monotonic_time();
 
 		VipsThreadGate *gate;
 
@@ -385,7 +365,7 @@ vips__thread_malloc_free( gint64 size )
 #endif /*VIPS_DEBUG*/
 
 	if( (profile = vips_thread_profile_get()) ) { 
-		gint64 time = vips_get_time(); 
+		gint64 time = g_get_monotonic_time();
 		VipsThreadGate *gate = profile->memory;
 
 		if( gate->start->i >= VIPS_GATE_SIZE ) {

--- a/libvips/iofuncs/init.c
+++ b/libvips/iofuncs/init.c
@@ -417,19 +417,6 @@ vips_init( const char *argv0 )
 	(void) _setmaxstdio( 2048 );
 #endif /*OS_WIN32*/
 
-#ifdef HAVE_TYPE_INIT
-	/* Before glib 2.36 you have to call this on startup.
-	 */
-	g_type_init();
-#endif /*HAVE_TYPE_INIT*/
-
-	/* Older glibs need this.
-	 */
-#ifndef HAVE_THREAD_NEW
-	if( !g_thread_supported() ) 
-		g_thread_init( NULL );
-#endif /*HAVE_THREAD_NEW*/
-
 	vips__threadpool_init();
 	vips__buffer_init();
 	vips__meta_init();

--- a/libvips/iofuncs/threadpool.c
+++ b/libvips/iofuncs/threadpool.c
@@ -129,12 +129,8 @@ vips_g_mutex_new( void )
 {
 	GMutex *mutex;
 
-#ifdef HAVE_MUTEX_INIT
 	mutex = g_new( GMutex, 1 );
 	g_mutex_init( mutex );
-#else
-	mutex = g_mutex_new();
-#endif
 
 	return( mutex );
 }
@@ -142,12 +138,8 @@ vips_g_mutex_new( void )
 void
 vips_g_mutex_free( GMutex *mutex )
 {
-#ifdef HAVE_MUTEX_INIT
 	g_mutex_clear( mutex );
 	g_free( mutex );
-#else
-	g_mutex_free( mutex );
-#endif
 }
 
 GCond *
@@ -155,12 +147,8 @@ vips_g_cond_new( void )
 {
 	GCond *cond;
 
-#ifdef HAVE_COND_INIT
 	cond = g_new( GCond, 1 );
 	g_cond_init( cond );
-#else
-	cond = g_cond_new();
-#endif
 
 	return( cond );
 }
@@ -168,12 +156,8 @@ vips_g_cond_new( void )
 void
 vips_g_cond_free( GCond *cond )
 {
-#ifdef HAVE_COND_INIT
 	g_cond_clear( cond );
 	g_free( cond );
-#else
-	g_cond_free( cond );
-#endif
 }
 
 /* TRUE if we are a vips worker thread. We sometimes manage resource allocation
@@ -239,11 +223,7 @@ vips_g_thread_new( const char *domain, GThreadFunc func, gpointer data )
 	else {
 #endif /*DEBUG_OUT_OF_THREADS*/
 
-#ifdef HAVE_THREAD_NEW
 	thread = g_thread_try_new( domain, vips_thread_run, info, &error );
-#else
-	thread = g_thread_create( vips_thread_run, info, TRUE, &error );
-#endif
 
 	VIPS_DEBUG_MSG_RED( "vips_g_thread_new: g_thread_create( %s ) = %p\n",
 		domain, thread );
@@ -1015,16 +995,9 @@ vips_threadpool_run( VipsImage *im,
 void
 vips__threadpool_init( void )
 {
-	/* We need to work with the pre-2.32 threading API.
-	 */
-#ifdef HAVE_PRIVATE_INIT
 	static GPrivate private = { 0 }; 
 
 	is_worker_key = &private;
-#else
-	if( !is_worker_key ) 
-		is_worker_key = g_private_new( NULL ); 
-#endif
 
 	if( g_getenv( "VIPS_STALL" ) )
 		vips__stall = TRUE;


### PR DESCRIPTION
This does mean libvips 8.11.0 will drop support for RHEL6 (glib 2.28.8), but that reached EOL in November 2020.