### PR TITLE
heifload: switch demand to thin strip

### DIFF
--- a/libvips/foreign/heifload.c
+++ b/libvips/foreign/heifload.c
@@ -621,7 +621,8 @@ vips_foreign_load_heif_set_header( VipsForeignLoadHeif *heif, VipsImage *out )
 	/* FIXME .. we always decode to RGB in generate. We should check for
 	 * all grey images, perhaps. 
 	 */
-	vips_image_pipelinev( out, VIPS_DEMAND_STYLE_SMALLTILE, NULL );
+	if( vips_image_pipelinev( out, VIPS_DEMAND_STYLE_THINSTRIP, NULL ) )
+		return( -1 );
 	vips_image_init_fields( out,
 		heif->page_width, heif->page_height * heif->n, bands, 
 		VIPS_FORMAT_UCHAR, VIPS_CODING_NONE, VIPS_INTERPRETATION_sRGB, 


### PR DESCRIPTION
At the moment, unrecoverable errors that occur during HEIF decoding are presented as warnings and subsequent tiles are still requested.

https://bugs.chromium.org/p/oss-fuzz/issues/detail?id=38115 provides an example image that takes minutes to process before ultimately failing. I suspect a few of the other oss-fuzz timeout-related issues might be linked to this too.

By switching to thin strip, the decoding error is detected and handled as soon as possible, however I'm unsure if this is the right way to fix the problem e.g. why is small tile demand not propagating errors?