### PR TITLE
vips2webp: force low duration frames to 100ms

### DIFF
--- a/libvips/foreign/vips2webp.c
+++ b/libvips/foreign/vips2webp.c
@@ -328,10 +328,17 @@ write_webp_anim( VipsWebPWrite *write, VipsImage *image, int page_height )
 
 	/* There might just be the old gif-delay field. This is centiseconds.
 	 */
-	gif_delay = 4;
+	gif_delay = 10;
 	if( vips_image_get_typeof( image, "gif-delay" ) &&
 		vips_image_get_int( image, "gif-delay", &gif_delay ) )
 		return( -1 );
+
+	/* Force frames with a small or no duration to 100ms
+	 * to be consistent with web browsers and other
+	 * transcoding tools.
+	 */
+	if( gif_delay <= 1 )
+		gif_delay = 10;
 
 	/* New images have an array of ints instead.
 	 */
@@ -371,7 +378,8 @@ write_webp_anim( VipsWebPWrite *write, VipsImage *image, int page_height )
 		page_index = top / page_height;
 		if( delay &&
 			page_index < delay_length )
-			timestamp_ms += delay[page_index];
+			timestamp_ms += delay[page_index] <= 10 ?
+				100 : delay[page_index];
 		else 
 			timestamp_ms += gif_delay * 10;
 	}

--- a/test/test-suite/test_foreign.py
+++ b/test/test-suite/test_foreign.py
@@ -682,10 +682,14 @@ class TestForeign:
             x1 = pyvips.Image.new_from_file(GIF_ANIM_FILE, n=-1)
             w1 = x1.webpsave_buffer(Q=10)
 
+            # our test gif has delay 0 for the first frame set in error,
+            # when converting to WebP this should result in a 100ms delay.
+            expected_delay = [100 if d <= 10 else d for d in x1.get("delay")]
+
             x2 = pyvips.Image.new_from_buffer(w1, "", n=-1)
             assert x1.width == x2.width
             assert x1.height == x2.height
-            assert x1.get("delay") == x2.get("delay")
+            assert expected_delay == x2.get("delay")
             assert x1.get("page-height") == x2.get("page-height")
             assert x1.get("gif-loop") == x2.get("gif-loop")
 


### PR DESCRIPTION
See:
https://bugs.chromium.org/p/webp/issues/detail?id=379
https://github.com/webmproject/libwebp/commit/09333097ed4fd474916edf723d1ad07f72a9ab4d

Resolves: https://github.com/weserv/images/issues/275.