### PR TITLE
Allow openjp2 version 2.3

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -848,9 +848,9 @@ AC_ARG_WITH([libopenjp2],
 
 # 2.4 is the first one to have working threading and tiling
 if test x"$with_libopenjp2" != x"no"; then
-  PKG_CHECK_MODULES(LIBOPENJP2, libopenjp2 >= 2.4,
+  PKG_CHECK_MODULES(LIBOPENJP2, libopenjp2 >= 2.3,
     [AC_DEFINE(HAVE_LIBOPENJP2,1,
-       [define if you have libopenjp2 >=2.4 installed.])
+       [define if you have libopenjp2 >=2.3 installed.])
      with_libopenjp2=yes
      PACKAGES_USED="$PACKAGES_USED libopenjp2"
     ],


### PR DESCRIPTION
Because this is the version available in Fedora / RHEL / CentOS ...

https://rpms.remirepo.net/rpmphp/zoom.php?rpm=openjpeg2

Only very recent version (e.g. Fedora 34) have version 2.4

Build and test suite passes with 2.3

Notice: security PoV, version 2.3.1 includes fix for various CVEs (and security of libopenjpg is probably not your problem)