### PR TITLE
CI: remove imagemagick as a dependency on macOS

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -64,7 +64,7 @@ jobs:
           brew update
           brew upgrade
           brew install autoconf automake libtool fftw fontconfig gtk-doc gobject-introspection glib libexif libgsf little-cms2 orc pango
-          brew install cfitsio imagemagick@6 libheif libjpeg-turbo libmatio librsvg libspng libtiff openexr openjpeg openslide poppler webp
+          brew install cfitsio libheif libjpeg-turbo libmatio librsvg libspng libtiff openexr openjpeg openslide poppler webp
 
       - name: Install Clang 10
         env:


### PR DESCRIPTION
(We can always add it back later should it start to work again.)