### PR TITLE
Fix typo in `magick7load`

### DIFF
--- a/libvips/foreign/magick7load.c
+++ b/libvips/foreign/magick7load.c
@@ -601,7 +601,7 @@ vips_foreign_load_magick7_parse( VipsForeignLoadMagick7 *magick7,
 
 	/* So we can finally set the height.
 	 */
-	if( read->n_frames > 1 ) {
+	if( magick7->n_frames > 1 ) {
 		vips_image_set_int( out, VIPS_META_PAGE_HEIGHT, out->Ysize );
 		out->Ysize *= magick7->n_frames;
 	}


### PR DESCRIPTION
Introduced in commit f92069b. I probably got confused with the IM 6 loader, which names this variable `read`, see:
https://github.com/libvips/libvips/blob/f92069b0353f3aebbe01793bf49a66895506b444/libvips/foreign/magick2vips.c#L537-L540