### PR TITLE
Ensure newly created file descriptors are non-inheritable

### DIFF
--- a/libvips/iofuncs/source.c
+++ b/libvips/iofuncs/source.c
@@ -100,13 +100,15 @@
 #define BINARYIZE(M) (M)
 #endif /*O_BINARY*/
 
-/* If we have O_NOINHERIT, add it to a mode flags set.
+/* If we have O_CLOEXEC or O_NOINHERIT, add it to a mode flags set.
  */
-#ifdef O_NOINHERIT
+#ifdef O_CLOEXEC
+#define CLOEXEC(M) ((M) | O_CLOEXEC)
+#elif defined(O_NOINHERIT)
 #define CLOEXEC(M) ((M) | O_NOINHERIT)
-#else /*!O_NOINHERIT*/
+#else /*!O_CLOEXEC && !O_NOINHERIT*/
 #define CLOEXEC(M) (M)
-#endif /*O_NOINHERIT*/
+#endif /*O_CLOEXEC*/
 
 #define MODE_READ CLOEXEC (BINARYIZE (O_RDONLY))
 

--- a/libvips/iofuncs/target.c
+++ b/libvips/iofuncs/target.c
@@ -87,13 +87,15 @@
 #define BINARYIZE(M) (M)
 #endif /*O_BINARY*/
 
-/* If we have O_NOINHERIT, add it to a mode flags set.
+/* If we have O_CLOEXEC or O_NOINHERIT, add it to a mode flags set.
  */
-#ifdef O_NOINHERIT
+#ifdef O_CLOEXEC
+#define CLOEXEC(M) ((M) | O_CLOEXEC)
+#elif defined(O_NOINHERIT)
 #define CLOEXEC(M) ((M) | O_NOINHERIT)
-#else /*!O_NOINHERIT*/
+#else /*!O_CLOEXEC && !O_NOINHERIT*/
 #define CLOEXEC(M) (M)
-#endif /*O_NOINHERIT*/
+#endif /*O_CLOEXEC*/
 
 #define MODE_WRITE CLOEXEC (BINARYIZE (O_WRONLY | O_CREAT | O_TRUNC))
 

--- a/libvips/iofuncs/util.c
+++ b/libvips/iofuncs/util.c
@@ -88,13 +88,15 @@
 #define BINARYIZE(M) (M)
 #endif /*O_BINARY*/
 
-/* If we have O_NOINHERIT, add it to a mode flags set.
+/* If we have O_CLOEXEC or O_NOINHERIT, add it to a mode flags set.
  */
-#ifdef O_NOINHERIT
+#ifdef O_CLOEXEC
+#define CLOEXEC(M) ((M) | O_CLOEXEC)
+#elif defined(O_NOINHERIT)
 #define CLOEXEC(M) ((M) | O_NOINHERIT)
-#else /*!O_NOINHERIT*/
+#else /*!O_CLOEXEC && !O_NOINHERIT*/
 #define CLOEXEC(M) (M)
-#endif /*O_NOINHERIT*/
+#endif /*O_CLOEXEC*/
 
 #define MODE_READ CLOEXEC (BINARYIZE (O_RDONLY))
 
@@ -707,7 +709,7 @@ vips__file_open_read( const char *filename, const char *fallback_dir,
 	else
 		mode = "rbN";
 #else /*!defined(G_PLATFORM_WIN32) && !defined(G_WITH_CYGWIN)*/
-	mode = "r";
+	mode = "re";
 #endif /*defined(G_PLATFORM_WIN32) || defined(G_WITH_CYGWIN)*/
 
 	if( (fp = vips__fopen( filename, mode )) )
@@ -743,7 +745,7 @@ vips__file_open_write( const char *filename, gboolean text_mode )
 	else
 		mode = "wbN";
 #else /*!defined(G_PLATFORM_WIN32) && !defined(G_WITH_CYGWIN)*/
-	mode = "w";
+	mode = "we";
 #endif /*defined(G_PLATFORM_WIN32) || defined(G_WITH_CYGWIN)*/
 
         if( !(fp = vips__fopen( filename, mode )) ) {

--- a/libvips/iofuncs/vips.c
+++ b/libvips/iofuncs/vips.c
@@ -136,13 +136,15 @@
 #define BINARYIZE(M) (M)
 #endif /*O_BINARY*/
 
-/* If we have O_NOINHERIT, add it to a mode flags set.
+/* If we have O_CLOEXEC or O_NOINHERIT, add it to a mode flags set.
  */
-#ifdef O_NOINHERIT
+#ifdef O_CLOEXEC
+#define CLOEXEC(M) ((M) | O_CLOEXEC)
+#elif defined(O_NOINHERIT)
 #define CLOEXEC(M) ((M) | O_NOINHERIT)
-#else /*!O_NOINHERIT*/
+#else /*!O_CLOEXEC && !O_NOINHERIT*/
 #define CLOEXEC(M) (M)
-#endif /*O_NOINHERIT*/
+#endif /*O_CLOEXEC*/
 
 /* Open mode for image write ... on some systems, have to set BINARY too.
  *


### PR DESCRIPTION
If you call `Process.Start` in .NET, `CreateProcess` is internally called with `bInheritHandles = true` which causes open file handles to be inherited (see https://github.com/dotnet/runtime/issues/13943). As described in https://devblogs.microsoft.com/oldnewthing/20111216-00/?p=8873, this can lead to surprising results when two threads within the same process both call `CreateProcess`.

Given that this leaking of file descriptors in child processes causes various annoying issues, I think it would be better to make newly created file descriptors non-inheritable in libvips by default. A similar thing is done in Python ([PEP 446](https://www.python.org/dev/peps/pep-0446/)) and Rust (https://github.com/rust-lang/rust/issues/24237).

Fixes: https://github.com/kleisauke/net-vips/issues/139.