### PR TITLE
Include vips.h before checking for G_OS_WIN32

### DIFF
--- a/libvips/iofuncs/source.c
+++ b/libvips/iofuncs/source.c
@@ -69,11 +69,12 @@
 #include <fcntl.h>
 #include <unistd.h>
 
+#include <vips/vips.h>
+
 #ifdef G_OS_WIN32
 #include <io.h>
 #endif /*G_OS_WIN32*/
 
-#include <vips/vips.h>
 #include <vips/debug.h>
 #include <vips/internal.h>
 

--- a/libvips/iofuncs/target.c
+++ b/libvips/iofuncs/target.c
@@ -56,11 +56,12 @@
 #include <fcntl.h>
 #include <unistd.h>
 
+#include <vips/vips.h>
+
 #ifdef G_OS_WIN32
 #include <io.h>
 #endif /*G_OS_WIN32*/
 
-#include <vips/vips.h>
 #include <vips/debug.h>
 #include <vips/internal.h>
 

--- a/libvips/iofuncs/util.c
+++ b/libvips/iofuncs/util.c
@@ -53,11 +53,12 @@
 #endif /*HAVE_IO_H*/
 #include <fcntl.h>
 
+#include <vips/vips.h>
+
 #ifdef G_OS_WIN32
 #include <windows.h>
 #endif /*G_OS_WIN32*/
 
-#include <vips/vips.h>
 #include <vips/debug.h>
 #include <vips/internal.h>
 

--- a/libvips/iofuncs/vips.c
+++ b/libvips/iofuncs/vips.c
@@ -94,11 +94,12 @@
 #include <expat.h>
 #include <errno.h>
 
+#include <vips/vips.h>
+
 #ifdef G_OS_WIN32
 #include <windows.h>
 #endif /*G_OS_WIN32*/
 
-#include <vips/vips.h>
 #include <vips/debug.h>
 #include <vips/internal.h>
 


### PR DESCRIPTION
Since this definition originates from GLib, it is necessary to include `vips/vips.h` prior to using it.