### PR TITLE
jxlload: use memmove for overlapping input buffer

### DIFF
--- a/libvips/foreign/jxlload.c
+++ b/libvips/foreign/jxlload.c
@@ -208,7 +208,7 @@ vips_foreign_load_jxl_fill_input( VipsForeignLoadJxl *jxl,
 		INPUT_BUFFER_SIZE - bytes_remaining );
 #endif /*DEBUG_VERBOSE*/
 
-	memcpy( jxl->input_buffer, 
+	memmove( jxl->input_buffer,
 		jxl->input_buffer + jxl->bytes_in_buffer - bytes_remaining,
 		bytes_remaining );
 	bytes_read = vips_source_read( jxl->source,


### PR DESCRIPTION
This is a possible quick fix for https://bugs.chromium.org/p/oss-fuzz/issues/detail?id=39481

It's likely there's an alternative/additional solution as we might want to guard against this occurring in the first place.