### PR TITLE
gifsave: expose bitdepth option

### DIFF
--- a/test/test-suite/test_foreign.py
+++ b/test/test-suite/test_foreign.py
@@ -1229,6 +1229,11 @@ class TestForeign:
         large_effort = self.colour.gifsave_buffer(effort=10)
         assert len(little_effort) > len(large_effort)
 
+        # Reducing bitdepth will typically reduce file size (and reduce quality)
+        bitdepth8 = self.colour.gifsave_buffer(bitdepth=8,effort=1)
+        bitdepth7 = self.colour.gifsave_buffer(bitdepth=7,effort=1)
+        assert len(bitdepth8) > len(bitdepth7)
+
         if have("webpload"):
             # Animated WebP to GIF
             x1 = pyvips.Image.new_from_file(WEBP_ANIMATED_FILE, n=-1)


### PR DESCRIPTION
This property provides control over the maximum number of colours in the output image palette, making the API more closely match that of `pngsave`.

Given the majority of CPU time when encoding GIF images is spent finding the nearest colour in the palette, lowering the bitdepth from 8 to 7 halves the maximum number of colours from 255 to 127 and reduces encoding time by ~20%.