### PR TITLE
set libvips orientation on magickload

### DIFF
--- a/libvips/foreign/magick2vips.c
+++ b/libvips/foreign/magick2vips.c
@@ -64,6 +64,8 @@
  * 	- added wrapper funcs for exception handling
  * 4/2/19
  * 	- add profile (xmp, ipct, etc.) read
+ * 12/11/21
+ * 	- set "orientation"
  */
 
 /*
@@ -540,6 +542,9 @@ parse_header( Read *read )
 	}
 
 	vips_image_set_int( im, VIPS_META_N_PAGES, read->n_pages );
+
+	vips_image_set_int( im, VIPS_META_ORIENTATION, 
+		VIPS_CLIP( 1, image->orientation, 8 ) );
 
 	return( 0 );
 }

--- a/libvips/foreign/magick7load.c
+++ b/libvips/foreign/magick7load.c
@@ -8,6 +8,8 @@
  * 	- sniff extra filetypes
  * 4/2/19
  * 	- add profile (xmp, ipct, etc.) read
+ * 12/11/21
+ * 	- set "orientation"
  */
 
 /*
@@ -607,6 +609,9 @@ vips_foreign_load_magick7_parse( VipsForeignLoadMagick7 *magick7,
 	}
 
 	vips_image_set_int( out, VIPS_META_N_PAGES, magick7->n_pages );
+
+	vips_image_set_int( out, VIPS_META_ORIENTATION, 
+		VIPS_CLIP( 1, image->orientation, 8 ) );
 
 	return( 0 );
 }


### PR DESCRIPTION
Pick up the imagemagick / graphicsmagick orientation field for libvips.

Tested with graphicsmagick, magick6 and magick7.

see https://github.com/libvips/libvips/issues/2528