### PR TITLE
nsgifload: ensure GIF_INSUFFICIENT_FRAME_DATA is unrecoverable

### DIFF
--- a/libvips/foreign/nsgifload.c
+++ b/libvips/foreign/nsgifload.c
@@ -355,15 +355,8 @@ vips_foreign_load_nsgif_header( VipsForeignLoad *load )
 #ifdef VERBOSE
 	print_animation( gif->anim );
 #endif /*VERBOSE*/
-	if( result != GIF_OK && 
-		result != GIF_WORKING &&
-		result != GIF_INSUFFICIENT_FRAME_DATA ) {
+	if( result != GIF_OK && result != GIF_WORKING ) {
 		vips_foreign_load_nsgif_error( gif, result ); 
-		return( -1 );
-	}
-	else if( result == GIF_INSUFFICIENT_FRAME_DATA &&
-		load->fail ) {
-		vips_error( class->nickname, "%s", _( "truncated GIF" ) );
 		return( -1 );
 	}
 


### PR DESCRIPTION
As discussed in https://github.com/libvips/libvips/pull/1709#issuecomment-808895573, this should fix all of the OSS Fuzz issues found so far today (currently 10).