### PR TITLE
Delete Cairo context on rsvg_handle_render_cairo error

### DIFF
--- a/libvips/foreign/svgload.c
+++ b/libvips/foreign/svgload.c
@@ -340,6 +340,7 @@ vips_foreign_load_svg_generate( VipsRegion *or,
 	 * running inside a non-threaded tilecache.
 	 */
 	if( !rsvg_handle_render_cairo( svg->page, cr ) ) {
+		cairo_destroy( cr );
 		vips_operation_invalidate( VIPS_OPERATION( svg ) );
 		vips_error( class->nickname, 
 			"%s", _( "SVG rendering failed" ) );


### PR DESCRIPTION
Even if `rsvg_handle_render_cairo` failed, we should delete the Cairo context. Otherwise, the context will leak.