### PR TITLE
Drop the operation cache before leak checking

### DIFF
--- a/libvips/iofuncs/init.c
+++ b/libvips/iofuncs/init.c
@@ -436,6 +436,7 @@ vips__atexit( void )
 
 		if( !done ) {
 			done = TRUE;
+			vips_cache_drop_all();
 			vips_leak();
 		}
 	}


### PR DESCRIPTION
CI currently detects leaks because the operation cache has not yet been dropped, see for example: 
https://github.com/libvips/libvips/runs/4038147480#step:17:256

Perhaps we should still call `exit(1)` when it detects any leaks? FWIW, although that is a dangerous thing to do, it is consistent with what LSan does.
https://github.com/llvm/llvm-project/blob/d480f968ad8b56d3ee4a6b6df5532d485b0ad01e/compiler-rt/lib/lsan/lsan_common_linux.cpp#L116-L121