### PR TITLE
gitignore: ignore .dirstamp files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -41,6 +41,7 @@ Vips-8.0.typelib
 *.pyc
 *.pyo
 .deps
+.dirstamp
 .libs
 aclocal.m4
 config.log


### PR DESCRIPTION
Somehow I sometimes encounter this file while committing, I think we could safely ignore this file.

(Split out from #2167)