### PR TITLE
Add gifsave operation, depends on cgif and libimagequant

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,11 +43,12 @@ jobs:
           DEBIAN_FRONTEND: noninteractive
         run: sudo -E apt-get update -qq -o Acquire::Retries=3
 
-      - name: Add libheif PPA
+      - name: Add Ubuntu PPAs
         if: contains(matrix.os, 'ubuntu')
         run: |
           sudo add-apt-repository ppa:strukturag/libde265
           sudo add-apt-repository ppa:strukturag/libheif
+          sudo add-apt-repository ppa:lovell/cgif
 
       - name: Install Ubuntu dependencies
         if: contains(matrix.os, 'ubuntu')
@@ -64,7 +65,7 @@ jobs:
             liblcms2-dev libpoppler-glib-dev librsvg2-dev
             libgif-dev libopenexr-dev libpango1.0-dev
             libgsf-1-dev libopenslide-dev libffi-dev
-            libopenjp2-7-dev
+            libopenjp2-7-dev libimagequant-dev libcgif-dev
 
       - name: Install macOS dependencies
         if: contains(matrix.os, 'macos')
@@ -72,7 +73,9 @@ jobs:
           brew update
           brew upgrade
           brew install autoconf automake libtool fftw fontconfig gtk-doc gobject-introspection glib libexif libgsf little-cms2 orc pango
-          brew install cfitsio libheif libjpeg-turbo libmatio librsvg libspng libtiff openexr openjpeg openslide poppler webp
+          brew install cfitsio libheif libimagequant libjpeg-turbo libmatio librsvg libspng libtiff openexr openjpeg openslide poppler webp
+          brew tap lovell/cgif-packaging https://github.com/lovell/cgif-packaging.git
+          brew install --build-bottle lovell/cgif-packaging/cgif
 
       - name: Install Clang 10
         env:

--- a/configure.ac
+++ b/configure.ac
@@ -1348,7 +1348,7 @@ VIPS_LIBS="$VIPS_LIBS $PNG_LIBS"
 AC_ARG_WITH([imagequant],
   AS_HELP_STRING([--without-imagequant], [build without imagequant (default: test)]))
 
-if test x"$with_imagequant" != x"no" && test x"$with_png" != x"no"; then
+if test x"$with_imagequant" != x"no"; then
   PKG_CHECK_MODULES(IMAGEQUANT, imagequant,
     [AC_DEFINE(HAVE_IMAGEQUANT,1,[define if you have imagequant installed.])
      with_imagequant=yes
@@ -1436,6 +1436,27 @@ fi
 VIPS_CFLAGS="$VIPS_CFLAGS $EXIF_CFLAGS"
 VIPS_LIBS="$VIPS_LIBS $EXIF_LIBS"
 
+# GIF save with libcgif (requires libimagequant also)
+AC_ARG_WITH([cgif],
+  AS_HELP_STRING([--without-cgif], [build without cgif (default: test)]))
+
+if test x"$with_imagequant" == x"yes" && test x"$with_cgif" != x"no"; then
+  PKG_CHECK_MODULES(CGIF, cgif,
+    [AC_DEFINE(HAVE_CGIF,1,[define if you have cgif installed.])
+      with_cgif=yes
+      PACKAGES_USED="$PACKAGES_USED cgif"
+    ],
+    [AC_MSG_WARN([libcgif not found])
+      with_cgif=no
+    ]
+  )
+else
+  with_cgif=no
+fi
+
+VIPS_CFLAGS="$VIPS_CFLAGS $CGIF_CFLAGS"
+VIPS_LIBS="$VIPS_LIBS $CGIF_LIBS"
+
 # fuzzing
 AC_ARG_VAR([LIB_FUZZING_ENGINE],
            [fuzzing library, e.g. /path/to/libFuzzer.a])
@@ -1468,7 +1489,7 @@ JXL load/save with libjxl: $with_libjxl (dynamic module: $with_libjxl_module), \
 JPEG2000 load/save with libopenjp2: $with_libopenjp2, \
 PNG load with libspng: $with_libspng, \
 PNG load/save with libpng: $with_png, \
-PNG quantisation to 8 bit: $with_imagequant, \
+quantisation to 8 bit: $with_imagequant, \
 TIFF load/save with libtiff: $with_tiff, \
 image pyramid save: $with_gsf, \
 HEIC/AVIF load/save with libheif: $with_heif (dynamic module: $with_heif_module), \
@@ -1481,6 +1502,7 @@ OpenSlide load: $with_openslide (dynamic module: $with_openslide_module), \
 Matlab load with matio: $with_matio, \
 NIfTI load/save with niftiio: $with_nifti, \
 FITS load/save with cfitsio: $with_cfitsio, \
+GIF save with cgif: $with_cgif, \
 Magick package: $with_magickpackage (dynamic module: $with_magick_module), \
 Magick API version: $magick_version, \
 load with libMagickCore: $enable_magickload, \
@@ -1577,7 +1599,7 @@ PNG load with libspng:                  $with_libspng
  (requires libspng-0.6 or later)
 PNG load/save with libpng:              $with_png
  (requires libpng-1.2.9 or later)
-PNG quantisation to 8 bit:              $with_imagequant
+quantisation to 8 bit:                  $with_imagequant
  (requires libimagequant)
 TIFF load/save with libtiff:            $with_tiff
 image pyramid save:                     $with_gsf
@@ -1596,6 +1618,8 @@ OpenSlide support:                      $with_openslide (dynamic module: $with_o
 Matlab load with matio:                 $with_matio
 NIfTI load/save with niftiio:           $with_nifti
 FITS load/save with cfitsio:            $with_cfitsio
+GIF save with cgif:                     $with_cgif
+ (requires libimagequant)
 Magick package:                         $with_magickpackage (dynamic module: $with_magick_module)
 Magick major API version:               $magick_version
 load with libMagickCore:                $enable_magickload

--- a/cplusplus/include/vips/VImage8.h
+++ b/cplusplus/include/vips/VImage8.h
@@ -1789,7 +1789,7 @@ public:
 	 */
 
 // headers for vips operations
-// Wed May 12 11:30:00 AM CEST 2021
+// Wed  4 Aug 12:48:13 BST 2021
 // this file is generated automatically, do not edit!
 
 /**
@@ -2933,6 +2933,51 @@ static VImage gifload_buffer( VipsBlob *buffer, VOption *options = 0 );
  * @return Output image.
  */
 static VImage gifload_source( VSource source, VOption *options = 0 );
+
+/**
+ * Save image to gif file.
+ *
+ * **Optional parameters**
+ *   - **dither** -- Amount of dithering, double.
+ *   - **effort** -- Quantisation effort, int.
+ *   - **strip** -- Strip all metadata from image, bool.
+ *   - **background** -- Background value, std::vector<double>.
+ *   - **page_height** -- Set page height for multipage save, int.
+ *
+ * @param filename Filename to save to.
+ * @param options Set of options.
+ */
+void gifsave( const char *filename, VOption *options = 0 ) const;
+
+/**
+ * Save image to gif buffer.
+ *
+ * **Optional parameters**
+ *   - **dither** -- Amount of dithering, double.
+ *   - **effort** -- Quantisation effort, int.
+ *   - **strip** -- Strip all metadata from image, bool.
+ *   - **background** -- Background value, std::vector<double>.
+ *   - **page_height** -- Set page height for multipage save, int.
+ *
+ * @param options Set of options.
+ * @return Buffer to save to.
+ */
+VipsBlob *gifsave_buffer( VOption *options = 0 ) const;
+
+/**
+ * Save image to target as gif.
+ *
+ * **Optional parameters**
+ *   - **dither** -- Amount of dithering, double.
+ *   - **effort** -- Quantisation effort, int.
+ *   - **strip** -- Strip all metadata from image, bool.
+ *   - **background** -- Background value, std::vector<double>.
+ *   - **page_height** -- Set page height for multipage save, int.
+ *
+ * @param target Target to save to.
+ * @param options Set of options.
+ */
+void gifsave_target( VTarget target, VOption *options = 0 ) const;
 
 /**
  * Global balance an image mosaic.

--- a/cplusplus/vips-operators.cpp
+++ b/cplusplus/vips-operators.cpp
@@ -1,5 +1,5 @@
 // bodies for vips operations
-// Wed May 12 11:30:00 AM CEST 2021
+// Wed  4 Aug 12:48:13 BST 2021
 // this file is generated automatically, do not edit!
 
 VImage VImage::CMC2LCh( VOption *options ) const
@@ -1260,6 +1260,34 @@ VImage VImage::gifload_source( VSource source, VOption *options )
             set( "source", source ) );
 
     return( out );
+}
+
+void VImage::gifsave( const char *filename, VOption *options ) const
+{
+    call( "gifsave",
+        (options ? options : VImage::option())->
+            set( "in", *this )->
+            set( "filename", filename ) );
+}
+
+VipsBlob *VImage::gifsave_buffer( VOption *options ) const
+{
+    VipsBlob *buffer;
+
+    call( "gifsave_buffer",
+        (options ? options : VImage::option())->
+            set( "in", *this )->
+            set( "buffer", &buffer ) );
+
+    return( buffer );
+}
+
+void VImage::gifsave_target( VTarget target, VOption *options ) const
+{
+    call( "gifsave_target",
+        (options ? options : VImage::option())->
+            set( "in", *this )->
+            set( "target", target ) );
 }
 
 VImage VImage::globalbalance( VOption *options ) const

--- a/fuzz/Makefile.am
+++ b/fuzz/Makefile.am
@@ -6,6 +6,7 @@ FUZZPROGS = \
 	jpegsave_buffer_fuzzer \
 	pngsave_buffer_fuzzer \
 	webpsave_buffer_fuzzer \
+	gifsave_buffer_fuzzer \
 	sharpen_fuzzer \
 	thumbnail_fuzzer \
 	smartcrop_fuzzer \

--- a/fuzz/gifsave_buffer_fuzzer.cc
+++ b/fuzz/gifsave_buffer_fuzzer.cc
@@ -1,0 +1,39 @@
+#include <vips/vips.h>
+
+extern "C" int
+LLVMFuzzerInitialize( int *argc, char ***argv )
+{
+	vips_concurrency_set( 1 );
+	return( 0 );
+}
+
+extern "C" int
+LLVMFuzzerTestOneInput( const guint8 *data, size_t size )
+{
+	VipsImage *image;
+	void *buf;
+	size_t len;
+
+	if( size > 100 * 1024 * 1024 )
+		return( 0 );
+
+	if( !(image = vips_image_new_from_buffer( data, size, "", NULL )) )
+		return( 0 );
+
+	if( image->Xsize > 100 ||
+		image->Ysize > 100 ||
+		image->Bands > 4 ) {
+		g_object_unref( image );
+		return( 0 );
+	}
+
+	if( vips_gifsave_buffer( image, &buf, &len, NULL ) ) {
+		g_object_unref( image );
+		return( 0 );
+	}
+
+	g_free( buf );
+	g_object_unref( image );
+
+	return( 0 );
+}

--- a/libvips/foreign/Makefile.am
+++ b/libvips/foreign/Makefile.am
@@ -6,6 +6,7 @@ libforeign_la_SOURCES = \
 	analyze2vips.c \
 	analyzeload.c \
 	cairo.c \
+	cgifsave.c \
 	csvload.c \
 	csvsave.c \
 	dbh.h \

--- a/libvips/foreign/cgifsave.c
+++ b/libvips/foreign/cgifsave.c
@@ -1,0 +1,522 @@
+/*
+
+    This file is part of VIPS.
+
+    VIPS is free software; you can redistribute it and/or modify
+    it under the terms of the GNU Lesser General Public License as published by
+    the Free Software Foundation; either version 2 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU Lesser General Public License for more details.
+
+    You should have received a copy of the GNU Lesser General Public License
+    along with this program; if not, write to the Free Software
+    Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+    02110-1301  USA
+
+ */
+
+/*
+    These files are distributed with VIPS - http://www.vips.ecs.soton.ac.uk
+ */
+
+#ifdef HAVE_CONFIG_H
+#include <config.h>
+#endif /*HAVE_CONFIG_H*/
+#include <vips/intl.h>
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+#include <vips/vips.h>
+
+#include "pforeign.h"
+
+#ifdef HAVE_CGIF
+
+#include <cgif.h>
+
+typedef struct _VipsForeignSaveCgif {
+	VipsForeignSave parent_object;
+
+	double dither;
+	int effort;
+
+	VipsTarget *target;
+} VipsForeignSaveCgif;
+
+typedef VipsForeignSaveClass VipsForeignSaveCgifClass;
+
+G_DEFINE_ABSTRACT_TYPE( VipsForeignSaveCgif, vips_foreign_save_cgif,
+	VIPS_TYPE_FOREIGN_SAVE );
+
+static void
+vips_foreign_save_cgif_dispose( GObject *gobject )
+{
+	VipsForeignSaveCgif *cgif = (VipsForeignSaveCgif *) gobject;
+
+	VIPS_UNREF( cgif->target );
+
+	G_OBJECT_CLASS( vips_foreign_save_cgif_parent_class )->
+		dispose( gobject );
+}
+
+/* Minimal callback wrapper around vips_target_write
+ */
+static int vips__cgif_write( void* target, const uint8_t* buffer,
+	const size_t length ) {
+	return vips_target_write( (VipsTarget*) target,
+		(const void*) buffer, (size_t) length );
+}
+
+static int
+vips_foreign_save_cgif_build( VipsObject *object )
+{
+	VipsForeignSave *save = (VipsForeignSave *) object;
+	VipsForeignSaveCgif *cgif = (VipsForeignSaveCgif *) object;
+
+	VipsImage **t;
+	int rgb;
+	int rgba;
+	gboolean has_transparency;
+	int page_height;
+	int *delay;
+	int delay_length;
+	int loop;
+	int top;
+	uint8_t * restrict paletteRgba;
+	uint8_t * restrict paletteRgb;
+
+	GIF *cgif_context;
+	GIFConfig cgif_config;
+	FrameConfig cgif_frame_config;
+
+	if( VIPS_OBJECT_CLASS( vips_foreign_save_cgif_parent_class )->
+		build( object ) )
+		return( -1 );
+
+	t = (VipsImage **) vips_object_local_array( VIPS_OBJECT( cgif ), 6 );
+
+	/* Animation properties
+	 */
+	page_height = vips_image_get_page_height( save->ready );
+	delay = NULL;
+	if( vips_image_get_typeof( save->ready, "delay" ) )
+		vips_image_get_array_int( save->ready, "delay",
+			&delay, &delay_length );
+	if( vips_image_get_typeof( save->ready, "loop" ) )
+		vips_image_get_int( save->ready, "loop", &loop );
+
+	/* Threshold alpha, if any, to fully transparent or opaque
+	 */
+	if( vips_image_hasalpha( save->ready ) ) {
+		if( vips_extract_band( save->ready, &t[0], 0, "n", 3, NULL ) ||
+			vips_extract_band( save->ready, &t[1], 3, NULL ) ||
+			vips_moreeq_const1( t[1], &t[2], 128, NULL ) ||
+			vips_bandjoin2( t[0], t[2], &t[3], NULL ) ) {
+			return( -1 );
+		}
+		VIPS_UNREF( save->ready );
+		save->ready = t[3];
+		g_object_ref( save->ready );
+	}
+
+	/* Generate indexed image (t[4]) and palette (t[5])
+	 */
+	if( vips__quantise_image( save->ready, &t[4], &t[5],
+		255, 100, cgif->dither, cgif->effort ) )
+		return( -1 );
+
+	/* Convert palette to RGB
+	 */
+	paletteRgba = (uint8_t*) VIPS_IMAGE_ADDR( t[5], 0, 0 );
+	paletteRgb = g_malloc0( t[5]->Xsize * 3 );
+	for( rgb = 0, rgba = 0; rgb < t[5]->Xsize * 3; rgb += 3 ) {
+		paletteRgb[rgb] = paletteRgba[rgba];
+		paletteRgb[rgb + 1] = paletteRgba[rgba + 1];
+		paletteRgb[rgb + 2] = paletteRgba[rgba + 2];
+		rgba += 4;
+	}
+	/* Does the palette contain a transparent pixel value?
+	   This will always the first entry, if any.
+	 */
+	has_transparency = paletteRgba[3] == 255 ? FALSE : TRUE;
+
+	/* Initiialise cgif
+	 */
+	memset( &cgif_config, 0, sizeof( GIFConfig ) );
+	cgif_config.width = t[4]->Xsize;
+	cgif_config.height = page_height;
+	cgif_config.pGlobalPalette = paletteRgb;
+	cgif_config.numGlobalPaletteEntries = t[5]->Xsize;
+	cgif_config.numLoops = loop;
+	cgif_config.attrFlags = GIF_ATTR_IS_ANIMATED;
+	if( has_transparency ) {
+		cgif_config.attrFlags |= GIF_ATTR_HAS_TRANSPARENCY;
+	}
+	cgif_config.pWriteFn = vips__cgif_write;
+	cgif_config.pContext = (void*) cgif->target;
+	cgif_context = cgif_newgif( &cgif_config );
+	g_free( paletteRgb );
+
+	/* Add each vips page as a cgif frame
+	 */
+	for( top = 0; top < t[4]->Ysize; top += page_height ) {
+		memset( &cgif_frame_config, 0, sizeof( FrameConfig ) );
+		cgif_frame_config.pImageData = (uint8_t*)
+			VIPS_IMAGE_ADDR( t[4], 0, top );
+		if( delay ) {
+			int page_index = top / page_height;
+			if( page_index < delay_length )
+				cgif_frame_config.delay =
+					VIPS_RINT( delay[page_index] / 10.0 );
+		}
+		if( !has_transparency ) {
+			/* Allow cgif to optimise by adding transparency
+			 */
+			cgif_frame_config.genFlags = FRAME_GEN_USE_TRANSPARENCY |
+				FRAME_GEN_USE_DIFF_WINDOW;
+		}
+		cgif_addframe( cgif_context, &cgif_frame_config );
+	}
+
+	cgif_close( cgif_context );
+	vips_target_finish( cgif->target );
+
+	return( 0 );
+}
+
+static const char *vips__save_cgif_suffs[] = { ".gif", NULL };
+
+#define UC VIPS_FORMAT_UCHAR
+static int bandfmt_gif[10] = {
+	UC, UC, UC, UC, UC, UC, UC, UC, UC, UC
+};
+
+static void
+vips_foreign_save_cgif_class_init( VipsForeignSaveCgifClass *class )
+{
+	GObjectClass *gobject_class = G_OBJECT_CLASS( class );
+	VipsObjectClass *object_class = (VipsObjectClass *) class;
+	VipsForeignClass *foreign_class = (VipsForeignClass *) class;
+	VipsForeignSaveClass *save_class = (VipsForeignSaveClass *) class;
+
+	gobject_class->dispose = vips_foreign_save_cgif_dispose;
+	gobject_class->set_property = vips_object_set_property;
+	gobject_class->get_property = vips_object_get_property;
+
+	object_class->nickname = "gifsave_base";
+	object_class->description = _( "save gif" );
+	object_class->build = vips_foreign_save_cgif_build;
+
+	foreign_class->suffs = vips__save_cgif_suffs;
+
+	save_class->saveable = VIPS_SAVEABLE_RGBA_ONLY;
+	save_class->format_table = bandfmt_gif;
+
+	VIPS_ARG_DOUBLE( class, "dither", 10,
+		_( "Dithering" ),
+		_( "Amount of dithering" ),
+		VIPS_ARGUMENT_OPTIONAL_INPUT,
+		G_STRUCT_OFFSET( VipsForeignSaveCgif, dither ),
+		0.0, 1.0, 1.0 );
+
+	VIPS_ARG_INT( class, "effort", 11,
+		_( "Effort" ),
+		_( "Quantisation effort" ),
+		VIPS_ARGUMENT_OPTIONAL_INPUT,
+		G_STRUCT_OFFSET( VipsForeignSaveCgif, effort ),
+		1, 10, 7 );
+
+}
+
+static void
+vips_foreign_save_cgif_init( VipsForeignSaveCgif *gif )
+{
+	gif->dither = 1.0;
+	gif->effort = 7;
+}
+
+typedef struct _VipsForeignSaveCgifTarget {
+	VipsForeignSaveCgif parent_object;
+
+	VipsTarget *target;
+} VipsForeignSaveCgifTarget;
+
+typedef VipsForeignSaveCgifClass VipsForeignSaveCgifTargetClass;
+
+G_DEFINE_TYPE( VipsForeignSaveCgifTarget, vips_foreign_save_cgif_target,
+	vips_foreign_save_cgif_get_type() );
+
+static int
+vips_foreign_save_cgif_target_build( VipsObject *object )
+{
+	VipsForeignSaveCgif *gif = (VipsForeignSaveCgif *) object;
+	VipsForeignSaveCgifTarget *target = (VipsForeignSaveCgifTarget *) object;
+
+	gif->target = target->target;
+	g_object_ref( gif->target );
+
+	if( VIPS_OBJECT_CLASS( vips_foreign_save_cgif_target_parent_class )->
+		build( object ) )
+		return( -1 );
+
+	return( 0 );
+}
+
+static void
+vips_foreign_save_cgif_target_class_init( VipsForeignSaveCgifTargetClass *class )
+{
+	GObjectClass *gobject_class = G_OBJECT_CLASS( class );
+	VipsObjectClass *object_class = (VipsObjectClass *) class;
+
+	gobject_class->set_property = vips_object_set_property;
+	gobject_class->get_property = vips_object_get_property;
+
+	object_class->nickname = "gifsave_target";
+	object_class->description = _( "save image to target as gif" );
+	object_class->build = vips_foreign_save_cgif_target_build;
+
+	VIPS_ARG_OBJECT( class, "target", 1,
+		_( "Target" ),
+		_( "Target to save to" ),
+		VIPS_ARGUMENT_REQUIRED_INPUT,
+		G_STRUCT_OFFSET( VipsForeignSaveCgifTarget, target ),
+		VIPS_TYPE_TARGET );
+
+}
+
+static void
+vips_foreign_save_cgif_target_init( VipsForeignSaveCgifTarget *target )
+{
+}
+
+typedef struct _VipsForeignSaveCgifFile {
+	VipsForeignSaveCgif parent_object;
+	char *filename;
+} VipsForeignSaveCgifFile;
+
+typedef VipsForeignSaveCgifClass VipsForeignSaveCgifFileClass;
+
+G_DEFINE_TYPE( VipsForeignSaveCgifFile, vips_foreign_save_cgif_file,
+	vips_foreign_save_cgif_get_type() );
+
+static int
+vips_foreign_save_cgif_file_build( VipsObject *object )
+{
+	VipsForeignSaveCgif *gif = (VipsForeignSaveCgif *) object;
+	VipsForeignSaveCgifFile *file = (VipsForeignSaveCgifFile *) object;
+
+	if( !(gif->target = vips_target_new_to_file( file->filename )) )
+		return( -1 );
+
+	if( VIPS_OBJECT_CLASS( vips_foreign_save_cgif_file_parent_class )->
+		build( object ) )
+		return( -1 );
+
+	return( 0 );
+}
+
+static void
+vips_foreign_save_cgif_file_class_init( VipsForeignSaveCgifFileClass *class )
+{
+	GObjectClass *gobject_class = G_OBJECT_CLASS( class );
+	VipsObjectClass *object_class = (VipsObjectClass *) class;
+
+	gobject_class->set_property = vips_object_set_property;
+	gobject_class->get_property = vips_object_get_property;
+
+	object_class->nickname = "gifsave";
+	object_class->description = _( "save image to gif file" );
+	object_class->build = vips_foreign_save_cgif_file_build;
+
+	VIPS_ARG_STRING( class, "filename", 1,
+		_( "Filename" ),
+		_( "Filename to save to" ),
+		VIPS_ARGUMENT_REQUIRED_INPUT,
+		G_STRUCT_OFFSET( VipsForeignSaveCgifFile, filename ),
+		NULL );
+}
+
+static void
+vips_foreign_save_cgif_file_init( VipsForeignSaveCgifFile *file )
+{
+}
+
+typedef struct _VipsForeignSaveCgifBuffer {
+	VipsForeignSaveCgif parent_object;
+	VipsArea *buf;
+} VipsForeignSaveCgifBuffer;
+
+typedef VipsForeignSaveCgifClass VipsForeignSaveCgifBufferClass;
+
+G_DEFINE_TYPE( VipsForeignSaveCgifBuffer, vips_foreign_save_cgif_buffer,
+	vips_foreign_save_cgif_get_type() );
+
+static int
+vips_foreign_save_cgif_buffer_build( VipsObject *object )
+{
+	VipsForeignSaveCgif *gif = (VipsForeignSaveCgif *) object;
+	VipsForeignSaveCgifBuffer *buffer = (VipsForeignSaveCgifBuffer *) object;
+
+	VipsBlob *blob;
+
+	if( !(gif->target = vips_target_new_to_memory()) )
+		return( -1 );
+
+	if( VIPS_OBJECT_CLASS( vips_foreign_save_cgif_buffer_parent_class )->
+		build( object ) )
+		return( -1 );
+
+	g_object_get( gif->target, "blob", &blob, NULL );
+	g_object_set( buffer, "buffer", blob, NULL );
+	vips_area_unref( VIPS_AREA( blob ) );
+
+	return( 0 );
+}
+
+static void
+vips_foreign_save_cgif_buffer_class_init( VipsForeignSaveCgifBufferClass *class )
+{
+	GObjectClass *gobject_class = G_OBJECT_CLASS( class );
+	VipsObjectClass *object_class = (VipsObjectClass *) class;
+
+	gobject_class->set_property = vips_object_set_property;
+	gobject_class->get_property = vips_object_get_property;
+
+	object_class->nickname = "gifsave_buffer";
+	object_class->description = _( "save image to gif buffer" );
+	object_class->build = vips_foreign_save_cgif_buffer_build;
+
+	VIPS_ARG_BOXED( class, "buffer", 1,
+		_( "Buffer" ),
+		_( "Buffer to save to" ),
+		VIPS_ARGUMENT_REQUIRED_OUTPUT,
+		G_STRUCT_OFFSET( VipsForeignSaveCgifBuffer, buf ),
+		VIPS_TYPE_BLOB );
+}
+
+static void
+vips_foreign_save_cgif_buffer_init( VipsForeignSaveCgifBuffer *buffer )
+{
+}
+
+#endif /*HAVE_CGIF*/
+
+/**
+ * vips_gifsave: (method)
+ * @in: image to save
+ * @filename: file to write to
+ * @...: %NULL-terminated list of optional named arguments
+ *
+ * Optional arguments:
+ *
+ * * @dither: %double, quantisation dithering level
+ * * @effort: %int, quantisation CPU effort
+ *
+ * Write a VIPS image to a file as GIF.
+ *
+ * Use @dither to set the degree of Floyd-Steinberg dithering
+ * and @effort to control the CPU effort (1 is the fastest,
+ * 10 is the slowest, 7 is the default).
+ *
+ * See also: vips_image_new_from_file().
+ *
+ * Returns: 0 on success, -1 on error.
+ */
+int
+vips_gifsave( VipsImage *in, const char *filename, ... )
+{
+	va_list ap;
+	int result;
+
+	va_start( ap, filename );
+	result = vips_call_split( "gifsave", ap, in, filename );
+	va_end( ap );
+
+	return( result );
+}
+
+/**
+ * vips_gifsave_buffer: (method)
+ * @in: image to save
+ * @buf: (array length=len) (element-type guint8): return output buffer here
+ * @len: (type gsize): return output length here
+ * @...: %NULL-terminated list of optional named arguments
+ *
+ * Optional arguments:
+ *
+ * * @dither: %double, quantisation dithering level
+ * * @effort: %int, quantisation CPU effort
+ *
+ * As vips_gifsave(), but save to a memory buffer.
+ *
+ * The address of the buffer is returned in @buf, the length of the buffer in
+ * @len. You are responsible for freeing the buffer with g_free() when you
+ * are done with it.
+ *
+ * See also: vips_gifsave(), vips_image_write_to_file().
+ *
+ * Returns: 0 on success, -1 on error.
+ */
+int
+vips_gifsave_buffer( VipsImage *in, void **buf, size_t *len, ... )
+{
+	va_list ap;
+	VipsArea *area;
+	int result;
+
+	area = NULL;
+
+	va_start( ap, len );
+	result = vips_call_split( "gifsave_buffer", ap, in, &area );
+	va_end( ap );
+
+	if( !result &&
+		area ) {
+		if( buf ) {
+			*buf = area->data;
+			area->free_fn = NULL;
+		}
+		if( len )
+			*len = area->length;
+
+		vips_area_unref( area );
+	}
+
+	return( result );
+}
+
+/**
+ * vips_gifsave_target: (method)
+ * @in: image to save
+ * @target: save image to this target
+ * @...: %NULL-terminated list of optional named arguments
+ *
+ * Optional arguments:
+ *
+ * * @dither: %double, quantisation dithering level
+ * * @effort: %int, quantisation CPU effort
+ *
+ * As vips_gifsave(), but save to a target.
+ *
+ * See also: vips_gifsave(), vips_image_write_to_target().
+ *
+ * Returns: 0 on success, -1 on error.
+ */
+int
+vips_gifsave_target( VipsImage *in, VipsTarget *target, ... )
+{
+	va_list ap;
+	int result;
+
+	va_start( ap, target );
+	result = vips_call_split( "gifsave_target", ap, in, target );
+	va_end( ap );
+
+	return( result );
+}

--- a/libvips/foreign/foreign.c
+++ b/libvips/foreign/foreign.c
@@ -2890,6 +2890,10 @@ vips_foreign_operation_init( void )
 	extern GType vips_foreign_load_nsgif_buffer_get_type( void ); 
 	extern GType vips_foreign_load_nsgif_source_get_type( void ); 
 
+	extern GType vips_foreign_save_cgif_file_get_type( void );
+	extern GType vips_foreign_save_cgif_buffer_get_type( void );
+	extern GType vips_foreign_save_cgif_target_get_type( void );
+
 	vips_foreign_load_csv_file_get_type(); 
 	vips_foreign_load_csv_source_get_type(); 
 	vips_foreign_save_csv_file_get_type(); 
@@ -2971,6 +2975,12 @@ vips_foreign_operation_init( void )
 	vips_foreign_load_nsgif_buffer_get_type(); 
 	vips_foreign_load_nsgif_source_get_type(); 
 #endif /*HAVE_NSGIF*/
+
+#ifdef HAVE_CGIF
+	vips_foreign_save_cgif_file_get_type();
+	vips_foreign_save_cgif_buffer_get_type();
+	vips_foreign_save_cgif_target_get_type();
+#endif /*HAVE_CGIF*/
 
 #ifdef HAVE_GSF
 	vips_foreign_save_dz_file_get_type(); 

--- a/libvips/include/vips/foreign.h
+++ b/libvips/include/vips/foreign.h
@@ -660,6 +660,13 @@ int vips_gifload_buffer( void *buf, size_t len, VipsImage **out, ... )
 int vips_gifload_source( VipsSource *source, VipsImage **out, ... )
 	__attribute__((sentinel));
 
+int vips_gifsave( VipsImage *in, const char *filename, ... )
+	__attribute__((sentinel));
+int vips_gifsave_buffer( VipsImage *in, void **buf, size_t *len, ... )
+	__attribute__((sentinel));
+int vips_gifsave_target( VipsImage *in, VipsTarget *target, ... )
+	__attribute__((sentinel));
+
 int vips_heifload( const char *filename, VipsImage **out, ... )
 	__attribute__((sentinel));
 int vips_heifload_buffer( void *buf, size_t len, VipsImage **out, ... )

--- a/test/test-suite/test_foreign.py
+++ b/test/test-suite/test_foreign.py
@@ -1208,6 +1208,40 @@ class TestForeign:
         # im2 = pyvips.Image.new_from_buffer(buf, "")
         # assert (im == im2).min() == 255
 
+    @skip_if_no("gifsave")
+    def test_gifsave(self):
+        # Animated GIF round trip
+        x1 = pyvips.Image.new_from_file(GIF_ANIM_FILE, n=-1)
+        b1 = x1.gifsave_buffer()
+        x2 = pyvips.Image.new_from_buffer(b1, "", n=-1)
+        assert x1.width == x2.width
+        assert x1.height == x2.height
+        assert x1.get("n-pages") == x2.get("n-pages")
+        assert x1.get("delay") == x2.get("delay")
+        assert x1.get("page-height") == x2.get("page-height")
+        assert x1.get("loop") == x2.get("loop")
+
+        # Reducing dither will typically reduce file size (and quality)
+        little_dither = self.colour.gifsave_buffer(dither=0.1, effort=1)
+        large_dither = self.colour.gifsave_buffer(dither=0.9, effort=1)
+        assert len(little_dither) < len(large_dither)
+
+        # Reducing effort will typically increase file size (and reduce quality)
+        little_effort = self.colour.gifsave_buffer(effort=1)
+        large_effort = self.colour.gifsave_buffer(effort=10)
+        assert len(little_effort) > len(large_effort)
+
+        if have("webpload"):
+            # Animated WebP to GIF
+            x1 = pyvips.Image.new_from_file(WEBP_ANIMATED_FILE, n=-1)
+            b1 = x1.gifsave_buffer()
+            x2 = pyvips.Image.new_from_buffer(b1, "", n=-1)
+            assert x1.width == x2.width
+            assert x1.height == x2.height
+            assert x1.get("n-pages") == x2.get("n-pages")
+            assert x1.get("delay") == x2.get("delay")
+            assert x1.get("page-height") == x2.get("page-height")
+            assert x1.get("loop") == x2.get("loop")
 
 if __name__ == '__main__':
     pytest.main()


### PR DESCRIPTION
This PR adds support for GIF encoding via the MIT-licenced [cgif](https://github.com/dloebl/cgif), which is performant, well maintained and tested, plus supports streaming. The aim is that this new saver will be easier/simpler/faster than the *magick-based approach.

It relies on libimagequant to generate the (global) palette and quantise, as we already do for 8-bit PNGs. The palette is intentionally limited to a maximum of 255 colours, which leaves cgif one extra colour for it to optimise frames.

The cgif library is not yet "officially" available via the usual package managers but I've created https://github.com/lovell/cgif-packaging to help start that process.

TODO (there may be more):

- [x] cgif: Improved transparency / disposal method - see https://github.com/dloebl/cgif/pull/5
- [x] cgif: Make available via package managers - see https://github.com/lovell/cgif-packaging
- [x] libvips: Unit tests
- [x] libvips/oss-fuzz: Add cgif as a dependency and create a fuzz test for the encoder - see https://github.com/google/oss-fuzz/pull/6241
- [ ] libvips: support frame-local palettes (this might be better as a follow up PR)
