### PR TITLE
Fix autogen warning

### DIFF
--- a/libvips/foreign/libnsgif/Makefile.am
+++ b/libvips/foreign/libnsgif/Makefile.am
@@ -2,7 +2,7 @@ EXTRA_DIST = \
 	README-ns \
 	README.md \
 	patches \
-  update.sh \	
+	update.sh \
 	utils 
 
 noinst_LTLIBRARIES = libnsgif.la


### PR DESCRIPTION
```
libvips/foreign/libnsgif/Makefile.am:5: warning: whitespace following trailing backslash
```

(Split out from #2167)