### PR TITLE
use /lib64 instead of /lib when needed

### DIFF
--- a/libvips/iofuncs/init.c
+++ b/libvips/iofuncs/init.c
@@ -1226,6 +1226,8 @@ vips_guess_libdir( const char *argv0, const char *env_name )
 	 */
 	if( strcmp( prefix, VIPS_PREFIX ) == 0 ) 
 		libdir = VIPS_LIBDIR;
+	else if ( strstr(VIPS_LIBDIR, "/lib64") )
+		libdir = g_strdup_printf( "%s/lib64", prefix );
 	else
 		libdir = g_strdup_printf( "%s/lib", prefix );
 


### PR DESCRIPTION
On RPM distribution

* /bin is a symlink to /usr/bin
* /lib is a symlink to /usr/lib
* /lib64 is a symlink to /usr/lib64

When /usr/bin/vips is used, plugins are search in /usr/lib64, as expected

```
$ strace vips dzsave test.svs abc 2>&1 | grep vips-modules
openat(AT_FDCWD, "/usr/lib64/vips-modules-8.11", O_RDONLY|O_NONBLOCK|O_CLOEXEC|O_DIRECTORY) = 3
```

When /bin/vips is used, plugins are search in /lib, , so of course are not found, which explain this problem

```
$ strace /bin/vips dzsave test.svs abc 2>&1 | grep vips-modules
openat(AT_FDCWD, "/lib/vips-modules-8.11", O_RDONLY|O_NONBLOCK|O_CLOEXEC|O_DIRECTORY) = -1 ENOENT (No such file or directory)
```

Using this patch, this work

```
$ strace /bin/vips --version 2>&1 | grep vips-modules
openat(AT_FDCWD, "/lib64/vips-modules-8.11", O_RDONLY|O_NONBLOCK|O_CLOEXEC|O_DIRECTORY) = 3

```