### PR TITLE
Set page height only for multi-page images

### DIFF
--- a/libvips/foreign/heifload.c
+++ b/libvips/foreign/heifload.c
@@ -605,8 +605,12 @@ vips_foreign_load_heif_set_header( VipsForeignLoadHeif *heif, VipsImage *out )
 #endif /*HAVE_HEIF_COLOR_PROFILE*/
 
 	vips_image_set_int( out, "heif-primary", heif->primary_page );
-	vips_image_set_int( out, "n-pages", heif->n_top );
-	if( vips_object_argument_isset( VIPS_OBJECT( heif ), "n" ) )
+	vips_image_set_int( out, VIPS_META_N_PAGES, heif->n_top );
+
+	/* Only set page-height if we have more than one page, or this could
+	 * accidentally turn into an animated image later.
+	 */
+	if( heif->n > 1 )
 		vips_image_set_int( out, 
 			VIPS_META_PAGE_HEIGHT, heif->page_height );
 

--- a/libvips/foreign/nsgifload.c
+++ b/libvips/foreign/nsgifload.c
@@ -299,7 +299,10 @@ vips_foreign_load_nsgif_set_header( VipsForeignLoadNsgif *gif,
 		VIPS_INTERPRETATION_sRGB, 1.0, 1.0 );
 	vips_image_pipelinev( image, VIPS_DEMAND_STYLE_FATSTRIP, NULL );
 
-	if( vips_object_argument_isset( VIPS_OBJECT( gif ), "n" ) )
+	/* Only set page-height if we have more than one page, or this could
+	 * accidentally turn into an animated image later.
+	 */
+	if( gif->n > 1 )
 		vips_image_set_int( image,
 			VIPS_META_PAGE_HEIGHT, gif->anim->height );
 	vips_image_set_int( image, VIPS_META_N_PAGES, 

--- a/libvips/foreign/pdfiumload.c
+++ b/libvips/foreign/pdfiumload.c
@@ -488,7 +488,11 @@ vips_foreign_load_pdf_header( VipsForeignLoad *load )
 	for( i = 1; i < pdf->n; i++ ) 
 		if( pdf->pages[i].height != pdf->pages[0].height )
 			break;
-	if( vips_object_argument_isset( VIPS_OBJECT( pdf ), "n" ) )
+
+	/* Only set page-height if we have more than one page, or this could
+	 * accidentally turn into an animated image later.
+	 */
+	if( pdf->n > 1 )
 		vips_image_set_int( load->out, 
 			VIPS_META_PAGE_HEIGHT, pdf->pages[0].height );
 

--- a/libvips/foreign/popplerload.c
+++ b/libvips/foreign/popplerload.c
@@ -361,7 +361,11 @@ vips_foreign_load_pdf_header( VipsForeignLoad *load )
 	for( i = 1; i < pdf->n; i++ ) 
 		if( pdf->pages[i].height != pdf->pages[0].height )
 			break;
-	if( vips_object_argument_isset( VIPS_OBJECT( pdf ), "n" ) )
+
+	/* Only set page-height if we have more than one page, or this could
+	 * accidentally turn into an animated image later.
+	 */
+	if( pdf->n > 1 )
 		vips_image_set_int( load->out, 
 			VIPS_META_PAGE_HEIGHT, pdf->pages[0].height );
 


### PR DESCRIPTION
See: https://github.com/lovell/sharp/issues/2890. Reproducer:
```bash
$ curl -LO https://github.com/lovell/sharp/raw/master/test/fixtures/animated-loop-3.gif
$ vipsthumbnail animated-loop-3.gif[page=0,n=1] -s x570 -o x.gif
$ vipsheader x.gif
x.gif: 740x285 uchar, 3 bands, srgb, gifload
$ vipsheader -f n-pages x.gif
2
$ vipsthumbnail animated-loop-3.gif[page=0] -s x570 -o x.gif
$ vipsheader x.gif
x.gif: 740x570 uchar, 3 bands, srgb, gifload
$ vipsheader -f n-pages x.gif
1
```

After this PR:
```bash
$ vipsthumbnail animated-loop-3.gif[page=0,n=1] -s x570 -o x.gif
$ vipsheader x.gif
x.gif: 740x570 uchar, 3 bands, srgb, gifload
$ vipsheader -f n-pages x.gif
1
$ vipsthumbnail animated-loop-3.gif[page=0] -s x570 -o x.gif
$ vipsheader x.gif
x.gif: 740x570 uchar, 3 bands, srgb, gifload
$ vipsheader -f n-pages x.gif
1
```

(This was found while rebasing PR https://github.com/lovell/sharp/pull/2789)