### PR TITLE
Incorporate #2506 also in {webp,magick7}load

### DIFF
--- a/libvips/foreign/magick7load.c
+++ b/libvips/foreign/magick7load.c
@@ -601,7 +601,7 @@ vips_foreign_load_magick7_parse( VipsForeignLoadMagick7 *magick7,
 
 	/* So we can finally set the height.
 	 */
-	if( vips_object_argument_isset( VIPS_OBJECT( magick7 ), "n" ) ) {
+	if( read->n_frames > 1 ) {
 		vips_image_set_int( out, VIPS_META_PAGE_HEIGHT, out->Ysize );
 		out->Ysize *= magick7->n_frames;
 	}

--- a/libvips/foreign/webp2vips.c
+++ b/libvips/foreign/webp2vips.c
@@ -519,8 +519,12 @@ read_header( Read *read, VipsImage *out )
 #endif /*DEBUG*/
 
 	if( flags & ANIMATION_FLAG ) { 
-		vips_image_set_int( out, 
-			VIPS_META_PAGE_HEIGHT, read->frame_height );
+		/* Only set page-height if we have more than one page, or
+		 * this could accidentally turn into an animated image later.
+		 */
+		if( read->n > 1 )
+			vips_image_set_int( out, 
+				VIPS_META_PAGE_HEIGHT, read->frame_height );
 
 		read->width = read->frame_width;
 		read->height = read->n * read->frame_height;


### PR DESCRIPTION
Before:
```
$ curl -LO https://github.com/lovell/sharp/raw/master/test/fixtures/animated-loop-3.webp
$ vipsthumbnail animated-loop-3.webp[page=0] -s x570 -o x.webp
$ vipsheader x.webp
x.webp: 740x285 uchar, 4 bands, srgb, webpload
$ vipsheader -f n-pages x.webp
2
```

After:
```
$ vipsthumbnail animated-loop-3.webp[page=0] -s x570 -o x.webp
$ vipsheader x.webp
x.webp: 740x570 uchar, 3 bands, srgb, webpload
$ vipsheader -f n-pages x.webp
vipsheader: vips_image_get: field "n-pages" not found
```

Note that the WebP loader does not set the `"n-pages"` field for non-animated WebP images, this is different from the libnsgif loader, which seems to always set this field.