### PR TITLE
Clean up more resources in vips_shutdown

### DIFF
--- a/libvips/iofuncs/init.c
+++ b/libvips/iofuncs/init.c
@@ -721,7 +721,6 @@ vips_shutdown( void )
 #endif /*HAVE_GSF*/
 
        VIPS_FREE(vips__argv0);
-       g_set_prgname(NULL);
 
 	/* In dev releases, always show leaks. But not more than once, it's
 	 * annoying.

--- a/libvips/iofuncs/init.c
+++ b/libvips/iofuncs/init.c
@@ -720,6 +720,9 @@ vips_shutdown( void )
 	gsf_shutdown(); 
 #endif /*HAVE_GSF*/
 
+       VIPS_FREE(vips__argv0);
+       g_set_prgname(NULL);
+
 	/* In dev releases, always show leaks. But not more than once, it's
 	 * annoying.
 	 */
@@ -735,6 +738,9 @@ vips_shutdown( void )
 
 		done = TRUE;
 	}
+
+       VIPS_FREEF( vips_g_mutex_free, vips__global_lock );
+       VIPS_FREEF( g_timer_destroy, vips__global_timer );
 }
 
 const char *


### PR DESCRIPTION
Hi,

I'm currently using libvips with my own application and I see a lots of possible leaks from libvips.
I know there is a debate whether we should spend time fixing the "possible" leaks or not.
Feel free to reject my pull request if it's not desired.
Note that most leaks are from GLib but at least someone is trying to fix them upstream, see https://gitlab.gnome.org/GNOME/glib/-/issues/2076.

I cloned the repository today so I'm up to date.
The following have been done before and after my patch:
- built libvips using `CFLAGS="-g -Wall" CXXFLAGS="-g -Wall" ./autogen.sh --enable-debug && make && sudo make install` on a fresh docker container based on ubuntu:hirsute image.
- built my test program using `clang `pkg-config --cflags vips` `pkg-config --libs vips` ./test.c`.
- ran valgind using the following: `GLIBCXX_FORCE_NEW=1 G_DEBUG=gc-friendly G_SLICE=always-malloc valgrind --suppressions=./suppressions/valgrind.supp --leak-check=full --show-leak-kinds=all --show-reachable=yes ./a.out`
- tested `make check` which fails on master and with my patch (same failed tests numbers).

My test program is as follow:
```
#include <vips/vips.h>
#include <stdio.h>

int main(int argc, char **argv)
{
  VIPS_INIT(argv[0]);
  vips_shutdown();
  return 0;
}
```

Valgrind output before my patch:

> ==26950== HEAP SUMMARY:
> ==26950==     in use at exit: 144,773 bytes in 1,655 blocks
> ==26950==   total heap usage: 2,392 allocs, 737 frees, 317,230 bytes allocated

Valgrind output after my patch:

> ==28646== HEAP SUMMARY:
> ==28646==     in use at exit: 144,727 bytes in 1,651 blocks
> ==28646==   total heap usage: 2,392 allocs, 741 frees, 317,230 bytes allocated

Feel free to ask me anything if needed.
Best regards