### PR TITLE
Update libnsgif

### DIFF
--- a/libvips/foreign/libnsgif/libnsgif.c
+++ b/libvips/foreign/libnsgif/libnsgif.c
@@ -676,7 +676,7 @@ gif__decode_complex(gif_animation *gif,
                                         }
                                         break;
                                 }
-                                res = lzw_decode(gif->lzw_ctx,
+                                res = lzw_decode_continuous(gif->lzw_ctx,
                                                 &uncompressed, &available);
                         }
 

--- a/libvips/foreign/libnsgif/libnsgif.c
+++ b/libvips/foreign/libnsgif/libnsgif.c
@@ -618,6 +618,83 @@ static gif_result gif__recover_previous_frame(const gif_animation *gif)
         return GIF_OK;
 }
 
+static inline gif_result
+gif__decode(gif_animation *gif,
+                unsigned int frame,
+                unsigned int width,
+                unsigned int height,
+                unsigned int offset_x,
+                unsigned int offset_y,
+                unsigned int interlace,
+                uint8_t minimum_code_size,
+                unsigned int *restrict frame_data,
+                unsigned int *restrict colour_table)
+{
+        const uint8_t *stack_base;
+        const uint8_t *stack_pos;
+        gif_result ret = GIF_OK;
+        lzw_result res;
+
+        /* Initialise the LZW decoding */
+        res = lzw_decode_init(gif->lzw_ctx, gif->gif_data,
+                        gif->buffer_size, gif->buffer_position,
+                        minimum_code_size, &stack_base, &stack_pos);
+        if (res != LZW_OK) {
+                return gif_error_from_lzw(res);
+        }
+
+        for (unsigned int y = 0; y < height; y++) {
+                unsigned int x;
+                unsigned int decode_y;
+                unsigned int *frame_scanline;
+
+                if (interlace) {
+                        decode_y = gif_interlaced_line(height, y) + offset_y;
+                } else {
+                        decode_y = y + offset_y;
+                }
+                frame_scanline = frame_data + offset_x + (decode_y * gif->width);
+
+                /* Rather than decoding pixel by pixel, we try to burst
+                 * out streams of data to remove the need for end-of
+                 * data checks every pixel.
+                 */
+                x = width;
+                while (x > 0) {
+                        unsigned int burst_bytes = (stack_pos - stack_base);
+                        if (burst_bytes > 0) {
+                                if (burst_bytes > x) {
+                                        burst_bytes = x;
+                                }
+                                x -= burst_bytes;
+                                while (burst_bytes-- > 0) {
+                                        register unsigned char colour;
+                                        colour = *--stack_pos;
+                                        if (((gif->frames[frame].transparency) &&
+                                             (colour != gif->frames[frame].transparency_index)) ||
+                                            (!gif->frames[frame].transparency)) {
+                                                *frame_scanline = colour_table[colour];
+                                        }
+                                        frame_scanline++;
+                                }
+                        } else {
+                                res = lzw_decode(gif->lzw_ctx, &stack_pos);
+                                if (res != LZW_OK) {
+                                        /* Unexpected end of frame, try to recover */
+                                        if (res == LZW_OK_EOD) {
+                                                ret = GIF_OK;
+                                        } else {
+                                                ret = gif_error_from_lzw(res);
+                                        }
+                                        break;
+                                }
+                        }
+                }
+        }
+
+        return ret;
+}
+
 /**
  * decode a gif frame
  *
@@ -638,11 +715,8 @@ gif_internal_decode_frame(gif_animation *gif,
         unsigned int flags, colour_table_size, interlace;
         unsigned int *colour_table;
         unsigned int *frame_data = 0;	// Set to 0 for no warnings
-        unsigned int *frame_scanline;
         unsigned int save_buffer_position;
         unsigned int return_value = 0;
-        unsigned int x, y, decode_y, burst_bytes;
-        register unsigned char colour;
 
         /* Ensure this frame is supposed to be decoded */
         if (gif->frames[frame].display == false) {
@@ -796,10 +870,6 @@ gif_internal_decode_frame(gif_animation *gif,
 
         /* If we are clearing the image we just clear, if not decode */
         if (!clear_image) {
-                lzw_result res;
-                const uint8_t *stack_base;
-                const uint8_t *stack_pos;
-
                 /* Ensure we have enough data for a 1-byte LZW code size +
                  * 1-byte gif trailer
                  */
@@ -863,62 +933,15 @@ gif_internal_decode_frame(gif_animation *gif,
                 gif->decoded_frame = frame;
                 gif->buffer_position = (gif_data - gif->gif_data) + 1;
 
-                /* Initialise the LZW decoding */
-                res = lzw_decode_init(gif->lzw_ctx, gif->gif_data,
-                                gif->buffer_size, gif->buffer_position,
-                                gif_data[0], &stack_base, &stack_pos);
-                if (res != LZW_OK) {
-                        return gif_error_from_lzw(res);
-                }
-
-                /* Decompress the data */
-                for (y = 0; y < height; y++) {
-                        if (interlace) {
-                                decode_y = gif_interlaced_line(height, y) + offset_y;
-                        } else {
-                                decode_y = y + offset_y;
-                        }
-                        frame_scanline = frame_data + offset_x + (decode_y * gif->width);
-
-                        /* Rather than decoding pixel by pixel, we try to burst
-                         * out streams of data to remove the need for end-of
-                         * data checks every pixel.
-                         */
-                        x = width;
-                        while (x > 0) {
-                                burst_bytes = (stack_pos - stack_base);
-                                if (burst_bytes > 0) {
-                                        if (burst_bytes > x) {
-                                                burst_bytes = x;
-                                        }
-                                        x -= burst_bytes;
-                                        while (burst_bytes-- > 0) {
-                                                colour = *--stack_pos;
-                                                if (((gif->frames[frame].transparency) &&
-                                                     (colour != gif->frames[frame].transparency_index)) ||
-                                                    (!gif->frames[frame].transparency)) {
-                                                        *frame_scanline = colour_table[colour];
-                                                }
-                                                frame_scanline++;
-                                        }
-                                } else {
-                                        res = lzw_decode(gif->lzw_ctx, &stack_pos);
-                                        if (res != LZW_OK) {
-                                                /* Unexpected end of frame, try to recover */
-                                                if (res == LZW_OK_EOD) {
-                                                        return_value = GIF_OK;
-                                                } else {
-                                                        return_value = gif_error_from_lzw(res);
-                                                }
-                                                goto gif_decode_frame_exit;
-                                        }
-                                }
-                        }
-                }
+                return_value = gif__decode(gif, frame, width, height,
+                                offset_x, offset_y, interlace, gif_data[0],
+                                frame_data, colour_table);
         } else {
                 /* Clear our frame */
                 if (gif->frames[frame].disposal_method == GIF_FRAME_CLEAR) {
+                        unsigned int y;
                         for (y = 0; y < height; y++) {
+                                unsigned int *frame_scanline;
                                 frame_scanline = frame_data + offset_x + ((offset_y + y) * gif->width);
                                 if (gif->frames[frame].transparency) {
                                         memset(frame_scanline,

--- a/libvips/foreign/libnsgif/libnsgif.c
+++ b/libvips/foreign/libnsgif/libnsgif.c
@@ -667,8 +667,6 @@ gif__decode(gif_animation *gif,
                         const uint8_t *uncompressed;
                         unsigned row_available;
                         if (available == 0) {
-                                res = lzw_decode(gif->lzw_ctx,
-                                                &uncompressed, &available);
                                 if (res != LZW_OK) {
                                         /* Unexpected end of frame, try to recover */
                                         if (res == LZW_OK_EOD) {
@@ -678,6 +676,8 @@ gif__decode(gif_animation *gif,
                                         }
                                         break;
                                 }
+                                res = lzw_decode(gif->lzw_ctx,
+                                                &uncompressed, &available);
                         }
 
                         row_available = x < available ? x : available;

--- a/libvips/foreign/libnsgif/lzw.c
+++ b/libvips/foreign/libnsgif/lzw.c
@@ -357,11 +357,10 @@ lzw_result lzw_decode(struct lzw_ctx *ctx,
 		lzw__dictionary_add_entry(ctx, (code_new < current_entry) ?
 				table[code_new].first_value :
 				ctx->previous_code_first);
-	}
 
-	/* Ensure code size is increased, if needed. */
-	if (current_entry == ctx->current_code_size_max) {
-		if (ctx->current_code_size < LZW_CODE_MAX) {
+		/* Ensure code size is increased, if needed. */
+		if (current_entry == ctx->current_code_size_max &&
+				ctx->current_code_size < LZW_CODE_MAX) {
 			ctx->current_code_size++;
 			ctx->current_code_size_max =
 					(1 << ctx->current_code_size) - 1;

--- a/libvips/foreign/libnsgif/lzw.c
+++ b/libvips/foreign/libnsgif/lzw.c
@@ -400,7 +400,7 @@ static inline uint32_t lzw__write_pixels(struct lzw_ctx *ctx,
 		uint32_t left)
 {
 	uint8_t *restrict output_pos = (uint8_t *)output + used;
-	struct lzw_table_entry * const table = ctx->table;
+	const struct lzw_table_entry * const table = ctx->table;
 	uint32_t space = length - used;
 	uint32_t count = left;
 
@@ -416,13 +416,13 @@ static inline uint32_t lzw__write_pixels(struct lzw_ctx *ctx,
 
 	/* Skip over any values we don't have space for. */
 	for (unsigned i = left; i != 0; i--) {
-		struct lzw_table_entry *entry = table + code;
+		const struct lzw_table_entry *entry = table + code;
 		code = entry->extends;
 	}
 
 	output_pos += count;
 	for (unsigned i = count; i != 0; i--) {
-		struct lzw_table_entry *entry = table + code;
+		const struct lzw_table_entry *entry = table + code;
 		*--output_pos = entry->value;
 		code = entry->extends;
 	}
@@ -491,7 +491,7 @@ static inline uint32_t lzw__write_pixels_map(struct lzw_ctx *ctx,
 		uint32_t left)
 {
 	uint32_t *restrict stack_pos = (uint32_t *)buffer + used;
-	struct lzw_table_entry * const table = ctx->table;
+	const struct lzw_table_entry * const table = ctx->table;
 	uint32_t space = length - used;
 	uint32_t count = left;
 
@@ -506,13 +506,13 @@ static inline uint32_t lzw__write_pixels_map(struct lzw_ctx *ctx,
 	ctx->output_left = left;
 
 	for (unsigned i = left; i != 0; i--) {
-		struct lzw_table_entry *entry = table + code;
+		const struct lzw_table_entry *entry = table + code;
 		code = entry->extends;
 	}
 
 	stack_pos += count;
 	for (unsigned i = count; i != 0; i--) {
-		struct lzw_table_entry *entry = table + code;
+		const struct lzw_table_entry *entry = table + code;
 		--stack_pos;
 		if (entry->value != ctx->transparency_idx) {
 			*stack_pos = ctx->colour_map[entry->value];

--- a/libvips/foreign/libnsgif/lzw.c
+++ b/libvips/foreign/libnsgif/lzw.c
@@ -269,13 +269,13 @@ lzw_result lzw_decode_init(
 		const uint8_t *compressed_data,
 		uint32_t compressed_data_len,
 		uint32_t compressed_data_pos,
-		uint8_t code_size,
+		uint8_t minimum_code_size,
 		const uint8_t ** const stack_base_out,
 		const uint8_t ** const stack_pos_out)
 {
 	struct lzw_dictionary_entry *table = ctx->table;
 
-	if (code_size >= LZW_CODE_MAX) {
+	if (minimum_code_size >= LZW_CODE_MAX) {
 		return LZW_BAD_ICODE;
 	}
 
@@ -288,10 +288,10 @@ lzw_result lzw_decode_init(
 	ctx->input.sb_bit_count = 0;
 
 	/* Initialise the dictionary building context */
-	ctx->initial_code_size = code_size + 1;
+	ctx->initial_code_size = minimum_code_size + 1;
 
-	ctx->clear_code = (1 << code_size) + 0;
-	ctx->eoi_code   = (1 << code_size) + 1;
+	ctx->clear_code = (1 << minimum_code_size) + 0;
+	ctx->eoi_code   = (1 << minimum_code_size) + 1;
 
 	/* Initialise the standard dictionary entries */
 	for (uint32_t i = 0; i < ctx->clear_code; ++i) {

--- a/libvips/foreign/libnsgif/lzw.c
+++ b/libvips/foreign/libnsgif/lzw.c
@@ -21,6 +21,8 @@
  * Decoder for GIF LZW data.
  */
 
+/** Maximum number of dictionary entries. */
+#define LZW_TABLE_ENTRY_MAX (1u << LZW_CODE_MAX)
 
 /**
  * Context for reading LZW data.
@@ -79,10 +81,10 @@ struct lzw_ctx {
 	uint32_t current_entry; /**< Next position in table to fill. */
 
 	/** Output value stack. */
-	uint8_t stack_base[1 << LZW_CODE_MAX];
+	uint8_t stack_base[LZW_TABLE_ENTRY_MAX];
 
 	/** LZW decode dictionary. Generated during decode. */
-	struct lzw_dictionary_entry table[1 << LZW_CODE_MAX];
+	struct lzw_dictionary_entry table[LZW_TABLE_ENTRY_MAX];
 };
 
 
@@ -342,7 +344,7 @@ lzw_result lzw_decode(struct lzw_ctx *ctx,
 	}
 
 	/* Add to the dictionary, only if there's space */
-	if (current_entry < (1 << LZW_CODE_MAX)) {
+	if (current_entry < LZW_TABLE_ENTRY_MAX) {
 		struct lzw_dictionary_entry *entry = table + current_entry;
 		entry->last_value     = last_value;
 		entry->first_value    = ctx->previous_code_first;

--- a/libvips/foreign/libnsgif/lzw.c
+++ b/libvips/foreign/libnsgif/lzw.c
@@ -36,7 +36,7 @@
  * Note that an individual LZW code can be split over up to three sub-blocks.
  */
 struct lzw_read_ctx {
-	const uint8_t *data;    /**< Pointer to start of input data */
+	const uint8_t *restrict data;    /**< Pointer to start of input data */
 	uint32_t data_len;      /**< Input data length */
 	uint32_t data_sb_next;  /**< Offset to sub-block size */
 
@@ -122,7 +122,7 @@ void lzw_context_destroy(struct lzw_ctx *ctx)
  * \param[in] ctx  LZW reading context, updated on success.
  * \return LZW_OK or LZW_OK_EOD on success, appropriate error otherwise.
  */
-static lzw_result lzw__block_advance(struct lzw_read_ctx *ctx)
+static lzw_result lzw__block_advance(struct lzw_read_ctx *restrict ctx)
 {
 	uint32_t block_size;
 	uint32_t next_block_pos = ctx->data_sb_next;
@@ -164,9 +164,9 @@ static lzw_result lzw__block_advance(struct lzw_read_ctx *ctx)
  * \return LZW_OK or LZW_OK_EOD on success, appropriate error otherwise.
  */
 static inline lzw_result lzw__read_code(
-		struct lzw_read_ctx *ctx,
+		struct lzw_read_ctx *restrict ctx,
 		uint8_t code_size,
-		uint32_t *code_out)
+		uint32_t *restrict code_out)
 {
 	uint32_t code = 0;
 	uint8_t current_bit = ctx->sb_bit & 0x7;

--- a/libvips/foreign/libnsgif/lzw.c
+++ b/libvips/foreign/libnsgif/lzw.c
@@ -437,3 +437,29 @@ lzw_result lzw_decode(struct lzw_ctx *ctx,
 	return lzw__decode(ctx, ctx->stack_base, sizeof(ctx->stack_base),
 			lzw__write_pixels, used);
 }
+
+/* Exported function, documented in lzw.h */
+lzw_result lzw_decode_continuous(struct lzw_ctx *ctx,
+		const uint8_t ** const data,
+		uint32_t *restrict used)
+{
+	*used = 0;
+	*data = ctx->stack_base;
+
+	if (ctx->output_left != 0) {
+		*used += lzw__write_pixels(ctx,
+				ctx->stack_base, sizeof(ctx->stack_base), *used,
+				ctx->output_code, ctx->output_left);
+	}
+
+	while (*used != sizeof(ctx->stack_base)) {
+		lzw_result res = lzw__decode(ctx,
+				ctx->stack_base, sizeof(ctx->stack_base),
+				lzw__write_pixels, used);
+		if (res != LZW_OK) {
+			return res;
+		}
+	}
+
+	return LZW_OK;
+}

--- a/libvips/foreign/libnsgif/lzw.c
+++ b/libvips/foreign/libnsgif/lzw.c
@@ -232,9 +232,9 @@ static lzw_result lzw__clear_codes(
 	uint8_t *stack_pos;
 
 	/* Reset dictionary building context */
-	ctx->current_code_size = ctx->initial_code_size + 1;
-	ctx->current_code_size_max = (1 << ctx->current_code_size) - 1;
-	ctx->current_entry = (1 << ctx->initial_code_size) + 2;
+	ctx->current_code_size = ctx->initial_code_size;
+	ctx->current_code_size_max = (1 << ctx->initial_code_size) - 1;
+	ctx->current_entry = ctx->eoi_code + 1;
 
 	/* There might be a sequence of clear codes, so process them all */
 	do {
@@ -288,7 +288,7 @@ lzw_result lzw_decode_init(
 	ctx->input.sb_bit_count = 0;
 
 	/* Initialise the dictionary building context */
-	ctx->initial_code_size = code_size;
+	ctx->initial_code_size = code_size + 1;
 
 	ctx->clear_code = (1 << code_size) + 0;
 	ctx->eoi_code   = (1 << code_size) + 1;

--- a/libvips/foreign/libnsgif/lzw.h
+++ b/libvips/foreign/libnsgif/lzw.h
@@ -106,4 +106,29 @@ lzw_result lzw_decode_continuous(struct lzw_ctx *ctx,
 		const uint8_t ** const data,
 		uint32_t *restrict used);
 
+/**
+ * Read LZW codes into client buffer, mapping output to colours.
+ *
+ * Ensure anything in output is used before calling this, as anything
+ * on the there before this call will be trampled.
+ *
+ * For transparency to work correctly, the given client buffer must have
+ * the values from the previous frame.  The transparency_idx should be a value
+ * of 256 or above, if the frame does not have transparency.
+ *
+ * \param[in]  ctx              LZW reading context, updated.
+ * \param[in]  transparency_idx Index representing transparency.
+ * \param[in]  colour_map       Index to pixel colour mapping
+ * \param[in]  data             Client buffer to fill with colour mapped values.
+ * \param[in]  length           Size of output array.
+ * \param[out] used             Returns the number of values written to data.
+ * \return LZW_OK on success, or appropriate error code otherwise.
+ */
+lzw_result lzw_decode_map_continuous(struct lzw_ctx *ctx,
+		uint32_t transparency_idx,
+		uint32_t *restrict colour_table,
+		uint32_t *restrict data,
+		uint32_t length,
+		uint32_t *restrict used);
+
 #endif

--- a/libvips/foreign/libnsgif/lzw.h
+++ b/libvips/foreign/libnsgif/lzw.h
@@ -91,4 +91,19 @@ lzw_result lzw_decode(struct lzw_ctx *ctx,
 		const uint8_t *restrict *const restrict data,
 		uint32_t *restrict used);
 
+/**
+ * Read input codes until end of lzw context owned output buffer.
+ *
+ * Ensure anything in output is used before calling this, as anything
+ * on the there before this call will be trampled.
+ *
+ * \param[in]  ctx   LZW reading context, updated.
+ * \param[out] data  Returns pointer to array of output values.
+ * \param[out] used  Returns the number of values written to data.
+ * \return LZW_OK on success, or appropriate error code otherwise.
+ */
+lzw_result lzw_decode_continuous(struct lzw_ctx *ctx,
+		const uint8_t ** const data,
+		uint32_t *restrict used);
+
 #endif

--- a/libvips/foreign/libnsgif/lzw.h
+++ b/libvips/foreign/libnsgif/lzw.h
@@ -67,9 +67,6 @@ void lzw_context_destroy(
  *                                  of a size byte at sub-block start.
  * \param[in]  minimum_code_size    The LZW Minimum Code Size.
  * \param[out] stack_base_out       Returns base of decompressed data stack.
- * \param[out] stack_pos_out        Returns current stack position.
- *                                  There are `stack_pos_out - stack_base_out`
- *                                  current stack entries.
  * \return LZW_OK on success, or appropriate error code otherwise.
  */
 lzw_result lzw_decode_init(
@@ -78,8 +75,7 @@ lzw_result lzw_decode_init(
 		uint32_t compressed_data_len,
 		uint32_t compressed_data_pos,
 		uint8_t minimum_code_size,
-		const uint8_t ** const stack_base_out,
-		const uint8_t ** const stack_pos_out);
+		const uint8_t ** const stack_base_out);
 
 /**
  * Fill the LZW stack with decompressed data
@@ -87,19 +83,14 @@ lzw_result lzw_decode_init(
  * Ensure anything on the stack is used before calling this, as anything
  * on the stack before this call will be trampled.
  *
- * Caller does not own `stack_pos_out`.
- *
- * \param[in]  ctx            LZW reading context, updated.
- * \param[out] stack_pos_out  Returns current stack position.
- *                            Use with `stack_base_out` value from previous
- *                            lzw_decode_init() call.
- *                            There are `stack_pos_out - stack_base_out`
- *                            current stack entries.
+ * \param[in]  ctx      LZW reading context, updated.
+ * \param[out] written  Returns the number of values written.
+ *                      Use with `stack_base_out` value from previous
+ *                      lzw_decode_init() call.
  * \return LZW_OK on success, or appropriate error code otherwise.
  */
 lzw_result lzw_decode(
 		struct lzw_ctx *ctx,
-		const uint8_t ** const stack_pos_out);
-
+		uint32_t *written);
 
 #endif

--- a/libvips/foreign/libnsgif/lzw.h
+++ b/libvips/foreign/libnsgif/lzw.h
@@ -65,7 +65,7 @@ void lzw_context_destroy(
  * \param[in]  compressed_data_len  Byte length of compressed data.
  * \param[in]  compressed_data_pos  Start position in data.  Must be position
  *                                  of a size byte at sub-block start.
- * \param[in]  code_size            The initial LZW code size to use.
+ * \param[in]  minimum_code_size    The LZW Minimum Code Size.
  * \param[out] stack_base_out       Returns base of decompressed data stack.
  * \param[out] stack_pos_out        Returns current stack position.
  *                                  There are `stack_pos_out - stack_base_out`
@@ -77,7 +77,7 @@ lzw_result lzw_decode_init(
 		const uint8_t *compressed_data,
 		uint32_t compressed_data_len,
 		uint32_t compressed_data_pos,
-		uint8_t code_size,
+		uint8_t minimum_code_size,
 		const uint8_t ** const stack_base_out,
 		const uint8_t ** const stack_pos_out);
 

--- a/libvips/foreign/libnsgif/lzw.h
+++ b/libvips/foreign/libnsgif/lzw.h
@@ -74,23 +74,21 @@ lzw_result lzw_decode_init(
 		const uint8_t *compressed_data,
 		uint32_t compressed_data_len,
 		uint32_t compressed_data_pos,
-		uint8_t minimum_code_size,
-		const uint8_t ** const stack_base_out);
+		uint8_t minimum_code_size);
 
 /**
- * Fill the LZW stack with decompressed data
+ * Read a single LZW code and write into lzw context owned output buffer.
  *
- * Ensure anything on the stack is used before calling this, as anything
- * on the stack before this call will be trampled.
+ * Ensure anything in output is used before calling this, as anything
+ * on the there before this call will be trampled.
  *
- * \param[in]  ctx      LZW reading context, updated.
- * \param[out] written  Returns the number of values written.
- *                      Use with `stack_base_out` value from previous
- *                      lzw_decode_init() call.
+ * \param[in]  ctx   LZW reading context, updated.
+ * \param[out] data  Returns pointer to array of output values.
+ * \param[out] used  Returns the number of values written to data.
  * \return LZW_OK on success, or appropriate error code otherwise.
  */
-lzw_result lzw_decode(
-		struct lzw_ctx *ctx,
-		uint32_t *written);
+lzw_result lzw_decode(struct lzw_ctx *ctx,
+		const uint8_t *restrict *const restrict data,
+		uint32_t *restrict used);
 
 #endif


### PR DESCRIPTION
This series syncs with the [upstream libnsgif](http://git.netsurf-browser.org/libnsgif.git/)'s changes to optimize LZW decompression.

Patches created with the following (from `libnsgif/src` directory):

```
git format-patch --relative bba28df0cc0c75338a63645c6a55aebfebe91c74
```

And applied with:

```
git am --directory=libvips/foreign/libnsgif/ ../libnsgif/src/*.patch
```