### PR TITLE
Add tiff zstd predictor support

### DIFF
--- a/libvips/foreign/tiffsave.c
+++ b/libvips/foreign/tiffsave.c
@@ -590,8 +590,8 @@ vips_foreign_save_tiff_buffer_init( VipsForeignSaveTiffBuffer *buffer )
  * User @level to set the ZSTD compression level. Use @lossless to
  * set WEBP lossless mode on. Use @Q to set the WEBP compression level.
  *
- * Use @predictor to set the predictor for lzw and deflate compression. It
- * defaults to #VIPS_FOREIGN_TIFF_PREDICTOR_HORIZONTAL, meaning horizontal
+ * Use @predictor to set the predictor for lzw, deflate and zstd compression.
+ * It defaults to #VIPS_FOREIGN_TIFF_PREDICTOR_HORIZONTAL, meaning horizontal
  * differencing. Please refer to the libtiff 
  * specifications for further discussion of various predictors. 
  *

--- a/libvips/foreign/vips2tiff.c
+++ b/libvips/foreign/vips2tiff.c
@@ -659,8 +659,13 @@ wtiff_write_header( Wtiff *wtiff, Layer *layer )
 		TIFFSetField( tif, TIFFTAG_WEBP_LEVEL, wtiff->Q );
 		TIFFSetField( tif, TIFFTAG_WEBP_LOSSLESS, wtiff->lossless );
 	}
-	if( wtiff->compression == COMPRESSION_ZSTD ) 
+	if( wtiff->compression == COMPRESSION_ZSTD ) {
 		TIFFSetField( tif, TIFFTAG_ZSTD_LEVEL, wtiff->level );
+
+		if( wtiff->predictor != VIPS_FOREIGN_TIFF_PREDICTOR_NONE )
+			TIFFSetField( tif, TIFFTAG_PREDICTOR,
+				wtiff->predictor );
+	}
 #endif /*HAVE_TIFF_COMPRESSION_WEBP*/
 
 	if( (wtiff->compression == COMPRESSION_ADOBE_DEFLATE ||
@@ -1862,8 +1867,13 @@ wtiff_copy_tiff( Wtiff *wtiff, TIFF *out, TIFF *in )
 		TIFFSetField( out, TIFFTAG_WEBP_LEVEL, wtiff->Q );
 		TIFFSetField( out, TIFFTAG_WEBP_LOSSLESS, wtiff->lossless );
 	}
-	if( wtiff->compression == COMPRESSION_ZSTD ) 
+	if( wtiff->compression == COMPRESSION_ZSTD ) {
 		TIFFSetField( out, TIFFTAG_ZSTD_LEVEL, wtiff->level );
+
+		if( wtiff->predictor != VIPS_FOREIGN_TIFF_PREDICTOR_NONE )
+			TIFFSetField( out, TIFFTAG_PREDICTOR,
+				wtiff->predictor );
+	}
 #endif /*HAVE_TIFF_COMPRESSION_WEBP*/
 
 	if( (wtiff->compression == COMPRESSION_ADOBE_DEFLATE ||


### PR DESCRIPTION
Hi, thank you for the quickly fix to #2128. And based on that I tried to make `--predictor` also available to ZSTD compression in tiff.

Before the commit, `vips` cannot set `predictor` on ZSTD compressed TIFF:
![Screenshot from 2021-03-04 23-41-58](https://user-images.githubusercontent.com/62105/109991293-290f0e00-7d45-11eb-8e6e-4b4ff9c7d267.png)

By this commit, `vips` now can set `predictor` on ZSTD TIFF:
![Screenshot from 2021-03-04 23-37-30](https://user-images.githubusercontent.com/62105/109991555-5f4c8d80-7d45-11eb-9c38-f649fe616b18.png)