### PR TITLE
Only build libjxl as a loadable module when it can be found

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -830,6 +830,7 @@ if test x"$with_libjxl" != x"no"; then
     ],
     [AC_MSG_WARN([libjxl not found; disabling libjxl support])
      with_libjxl=no
+     with_libjxl_module=no
     ]
   )
 fi


### PR DESCRIPTION
This was noticed within the CI, see: https://github.com/libvips/libvips/runs/2599127347#step:12:417.