### PR TITLE
fails if library is requested and missing

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -832,7 +832,7 @@ AC_ARG_WITH([libjxl],
   [with_libjxl=test])
 
 # libjxl as a dynamically loadable module
-AS_IF([test x"$with_libjxl" = x"module" -o x"$with_libjxl" = x"tst"],
+AS_IF([test x"$with_libjxl" = x"module" -o x"$with_libjxl" = x"test"],
   [with_libjxl_module=$gmodule_supported_flag],
   [with_libjxl_module=no])
 

--- a/configure.ac
+++ b/configure.ac
@@ -829,10 +829,10 @@ VIPS_LIBS="$VIPS_LIBS $NIFTI_LIBS"
 AC_ARG_WITH([libjxl],
   AS_HELP_STRING([--without-libjxl], [build without libjxl (default: test)]),
   [with_libjxl=$withval],
-  [with_libjxl=$gmodule_with_flag])
+  [with_libjxl=test])
 
 # libjxl as a dynamically loadable module
-AS_IF([test x"$with_libjxl" = x"module"],
+AS_IF([test x"$with_libjxl" = x"module" -o x"$with_libjxl" = x"tst"],
   [with_libjxl_module=$gmodule_supported_flag],
   [with_libjxl_module=no])
 
@@ -844,7 +844,9 @@ if test x"$with_libjxl" != x"no"; then
      AS_IF([test x"$with_libjxl_module" = x"no"],
        [PACKAGES_USED="$PACKAGES_USED libjxl"])
     ],
-    [AC_MSG_WARN([libjxl not found; disabling libjxl support])
+    [AS_IF([test x"$with_libjxl" = x"test"],
+       AC_MSG_WARN([libjxl not found; disabling libjxl support]),
+       AC_MSG_ERROR([libjxl not found]))
      with_libjxl=no
      with_libjxl_module=no
     ]


### PR DESCRIPTION
Open for discussion, so only done for 1 library (jxl)

If a library is requested, ie when build using --with-libjxl, --with-libjxl=yes or --with-libjxl=module, and if the library is missing, the configure should fails and not silently (only warning) disable the requested feature

Examples, Auto mode

```
./configure
...
checking for LIBJXL... no
configure: WARNING: libjxl not found; disabling libjxl support
...
JXL load/save with libjxl:              no (dynamic module: no)

```

And, Explicitly required mode

```
./configure --with-libjxl=module
...
checking for LIBJXL... no
configure: error: libjxl not found

```