### PR TITLE
Introduce unlimited flag, enabling unlimited text chunks in PNGs

### DIFF
--- a/cplusplus/include/vips/VImage8.h
+++ b/cplusplus/include/vips/VImage8.h
@@ -4562,7 +4562,7 @@ VImage phasecor( VImage in2, VOption *options = 0 ) const;
  *   - **sequential** -- Sequential read only, bool.
  *   - **fail** -- Fail on first error, bool.
  *   - **disc** -- Open to disc, bool.
- *   - **unlimited** -- Allow any number of text chunks.
+ *   - **unlimited** -- Remove all denial of service limits.
  *
  * @param filename Filename to load from.
  * @param options Set of options.
@@ -4579,7 +4579,7 @@ static VImage pngload( const char *filename, VOption *options = 0 );
  *   - **sequential** -- Sequential read only, bool.
  *   - **fail** -- Fail on first error, bool.
  *   - **disc** -- Open to disc, bool.
- *   - **unlimited** -- Allow any number of text chunks.
+ *   - **unlimited** -- Remove all denial of service limits.
  *
  * @param buffer Buffer to load from.
  * @param options Set of options.
@@ -4596,7 +4596,7 @@ static VImage pngload_buffer( VipsBlob *buffer, VOption *options = 0 );
  *   - **sequential** -- Sequential read only, bool.
  *   - **fail** -- Fail on first error, bool.
  *   - **disc** -- Open to disc, bool.
- *   - **unlimited** -- Allow any number of text chunks.
+ *   - **unlimited** -- Remove all denial of service limits.
  *
  * @param source Source to load from.
  * @param options Set of options.

--- a/cplusplus/include/vips/VImage8.h
+++ b/cplusplus/include/vips/VImage8.h
@@ -4562,6 +4562,7 @@ VImage phasecor( VImage in2, VOption *options = 0 ) const;
  *   - **sequential** -- Sequential read only, bool.
  *   - **fail** -- Fail on first error, bool.
  *   - **disc** -- Open to disc, bool.
+ *   - **unlimited** -- Allow any number of text chunks.
  *
  * @param filename Filename to load from.
  * @param options Set of options.
@@ -4578,6 +4579,7 @@ static VImage pngload( const char *filename, VOption *options = 0 );
  *   - **sequential** -- Sequential read only, bool.
  *   - **fail** -- Fail on first error, bool.
  *   - **disc** -- Open to disc, bool.
+ *   - **unlimited** -- Allow any number of text chunks.
  *
  * @param buffer Buffer to load from.
  * @param options Set of options.
@@ -4594,6 +4596,7 @@ static VImage pngload_buffer( VipsBlob *buffer, VOption *options = 0 );
  *   - **sequential** -- Sequential read only, bool.
  *   - **fail** -- Fail on first error, bool.
  *   - **disc** -- Open to disc, bool.
+ *   - **unlimited** -- Allow any number of text chunks.
  *
  * @param source Source to load from.
  * @param options Set of options.

--- a/libvips/foreign/pforeign.h
+++ b/libvips/foreign/pforeign.h
@@ -177,9 +177,9 @@ int vips__jpeg_read_source( VipsSource *source, VipsImage *out,
 int vips__isjpeg_source( VipsSource *source );
 
 int vips__png_ispng_source( VipsSource *source );
-int vips__png_header_source( VipsSource *source, VipsImage *out );
+int vips__png_header_source( VipsSource *source, VipsImage *out, gboolean unlimited );
 int vips__png_read_source( VipsSource *source, VipsImage *out, 
-	gboolean fail );
+	gboolean fail, gboolean unlimited );
 gboolean vips__png_isinterlaced_source( VipsSource *source );
 extern const char *vips__png_suffs[];
 

--- a/libvips/foreign/pforeign.h
+++ b/libvips/foreign/pforeign.h
@@ -180,7 +180,7 @@ int vips__png_ispng_source( VipsSource *source );
 int vips__png_header_source( VipsSource *source, VipsImage *out, gboolean unlimited );
 int vips__png_read_source( VipsSource *source, VipsImage *out, 
 	gboolean fail, gboolean unlimited );
-gboolean vips__png_isinterlaced_source( VipsSource *source );
+gboolean vips__png_isinterlaced_source( VipsSource *source, gboolean unlimited );
 extern const char *vips__png_suffs[];
 
 int vips__png_write_target( VipsImage *in, VipsTarget *target,

--- a/libvips/foreign/pforeign.h
+++ b/libvips/foreign/pforeign.h
@@ -180,7 +180,7 @@ int vips__png_ispng_source( VipsSource *source );
 int vips__png_header_source( VipsSource *source, VipsImage *out, gboolean unlimited );
 int vips__png_read_source( VipsSource *source, VipsImage *out, 
 	gboolean fail, gboolean unlimited );
-gboolean vips__png_isinterlaced_source( VipsSource *source, gboolean unlimited );
+gboolean vips__png_isinterlaced_source( VipsSource *source );
 extern const char *vips__png_suffs[];
 
 int vips__png_write_target( VipsImage *in, VipsTarget *target,

--- a/libvips/foreign/pforeign.h
+++ b/libvips/foreign/pforeign.h
@@ -45,6 +45,8 @@ extern "C" {
 )
 #endif /*HAVE_CHECKED_MUL*/
 
+#define MAX_PNG_TEXT_CHUNKS 20
+
 void vips__tiff_init( void );
 
 int vips__tiff_write( VipsImage *in, const char *filename, 

--- a/libvips/foreign/pngload.c
+++ b/libvips/foreign/pngload.c
@@ -59,7 +59,7 @@ typedef struct _VipsForeignLoadPng {
 	 */
 	VipsSource *source;
 
-	/* Allow any number of text chunks.
+	/* remove all denial of service limits.
 	 */
 	gboolean unlimited;
 
@@ -166,7 +166,7 @@ vips_foreign_load_png_class_init( VipsForeignLoadPngClass *class )
 
 	VIPS_ARG_BOOL( class, "unlimited", 23,
 		_( "Unlimited" ),
-		_( "Allow any number of text chunks" ),
+		_( "Remove all denial of service limits" ),
 		VIPS_ARGUMENT_OPTIONAL_INPUT,
 		G_STRUCT_OFFSET( VipsForeignLoadPng, unlimited ),
 		FALSE );
@@ -409,13 +409,17 @@ vips_foreign_load_png_buffer_init( VipsForeignLoadPngBuffer *buffer )
  *
  * Optional arguments:
  *
- * * @unlimited: %gboolean, allow any number of text chunks
+ * * @unlimited: %gboolean, remove all denial of service limits
  *
  * Read a PNG file into a VIPS image. It can read all png images, including 8-
  * and 16-bit images, 1 and 3 channel, with and without an alpha channel.
  *
  * Any ICC profile is read and attached to the VIPS image. It also supports
  * XMP metadata.
+ *
+ * By default, the PNG loader limits the number of text and data chunks to 
+ * block some denial of service attacks. Set @unlimited to disable these 
+ * limits.
  *
  * See also: vips_image_new_from_file().
  *
@@ -443,7 +447,7 @@ vips_pngload( const char *filename, VipsImage **out, ... )
  *
  * Optional arguments:
  *
- * * @unlimited: %gboolean, allow any number of text chunks
+ * * @unlimited: %gboolean, Remove all denial of service limits
  *
  * Exactly as vips_pngload(), but read from a PNG-formatted memory block.
  *
@@ -482,7 +486,7 @@ vips_pngload_buffer( void *buf, size_t len, VipsImage **out, ... )
  *
  * Optional arguments:
  *
- * * @unlimited: %gboolean, allow any number of text chunks
+ * * @unlimited: %gboolean, Remove all denial of service limits
  *
  * Exactly as vips_pngload(), but read from a source. 
  *

--- a/libvips/foreign/pngload.c
+++ b/libvips/foreign/pngload.c
@@ -162,13 +162,6 @@ vips_foreign_load_png_class_init( VipsForeignLoadPngClass *class )
 	load_class->header = vips_foreign_load_png_header;
 	load_class->load = vips_foreign_load_png_load;
 
-	VIPS_ARG_BOOL( class, "unlimited", 23,
-		_( "Unlimited" ),
-		_( "Allow any number of text chunks" ),
-		VIPS_ARGUMENT_OPTIONAL_INPUT,
-		G_STRUCT_OFFSET( VipsForeignLoadPng, unlimited ),
-		FALSE );
-
 }
 
 static void

--- a/libvips/foreign/pngload.c
+++ b/libvips/foreign/pngload.c
@@ -85,9 +85,10 @@ static VipsForeignFlags
 vips_foreign_load_png_get_flags_source( VipsSource *source )
 {
 	VipsForeignFlags flags;
+	VipsForeignLoadPng *png = (VipsForeignLoadPng *) load;
 
 	flags = 0;
-	if( vips__png_isinterlaced_source( source ) )
+	if( vips__png_isinterlaced_source( png->source, png->unlimited ) )
 		flags |= VIPS_FOREIGN_PARTIAL;
 	else
 		flags |= VIPS_FOREIGN_SEQUENTIAL;

--- a/libvips/foreign/pngload.c
+++ b/libvips/foreign/pngload.c
@@ -122,7 +122,7 @@ vips_foreign_load_png_header( VipsForeignLoad *load )
 {
 	VipsForeignLoadPng *png = (VipsForeignLoadPng *) load;
 
-	if( vips__png_header_source( png->source, load->out ) )
+	if( vips__png_header_source( png->source, load->out, png->unlimited ) )
 		return( -1 );
 
 	return( 0 );
@@ -133,7 +133,7 @@ vips_foreign_load_png_load( VipsForeignLoad *load )
 {
 	VipsForeignLoadPng *png = (VipsForeignLoadPng *) load;
 
-	if( vips__png_read_source( png->source, load->real, load->fail ) )
+	if( vips__png_read_source( png->source, load->real, load->fail, png->unlimited ) )
 		return( -1 );
 
 	return( 0 );
@@ -162,6 +162,12 @@ vips_foreign_load_png_class_init( VipsForeignLoadPngClass *class )
 	load_class->header = vips_foreign_load_png_header;
 	load_class->load = vips_foreign_load_png_load;
 
+	VIPS_ARG_BOOL( class, "unlimited", 23,
+		_( "Unlimited" ),
+		_( "Allow any number of text chunks" ),
+		VIPS_ARGUMENT_OPTIONAL_INPUT,
+		G_STRUCT_OFFSET( VipsForeignLoadPng, unlimited ),
+		FALSE );
 }
 
 static void
@@ -229,13 +235,6 @@ vips_foreign_load_png_source_class_init( VipsForeignLoadPngSourceClass *class )
 		VIPS_ARGUMENT_REQUIRED_INPUT, 
 		G_STRUCT_OFFSET( VipsForeignLoadPngSource, source ),
 		VIPS_TYPE_SOURCE );
-
-	VIPS_ARG_BOOL( class, "unlimited", 23,
-		_( "Unlimited" ),
-		_( "Allow any number of text chunks" ),
-		VIPS_ARGUMENT_OPTIONAL_INPUT,
-		G_STRUCT_OFFSET( VipsForeignLoadPng, unlimited ),
-		FALSE );
 
 }
 
@@ -314,14 +313,6 @@ vips_foreign_load_png_file_class_init( VipsForeignLoadPngFileClass *class )
 		VIPS_ARGUMENT_REQUIRED_INPUT, 
 		G_STRUCT_OFFSET( VipsForeignLoadPngFile, filename ),
 		NULL );
-
-	VIPS_ARG_BOOL( class, "unlimited", 23,
-		_( "Unlimited" ),
-		_( "Allow any number of text chunks" ),
-		VIPS_ARGUMENT_OPTIONAL_INPUT,
-		G_STRUCT_OFFSET( VipsForeignLoadPng, unlimited ),
-		FALSE );
-
 }
 
 static void
@@ -399,13 +390,6 @@ vips_foreign_load_png_buffer_class_init( VipsForeignLoadPngBufferClass *class )
 		G_STRUCT_OFFSET( VipsForeignLoadPngBuffer, blob ),
 		VIPS_TYPE_BLOB );
 
-	VIPS_ARG_BOOL( class, "unlimited", 23,
-		_( "Unlimited" ),
-		_( "Allow any number of text chunks" ),
-		VIPS_ARGUMENT_OPTIONAL_INPUT,
-		G_STRUCT_OFFSET( VipsForeignLoadPngBuffer, unlimited ),
-		FALSE );
-		
 }
 
 static void

--- a/libvips/foreign/pngload.c
+++ b/libvips/foreign/pngload.c
@@ -148,6 +148,8 @@ vips_foreign_load_png_class_init( VipsForeignLoadPngClass *class )
 	VipsForeignLoadClass *load_class = (VipsForeignLoadClass *) class;
 
 	gobject_class->dispose = vips_foreign_load_png_dispose;
+	gobject_class->set_property = vips_object_set_property;
+	gobject_class->get_property = vips_object_get_property;
 
 	object_class->nickname = "pngload_base";
 	object_class->description = _( "load png base class" );

--- a/libvips/foreign/pngload.c
+++ b/libvips/foreign/pngload.c
@@ -59,6 +59,10 @@ typedef struct _VipsForeignLoadPng {
 	 */
 	VipsSource *source;
 
+	/* Allow any number of text chunks.
+	 */
+	gboolean unlimited;
+
 } VipsForeignLoadPng;
 
 typedef VipsForeignLoadClass VipsForeignLoadPngClass;
@@ -158,6 +162,13 @@ vips_foreign_load_png_class_init( VipsForeignLoadPngClass *class )
 	load_class->header = vips_foreign_load_png_header;
 	load_class->load = vips_foreign_load_png_load;
 
+	VIPS_ARG_BOOL( class, "unlimited", 23,
+		_( "Unlimited" ),
+		_( "Allow any number of text chunks" ),
+		VIPS_ARGUMENT_OPTIONAL_INPUT,
+		G_STRUCT_OFFSET( VipsForeignLoadPng, unlimited ),
+		FALSE );
+
 }
 
 static void
@@ -225,6 +236,13 @@ vips_foreign_load_png_source_class_init( VipsForeignLoadPngSourceClass *class )
 		VIPS_ARGUMENT_REQUIRED_INPUT, 
 		G_STRUCT_OFFSET( VipsForeignLoadPngSource, source ),
 		VIPS_TYPE_SOURCE );
+
+	VIPS_ARG_BOOL( class, "unlimited", 23,
+		_( "Unlimited" ),
+		_( "Allow any number of text chunks" ),
+		VIPS_ARGUMENT_OPTIONAL_INPUT,
+		G_STRUCT_OFFSET( VipsForeignLoadPng, unlimited ),
+		FALSE );
 
 }
 
@@ -303,6 +321,14 @@ vips_foreign_load_png_file_class_init( VipsForeignLoadPngFileClass *class )
 		VIPS_ARGUMENT_REQUIRED_INPUT, 
 		G_STRUCT_OFFSET( VipsForeignLoadPngFile, filename ),
 		NULL );
+
+	VIPS_ARG_BOOL( class, "unlimited", 23,
+		_( "Unlimited" ),
+		_( "Allow any number of text chunks" ),
+		VIPS_ARGUMENT_OPTIONAL_INPUT,
+		G_STRUCT_OFFSET( VipsForeignLoadPng, unlimited ),
+		FALSE );
+
 }
 
 static void
@@ -380,6 +406,13 @@ vips_foreign_load_png_buffer_class_init( VipsForeignLoadPngBufferClass *class )
 		G_STRUCT_OFFSET( VipsForeignLoadPngBuffer, blob ),
 		VIPS_TYPE_BLOB );
 
+	VIPS_ARG_BOOL( class, "unlimited", 23,
+		_( "Unlimited" ),
+		_( "Allow any number of text chunks" ),
+		VIPS_ARGUMENT_OPTIONAL_INPUT,
+		G_STRUCT_OFFSET( VipsForeignLoadPngBuffer, unlimited ),
+		FALSE );
+		
 }
 
 static void
@@ -394,6 +427,10 @@ vips_foreign_load_png_buffer_init( VipsForeignLoadPngBuffer *buffer )
  * @filename: file to load
  * @out: (out): decompressed image
  * @...: %NULL-terminated list of optional named arguments
+ *
+ * Optional arguments:
+ *
+ * * @unlimited: %gboolean, allow any number of text chunks
  *
  * Read a PNG file into a VIPS image. It can read all png images, including 8-
  * and 16-bit images, 1 and 3 channel, with and without an alpha channel.
@@ -424,6 +461,10 @@ vips_pngload( const char *filename, VipsImage **out, ... )
  * @len: (type gsize): size of memory area
  * @out: (out): image to write
  * @...: %NULL-terminated list of optional named arguments
+ *
+ * Optional arguments:
+ *
+ * * @unlimited: %gboolean, allow any number of text chunks
  *
  * Exactly as vips_pngload(), but read from a PNG-formatted memory block.
  *
@@ -459,6 +500,10 @@ vips_pngload_buffer( void *buf, size_t len, VipsImage **out, ... )
  * @source: source to load from
  * @out: (out): image to write
  * @...: %NULL-terminated list of optional named arguments
+ *
+ * Optional arguments:
+ *
+ * * @unlimited: %gboolean, allow any number of text chunks
  *
  * Exactly as vips_pngload(), but read from a source. 
  *

--- a/libvips/foreign/pngload.c
+++ b/libvips/foreign/pngload.c
@@ -85,10 +85,9 @@ static VipsForeignFlags
 vips_foreign_load_png_get_flags_source( VipsSource *source )
 {
 	VipsForeignFlags flags;
-	VipsForeignLoadPng *png = (VipsForeignLoadPng *) load;
 
 	flags = 0;
-	if( vips__png_isinterlaced_source( png->source, png->unlimited ) )
+	if( vips__png_isinterlaced_source( source ) )
 		flags |= VIPS_FOREIGN_PARTIAL;
 	else
 		flags |= VIPS_FOREIGN_SEQUENTIAL;

--- a/libvips/foreign/spngload.c
+++ b/libvips/foreign/spngload.c
@@ -63,6 +63,10 @@ typedef struct _VipsForeignLoadPng {
 	 */
 	VipsSource *source;
 
+	/* Allow any number of text chunks.
+	 */
+	gboolean unlimited;
+
 	spng_ctx *ctx;
 	struct spng_ihdr ihdr;
 	enum spng_format fmt;
@@ -249,7 +253,8 @@ vips_foreign_load_png_set_header( VipsForeignLoadPng *png, VipsImage *image )
 		/* Very large numbers of text chunks are used in DoS
 		 * attacks.
 		 */
-		if( n_text > 10 ) {
+
+		if( !png->unlimited && n_text > 10 ) {
 			vips_error( class->nickname, 
 				"%s", _( "too many text chunks" ) );
 			return( -1 );
@@ -662,6 +667,13 @@ vips_foreign_load_png_class_init( VipsForeignLoadPngClass *class )
 	load_class->header = vips_foreign_load_png_header;
 	load_class->load = vips_foreign_load_png_load;
 
+	VIPS_ARG_BOOL( class, "unlimited", 23,
+		_( "Unlimited" ),
+		_( "Allow any number of text chunks" ),
+		VIPS_ARGUMENT_OPTIONAL_INPUT,
+		G_STRUCT_OFFSET( VipsForeignLoadPng, unlimited ),
+		FALSE );
+
 }
 
 static void
@@ -737,6 +749,13 @@ vips_foreign_load_png_source_class_init( VipsForeignLoadPngSourceClass *class )
 		VIPS_ARGUMENT_REQUIRED_INPUT, 
 		G_STRUCT_OFFSET( VipsForeignLoadPngSource, source ),
 		VIPS_TYPE_SOURCE );
+
+	VIPS_ARG_BOOL( class, "unlimited", 23,
+		_( "Unlimited" ),
+		_( "Allow any number of text chunks" ),
+		VIPS_ARGUMENT_OPTIONAL_INPUT,
+		G_STRUCT_OFFSET( VipsForeignLoadPng, unlimited ),
+		FALSE );
 
 }
 
@@ -817,6 +836,14 @@ vips_foreign_load_png_file_class_init( VipsForeignLoadPngFileClass *class )
 		VIPS_ARGUMENT_REQUIRED_INPUT, 
 		G_STRUCT_OFFSET( VipsForeignLoadPngFile, filename ),
 		NULL );
+
+	VIPS_ARG_BOOL( class, "unlimited", 23,
+		_( "Unlimited" ),
+		_( "Allow any number of text chunks" ),
+		VIPS_ARGUMENT_OPTIONAL_INPUT,
+		G_STRUCT_OFFSET( VipsForeignLoadPng, unlimited ),
+		FALSE );
+
 }
 
 static void
@@ -893,6 +920,13 @@ vips_foreign_load_png_buffer_class_init( VipsForeignLoadPngBufferClass *class )
 		VIPS_ARGUMENT_REQUIRED_INPUT, 
 		G_STRUCT_OFFSET( VipsForeignLoadPngBuffer, blob ),
 		VIPS_TYPE_BLOB );
+
+	VIPS_ARG_BOOL( class, "unlimited", 23,
+		_( "Unlimited" ),
+		_( "Allow any number of text chunks" ),
+		VIPS_ARGUMENT_OPTIONAL_INPUT,
+		G_STRUCT_OFFSET( VipsForeignLoadPng, unlimited ),
+		FALSE );
 
 }
 

--- a/libvips/foreign/spngload.c
+++ b/libvips/foreign/spngload.c
@@ -667,13 +667,6 @@ vips_foreign_load_png_class_init( VipsForeignLoadPngClass *class )
 	load_class->header = vips_foreign_load_png_header;
 	load_class->load = vips_foreign_load_png_load;
 
-	VIPS_ARG_BOOL( class, "unlimited", 23,
-		_( "Unlimited" ),
-		_( "Allow any number of text chunks" ),
-		VIPS_ARGUMENT_OPTIONAL_INPUT,
-		G_STRUCT_OFFSET( VipsForeignLoadPng, unlimited ),
-		FALSE );
-
 }
 
 static void

--- a/libvips/foreign/spngload.c
+++ b/libvips/foreign/spngload.c
@@ -63,7 +63,7 @@ typedef struct _VipsForeignLoadPng {
 	 */
 	VipsSource *source;
 
-	/* Allow any number of text chunks.
+	/* Remove DoS limits.
 	 */
 	gboolean unlimited;
 
@@ -254,7 +254,7 @@ vips_foreign_load_png_set_header( VipsForeignLoadPng *png, VipsImage *image )
 		 * attacks.
 		 */
 
-		if( !png->unlimited && n_text > 10 ) {
+		if( !png->unlimited && n_text > MAX_PNG_TEXT_CHUNKS ) {
 			vips_error( class->nickname, 
 				"%s", _( "too many text chunks" ) );
 			return( -1 );
@@ -673,7 +673,7 @@ vips_foreign_load_png_class_init( VipsForeignLoadPngClass *class )
 
 	VIPS_ARG_BOOL( class, "unlimited", 23,
 		_( "Unlimited" ),
-		_( "Allow any number of text chunks" ),
+		_( "Remove all denial of service limits" ),
 		VIPS_ARGUMENT_OPTIONAL_INPUT,
 		G_STRUCT_OFFSET( VipsForeignLoadPng, unlimited ),
 		FALSE );

--- a/libvips/foreign/spngload.c
+++ b/libvips/foreign/spngload.c
@@ -354,8 +354,10 @@ vips_foreign_load_png_header( VipsForeignLoad *load )
 	 * No need to test the decoded image size -- the user can do that if
 	 * they wish.
 	 */
-	spng_set_image_limits( png->ctx, VIPS_MAX_COORD, VIPS_MAX_COORD );
-	spng_set_chunk_limits( png->ctx, 60 * 1024 * 1024, 60 * 1024 * 1024 );
+	if ( !png->unlimited ) {
+		spng_set_image_limits( png->ctx, VIPS_MAX_COORD, VIPS_MAX_COORD );
+		spng_set_chunk_limits( png->ctx, 60 * 1024 * 1024, 60 * 1024 * 1024 );
+	}
 
 	if( vips_source_rewind( png->source ) ) 
 		return( -1 );
@@ -653,6 +655,8 @@ vips_foreign_load_png_class_init( VipsForeignLoadPngClass *class )
 	VipsForeignLoadClass *load_class = (VipsForeignLoadClass *) class;
 
 	gobject_class->dispose = vips_foreign_load_png_dispose;
+	gobject_class->set_property = vips_object_set_property;
+	gobject_class->get_property = vips_object_get_property;
 
 	object_class->nickname = "pngload_base";
 	object_class->description = _( "load png base class" );
@@ -667,6 +671,12 @@ vips_foreign_load_png_class_init( VipsForeignLoadPngClass *class )
 	load_class->header = vips_foreign_load_png_header;
 	load_class->load = vips_foreign_load_png_load;
 
+	VIPS_ARG_BOOL( class, "unlimited", 23,
+		_( "Unlimited" ),
+		_( "Allow any number of text chunks" ),
+		VIPS_ARGUMENT_OPTIONAL_INPUT,
+		G_STRUCT_OFFSET( VipsForeignLoadPng, unlimited ),
+		FALSE );
 }
 
 static void
@@ -742,13 +752,6 @@ vips_foreign_load_png_source_class_init( VipsForeignLoadPngSourceClass *class )
 		VIPS_ARGUMENT_REQUIRED_INPUT, 
 		G_STRUCT_OFFSET( VipsForeignLoadPngSource, source ),
 		VIPS_TYPE_SOURCE );
-
-	VIPS_ARG_BOOL( class, "unlimited", 23,
-		_( "Unlimited" ),
-		_( "Allow any number of text chunks" ),
-		VIPS_ARGUMENT_OPTIONAL_INPUT,
-		G_STRUCT_OFFSET( VipsForeignLoadPng, unlimited ),
-		FALSE );
 
 }
 
@@ -829,14 +832,6 @@ vips_foreign_load_png_file_class_init( VipsForeignLoadPngFileClass *class )
 		VIPS_ARGUMENT_REQUIRED_INPUT, 
 		G_STRUCT_OFFSET( VipsForeignLoadPngFile, filename ),
 		NULL );
-
-	VIPS_ARG_BOOL( class, "unlimited", 23,
-		_( "Unlimited" ),
-		_( "Allow any number of text chunks" ),
-		VIPS_ARGUMENT_OPTIONAL_INPUT,
-		G_STRUCT_OFFSET( VipsForeignLoadPng, unlimited ),
-		FALSE );
-
 }
 
 static void
@@ -913,13 +908,6 @@ vips_foreign_load_png_buffer_class_init( VipsForeignLoadPngBufferClass *class )
 		VIPS_ARGUMENT_REQUIRED_INPUT, 
 		G_STRUCT_OFFSET( VipsForeignLoadPngBuffer, blob ),
 		VIPS_TYPE_BLOB );
-
-	VIPS_ARG_BOOL( class, "unlimited", 23,
-		_( "Unlimited" ),
-		_( "Allow any number of text chunks" ),
-		VIPS_ARGUMENT_OPTIONAL_INPUT,
-		G_STRUCT_OFFSET( VipsForeignLoadPng, unlimited ),
-		FALSE );
 
 }
 

--- a/libvips/foreign/vipspng.c
+++ b/libvips/foreign/vipspng.c
@@ -271,7 +271,8 @@ read_new( VipsSource *source, VipsImage *out, gboolean fail, gboolean unlimited 
 	read->pInfo = NULL;
 	read->row_pointer = NULL;
 	read->source = source;
-	read->unlimited = unlimited
+	read->unlimited = unlimited;
+
 	g_object_ref( source );
 
 	g_signal_connect( out, "close", 
@@ -816,7 +817,7 @@ vips__png_read_source( VipsSource *source, VipsImage *out, gboolean fail, gboole
  * served partially from there. Non-interlaced PNGs may be read sequentially.
  */
 gboolean
-vips__png_isinterlaced_source( VipsSource *source )
+vips__png_isinterlaced_source( VipsSource *source, gboolean unlimited )
 {
 	VipsImage *image;
 	Read *read;
@@ -824,7 +825,7 @@ vips__png_isinterlaced_source( VipsSource *source )
 
 	image = vips_image_new();
 
-	if( !(read = read_new( source, image, TRUE )) ) { 
+	if( !(read = read_new( source, image, TRUE, unlimited )) ) { 
 		g_object_unref( image );
 		return( -1 );
 	}

--- a/libvips/foreign/vipspng.c
+++ b/libvips/foreign/vipspng.c
@@ -564,7 +564,8 @@ png2vips_header( Read *read, VipsImage *out )
 		/* Very large numbers of text chunks are used in DoS
 		 * attacks.
 		 */
-		if( num_text > 10 ) {
+
+		if( !read->unlimited && num_text > 10 ) {
 			vips_error( "vipspng", 
 				"%s", _( "too many text chunks" ) );
 			return( -1 );

--- a/libvips/foreign/vipspng.c
+++ b/libvips/foreign/vipspng.c
@@ -817,7 +817,7 @@ vips__png_read_source( VipsSource *source, VipsImage *out, gboolean fail, gboole
  * served partially from there. Non-interlaced PNGs may be read sequentially.
  */
 gboolean
-vips__png_isinterlaced_source( VipsSource *source, gboolean unlimited )
+vips__png_isinterlaced_source( VipsSource *source )
 {
 	VipsImage *image;
 	Read *read;
@@ -825,7 +825,7 @@ vips__png_isinterlaced_source( VipsSource *source, gboolean unlimited )
 
 	image = vips_image_new();
 
-	if( !(read = read_new( source, image, TRUE, unlimited )) ) { 
+	if( !(read = read_new( source, image, TRUE, FALSE )) ) { 
 		g_object_unref( image );
 		return( -1 );
 	}

--- a/libvips/foreign/vipspng.c
+++ b/libvips/foreign/vipspng.c
@@ -567,7 +567,7 @@ png2vips_header( Read *read, VipsImage *out )
 		/* Very large numbers of text chunks are used in DoS
 		 * attacks.
 		 */
-		if( !read->unlimited && num_text > 10 ) {
+		if( !read->unlimited && num_text > MAX_PNG_TEXT_CHUNKS ) {
 			vips_error( "vipspng", 
 				"%s", _( "too many text chunks" ) );
 			return( -1 );


### PR DESCRIPTION
Following this discussion: https://github.com/libvips/libvips/discussions/2418

Adds the flag: `unlimited`, which allows for unlimited-many text chunks when reading PNGs.

Open to feedback