### PR TITLE
Compress fallback colour profiles with zlib (zopfli, via pigz)

### DIFF
--- a/libvips/colour/wrap-profiles.sh
+++ b/libvips/colour/wrap-profiles.sh
@@ -15,7 +15,7 @@ echo "#include \"profiles.h\"" >> $out
 echo "" >> $out
 
 profile_names=
-for file in $in/*; do 
+for file in $in/*.icm; do
   root=${file%.icm}
   base=${root##*/} 
   profile_name=vips__profile_fallback_$base
@@ -24,7 +24,7 @@ for file in $in/*; do
   echo "    \"$base\"," >> $out
   echo "    $(stat --format=%s $file)," >> $out
   echo "    {" >> $out
-  hexdump -v -e '" 0x" 1/1 "%02X,"' $file | fmt >> $out
+  pigz -c -z -11 $file | hexdump -v -e '" 0x" 1/1 "%02X,"' | fmt >> $out
   echo "    }" >> $out
   echo "};" >> $out
   echo  >> $out


### PR DESCRIPTION
At runtime, this change decompresses colour profiles on the fly, as required. This reduces the shared library binary size (and therefore memory consumption) by 580KB, which at `-O2` represents a 17% saving.

Before:
```
5892519 profiles.c
3362808 libvips.so.42.13.0
```

After:
```
2360469 profiles.c
2782232 libvips.so.42.13.0
```

I'm unsure if the existing libvips test suite covers this, but the sharp tests do and they pass.