### PR TITLE
Unref source on vips_foreign_load_pdf_close

### DIFF
--- a/libvips/foreign/pdfiumload.c
+++ b/libvips/foreign/pdfiumload.c
@@ -187,6 +187,7 @@ vips_foreign_load_pdf_close( VipsForeignLoadPdf *pdf )
 
 	VIPS_FREEF( FPDF_ClosePage, pdf->page ); 
 	VIPS_FREEF( FPDF_CloseDocument, pdf->doc ); 
+	VIPS_UNREF( pdf->source );
 
 	g_mutex_unlock( vips_pdfium_mutex );
 }


### PR DESCRIPTION
Closes #2306 

This fixes the leak for my case but I'm not sure if `pdf->source` should be checked for NULL.