### PR TITLE
Text colour rendering

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -62,7 +62,6 @@ jobs:
         if: contains(matrix.os, 'macos')
         run: |
           brew update 
-          brew upgrade
           brew install
             autoconf automake libtool
             gtk-doc gobject-introspection

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -60,7 +60,9 @@ jobs:
 
       - name: Install macOS dependencies
         if: contains(matrix.os, 'macos')
-        run:
+        run: |
+          brew update 
+          brew upgrade
           brew install
             autoconf automake libtool
             gtk-doc gobject-introspection

--- a/ChangeLog
+++ b/ChangeLog
@@ -22,6 +22,7 @@
 - add vips_image_[set|get]_array_double()
 - add GIF load with libnsgif
 - add JPEG2000 load and save
+- add "rgba" flag to vips_text() to enable full colour text rendering
 
 22/12/20 start 8.10.6
 - don't seek on bad file descriptors [kleisauke]

--- a/README.md
+++ b/README.md
@@ -243,10 +243,10 @@ If you are going to be using libvips with untrusted images, perhaps in a
 web server, for example, you should consider the security implications of
 enabling a package with such a large attack surface. 
 
-### pangoft2
+### pangocairo
 
 If available, libvips adds support for text rendering. You need the
-package pangoft2 in `pkg-config --list-all`.
+package pangocairo in `pkg-config --list-all`.
 
 ### orc-0.4
 

--- a/configure.ac
+++ b/configure.ac
@@ -1083,25 +1083,25 @@ fi
 VIPS_CFLAGS="$VIPS_CFLAGS $LIBWEBP_CFLAGS"
 VIPS_LIBS="$VIPS_LIBS $LIBWEBP_LIBS"
 
-# pangoft2
-AC_ARG_WITH([pangoft2], 
-  AS_HELP_STRING([--without-pangoft2], 
-    [build without pangoft2 (default: test)]))
+# pangocairo for text rendering
+AC_ARG_WITH([pangocairo], 
+  AS_HELP_STRING([--without-pangocairo], 
+    [build without pangocairo (default: test)]))
 
-if test x"$with_pangoft2" != x"no"; then
-  PKG_CHECK_MODULES(PANGOFT2, pangoft2,
-    [AC_DEFINE(HAVE_PANGOFT2,1,[define if you have pangoft2 installed.])
-     with_pangoft2=yes
-     PACKAGES_USED="$PACKAGES_USED pangoft2"
+if test x"$with_pangocairo" != x"no"; then
+  PKG_CHECK_MODULES(PANGOCAIRO, pangocairo,
+    [AC_DEFINE(HAVE_PANGOCAIRO,1,[define if you have pangocairo installed.])
+     with_pangocairo=yes
+     PACKAGES_USED="$PACKAGES_USED pangocairo"
     ],
-    [AC_MSG_WARN([pangoft2 not found; disabling pangoft2 support])
-     with_pangoft2=no
+    [AC_MSG_WARN([pangocairo not found; disabling pangocairo support])
+     with_pangocairo=no
     ]
   )
 fi
 
-VIPS_CFLAGS="$VIPS_CFLAGS $PANGOFT2_CFLAGS"
-VIPS_LIBS="$VIPS_LIBS $PANGOFT2_LIBS"
+VIPS_CFLAGS="$VIPS_CFLAGS $PANGOCAIRO_CFLAGS"
+VIPS_LIBS="$VIPS_LIBS $PANGOCAIRO_LIBS"
 
 # look for TIFF with pkg-config ... fall back to our tester
 # pkgconfig support for libtiff starts with libtiff-4
@@ -1325,7 +1325,7 @@ use fftw3 for FFT: $with_fftw, \
 accelerate loops with orc: $with_orc, \
 ICC profile support with lcms: $with_lcms, \
 zlib: $with_zlib, \
-text rendering with pangoft2: $with_pangoft2, \
+text rendering with pangocairo: $with_pangocairo, \
 EXIF metadata support with libexif: $with_libexif, \
 JPEG load/save with libjpeg: $with_jpeg, \
 PNG load with libspng: $with_libspng, \
@@ -1427,7 +1427,7 @@ accelerate loops with orc:              $with_orc
  (requires orc-0.4.11 or later)
 ICC profile support with lcms:          $with_lcms
 zlib:                                   $with_zlib
-text rendering with pangoft2:           $with_pangoft2
+text rendering with pangocairo:         $with_pangocairo
 EXIF metadata support with libexif:     $with_libexif
 
 ## File format support

--- a/libvips/create/create.c
+++ b/libvips/create/create.c
@@ -116,9 +116,9 @@ vips_create_operation_init( void )
 	extern GType vips_gaussmat_get_type( void ); 
 	extern GType vips_logmat_get_type( void ); 
 	extern GType vips_gaussnoise_get_type( void ); 
-#ifdef HAVE_PANGOFT2
+#ifdef HAVE_PANGOCAIRO
 	extern GType vips_text_get_type( void ); 
-#endif /*HAVE_PANGOFT2*/
+#endif /*HAVE_PANGOCAIRO*/
 	extern GType vips_xyz_get_type( void ); 
 	extern GType vips_eye_get_type( void ); 
 	extern GType vips_grey_get_type( void ); 
@@ -146,9 +146,9 @@ vips_create_operation_init( void )
 	vips_gaussmat_get_type();
 	vips_logmat_get_type();
 	vips_gaussnoise_get_type(); 
-#ifdef HAVE_PANGOFT2
+#ifdef HAVE_PANGOCAIRO
 	vips_text_get_type(); 
-#endif /*HAVE_PANGOFT2*/
+#endif /*HAVE_PANGOCAIRO*/
 	vips_xyz_get_type(); 
 	vips_eye_get_type(); 
 	vips_grey_get_type(); 

--- a/libvips/create/text.c
+++ b/libvips/create/text.c
@@ -345,10 +345,10 @@ vips_text_build( VipsObject *object )
 	VipsObjectClass *class = VIPS_OBJECT_GET_CLASS( object );
 	VipsCreate *create = VIPS_CREATE( object );
 	VipsText *text = (VipsText *) object;
+	VipsImage **t = (VipsImage **) vips_object_local_array( object, 3 );
 
 	VipsRect extents;
-	int bands;
-	VipsInterpretation interpretation;
+	VipsImage *image;
 	cairo_surface_t *surface;
 	cairo_t *cr;
 
@@ -407,36 +407,29 @@ vips_text_build( VipsObject *object )
 		return( -1 );
 	}
 
-	if( text->rgba ) {
-		interpretation = VIPS_INTERPRETATION_sRGB;
-		bands = 4;
-	}
-	else {
-		interpretation = VIPS_INTERPRETATION_MULTIBAND;
-		bands = 1;
-	}
-
 	/* Set DPI as pixels/mm.
 	 */
-	vips_image_init_fields( create->out,
-		extents.width, extents.height, bands, 
+	image = t[0] = vips_image_new_memory();
+	vips_image_init_fields( image,
+		extents.width, extents.height, 4, 
 		VIPS_FORMAT_UCHAR, VIPS_CODING_NONE, 
-		interpretation, text->dpi / 25.4, text->dpi / 25.4 );
+		VIPS_INTERPRETATION_sRGB,
+		text->dpi / 25.4, text->dpi / 25.4 );
 
-	vips_image_pipelinev( create->out, VIPS_DEMAND_STYLE_ANY, NULL );
-	create->out->Xoffset = extents.left;
-	create->out->Yoffset = extents.top;
+	vips_image_pipelinev( image, VIPS_DEMAND_STYLE_ANY, NULL );
+	image->Xoffset = extents.left;
+	image->Yoffset = extents.top;
 
-	if( vips_image_write_prepare( create->out ) ) {
+	if( vips_image_write_prepare( image ) ) {
 		g_mutex_unlock( vips_text_lock ); 
 		return( -1 );
 	}
 
 	surface = cairo_image_surface_create_for_data( 
-		VIPS_IMAGE_ADDR( create->out, 0, 0 ), 
-		text->rgba ? CAIRO_FORMAT_ARGB32 : CAIRO_FORMAT_A8, 
-		create->out->Xsize, create->out->Ysize,
-		VIPS_IMAGE_SIZEOF_LINE( create->out ) );
+		VIPS_IMAGE_ADDR( image, 0, 0 ), 
+		CAIRO_FORMAT_ARGB32,
+		image->Xsize, image->Ysize,
+		VIPS_IMAGE_SIZEOF_LINE( image ) );
 	cr = cairo_create( surface );
 	cairo_surface_destroy( surface );
 
@@ -454,12 +447,25 @@ vips_text_build( VipsObject *object )
 		/* Cairo makes pre-multipled BRGA -- we must byteswap and 
 		 * unpremultiply.
 		 */
-		for( y = 0; y < create->out->Ysize; y++ ) 
+		for( y = 0; y < image->Ysize; y++ ) 
 			vips__premultiplied_bgra2rgba( 
 				(guint32 *) 
-					VIPS_IMAGE_ADDR( create->out, 0, y ),
-				create->out->Xsize ); 
+					VIPS_IMAGE_ADDR( image, 0, y ),
+				image->Xsize ); 
 	}
+	else {
+		/* We just want the alpha channel.
+		 */
+		if( vips_extract_band( image, &t[1], 3, NULL ) ||
+			vips_copy( t[1], &t[2], 
+				"interpretation", VIPS_INTERPRETATION_MULTIBAND,
+				NULL ) )
+			return( -1 );
+		image = t[2];
+	}
+
+	if( vips_image_write( image, create->out ) )
+		return( -1 );
 
 	return( 0 );
 }

--- a/libvips/create/text.c
+++ b/libvips/create/text.c
@@ -84,6 +84,7 @@
 #include <cairo.h>
 #include <pango/pango.h>
 #include <pango/pangocairo.h>
+#include <fontconfig/fontconfig.h>
 
 #include "pcreate.h"
 
@@ -371,7 +372,6 @@ vips_text_build( VipsObject *object )
 	text->context = pango_font_map_create_context( 
 		PANGO_FONT_MAP( vips_text_fontmap ) );
 
-	/*
 	if( text->fontfile &&
 		!g_hash_table_lookup( vips_text_fontfiles, text->fontfile ) ) {
 		if( !FcConfigAppFontAddFile( NULL, 
@@ -386,7 +386,6 @@ vips_text_build( VipsObject *object )
 			text->fontfile,
 			g_strdup( text->fontfile ) );
 	}
-	 */
 
 	/* If our caller set height and not dpi, we adjust dpi until 
 	 * we get a fit.


### PR DESCRIPTION
Add full-colour text rendering to `vips_text()` with an `rgba` flag.

Example:

```
$ vips text x.png "😀<span foreground='red'>red</span><span background='cyan'>blue</span>" --dpi 300 --rgba
```

To make:

![x](https://user-images.githubusercontent.com/580843/114408051-f3a9db80-9ba0-11eb-9d14-68c6943fd36c.png)

Seems to work!

Non-rgba rendering works too, though there are some differences. For example, before emojii rendered in greyscale, but now you just get a mask shape.

```
$ vips text x2.png "😀<span foreground='red'>red</span>" --dpi 300
```

To make:

![x2](https://user-images.githubusercontent.com/580843/114413305-c6abf780-9ba5-11eb-8537-38588bba4dc7.png)

Perhaps this is OK?

This is a change to libvips dependencies, so packagers will need to update.