### PR TITLE
Cleanup configure.ac and #ifdef's

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -141,69 +141,35 @@ AM_CONDITIONAL(ENABLE_DEPRECATED, [test x"$enable_deprecated" = x"yes"])
 # this gets pasted into version.h as a #define
 AC_SUBST(VIPS_ENABLE_DEPRECATED)
 
-AC_MSG_CHECKING([for native Win32])
-case "$host" in
-  *-*-mingw*)
-    vips_os_win32=yes
-    ;;
-  *)
-    vips_os_win32=no
-    ;;
-esac
-AC_MSG_RESULT([$vips_os_win32])
-
-if test x"$vips_os_win32" = x"yes"; then
-  AC_DEFINE(OS_WIN32,1,[native win32])
-
-  # makes gcc use win native alignment
-  VIPS_CFLAGS="-mms-bitfields $VIPS_CFLAGS"
-fi
-
-# CImg needs flags changed on win32
-AM_CONDITIONAL(OS_WIN32, [test x"$vips_os_win32" = x"yes"])
-
-# Cygwin/mingw need binary open to avoid CR/LF madness
-# ... should be a better way to test for this
-AC_MSG_CHECKING([for binary open needed])
+AC_MSG_CHECKING([for -mms-bitfields support])
 case "$host_os" in
-  cygwin* | mingw*)
-    vips_binary_open=yes
+  mingw*)
+    # makes gcc use win native alignment
+    # GCC >= 4.7 and Clang >= 11 does this automatically, see:
+    # https://gitlab.gnome.org/GNOME/glib/-/merge_requests/1510#note_841637
+    VIPS_CFLAGS="-mms-bitfields $VIPS_CFLAGS"
+    AC_MSG_RESULT([yes])
     ;;
   *)
-    vips_binary_open=no
+    AC_MSG_RESULT([no])
     ;;
 esac
-AC_MSG_RESULT([$vips_binary_open])
-if test x"$vips_binary_open" = x"yes"; then
-  AC_DEFINE(BINARY_OPEN,1,[define to open non-text files in binary mode])
-fi
-
-AC_MSG_CHECKING([for Mac OS X])
-case "$host" in
-  *-*-darwin*)
-    vips_os_darwin=yes
-    ;;
-  *)
-    vips_os_darwin=no
-    ;;
-esac
-AC_MSG_RESULT([$vips_os_darwin])
-
-if test x"$vips_os_darwin" = x"yes"; then
-  AC_DEFINE(VIPS_OS_DARWIN,1,[native Mac OS X])
-fi
 
 # set the default directory for ICC profiles
-if test x"$vips_os_darwin" = x"yes"; then
-  profile_dir="/Library/ColorSync/Profiles"
-elif test x"$vips_os_win32" = x"yes"; then
-  # need double escapes since this will get pasted into a #define in a C
-  # header ... the C:\Windows is usually overrwritten with the result of
-  # GetWindowsDirectoryW()
-  profile_dir="C:\\\\Windows\\\\System32\\\\spool\\\\drivers\\\\color"
-else
-  profile_dir="/usr/share/color/icc"
-fi
+case "$host_os" in
+  darwin*)
+    profile_dir="/Library/ColorSync/Profiles"
+    ;;
+  mingw*)
+    # need double escapes since this will get pasted into a #define in a C
+    # header ... the C:\Windows is usually overwritten with the result of
+    # GetWindowsDirectoryW()
+    profile_dir="C:\\\\Windows\\\\System32\\\\spool\\\\drivers\\\\color"
+    ;;
+  *)
+    profile_dir="/usr/share/color/icc"
+    ;;
+esac
 AC_DEFINE_UNQUOTED(VIPS_ICC_DIR,"$profile_dir",[default directory for ICC profiles])
 
 # we want largefile support, if possible
@@ -447,19 +413,14 @@ PKG_CHECK_MODULES(DATE_TIME_FORMAT_ISO8601, glib-2.0 >= 2.62,
 # thread by default
 save_pthread_LIBS="$LIBS"
 save_pthread_CFLAGS="$CFLAGS"
-LIBS="$LIBS $GTHREAD_LIBS"
-CFLAGS="$CFLAGS $GTHREAD_CFLAGS"
+LIBS="$LIBS $REQUIRED_LIBS"
+CFLAGS="$CFLAGS $REQUIRED_CFLAGS"
 AC_CHECK_FUNC(pthread_setattr_default_np,
   [AC_DEFINE(HAVE_PTHREAD_DEFAULT_NP,1,[have pthread_setattr_default_np().])
   ]
 )
 LIBS="$save_pthread_LIBS"
 CFLAGS="$save_pthread_CFLAGS"
-
-if test x"$vips_os_win32" = x"yes"; then
-  AC_DEFINE(HAVE_G_WIN32_GET_COMMAND_LINE,1,[define if your glib has g_win32_get_command_line().])
-  have_g_win32_get_command_line=yes
-fi
 
 # from 2.48 we have g_uint_checked_mul() etc.
 PKG_CHECK_MODULES(HAVE_CHECKED_MUL, glib-2.0 >= 2.48,
@@ -1231,13 +1192,13 @@ if test x"$LIB_FUZZING_ENGINE" = x; then
 fi
 
 # Gather all up for VIPS_CFLAGS, VIPS_INCLUDES, VIPS_LIBS
-VIPS_CFLAGS="$VIPS_CFLAGS $GTHREAD_CFLAGS $GIO_CFLAGS $REQUIRED_CFLAGS $EXPAT_CFLAGS $ZLIB_CFLAGS $PANGOFT2_CFLAGS $GSF_CFLAGS $FFTW_CFLAGS $MAGICK_CFLAGS $JPEG_CFLAGS $SPNG_CFLAGS $PNG_CFLAGS $IMAGEQUANT_CFLAGS $EXIF_CFLAGS $MATIO_CFLAGS $CFITSIO_CFLAGS $LIBWEBP_CFLAGS $LIBWEBPMUX_CFLAGS $GIFLIB_INCLUDES $RSVG_CFLAGS $PDFIUM_CFLAGS $POPPLER_CFLAGS $OPENEXR_CFLAGS $OPENSLIDE_CFLAGS $ORC_CFLAGS $TIFF_CFLAGS $LCMS_CFLAGS $HEIF_CFLAGS" VIPS_CFLAGS="$VIPS_DEBUG_FLAGS $VIPS_CFLAGS"
+VIPS_CFLAGS="$VIPS_CFLAGS $GIO_CFLAGS $REQUIRED_CFLAGS $EXPAT_CFLAGS $ZLIB_CFLAGS $PANGOFT2_CFLAGS $GSF_CFLAGS $FFTW_CFLAGS $MAGICK_CFLAGS $JPEG_CFLAGS $SPNG_CFLAGS $PNG_CFLAGS $IMAGEQUANT_CFLAGS $EXIF_CFLAGS $MATIO_CFLAGS $CFITSIO_CFLAGS $LIBWEBP_CFLAGS $GIFLIB_INCLUDES $RSVG_CFLAGS $PDFIUM_CFLAGS $POPPLER_CFLAGS $OPENEXR_CFLAGS $OPENSLIDE_CFLAGS $ORC_CFLAGS $TIFF_CFLAGS $LCMS_CFLAGS $HEIF_CFLAGS" VIPS_CFLAGS="$VIPS_DEBUG_FLAGS $VIPS_CFLAGS"
 VIPS_INCLUDES="$ZLIB_INCLUDES $PNG_INCLUDES $TIFF_INCLUDES $JPEG_INCLUDES $NIFTI_INCLUDES" 
-VIPS_LIBS="$ZLIB_LIBS $HEIF_LIBS $MAGICK_LIBS $SPNG_LIBS $PNG_LIBS $IMAGEQUANT_LIBS $TIFF_LIBS $JPEG_LIBS $GTHREAD_LIBS $GIO_LIBS $REQUIRED_LIBS $EXPAT_LIBS $PANGOFT2_LIBS $GSF_LIBS $FFTW_LIBS $ORC_LIBS $LCMS_LIBS $GIFLIB_LIBS $RSVG_LIBS $NIFTI_LIBS $PDFIUM_LIBS $POPPLER_LIBS $OPENEXR_LIBS $OPENSLIDE_LIBS $CFITSIO_LIBS $LIBWEBP_LIBS $LIBWEBPMUX_LIBS $MATIO_LIBS $EXIF_LIBS -lm"
+VIPS_LIBS="$ZLIB_LIBS $HEIF_LIBS $MAGICK_LIBS $SPNG_LIBS $PNG_LIBS $IMAGEQUANT_LIBS $TIFF_LIBS $JPEG_LIBS $GIO_LIBS $REQUIRED_LIBS $EXPAT_LIBS $PANGOFT2_LIBS $GSF_LIBS $FFTW_LIBS $ORC_LIBS $LCMS_LIBS $GIFLIB_LIBS $RSVG_LIBS $NIFTI_LIBS $PDFIUM_LIBS $POPPLER_LIBS $OPENEXR_LIBS $OPENSLIDE_LIBS $CFITSIO_LIBS $LIBWEBP_LIBS $MATIO_LIBS $EXIF_LIBS -lm"
 
 # autoconf hates multi-line AC_SUBST so we have to have another copy of this
 # thing
-VIPS_CONFIG="native win32: $vips_os_win32, native OS X: $vips_os_darwin, open files in binary mode: $vips_binary_open, enable debug: $enable_debug, enable deprecated library components: $enable_deprecated, enable docs with gtkdoc: $enable_gtk_doc, gobject introspection: $found_introspection, enable radiance support: $with_radiance, enable analyze support: $with_analyze, enable PPM support: $with_ppm, generate C++ docs: $with_doxygen, use fftw3 for FFT: $with_fftw, Magick package: $with_magickpackage, Magick API version: $magick_version, load with libMagick: $enable_magickload, save with libMagick: $enable_magicksave, accelerate loops with orc: $with_orc, ICC profile support with lcms: $with_lcms, file import with niftiio: $with_nifti, file import with libheif: $with_heif, file import with OpenEXR: $with_OpenEXR, file import with OpenSlide: $with_openslide, file import with matio: $with_matio, PDF import with PDFium: $with_pdfium, PDF import with poppler-glib: $with_poppler, SVG import with librsvg-2.0: $with_rsvg, zlib: $with_zlib, file import with cfitsio: $with_cfitsio, file import/export with libwebp: $with_libwebp, text rendering with pangoft2: $with_pangoft2, file import/export with libspng: $with_libspng, file import/export with libpng: $with_png, support 8bpp PNG quantisation: $with_imagequant, file import/export with libtiff: $with_tiff, file import/export with giflib: $with_giflib, file import/export with libjpeg: $with_jpeg, image pyramid export: $with_gsf, use libexif to load/save JPEG metadata: $with_libexif"
+VIPS_CONFIG="enable debug: $enable_debug, enable deprecated library components: $enable_deprecated, enable docs with gtkdoc: $enable_gtk_doc, gobject introspection: $found_introspection, enable radiance support: $with_radiance, enable analyze support: $with_analyze, enable PPM support: $with_ppm, generate C++ docs: $with_doxygen, use fftw3 for FFT: $with_fftw, Magick package: $with_magickpackage, Magick API version: $magick_version, load with libMagick: $enable_magickload, save with libMagick: $enable_magicksave, accelerate loops with orc: $with_orc, ICC profile support with lcms: $with_lcms, file import with niftiio: $with_nifti, file import with libheif: $with_heif, file import with OpenEXR: $with_OpenEXR, file import with OpenSlide: $with_openslide, file import with matio: $with_matio, PDF import with PDFium: $with_pdfium, PDF import with poppler-glib: $with_poppler, SVG import with librsvg-2.0: $with_rsvg, zlib: $with_zlib, file import with cfitsio: $with_cfitsio, file import/export with libwebp: $with_libwebp, text rendering with pangoft2: $with_pangoft2, file import/export with libspng: $with_libspng, file import/export with libpng: $with_png, support 8bpp PNG quantisation: $with_imagequant, file import/export with libtiff: $with_tiff, file import/export with giflib: $with_giflib, file import/export with libjpeg: $with_jpeg, image pyramid export: $with_gsf, use libexif to load/save JPEG metadata: $with_libexif"
 
 AC_SUBST(VIPS_LIBDIR)
 
@@ -1301,9 +1262,6 @@ AC_OUTPUT
 # also add any new items to VIPS_CONFIG above
 AC_MSG_RESULT([dnl
 * build options
-native win32:				$vips_os_win32
-native OS X:				$vips_os_darwin
-open files in binary mode: 		$vips_binary_open
 enable debug:				$enable_debug
 enable deprecated library components:	$enable_deprecated
 enable docs with gtkdoc:		$enable_gtk_doc
@@ -1351,11 +1309,3 @@ image pyramid export:			$with_gsf
   (requires libgsf-1 1.14.26 or later)
 use libexif to load/save JPEG metadata: $with_libexif
 ])
-
-if test x"$vips_os_win32" = x"yes"; then
-  if test x"$have_g_win32_get_command_line" != x"yes"; then
-    AC_MSG_RESULT([dnl
-Your glib is too old, vips will not support unicode command-line arguments.
-    ])
-  fi
-fi

--- a/libvips/foreign/tiff.c
+++ b/libvips/foreign/tiff.c
@@ -104,7 +104,7 @@ vips__tiff_openout( const char *path, gboolean bigtiff )
 
 	/* Need the utf-16 version on Windows.
 	 */
-#ifdef OS_WIN32
+#ifdef G_OS_WIN32
 {
 	GError *error = NULL;
 	wchar_t *path16;
@@ -119,9 +119,9 @@ vips__tiff_openout( const char *path, gboolean bigtiff )
 
 	g_free( path16 );
 }
-#else /*!OS_WIN32*/
+#else /*!G_OS_WIN32*/
 	tif = TIFFOpen( path, mode );
-#endif /*OS_WIN32*/
+#endif /*G_OS_WIN32*/
 
 	if( !tif ) {
 		vips_error( "tiff",

--- a/libvips/include/vips/object.h
+++ b/libvips/include/vips/object.h
@@ -365,7 +365,6 @@ int vips_object_get_argument_priority( VipsObject *object, const char *name );
 	VIPS_ARGUMENT_COLLECT_END
  
  */
-#if GLIB_CHECK_VERSION( 2, 24, 0 )
 #define VIPS_ARGUMENT_COLLECT_SET( PSPEC, ARG_CLASS, AP ) \
 	if( (ARG_CLASS->flags & VIPS_ARGUMENT_INPUT) ) { \
 		GValue value = { 0, }; \
@@ -383,25 +382,6 @@ int vips_object_get_argument_priority( VipsObject *object, const char *name );
 			VIPS_DEBUG_MSG( "VIPS_OBJECT_COLLECT_SET: err\n" ); \
 			g_free( error ); \
 		}
-#else
-#define VIPS_ARGUMENT_COLLECT_SET( PSPEC, ARG_CLASS, AP ) \
-	if( (ARG_CLASS->flags & VIPS_ARGUMENT_INPUT) ) { \
-		GValue value = { 0, }; \
-		gchar *error = NULL; \
- 		\
-		/* Input args are given inline, eg. ("factor", 12.0)  \
-		 * and must be collected. \
-		 */ \
-		g_value_init( &value, G_PARAM_SPEC_VALUE_TYPE( PSPEC ) ); \
-		G_VALUE_COLLECT( &value, AP, 0, &error ); \
-		\
-		/* Don't bother with the error message. \
-		 */ \
-		if( error ) { \
-			VIPS_DEBUG_MSG( "VIPS_OBJECT_COLLECT_SET: err\n" ); \
-			g_free( error ); \
-		}
-#endif
 
 #define VIPS_ARGUMENT_COLLECT_GET( PSPEC, ARG_CLASS, AP ) \
 		g_value_unset( &value ); \

--- a/libvips/iofuncs/error.c
+++ b/libvips/iofuncs/error.c
@@ -65,10 +65,10 @@
 #include <vips/thread.h>
 #include <vips/debug.h>
 
-#ifdef OS_WIN32
+#ifdef G_OS_WIN32
 #include <windows.h>
 #include <lmerr.h>
-#endif /*OS_WIN32*/
+#endif /*G_OS_WIN32*/
 
 /**
  * SECTION: errors
@@ -294,7 +294,7 @@ vips_verror_system( int err, const char *domain, const char *fmt, va_list ap )
 {
 	vips_verror( domain, fmt, ap );
 
-#ifdef OS_WIN32
+#ifdef G_OS_WIN32
 {
 	char *buf;
 
@@ -310,7 +310,7 @@ vips_verror_system( int err, const char *domain, const char *fmt, va_list ap )
 		LocalFree( buf );
 	}
 }
-#else /*OS_WIN32*/
+#else /*!G_OS_WIN32*/
 {
 	char *buf;
 
@@ -318,7 +318,7 @@ vips_verror_system( int err, const char *domain, const char *fmt, va_list ap )
 	vips_error( _( "unix error" ), "%s", buf );
 	g_free( buf );
 }
-#endif /*OS_WIN32*/
+#endif /*G_OS_WIN32*/
 }
 
 /**

--- a/libvips/iofuncs/image.c
+++ b/libvips/iofuncs/image.c
@@ -1676,14 +1676,7 @@ vips_image_temp_name( char *name, int size )
 {
 	static int global_serial = 0;
 
-	/* Old glibs named this differently.
-	 */
-	int serial =
-#if GLIB_CHECK_VERSION( 2, 30, 0 )
-		g_atomic_int_add( &global_serial, 1 );
-#else
-		g_atomic_int_exchange_and_add( &global_serial, 1 );
-#endif
+	int serial = g_atomic_int_add( &global_serial, 1 );
 
 	vips_snprintf( name, size, "temp-%d", serial );
 }

--- a/libvips/iofuncs/mapfile.c
+++ b/libvips/iofuncs/mapfile.c
@@ -77,18 +77,16 @@
 #ifdef HAVE_UNISTD_H
 #include <unistd.h>
 #endif /*HAVE_UNISTD_H*/
-#ifdef OS_WIN32 
-#ifndef S_ISREG
-#define S_ISREG(m) (!!(m & _S_IFREG))
-#endif
-#endif /*OS_WIN32*/
 
 #include <vips/vips.h>
 
-#ifdef OS_WIN32
+#ifdef G_OS_WIN32
+#ifndef S_ISREG
+#define S_ISREG(m) (!!(m & _S_IFREG))
+#endif
 #include <windows.h>
 #include <io.h>
-#endif /*OS_WIN32*/
+#endif /*G_OS_WIN32*/
 
 /* Does this fd support mmap. Pipes won't, for example.
  */
@@ -99,7 +97,7 @@ vips__mmap_supported( int fd )
 	size_t length = 4096;
 	off_t offset = 0;
 
-#ifdef OS_WIN32
+#ifdef G_OS_WIN32
 {
 	HANDLE hFile = (HANDLE) _get_osfhandle( fd );
 
@@ -128,7 +126,7 @@ vips__mmap_supported( int fd )
 	CloseHandle( hMMFile );
 	UnmapViewOfFile( baseaddr );
 }
-#else /*!OS_WIN32*/
+#else /*!G_OS_WIN32*/
 {
 	int prot = PROT_READ;
 	int flags = MAP_SHARED;
@@ -138,7 +136,7 @@ vips__mmap_supported( int fd )
 		return( FALSE ); 
 	munmap( baseaddr, length );
 }
-#endif /*OS_WIN32*/
+#endif /*G_OS_WIN32*/
 
 	return( TRUE );
 }
@@ -153,7 +151,7 @@ vips__mmap( int fd, int writeable, size_t length, gint64 offset )
 		length, offset );
 #endif /*DEBUG*/
 
-#ifdef OS_WIN32
+#ifdef G_OS_WIN32
 {
 	HANDLE hFile = (HANDLE) _get_osfhandle( fd );
 
@@ -203,7 +201,7 @@ vips__mmap( int fd, int writeable, size_t length, gint64 offset )
 	 */
 	CloseHandle( hMMFile );
 }
-#else /*!OS_WIN32*/
+#else /*!G_OS_WIN32*/
 {
 	int prot;
 	int flags;
@@ -237,7 +235,7 @@ vips__mmap( int fd, int writeable, size_t length, gint64 offset )
 		return( NULL ); 
 	}
 }
-#endif /*OS_WIN32*/
+#endif /*G_OS_WIN32*/
 
 	return( baseaddr );
 }
@@ -245,19 +243,19 @@ vips__mmap( int fd, int writeable, size_t length, gint64 offset )
 int
 vips__munmap( const void *start, size_t length )
 {
-#ifdef OS_WIN32
+#ifdef G_OS_WIN32
 	if( !UnmapViewOfFile( (void *) start ) ) {
 		vips_error_system( GetLastError(), "vips_mapfile",
 			"%s", _( "unable to UnmapViewOfFile" ) );
 		return( -1 );
 	}
-#else /*!OS_WIN32*/
+#else /*!G_OS_WIN32*/
 	if( munmap( (void *) start, length ) < 0 ) {
 		vips_error_system( errno, "vips_mapfile", 
 			"%s", _( "unable to munmap file" ) );
 		return( -1 );
 	}
-#endif /*OS_WIN32*/
+#endif /*G_OS_WIN32*/
 
 	return( 0 );
 }
@@ -345,7 +343,7 @@ vips_remapfilerw( VipsImage *image )
 	printf( "vips_remapfilerw:\n" ); 
 #endif /*DEBUG*/
 
-#ifdef OS_WIN32
+#ifdef G_OS_WIN32
 {
 	HANDLE hFile = (HANDLE) _get_osfhandle( image->fd );
         HANDLE hMMFile;
@@ -377,7 +375,7 @@ vips_remapfilerw( VipsImage *image )
 	 */
 	CloseHandle( hMMFile );
 }
-#else /*!OS_WIN32*/
+#else /*!G_OS_WIN32*/
 {
 	assert( image->dtype == VIPS_IMAGE_MMAPIN );
 
@@ -390,7 +388,7 @@ vips_remapfilerw( VipsImage *image )
 		return( -1 ); 
 	}
 }
-#endif /*OS_WIN32*/
+#endif /*G_OS_WIN32*/
 
 	image->dtype = VIPS_IMAGE_MMAPINRW;
 

--- a/libvips/iofuncs/source.c
+++ b/libvips/iofuncs/source.c
@@ -65,23 +65,24 @@
 #include <sys/stat.h>
 #include <fcntl.h>
 #include <unistd.h>
-#ifdef OS_WIN32
-#include <io.h>
-#endif /*OS_WIN32*/
 
 #include <vips/vips.h>
 #include <vips/internal.h>
 #include <vips/debug.h>
 
+#ifdef G_OS_WIN32
+#include <io.h>
+#endif /*G_OS_WIN32*/
+
 /* Try to make an O_BINARY ... sometimes need the leading '_'.
  */
-#ifdef BINARY_OPEN
+#ifdef G_PLATFORM_WIN32
 #ifndef O_BINARY
 #ifdef _O_BINARY
 #define O_BINARY _O_BINARY
 #endif /*_O_BINARY*/
 #endif /*!O_BINARY*/
-#endif /*BINARY_OPEN*/
+#endif /*G_PLATFORM_WIN32*/
 
 /* If we have O_BINARY, add it to a mode flags set.
  */
@@ -307,12 +308,12 @@ vips_source_build( VipsObject *object )
 		connection->descriptor = dup( connection->descriptor );
 		connection->close_descriptor = connection->descriptor;
 
-#ifdef OS_WIN32
+#ifdef G_OS_WIN32
 		/* Windows will create eg. stdin and stdout in text mode.
 		 * We always read in binary mode.
 		 */
 		_setmode( connection->descriptor, _O_BINARY );
-#endif /*OS_WIN32*/
+#endif /*G_OS_WIN32*/
 	}
 
 	if( vips_object_argument_isset( object, "blob" ) ) {

--- a/libvips/iofuncs/target.c
+++ b/libvips/iofuncs/target.c
@@ -55,23 +55,24 @@
 #include <sys/stat.h>
 #include <fcntl.h>
 #include <unistd.h>
-#ifdef OS_WIN32
-#include <io.h>
-#endif /*OS_WIN32*/
 
 #include <vips/vips.h>
 #include <vips/internal.h>
 #include <vips/debug.h>
 
+#ifdef G_OS_WIN32
+#include <io.h>
+#endif /*G_OS_WIN32*/
+
 /* Try to make an O_BINARY ... sometimes need the leading '_'.
  */
-#ifdef BINARY_OPEN
+#ifdef G_PLATFORM_WIN32
 #ifndef O_BINARY
 #ifdef _O_BINARY
 #define O_BINARY _O_BINARY
 #endif /*_O_BINARY*/
 #endif /*!O_BINARY*/
-#endif /*BINARY_OPEN*/
+#endif /*G_PLATFORM_WIN32*/
 
 /* If we have O_BINARY, add it to a mode flags set.
  */
@@ -143,12 +144,12 @@ vips_target_build( VipsObject *object )
 		connection->descriptor = dup( connection->descriptor );
 		connection->close_descriptor = connection->descriptor;
 
-#ifdef OS_WIN32
+#ifdef G_OS_WIN32
 		/* Windows will create eg. stdin and stdout in text mode.
 		 * We always write in binary mode.
 		 */
 		_setmode( connection->descriptor, _O_BINARY );
-#endif /*OS_WIN32*/
+#endif /*G_OS_WIN32*/
 	}
 	else if( target->memory ) 
 		target->memory_buffer = g_byte_array_new();

--- a/libvips/iofuncs/threadpool.c
+++ b/libvips/iofuncs/threadpool.c
@@ -75,9 +75,9 @@
 #include <vips/thread.h>
 #include <vips/debug.h>
 
-#ifdef OS_WIN32
+#ifdef G_OS_WIN32
 #include <windows.h>
-#endif /*OS_WIN32*/
+#endif /*G_OS_WIN32*/
 
 /**
  * SECTION: threadpool
@@ -338,7 +338,7 @@ get_num_processors( void )
 
 #endif /*G_OS_UNIX*/
 
-#ifdef OS_WIN32
+#ifdef G_OS_WIN32
 {
 	/* Count the CPUs currently available to this process.  
 	 */
@@ -365,7 +365,7 @@ get_num_processors( void )
 			nproc = af_count;
 	}
 }
-#endif /*OS_WIN32*/
+#endif /*G_OS_WIN32*/
 
 	return( nproc );
 #endif /*!GLIB_CHECK_VERSION( 2, 48, 1 )*/

--- a/libvips/iofuncs/vips.c
+++ b/libvips/iofuncs/vips.c
@@ -115,13 +115,13 @@
 
 /* Try to make an O_BINARY ... sometimes need the leading '_'.
  */
-#ifdef BINARY_OPEN
+#ifdef G_PLATFORM_WIN32
 #ifndef O_BINARY
 #ifdef _O_BINARY
 #define O_BINARY _O_BINARY
 #endif /*_O_BINARY*/
 #endif /*!O_BINARY*/
-#endif /*BINARY_OPEN*/
+#endif /*G_PLATFORM_WIN32*/
 
 /* If we have O_BINARY, add it to a mode flags set.
  */

--- a/libvips/iofuncs/window.c
+++ b/libvips/iofuncs/window.c
@@ -58,9 +58,9 @@
 #include <vips/internal.h>
 #include <vips/thread.h>
 
-#ifdef OS_WIN32
+#ifdef G_OS_WIN32
 #include <windows.h>
-#endif /*OS_WIN32*/
+#endif /*G_OS_WIN32*/
 
 /* Sanity checking ... write to this during read tests to make sure we don't
  * get optimized out.
@@ -189,15 +189,15 @@ vips_getpagesize( void )
 	static int pagesize = 0;
 
 	if( !pagesize ) {
-#ifdef OS_WIN32
+#ifdef G_OS_WIN32
 		SYSTEM_INFO si;
 
 		GetSystemInfo( &si );
 
 		pagesize = si.dwAllocationGranularity;
-#else /*OS_WIN32*/
+#else /*!G_OS_WIN32*/
 		pagesize = getpagesize();
-#endif /*OS_WIN32*/
+#endif /*G_OS_WIN32*/
 
 #ifdef DEBUG_TOTAL
 		printf( "vips_getpagesize: 0x%x\n", pagesize );

--- a/libvips/mosaicing/lrmerge.c
+++ b/libvips/mosaicing/lrmerge.c
@@ -1123,16 +1123,9 @@ vips__add_mosaic_name( VipsImage *image )
 {
 	static int global_serial = 0;
 
-	/* Old glibs named this differently.
-	 *
-	 * TODO(kleisauke): Could we call vips_image_temp_name instead?
+	/* TODO(kleisauke): Could we call vips_image_temp_name instead?
 	 */
-	int serial =
-#if GLIB_CHECK_VERSION( 2, 30, 0 )
-		g_atomic_int_add( &global_serial, 1 );
-#else
-		g_atomic_int_exchange_and_add( &global_serial, 1 );
-#endif
+	int serial = g_atomic_int_add( &global_serial, 1 );
 
 	char name[256];
 

--- a/tools/vips.c
+++ b/tools/vips.c
@@ -101,9 +101,9 @@
 #include <vips/vips7compat.h>
 #endif
 
-#ifdef OS_WIN32
+#ifdef G_OS_WIN32
 #define strcasecmp(a,b) _stricmp(a,b)
-#endif
+#endif /*G_OS_WIN32*/
 
 static char *main_option_plugin = NULL;
 static gboolean main_option_version;
@@ -458,11 +458,11 @@ parse_options( GOptionContext *context, int *argc, char **argv )
 		"OPER", _( "execute vips operation OPER" ) );
 	g_option_context_set_summary( context, vips_buf_all( &buf ) );
 
-#ifdef HAVE_G_WIN32_GET_COMMAND_LINE
+#ifdef G_OS_WIN32
 	if( !g_option_context_parse_strv( context, &argv, &error ) ) 
-#else /*!HAVE_G_WIN32_GET_COMMAND_LINE*/
+#else /*!G_OS_WIN32*/
 	if( !g_option_context_parse( context, argc, &argv, &error ) ) 
-#endif /*HAVE_G_WIN32_GET_COMMAND_LINE*/
+#endif /*G_OS_WIN32*/
 	{
 		if( error ) {
 			fprintf( stderr, "%s\n", error->message );
@@ -531,9 +531,9 @@ main( int argc, char **argv )
 	/* On Windows, argv is ascii-only .. use this to get a utf-8 version of
 	 * the args.
 	 */
-#ifdef HAVE_G_WIN32_GET_COMMAND_LINE
+#ifdef G_OS_WIN32
 	argv = g_win32_get_command_line();
-#endif /*HAVE_G_WIN32_GET_COMMAND_LINE*/
+#endif /*G_OS_WIN32*/
 
 #ifdef DEBUG_FATAL
 	/* Set masks for debugging ... stop on any problem. 
@@ -582,11 +582,11 @@ main( int argc, char **argv )
 	 */
 	g_option_context_set_help_enabled( context, FALSE );
 
-#ifdef HAVE_G_WIN32_GET_COMMAND_LINE
+#ifdef G_OS_WIN32
 	if( !g_option_context_parse_strv( context, &argv, &error ) ) 
-#else /*!HAVE_G_WIN32_GET_COMMAND_LINE*/
+#else /*!G_OS_WIN32*/
 	if( !g_option_context_parse( context, &argc, &argv, &error ) ) 
-#endif /*HAVE_G_WIN32_GET_COMMAND_LINE*/
+#endif /*G_OS_WIN32*/
 	{
 		if( error ) {
 			fprintf( stderr, "%s\n", error->message );
@@ -753,9 +753,9 @@ main( int argc, char **argv )
 
 	g_option_context_free( context );
 
-#ifdef HAVE_G_WIN32_GET_COMMAND_LINE
+#ifdef G_OS_WIN32
 	g_strfreev( argv ); 
-#endif /*HAVE_G_WIN32_GET_COMMAND_LINE*/
+#endif /*G_OS_WIN32*/
 
 	vips_shutdown();
 

--- a/tools/vipsedit.c
+++ b/tools/vipsedit.c
@@ -141,9 +141,9 @@ main( int argc, char **argv )
 	/* On Windows, argv is ascii-only .. use this to get a utf-8 version of
 	 * the args.
 	 */
-#ifdef HAVE_G_WIN32_GET_COMMAND_LINE
+#ifdef G_OS_WIN32
 	argv = g_win32_get_command_line();
-#endif /*HAVE_G_WIN32_GET_COMMAND_LINE*/
+#endif /*G_OS_WIN32*/
 
 	context = g_option_context_new( 
 		_( "vipsedit - edit vips file header" ) );
@@ -153,11 +153,11 @@ main( int argc, char **argv )
 	g_option_group_set_translation_domain( main_group, GETTEXT_PACKAGE );
 	g_option_context_set_main_group( context, main_group );
 
-#ifdef HAVE_G_WIN32_GET_COMMAND_LINE
+#ifdef G_OS_WIN32
 	if( !g_option_context_parse_strv( context, &argv, &error ) ) 
-#else /*!HAVE_G_WIN32_GET_COMMAND_LINE*/
+#else /*!G_OS_WIN32*/
 	if( !g_option_context_parse( context, &argc, &argv, &error ) ) 
-#endif /*HAVE_G_WIN32_GET_COMMAND_LINE*/
+#endif /*G_OS_WIN32*/
 	{
 		vips_g_error( &error );
 
@@ -272,9 +272,9 @@ main( int argc, char **argv )
 
 	g_option_context_free( context );
 
-#ifdef HAVE_G_WIN32_GET_COMMAND_LINE
+#ifdef G_OS_WIN32
 	g_strfreev( argv ); 
-#endif /*HAVE_G_WIN32_GET_COMMAND_LINE*/
+#endif /*G_OS_WIN32*/
 
 	vips_shutdown();
 

--- a/tools/vipsheader.c
+++ b/tools/vipsheader.c
@@ -180,9 +180,9 @@ main( int argc, char *argv[] )
 	/* On Windows, argv is ascii-only .. use this to get a utf-8 version of
 	 * the args.
 	 */
-#ifdef HAVE_G_WIN32_GET_COMMAND_LINE
+#ifdef G_OS_WIN32
 	argv = g_win32_get_command_line();
-#endif /*HAVE_G_WIN32_GET_COMMAND_LINE*/
+#endif /*G_OS_WIN32*/
 
         context = g_option_context_new( _( "- print image header" ) );
 	main_group = g_option_group_new( NULL, NULL, NULL, NULL, NULL );
@@ -191,11 +191,11 @@ main( int argc, char *argv[] )
 	g_option_group_set_translation_domain( main_group, GETTEXT_PACKAGE );
 	g_option_context_set_main_group( context, main_group );
 
-#ifdef HAVE_G_WIN32_GET_COMMAND_LINE
+#ifdef G_OS_WIN32
 	if( !g_option_context_parse_strv( context, &argv, &error ) ) 
-#else /*!HAVE_G_WIN32_GET_COMMAND_LINE*/
+#else /*!G_OS_WIN32*/
 	if( !g_option_context_parse( context, &argc, &argv, &error ) ) 
-#endif /*HAVE_G_WIN32_GET_COMMAND_LINE*/
+#endif /*G_OS_WIN32*/
 	{
 		if( error ) {
 			fprintf( stderr, "%s\n", error->message );
@@ -247,9 +247,9 @@ main( int argc, char *argv[] )
 
 	/* We don't free this on error exit, sadly.
 	 */
-#ifdef HAVE_G_WIN32_GET_COMMAND_LINE
+#ifdef G_OS_WIN32
 	g_strfreev( argv ); 
-#endif /*HAVE_G_WIN32_GET_COMMAND_LINE*/
+#endif /*G_OS_WIN32*/
 
 	vips_shutdown();
 

--- a/tools/vipsthumbnail.c
+++ b/tools/vipsthumbnail.c
@@ -500,9 +500,9 @@ main( int argc, char **argv )
 	/* On Windows, argv is ascii-only .. use this to get a utf-8 version of
 	 * the args.
 	 */
-#ifdef HAVE_G_WIN32_GET_COMMAND_LINE
+#ifdef G_OS_WIN32
 	argv = g_win32_get_command_line();
-#endif /*HAVE_G_WIN32_GET_COMMAND_LINE*/
+#endif /*G_OS_WIN32*/
 
         context = g_option_context_new( _( "- thumbnail generator" ) );
 
@@ -512,11 +512,11 @@ main( int argc, char **argv )
 	g_option_group_set_translation_domain( main_group, GETTEXT_PACKAGE );
 	g_option_context_set_main_group( context, main_group );
 
-#ifdef HAVE_G_WIN32_GET_COMMAND_LINE
+#ifdef G_OS_WIN32
 	if( !g_option_context_parse_strv( context, &argv, &error ) ) 
-#else /*!HAVE_G_WIN32_GET_COMMAND_LINE*/
+#else /*!G_OS_WIN32*/
 	if( !g_option_context_parse( context, &argc, &argv, &error ) ) 
-#endif /*HAVE_G_WIN32_GET_COMMAND_LINE*/
+#endif /*G_OS_WIN32*/
 	{
 		if( error ) {
 			fprintf( stderr, "%s\n", error->message );
@@ -563,9 +563,9 @@ main( int argc, char **argv )
 
 	/* We don't free this on error exit, sadly.
 	 */
-#ifdef HAVE_G_WIN32_GET_COMMAND_LINE
+#ifdef G_OS_WIN32
 	g_strfreev( argv ); 
-#endif /*HAVE_G_WIN32_GET_COMMAND_LINE*/
+#endif /*G_OS_WIN32*/
 
 	vips_shutdown();
 


### PR DESCRIPTION
This PR cleanups `configure.ac` and a bunch of `#ifdef`'s. I used this renaming/remove strategy:
- `OS_WIN32` -> `G_OS_WIN32` (GLib definition when compiling for native Win32)
- `BINARY_OPEN` ->  `G_PLATFORM_WIN32` (GLib definition when compiling for native Win32 or Cygwin environments)
- `HAVE_G_WIN32_GET_COMMAND_LINE` -> `G_OS_WIN32`
- `VIPS_OS_DARWIN` -> <kbd>Delete</kbd> (appears to be unused)

This implies that the old definitions should no longer be used. Note that since the new definitions originates from GLib, it is necessary to include `vips/vips.h` prior to using them.

After this renaming, the following decoupled variables were removed from `configure.ac`:
- `vips_os_win32`
- `vips_binary_open`
- `have_g_win32_get_command_line`
- `vips_os_darwin`

Plus a couple of no longer defined variables:
- `GTHREAD_CFLAGS` / `GTHREAD_LIBS` - removed with https://github.com/libvips/libvips/commit/117dbd888a15f9be73661aeebd32ce762c82e5f6.
- `LIBWEBPMUX_CFLAGS`  / `LIBWEBPMUX_LIBS` - removed with https://github.com/libvips/libvips/commit/801a2a71443c33679ae9a18a1c9f8db8764152e4.

Finally, I removed some redundant `#if GLIB_CHECK_VERSION( x, y, z )` guards that are no longer necessary after commit https://github.com/libvips/libvips/commit/117dbd888a15f9be73661aeebd32ce762c82e5f6.