### PR TITLE
Fix a few `-Wstrict-aliasing=1` warnings

### DIFF
--- a/libvips/colour/LCh2Lab.c
+++ b/libvips/colour/LCh2Lab.c
@@ -57,6 +57,22 @@ typedef VipsColourTransformClass VipsLCh2LabClass;
 
 G_DEFINE_TYPE( VipsLCh2Lab, vips_LCh2Lab, VIPS_TYPE_COLOUR_TRANSFORM );
 
+/**
+ * vips_col_Ch2ab:
+ * @C: Chroma
+ * @h: Hue angle (degrees)
+ * @a: return CIE a* value
+ * @b: return CIE b* value
+ *
+ * Calculate ab from Ch, h in degrees.
+ */
+void
+vips_col_Ch2ab( float C, float h, float *a, float *b )
+{
+	*a = C * cos( VIPS_RAD( h ) );
+	*b = C * sin( VIPS_RAD( h ) );
+}
+
 /* Process a buffer of data.
  */
 static void
@@ -75,8 +91,7 @@ vips_LCh2Lab_line( VipsColour *colour, VipsPel *out, VipsPel **in, int width )
 
 		p += 3;
 
-		a = C * cos( VIPS_RAD( h ) );
-		b = C * sin( VIPS_RAD( h ) );
+		vips_col_Ch2ab( C, h, &a, &b );
 
 		q[0] = L;
 		q[1] = a;
@@ -84,35 +99,6 @@ vips_LCh2Lab_line( VipsColour *colour, VipsPel *out, VipsPel **in, int width )
 
 		q += 3;
 	}
-}
-
-/**
- * vips_col_Ch2ab:
- * @C: Chroma
- * @h: Hue angle (degrees)
- * @a: return CIE a* value
- * @b: return CIE b* value
- *
- * Calculate ab from Ch, h in degrees.
- */
-void
-vips_col_Ch2ab( float C, float h, float *a, float *b )
-{
-	float in[3];
-	float out[3];
-	float *x;
-
-	/* could be anything, we don't use this value, but we must supply one
-	 * or static analyzers will complain.
-	 */
-	in[0] = 50.0;
-
-	in[1] = C;
-	in[2] = h;
-	x = &in[0];
-	vips_LCh2Lab_line( NULL, (VipsPel *) out, (VipsPel **) &x, 1 );
-	*a = out[1];
-	*b = out[2];
 }
 
 static void


### PR DESCRIPTION
GCC 11.x could produce bad assembly code due to this. See for example: https://godbolt.org/z/8vT7W8d1o.

```
Lab2XYZ.c: In function ‘vips_col_Lab2XYZ’:
Lab2XYZ.c:250:43: warning: dereferencing type-punned pointer might break strict-aliasing rules [-Wstrict-aliasing]
  250 |         vips_Lab2XYZ_line( (VipsColour *) &Lab2XYZ,
      |                                           ^~~~~~~~
Lab2XYZ.c:251:47: warning: dereferencing type-punned pointer might break strict-aliasing rules [-Wstrict-aliasing]
  251 |                 (VipsPel *) out, (VipsPel **) &x, 1 );
      |                                               ^~
LCh2Lab.c: In function ‘vips_col_Ch2ab’:
LCh2Lab.c:113:64: warning: dereferencing type-punned pointer might break strict-aliasing rules [-Wstrict-aliasing]
  113 |         vips_LCh2Lab_line( NULL, (VipsPel *) out, (VipsPel **) &x, 1 );
      |                                                                ^~
XYZ2Lab.c: In function ‘vips_col_XYZ2Lab’:
XYZ2Lab.c:185:43: warning: dereferencing type-punned pointer might break strict-aliasing rules [-Wstrict-aliasing]
  185 |         vips_XYZ2Lab_line( (VipsColour *) &XYZ2Lab,
      |                                           ^~~~~~~~
XYZ2Lab.c:186:47: warning: dereferencing type-punned pointer might break strict-aliasing rules [-Wstrict-aliasing]
  186 |                 (VipsPel *) out, (VipsPel **) &x, 1 );
      |                                               ^~
```