### PR TITLE
experiment with removing shutdown from atexit

### DIFF
--- a/libvips/iofuncs/init.c
+++ b/libvips/iofuncs/init.c
@@ -425,9 +425,10 @@ vips__atexit( void )
 	{
 		static gboolean done = FALSE;
 
-		done = TRUE;
-		if( !done )
+		if( !done ) {
+			done = TRUE;
 			vips_leak();
+		}
 	}
 }
 

--- a/libvips/iofuncs/sinkscreen.c
+++ b/libvips/iofuncs/sinkscreen.c
@@ -1054,8 +1054,7 @@ vips__sink_screen_once( void *data )
 	vips_semaphore_init( &n_render_dirty_sem, 0, "n_render_dirty" );
 
 	/* Don't use vips__thread_execute() since this thread will only be
-	 * ended by _shutdown, and that isn't always called early enough on
-	 * windows from atexit().
+	 * ended by vips_shutdown, and that isn't always called.
 	 */
 	render_thread = vips_g_thread_new( "sink_screen",
 		render_thread_main, NULL );


### PR DESCRIPTION
Because atexit() can be called at almost any point during process termination,
including after worker threads have been force-quit, we can't use it for
cleanup.

New policy: use vips_shutdown() explicitly if you need to clean up,
though it's optional. Only use atexit() for leak checking.