### PR TITLE
Fix make uninstall with Doxygen

### DIFF
--- a/cplusplus/Makefile.am
+++ b/cplusplus/Makefile.am
@@ -42,6 +42,9 @@ install-htmlDATA:
 	-mkdir -p $(DESTDIR)$(htmldir)
 	-cp -r html $(DESTDIR)$(htmldir)
 
+uninstall-htmlDATA:
+	rm -rf $(DESTDIR)$(htmldir)/html
+
 EXTRA_DIST = \
 	README.md \
 	vips-operators.cpp \


### PR DESCRIPTION
```
make[2]: Entering directory '/home/kleisauke/libvips/cplusplus'
 ( cd '/usr/share/doc/vips' && rm -f html )
rm: cannot remove 'html': Is a directory
make[2]: *** [Makefile:672: uninstall-htmlDATA] Error 1
```

(Split out from #2167)