### PR TITLE
nsgifload: enforce maximum GIF dimensions of 16383

### DIFF
--- a/libvips/foreign/nsgifload.c
+++ b/libvips/foreign/nsgifload.c
@@ -534,17 +534,17 @@ vips_foreign_load_nsgif_class_init( VipsForeignLoadNsgifClass *class )
 static void *
 vips_foreign_load_nsgif_bitmap_create( int width, int height )
 {
-	/* Check GIF dimensions fit within 16-bit unsigned.
+	/* Enforce max GIF dimensions of 16383 (0x7FFF).
 	 */
 	if( width <= 0 ||
-		width > 65535 ||
+		width > 16383 ||
 		height <= 0 ||
-		height > 65535 ) {
+		height > 16383 ) {
 		vips_error( "gifload",
-			"%s", _( "dimensions out of range ") );
+			"%s", _( "bad image dimensions") );
 		return( NULL );
 	}
-	return g_malloc0( width * height * 4 );
+	return g_malloc0( (gsize) width * height * 4 );
 }
 
 static void 


### PR DESCRIPTION
As discussed in https://github.com/libvips/libvips/pull/2176

The GIF spec allows dimensions up to 65535 (16-bit unsigned), but this equates to 17GB/frame.

A common task is to convert animated GIF to animated WebP, and the latter supports dimensions up to 16383 (14-bit unsigned), so that seems like a sensible limit and equates to 1GB/frame.

Also makes the error message consistent with other loaders.