### PR TITLE
VImage: reserve vector before push_back loop

### DIFF
--- a/cplusplus/VImage.cpp
+++ b/cplusplus/VImage.cpp
@@ -767,6 +767,7 @@ std::vector<VImage>
 VImage::bandsplit( VOption *options ) const
 {
 	std::vector<VImage> b;
+	b.reserve(bands());
 
 	for( int i = 0; i < bands(); i++ )
 		b.push_back( extract_band( i ) );


### PR DESCRIPTION
Avoids unnecessary resizes.

Found with clang-tidy's performance-inefficient-vector-operation

Signed-off-by: Rosen Penev <rosenp@gmail.com>