### PR TITLE
CI: ensure brew install commands are on a single line, split into base dependencies vs image formats

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -61,17 +61,10 @@ jobs:
       - name: Install macOS dependencies
         if: contains(matrix.os, 'macos')
         run: |
-          brew update 
-          brew install
-            autoconf automake libtool
-            gtk-doc gobject-introspection
-            cfitsio fftw giflib
-            glib libexif libgsf
-            libheif libjpeg-turbo libmatio
-            librsvg libspng libtiff
-            little-cms2 openexr openslide
-            orc pango poppler webp
-            openjpeg
+          brew update
+          brew upgrade
+          brew install autoconf automake libtool fftw fontconfig gtk-doc gobject-introspection glib libexif libgsf little-cms2 orc pango
+          brew install cfitsio imagemagick libheif libjpeg-turbo libmatio librsvg libspng libtiff openexr openjpeg openslide poppler webp
 
       - name: Install Clang 10
         env:


### PR DESCRIPTION
Due to the (necessary) addition of `brew update`, this is now considered a multi-command script so every new line must be its own command.

(CI is currently failing on the `master` branch and in recent PRs due to this.)