### PR TITLE
drop last remnant of dmalloc

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -190,7 +190,6 @@ AC_PROG_CC_STDC
 AC_PROG_CXX
 AC_PROG_INSTALL
 AC_PROG_LN_S
-AM_WITH_DMALLOC
 
 AC_ARG_WITH([doxygen], 
   AS_HELP_STRING([--without-doxygen], [build without doxygen (default: test)]))

--- a/libvips/resample/bicubic.cpp
+++ b/libvips/resample/bicubic.cpp
@@ -54,10 +54,6 @@
 
 #include "templates.h"
 
-#ifdef WITH_DMALLOC
-#include <dmalloc.h>
-#endif /*WITH_DMALLOC*/
-
 #define VIPS_TYPE_INTERPOLATE_BICUBIC \
 	(vips_interpolate_bicubic_get_type())
 #define VIPS_INTERPOLATE_BICUBIC( obj ) \


### PR DESCRIPTION
Drop last remnant of dmalloc which was removed in version 7.28.0 with https://github.com/libvips/libvips/commit/ae8faf6597c738b5d8adf9f6c29fc7d02203ca44

Signed-off-by: Fabrice Fontaine <fontaine.fabrice@gmail.com>