### PR TITLE
Simplify preprocessor directives

### DIFF
--- a/libvips/iofuncs/image.c
+++ b/libvips/iofuncs/image.c
@@ -801,12 +801,11 @@ static void
 vips_image_add_progress( VipsImage *image )
 {
 	if( vips__progress || 
+		g_getenv( "VIPS_PROGRESS" )
 #if ENABLE_DEPRECATED
-		g_getenv( "VIPS_PROGRESS" ) ||
-		g_getenv( "IM_PROGRESS" ) ) {
-#else
-		g_getenv( "VIPS_PROGRESS" ) ) {
+		|| g_getenv( "IM_PROGRESS" )
 #endif
+		) {
 
 		/* Keep the %complete we displayed last time here.
 		 */
@@ -2507,12 +2506,11 @@ vips_get_disc_threshold( void )
 		 */
 		threshold = 100 * 1024 * 1024;
 
+		if( (env = g_getenv( "VIPS_DISC_THRESHOLD" ))
 #if ENABLE_DEPRECATED
-		if( (env = g_getenv( "VIPS_DISC_THRESHOLD" )) || 
-			(env = g_getenv( "IM_DISC_THRESHOLD" )) ) 
-#else
-		if( (env = g_getenv( "VIPS_DISC_THRESHOLD" )) )
+			|| (env = g_getenv( "IM_DISC_THRESHOLD" ))
 #endif
+		  )
 			threshold = vips__parse_size( env );
 
 		if( vips__disc_threshold ) 

--- a/libvips/iofuncs/init.c
+++ b/libvips/iofuncs/init.c
@@ -449,12 +449,11 @@ vips_init( const char *argv0 )
 	g_free( locale );
 	bind_textdomain_codeset( GETTEXT_PACKAGE, "UTF-8" );
 
+	if( g_getenv( "VIPS_INFO" )
 #if ENABLE_DEPRECATED
-	if( g_getenv( "VIPS_INFO" ) || 
-		g_getenv( "IM_INFO" ) ) 
-#else
-	if( g_getenv( "VIPS_INFO" ) ) 
+		|| g_getenv( "IM_INFO" )
 #endif
+	)
 		vips_verbose();
 	if( g_getenv( "VIPS_PROFILE" ) )
 		vips_profile_set( TRUE );
@@ -568,12 +567,11 @@ vips_init( const char *argv0 )
 	 * set up if you are using libvips from something like Ruby. Allow this
 	 * env var hack as a workaround. 
 	 */
+	if( g_getenv( "VIPS_WARNING" )
 #if ENABLE_DEPRECATED
-	if( g_getenv( "VIPS_WARNING" ) ||
-		g_getenv( "IM_WARNING" ) ) 
-#else
-	if( g_getenv( "VIPS_WARNING" ) )
+		|| g_getenv( "IM_WARNING" )
 #endif
+	)
 		g_log_set_handler( G_LOG_DOMAIN, G_LOG_LEVEL_WARNING, 
 			empty_log_handler, NULL );
 

--- a/libvips/iofuncs/threadpool.c
+++ b/libvips/iofuncs/threadpool.c
@@ -406,13 +406,11 @@ vips_concurrency_get( void )
 	 */
 	if( vips__concurrency > 0 )
 		nthr = vips__concurrency;
+	else if( ((str = g_getenv( "VIPS_CONCURRENCY" ))
 #if ENABLE_DEPRECATED
-	else if( ((str = g_getenv( "VIPS_CONCURRENCY" )) ||
-		(str = g_getenv( "IM_CONCURRENCY" ))) && 
-#else
-	else if( (str = g_getenv( "VIPS_CONCURRENCY" )) && 
+		|| (str = g_getenv( "IM_CONCURRENCY" ))
 #endif
-		(x = atoi( str )) > 0 )
+	) && (x = atoi( str )) > 0 )
 		nthr = x;
 	else 
 		nthr = get_num_processors();

--- a/libvips/iofuncs/vector.c
+++ b/libvips/iofuncs/vector.c
@@ -102,12 +102,11 @@ vips_vector_init( void )
 	/* Look for the environment variable VIPS_NOVECTOR and use that to turn
 	 * off as well.
 	 */
+	if( g_getenv( "VIPS_NOVECTOR" )
 #if ENABLE_DEPRECATED
-	if( g_getenv( "VIPS_NOVECTOR" ) || 
-		g_getenv( "IM_NOVECTOR" ) ) 
-#else
-	if( g_getenv( "VIPS_NOVECTOR" ) )
+		|| g_getenv( "IM_NOVECTOR" )
 #endif
+	)
 		vips__vector_enabled = FALSE;
 
 #endif /*HAVE_ORC*/


### PR DESCRIPTION
We can simplify these directives into one statement, instead of duplicating the `#else` branch.

(Split out from #2167)