### PR TITLE
Reuse threads by using the thread pool of GLib (#2038)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -103,6 +103,7 @@ jobs:
           echo "ASAN_DSO=$ASAN_DSO" >> $GITHUB_ENV
           echo "ASAN_OPTIONS=suppressions=${{ github.workspace }}/suppressions/asan.supp" >> $GITHUB_ENV
           echo "LSAN_OPTIONS=suppressions=${{ github.workspace }}/suppressions/lsan.supp" >> $GITHUB_ENV
+          echo "TSAN_OPTIONS=suppressions=${{ github.workspace }}/suppressions/tsan.supp" >> $GITHUB_ENV
           echo "UBSAN_OPTIONS=suppressions=${{ github.workspace }}/suppressions/ubsan.supp:print_stacktrace=1" >> $GITHUB_ENV
           echo "LD_LIBRARY_PATH=$LLVM_PREFIX/lib:`dirname $ASAN_DSO`" >> $GITHUB_ENV
           echo "$LLVM_PREFIX/bin" >> $GITHUB_PATH

--- a/libvips/deprecated/vips7compat.c
+++ b/libvips/deprecated/vips7compat.c
@@ -5694,7 +5694,7 @@ vips_get_option_group( void )
 }
 
 /* We used to use this for system() back in the day. But it's awkward to make
- * it work properly on win32, so this is nonw deprecated.
+ * it work properly on win32, so this is now deprecated.
  */
 FILE *
 vips_popenf( const char *fmt, const char *mode, ... )
@@ -5703,3 +5703,16 @@ vips_popenf( const char *fmt, const char *mode, ... )
         return( NULL );
 }
 
+GThread *
+vips_g_thread_new( const char *domain, GThreadFunc func, gpointer data )
+{
+	vips_error( "vips_g_thread_new", "%s", _( "deprecated" ) );
+	return( NULL );
+}
+
+void *
+vips_g_thread_join( GThread *thread )
+{
+	vips_error( "vips_g_thread_join", "%s", _( "deprecated" ) );
+	return( NULL );
+}

--- a/libvips/include/vips/internal.h
+++ b/libvips/include/vips/internal.h
@@ -111,6 +111,7 @@ extern gboolean vips__cache_trace;
 extern int vips__n_active_threads;
 
 void vips__threadpool_init( void );
+void vips__threadpool_shutdown( void );
 
 void vips__cache_init( void );
 

--- a/libvips/include/vips/internal.h
+++ b/libvips/include/vips/internal.h
@@ -108,8 +108,6 @@ extern char *vips__disc_threshold;
 extern gboolean vips__cache_dump;
 extern gboolean vips__cache_trace;
 
-extern int vips__n_active_threads;
-
 void vips__threadpool_init( void );
 void vips__threadpool_shutdown( void );
 

--- a/libvips/include/vips/internal.h
+++ b/libvips/include/vips/internal.h
@@ -140,6 +140,7 @@ int vips_mapfilerw( VipsImage * );
 int vips_remapfilerw( VipsImage * );
 
 void vips__buffer_init( void );
+void vips__buffer_shutdown( void );
 
 void vips__copy_4byte( int swap, unsigned char *to, unsigned char *from );
 void vips__copy_2byte( gboolean swap, unsigned char *to, unsigned char *from );

--- a/libvips/include/vips/thread.h
+++ b/libvips/include/vips/thread.h
@@ -47,11 +47,6 @@ void vips_g_mutex_free( GMutex * );
 GCond *vips_g_cond_new( void );
 void vips_g_cond_free( GCond * );
 
-/* ... and for GThread.
- */
-GThread *vips_g_thread_new( const char *, GThreadFunc, gpointer );
-void *vips_g_thread_join( GThread *thread );
-
 gboolean vips_thread_isworker( void );
 
 #ifdef __cplusplus

--- a/libvips/include/vips/threadpool.h
+++ b/libvips/include/vips/threadpool.h
@@ -5,6 +5,8 @@
  * 17/3/10
  * 	- from threadgroup
  * 	- rework with a simpler distributed work allocation model
+ * 02/02/20 kleisauke
+ * 	- reuse threads by using GLib's threadpool
  */
 
 /*
@@ -130,6 +132,7 @@ typedef int (*VipsThreadpoolWorkFn)( VipsThreadState *state, void *a );
  */
 typedef int (*VipsThreadpoolProgressFn)( void *a );
 
+int vips_threadpool_push( const char *name, GFunc func, gpointer data );
 int vips_threadpool_run( VipsImage *im, 
 	VipsThreadStartFn start, 
 	VipsThreadpoolAllocateFn allocate, 

--- a/libvips/include/vips/vips7compat.h
+++ b/libvips/include/vips/vips7compat.h
@@ -1224,6 +1224,11 @@ VipsWindow *vips_window_ref( VipsImage *im, int top, int height );
 FILE *vips_popenf( const char *fmt, const char *mode, ... )
 	__attribute__((format(printf, 1, 3)));
 
+/* old GThread API.
+ */
+GThread *vips_g_thread_new( const char *, GThreadFunc, gpointer );
+void *vips_g_thread_join( GThread *thread );
+
 /* This stuff is very, very old and should not be used by anyone now.
  */
 #ifdef VIPS_ENABLE_ANCIENT

--- a/libvips/iofuncs/buffer.c
+++ b/libvips/iofuncs/buffer.c
@@ -675,3 +675,13 @@ vips__buffer_init( void )
 #endif /*DEBUG_CREATE*/
 }
 
+void
+vips__buffer_shutdown( void )
+{
+	VipsBufferThread *buffer_thread;
+
+	if( (buffer_thread = g_private_get( buffer_thread_key )) ) {
+		buffer_thread_free( buffer_thread );
+		g_private_set( buffer_thread_key, NULL );
+	}
+}

--- a/libvips/iofuncs/gate.c
+++ b/libvips/iofuncs/gate.c
@@ -245,15 +245,13 @@ vips__thread_profile_attach( const char *thread_name )
 
 	VIPS_DEBUG_MSG( "vips__thread_profile_attach: %s\n", thread_name ); 
 
-	g_assert( !g_private_get( vips_thread_profile_key ) );
-
 	profile = g_new( VipsThreadProfile, 1 );
 	profile->name = thread_name; 
 	profile->gates = g_hash_table_new_full( 
 		g_direct_hash, g_str_equal, 
 		NULL, (GDestroyNotify) vips_thread_gate_free );
 	profile->memory = vips_thread_gate_new( "memory" ); 
-	g_private_set( vips_thread_profile_key, profile );
+	g_private_replace( vips_thread_profile_key, profile );
 }
 
 static VipsThreadProfile *

--- a/libvips/iofuncs/init.c
+++ b/libvips/iofuncs/init.c
@@ -641,12 +641,6 @@ vips_leak( void )
 		n_leaks += strlen( vips_error_buffer() );
 	}
 
-	if( vips__n_active_threads > 0 ) {
-		vips_buf_appendf( &buf, "threads: %d not joined\n", 
-			vips__n_active_threads ); 
-		n_leaks += vips__n_active_threads;
-	}
-
 	fprintf( stderr, "%s", vips_buf_all( &buf ) );
 
 	n_leaks += vips__print_renders();

--- a/libvips/iofuncs/init.c
+++ b/libvips/iofuncs/init.c
@@ -672,6 +672,7 @@ void
 vips_thread_shutdown( void )
 {
 	vips__thread_profile_detach();
+	vips__buffer_shutdown();
 }
 
 /**

--- a/libvips/iofuncs/init.c
+++ b/libvips/iofuncs/init.c
@@ -665,7 +665,7 @@ vips_leak( void )
  *
  * This function needs to be called when a thread that has been using vips
  * exits. It is called for you by vips_shutdown() and for any threads created
- * by vips_g_thread_new(). 
+ * within the #VipsThreadPool. 
  *
  * You will need to call it from threads created in
  * other ways or there will be memory leaks. If you do not call it, vips 
@@ -718,6 +718,8 @@ vips_shutdown( void )
 	vips_thread_shutdown();
 
 	vips__thread_profile_stop();
+
+	vips__threadpool_shutdown();
 
 #ifdef HAVE_GSF
 	gsf_shutdown(); 

--- a/libvips/iofuncs/sink.c
+++ b/libvips/iofuncs/sink.c
@@ -171,7 +171,7 @@ sink_area_position( SinkArea *area, int top, int height )
 static gboolean
 sink_area_allocate_fn( VipsThreadState *state, void *a, gboolean *stop )
 {
-	SinkThreadState *wstate = (SinkThreadState *) state;
+	SinkThreadState *sstate = (SinkThreadState *) state;
 	Sink *sink = (Sink *) a;
 	SinkBase *sink_base = (SinkBase *) sink;
 
@@ -227,7 +227,7 @@ sink_area_allocate_fn( VipsThreadState *state, void *a, gboolean *stop )
 
 	/* The thread needs to know which area it's writing to.
 	 */
-	wstate->area = sink->area;
+	sstate->area = sink->area;
 
 	VIPS_DEBUG_MSG( "  %p allocated %d x %d:\n", 
 		g_thread_self(), state->pos.left, state->pos.top );

--- a/libvips/iofuncs/sinkmemory.c
+++ b/libvips/iofuncs/sinkmemory.c
@@ -173,7 +173,7 @@ sink_memory_area_position( SinkMemoryArea *area, int top, int height )
 static gboolean
 sink_memory_area_allocate_fn( VipsThreadState *state, void *a, gboolean *stop )
 {
-	SinkMemoryThreadState *wstate = (SinkMemoryThreadState *) state;
+	SinkMemoryThreadState *smstate = (SinkMemoryThreadState *) state;
 	SinkMemory *memory = (SinkMemory *) a;
 	SinkBase *sink_base = (SinkBase *) memory;
 
@@ -229,7 +229,7 @@ sink_memory_area_allocate_fn( VipsThreadState *state, void *a, gboolean *stop )
 
 	/* The thread needs to know which area it's writing to.
 	 */
-	wstate->area = memory->area;
+	smstate->area = memory->area;
 
 	VIPS_DEBUG_MSG( "  %p allocated %d x %d:\n", 
 		g_thread_self(), state->pos.left, state->pos.top );
@@ -255,8 +255,8 @@ static int
 sink_memory_area_work_fn( VipsThreadState *state, void *a )
 {
 	SinkMemory *memory = (SinkMemory *) a;
-	SinkMemoryThreadState *wstate = (SinkMemoryThreadState *) state;
-	SinkMemoryArea *area = wstate->area;
+	SinkMemoryThreadState *smstate = (SinkMemoryThreadState *) state;
+	SinkMemoryArea *area = smstate->area;
 
 	int result;
 

--- a/libvips/iofuncs/threadpool.c
+++ b/libvips/iofuncs/threadpool.c
@@ -201,7 +201,8 @@ vips_thread_main_loop( gpointer thread_data, gpointer pool_data )
 	VipsThreadExec *exec = (VipsThreadExec *) thread_data;
 
 	/* Set this to something (anything) to tag this thread as a vips 
-	 * worker.
+	 * worker. No need to call g_private_replace as there is no
+	 * GDestroyNotify handler associated with a worker.
 	 */
 	g_private_set( is_worker_key, thread_data );
 

--- a/suppressions/tsan.supp
+++ b/suppressions/tsan.supp
@@ -1,0 +1,115 @@
+# an unlocked FALSE/TRUE assignment, which is fine
+race:vips_region_prepare_to
+race:render_kill
+race:render_reschedule
+
+# an unlocked NULL assignment, which is fine
+race:render_thread
+
+# unlocked read of pixels-processed-so-far, which is fine
+race:vips_sink_base_progress
+race:wbuffer_allocate_fn
+race:sink_memory_area_allocate_fn
+
+# use of *stop from generate funcs is unlocked, but fine
+race:vips_threadpool_run
+
+# guarded with vips_tracked_mutex, so it should be fine
+race:vips_tracked_mem
+race:vips_tracked_allocs
+race:vips_tracked_files
+
+# guarded with task->allocate_lock, so it should be fine
+race:vips_thread_allocate
+race:vips_task_work_unit
+
+# guarded with vips_cache_lock, so it should be fine
+race:vips_cache_table
+race:vips_cache_drop_all
+race:vips_cache_get_first
+race:vips_cache_get_lru_cb
+race:vips_cache_remove
+
+# guarded with vips__global_lock, so it should be fine
+race:vips_error_freeze_count
+race:vips__link_make
+race:vips__link_map
+race:vips__link_break_all
+race:tile_name
+
+# the double-buffered output and write-behind thread are non-racy
+race:wbuffer_new
+race:wbuffer_write
+race:wbuffer_work_fn
+race:wbuffer_free
+race:write_thread_state_new
+
+# thread-local variables (i.e. GPrivate) are harmless
+race:vips_thread_profile_key
+race:buffer_thread_key
+
+# glib signals are probably non-racy
+race:vips_image_preeval
+race:vips_image_eval
+race:vips_image_posteval
+race:vips_image_written
+race:vips_image_real_written
+race:vips_image_save_cb
+race:render_close_cb
+race:readjpeg_close_cb
+
+# semaphores are probably non-racy
+race:vips_semaphore_*
+
+# guarded with sink->sslock, so it should be fine
+race:sink_call_start
+race:sink_call_stop
+race:vips_hist_find_start
+race:vips_hist_find_stop
+race:vips_statistic_scan_start
+race:vips_statistic_scan_stop
+race:vips_max_stop
+race:vips_values_add
+race:vips_deviate_stop
+race:vips_arithmetic_start
+race:histogram_new
+
+# per-thread state allocate/dispose functions are non-racy
+race:sink_thread_state_class_init
+race:vips_thread_state_init
+race:vips_thread_state_build
+race:vips_thread_state_set
+race:vips_thread_state_dispose
+race:write_thread_state_new
+race:vips_sink_base_init
+race:vips_sink_thread_state_new
+race:sink_memory_init
+race:sink_memory_thread_state_new
+race:sink_memory_free
+race:sink_thread_state_build
+race:sink_thread_state_dispose
+race:buffer_cache_free
+race:sink_init
+race:sink_free
+race:vips_sequential_dispose
+race:vips_block_cache_dispose
+race:vips_image_init
+race:vips_image_build
+race:vips_image_finalize
+race:vips_image_dispose
+
+# guarded with image->sslock, so it should be fine
+race:vips__region_start
+race:vips__region_stop
+race:vips_region_dispose
+race:vips__region_take_ownership
+
+# is fine now, see: https://github.com/libvips/libvips/pull/1211
+race:vips_image_temp_name
+
+# is fine now, see: https://github.com/libvips/libvips/pull/1483
+race:meta_new
+race:meta_cp
+race:vips_image_set
+race:vips__image_copy_fields_array
+race:vips__image_meta_copy


### PR DESCRIPTION
This PR revamps the threading system of libvips by using [GLib's threadpool](https://developer.gnome.org/glib/stable/glib-Thread-Pools.html) as discussed in #2038. This implementation allows reuse of already started threads.

Here is a brief overview of the related changes within this PR (see the individual commits for more details).
- Add `vips_threadpool_push` for inserting an new function into the list of tasks to be executed by libvips' thread pool.
- Add `vips__threadpool_shutdown` to shutdown the thread pool during [`vips_shutdown()`](https://libvips.github.io/libvips/API/current/libvips-vips.html#vips-shutdown).
- Add `vips__buffer_shutdown` to free the calculated pixel buffer cache early during [`vips_thread_shutdown()`](https://libvips.github.io/libvips/API/current/libvips-vips.html#vips-thread-shutdown).
- Remove `vips__n_active_threads`, as this is no longer necessary (it was used to check whether all threads are joined).
- Deprecate `vips_g_thread_new` and `vips_g_thread_join` which was a wrapper around the old GThread API.
- Remove mutex lock for `VipsThreadStartFn`.
- Move `sink_disc` and `sink_screen` threads to the thread pool.
- Add suppressions file for ThreadSanitizer.
- Swap `g_private_set` with `g_private_replace` where possible.
- Use `gatomicrefcount` in `sinkscreen.c`.

This was benchmarked on [Linux](https://github.com/kleisauke/vips-microbench/blob/master/results/reuse-threads.md) and [Windows](https://gist.github.com/kleisauke/cf6a115c65894d27eda4a8d9379776f7) with relative speed-ups varying between ~4% and ~15% depending on the benchmark and the OS it was run on. A soak-test based on https://github.com/libvips/libvips/pull/1240#issuecomment-467876334 can be found [here](https://gist.github.com/kleisauke/fbc5a8bb418da2f660c06bdd07115e10).

This PR was tested last week within production on [images.weserv.nl](https://images.weserv.nl/) without any problems. We noticed an immediate reduction in the number of interrupts and `fork()` / `clone()` system calls, see:
Interrupts and context switches | `fork()` / `clone()` system calls
:--: | :--:
![Interrupts](https://kleisauke.nl/interrupts-pinpoint=1619352619,1620043819.png) | ![fork() / clone() syscalls](https://kleisauke.nl/forks-pinpoint=1619352619,1620043819.png)
_(Click to enlarge)_ | _(Click to enlarge)_

<details>
  <summary>API Changes</summary>

The following symbols are added to the public API:
* ```c
  int vips_threadpool_push( const char *name, GFunc func, gpointer data );
  ```
  _For inserting an new function into the list of tasks to be executed by libvips' thread pool._

The following symbols are added to the private API:
* ```c
  void vips__threadpool_shutdown( void );
  ```
  _To shutdown the thread pool during [`vips_shutdown()`](https://libvips.github.io/libvips/API/current/libvips-vips.html#vips-shutdown)._

* ```c
  void vips__buffer_shutdown( void );
  ```
  _To free the calculated pixel buffer cache early during [`vips_thread_shutdown()`](https://libvips.github.io/libvips/API/current/libvips-vips.html#vips-thread-shutdown)._

The following symbols are removed from the private API:
* ```c
  int vips__n_active_threads;
  ```
  _Used to check whether all threads are joined, no longer necessary._

The following symbols are deprecated and should no longer be used:

* ```c
  GThread *vips_g_thread_new( const char *domain, GThreadFunc func, gpointer data );
  ```
  _Wrapper around the [GThread API](https://developer.gnome.org/glib/stable/glib-Threads.html), use [`g_thread_try_new`](https://developer.gnome.org/glib/stable/glib-Threads.html#g-thread-try-new) instead._

* ```c
  void *vips_g_thread_join( GThread *thread );
  ```
  _Wrapper around the [GThread API](https://developer.gnome.org/glib/stable/glib-Threads.html), use [`g_thread_join`](https://developer.gnome.org/glib/stable/glib-Threads.html#g-thread-join) instead._

`abi-compliance-checker` result:
https://kleisauke.nl/compat_reports/vips/master_to_reuse-threads/compat_report.html
</details>