### PR TITLE
quantise: support optional thresholding of alpha channel

### DIFF
--- a/libvips/foreign/pforeign.h
+++ b/libvips/foreign/pforeign.h
@@ -219,7 +219,8 @@ int vips__webp_write_target( VipsImage *image, VipsTarget *target,
 
 int vips__quantise_image( VipsImage *in, 
 	VipsImage **index_out, VipsImage **palette_out,
-	int colours, int Q, double dither, int effort );
+	int colours, int Q, double dither, int effort,
+	gboolean threshold_alpha );
 
 extern const char *vips_foreign_nifti_suffs[];
 

--- a/libvips/foreign/quantise.c
+++ b/libvips/foreign/quantise.c
@@ -106,13 +106,15 @@ vips__quantise_new( VipsImage *in,
 int
 vips__quantise_image( VipsImage *in, 
 	VipsImage **index_out, VipsImage **palette_out,
-	int colours, int Q, double dither, int effort )
+	int colours, int Q, double dither, int effort,
+	gboolean threshold_alpha )
 {
 	Quantise *quantise;
 	VipsImage *index;
 	VipsImage *palette;
 	const liq_palette *lp;
 	int i;
+	gboolean added_alpha = FALSE;
 
 	quantise = vips__quantise_new( in, index_out, palette_out, 
 		colours, Q, dither, effort );
@@ -135,6 +137,7 @@ vips__quantise_image( VipsImage *in,
 			vips__quantise_free( quantise ); 
 			return( -1 );
 		}
+		added_alpha = TRUE;
 		in = quantise->t[1];
 	}
 
@@ -143,6 +146,19 @@ vips__quantise_image( VipsImage *in,
 		return( -1 );
 	}
 	in = quantise->t[2];
+
+	/* Threshold alpha channel.
+	 */
+	if( threshold_alpha && !added_alpha ) {
+		VipsPel * restrict p = VIPS_IMAGE_ADDR( in, 0, 0 );
+		const guint64 n_pels = VIPS_IMAGE_N_PELS( in );
+		guint64 i;
+
+		for( i = 0; i < n_pels; i++ ) {
+			p[3] = p[3] > 128 ? 255 : 0;
+			p += 4;
+		}
+	}
 
 	quantise->attr = liq_attr_create();
 	liq_set_max_colors( quantise->attr, colours );
@@ -215,7 +231,8 @@ vips__quantise_image( VipsImage *in,
 int
 vips__quantise_image( VipsImage *in, 
 	VipsImage **index_out, VipsImage **palette_out,
-	int colours, int Q, double dither )
+	int colours, int Q, double dither, int effort,
+	gboolean threshold_alpha )
 {
   vips_error( "vips__quantise_image", 
       "%s", _( "libvips not built with quantisation support" ) ); 

--- a/libvips/foreign/vipspng.c
+++ b/libvips/foreign/vipspng.c
@@ -1190,7 +1190,7 @@ write_vips( Write *write,
 		int trans_count;
 
 		if( vips__quantise_image( in, &im_index, &im_palette, 
-			1 << bitdepth, Q, dither, effort ) )
+			1 << bitdepth, Q, dither, effort, FALSE ) )
 			return( -1 );
 
 		palette_count = im_palette->Xsize;


### PR DESCRIPTION
Moving the threshold logic from `gifsave` to `quantise`, where we already have all the pixel values in memory, improves the performance of writing GIFs that have an existing alpha channel by ~15%.

Before:
```
63,385,110,223 (36.61%) libimagequant/_build/../libimagequant.c:liq_write_remapped_image_rows [/usr/local/lib/x86_64-linux-gnu/libimagequant.so]
14,773,585,680 ( 8.53%) libvips/conversion/extract.c:vips_extract_band_buffer [/usr/local/lib/libvips.so.42.14.0]
14,768,059,320 ( 8.53%) libvips/conversion/bandjoin.c:vips_bandjoin_buffer [/usr/local/lib/libvips.so.42.14.0]
13,847,368,990 ( 8.00%) /usr/lib/gcc/x86_64-linux-gnu/9/include/xmmintrin.h:nearest_search
10,932,738,351 ( 6.31%) libimagequant/_build/../nearest.c:nearest_search [/usr/local/lib/x86_64-linux-gnu/libimagequant.so]
```
After:
```
63,385,110,223 (46.30%)  libimagequant/_build/../libimagequant.c:liq_write_remapped_image_rows [/usr/local/lib/x86_64-linux-gnu/libimagequant.so]
13,847,368,990 (10.12%)  /usr/lib/gcc/x86_64-linux-gnu/9/include/xmmintrin.h:nearest_search
10,932,738,351 ( 7.99%)  libimagequant/_build/../nearest.c:nearest_search [/usr/local/lib/x86_64-linux-gnu/libimagequant.so]
```

