### PR TITLE
Ensure compatibility with Cygwin

### DIFF
--- a/libvips/iofuncs/source.c
+++ b/libvips/iofuncs/source.c
@@ -76,13 +76,13 @@
 
 /* Try to make an O_BINARY ... sometimes need the leading '_'.
  */
-#ifdef G_PLATFORM_WIN32
+#if defined(G_PLATFORM_WIN32) || defined(G_WITH_CYGWIN)
 #ifndef O_BINARY
 #ifdef _O_BINARY
 #define O_BINARY _O_BINARY
 #endif /*_O_BINARY*/
 #endif /*!O_BINARY*/
-#endif /*G_PLATFORM_WIN32*/
+#endif /*defined(G_PLATFORM_WIN32) || defined(G_WITH_CYGWIN)*/
 
 /* If we have O_BINARY, add it to a mode flags set.
  */

--- a/libvips/iofuncs/target.c
+++ b/libvips/iofuncs/target.c
@@ -66,13 +66,13 @@
 
 /* Try to make an O_BINARY ... sometimes need the leading '_'.
  */
-#ifdef G_PLATFORM_WIN32
+#if defined(G_PLATFORM_WIN32) || defined(G_WITH_CYGWIN)
 #ifndef O_BINARY
 #ifdef _O_BINARY
 #define O_BINARY _O_BINARY
 #endif /*_O_BINARY*/
 #endif /*!O_BINARY*/
-#endif /*G_PLATFORM_WIN32*/
+#endif /*defined(G_PLATFORM_WIN32) || defined(G_WITH_CYGWIN)*/
 
 /* If we have O_BINARY, add it to a mode flags set.
  */

--- a/libvips/iofuncs/util.c
+++ b/libvips/iofuncs/util.c
@@ -67,13 +67,13 @@
 
 /* Try to make an O_BINARY ... sometimes need the leading '_'.
  */
-#ifdef G_PLATFORM_WIN32
+#if defined(G_PLATFORM_WIN32) || defined(G_WITH_CYGWIN)
 #ifndef O_BINARY
 #ifdef _O_BINARY
 #define O_BINARY _O_BINARY
 #endif /*_O_BINARY*/
 #endif /*!O_BINARY*/
-#endif /*G_PLATFORM_WIN32*/
+#endif /*defined(G_PLATFORM_WIN32) || defined(G_WITH_CYGWIN)*/
 
 /* If we have O_BINARY, add it to a mode flags set.
  */
@@ -698,14 +698,14 @@ vips__file_open_read( const char *filename, const char *fallback_dir,
 	char *mode;
 	FILE *fp;
 
-#ifdef G_PLATFORM_WIN32
+#if defined(G_PLATFORM_WIN32) || defined(G_WITH_CYGWIN)
 	if( text_mode )
 		mode = "r";
 	else
 		mode = "rb";
-#else /*!G_PLATFORM_WIN32*/
+#else /*!defined(G_PLATFORM_WIN32) && !defined(G_WITH_CYGWIN)*/
 	mode = "r";
-#endif /*G_PLATFORM_WIN32*/
+#endif /*defined(G_PLATFORM_WIN32) || defined(G_WITH_CYGWIN)*/
 
 	if( (fp = vips__fopen( filename, mode )) )
 		return( fp );
@@ -734,14 +734,14 @@ vips__file_open_write( const char *filename, gboolean text_mode )
 	char *mode;
 	FILE *fp;
 
-#ifdef G_PLATFORM_WIN32
+#if defined(G_PLATFORM_WIN32) || defined(G_WITH_CYGWIN)
 	if( text_mode )
 		mode = "w";
 	else
 		mode = "wb";
-#else /*!G_PLATFORM_WIN32*/
+#else /*!defined(G_PLATFORM_WIN32) && !defined(G_WITH_CYGWIN)*/
 	mode = "w";
-#endif /*G_PLATFORM_WIN32*/
+#endif /*defined(G_PLATFORM_WIN32) || defined(G_WITH_CYGWIN)*/
 
         if( !(fp = vips__fopen( filename, mode )) ) {
 		vips_error_system( errno, "vips__file_open_write", 

--- a/libvips/iofuncs/vips.c
+++ b/libvips/iofuncs/vips.c
@@ -115,13 +115,13 @@
 
 /* Try to make an O_BINARY ... sometimes need the leading '_'.
  */
-#ifdef G_PLATFORM_WIN32
+#if defined(G_PLATFORM_WIN32) || defined(G_WITH_CYGWIN)
 #ifndef O_BINARY
 #ifdef _O_BINARY
 #define O_BINARY _O_BINARY
 #endif /*_O_BINARY*/
 #endif /*!O_BINARY*/
-#endif /*G_PLATFORM_WIN32*/
+#endif /*defined(G_PLATFORM_WIN32) || defined(G_WITH_CYGWIN)*/
 
 /* If we have O_BINARY, add it to a mode flags set.
  */


### PR DESCRIPTION
`G_PLATFORM_WIN32` is no longer defined for Cygwin, see:
https://github.com/GNOME/glib/blob/b4522e680cfe6288e52aba0e99131ef849263047/meson.build#L221-L226

This PR ensures that it remains compatible with Cygwin after commit https://github.com/libvips/libvips/commit/3ed50e0427f731803a7b41d02fea0e780837b53e.