### PR TITLE
Quantizr support

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -1362,6 +1362,8 @@ VIPS_CFLAGS="$VIPS_CFLAGS $PNG_CFLAGS"
 VIPS_INCLUDES="$VIPS_INCLUDES $PNG_INCLUDES"
 VIPS_LIBS="$VIPS_LIBS $PNG_LIBS"
 
+with_quantization=no
+
 # look for libimagequant with pkg-config (only if libpng is enabled)
 AC_ARG_WITH([imagequant],
   AS_HELP_STRING([--without-imagequant], [build without imagequant (default: test)]))
@@ -1370,11 +1372,10 @@ if test x"$with_imagequant" != x"no"; then
   PKG_CHECK_MODULES(IMAGEQUANT, imagequant,
     [AC_DEFINE(HAVE_IMAGEQUANT,1,[define if you have imagequant installed.])
      with_imagequant=yes
+     with_quantization=yes
      PACKAGES_USED="$PACKAGES_USED imagequant"
     ],
-    [AC_MSG_WARN([libimagequant not found; disabling 8bpp PNG support])
-     with_imagequant=no
-    ]
+    [with_imagequant=no]
   )
 else
   with_imagequant=no
@@ -1382,6 +1383,30 @@ fi
 
 VIPS_CFLAGS="$VIPS_CFLAGS $IMAGEQUANT_CFLAGS"
 VIPS_LIBS="$VIPS_LIBS $IMAGEQUANT_LIBS"
+
+# look for quantizr with pkg-config (only if libpng is enabled)
+AC_ARG_WITH([quantizr],
+  AS_HELP_STRING([--without-quantizr], [build without quantizr (default: test)]))
+
+if test x"$with_quantizr" != x"no"; then
+  PKG_CHECK_MODULES(QUANTIZR, quantizr,
+    [AC_DEFINE(HAVE_QUANTIZR,1,[define if you have quantizr installed.])
+     with_quantizr=yes
+     with_quantization=yes
+     PACKAGES_USED="$PACKAGES_USED quantizr"
+    ],
+    [with_quantizr=no]
+  )
+else
+  with_quantizr=no
+fi
+
+VIPS_CFLAGS="$VIPS_CFLAGS $QUANTIZR_CFLAGS"
+VIPS_LIBS="$VIPS_LIBS $QUANTIZR_LIBS"
+
+if test x"$with_quantization" == x"no"; then
+  AC_MSG_WARN([quantizr not found; disabling 8bpp PNG support])
+fi
 
 # look for libjpeg with pkg-config ... fall back to our tester
 AC_ARG_WITH([jpeg], 
@@ -1458,7 +1483,7 @@ VIPS_LIBS="$VIPS_LIBS $EXIF_LIBS"
 AC_ARG_WITH([cgif],
   AS_HELP_STRING([--without-cgif], [build without cgif (default: test)]))
 
-if test x"$with_imagequant" == x"yes" && test x"$with_cgif" != x"no"; then
+if test x"$with_quantization" == x"yes" && test x"$with_cgif" != x"no"; then
   PKG_CHECK_MODULES(CGIF, cgif,
     [AC_DEFINE(HAVE_CGIF,1,[define if you have cgif installed.])
       with_cgif=yes
@@ -1617,8 +1642,8 @@ PNG load with libspng:                  $with_libspng
  (requires libspng-0.6 or later)
 PNG load/save with libpng:              $with_png
  (requires libpng-1.2.9 or later)
-quantisation to 8 bit:                  $with_imagequant
- (requires libimagequant)
+quantisation to 8 bit:                  $with_quantization
+ (requires libimagequant or quantizr)
 TIFF load/save with libtiff:            $with_tiff
 image pyramid save:                     $with_gsf
  (requires libgsf-1 1.14.26 or later)
@@ -1637,7 +1662,7 @@ Matlab load with matio:                 $with_matio
 NIfTI load/save with niftiio:           $with_nifti
 FITS load/save with cfitsio:            $with_cfitsio
 GIF save with cgif:                     $with_cgif
- (requires cgif, libimagequant)
+ (requires cgif, libimagequant or quantizr)
 Magick package:                         $with_magickpackage (dynamic module: $with_magick_module)
 Magick major API version:               $magick_version
 load with libMagickCore:                $enable_magickload

--- a/libvips/foreign/pforeign.h
+++ b/libvips/foreign/pforeign.h
@@ -217,11 +217,6 @@ int vips__webp_write_target( VipsImage *image, VipsTarget *target,
 	gboolean min_size, int kmin, int kmax,
 	gboolean strip, const char *profile );
 
-int vips__quantise_image( VipsImage *in, 
-	VipsImage **index_out, VipsImage **palette_out,
-	int colours, int Q, double dither, int effort,
-	gboolean threshold_alpha );
-
 extern const char *vips_foreign_nifti_suffs[];
 
 VipsBandFormat vips__foreign_nifti_datatype2BandFmt( int datatype );

--- a/libvips/foreign/quantise.h
+++ b/libvips/foreign/quantise.h
@@ -1,0 +1,85 @@
+/* common defs for image quantisation
+ */
+
+/*
+
+    Copyright (C) 1991-2005 The National Gallery
+
+    This library is free software; you can redistribute it and/or
+    modify it under the terms of the GNU Lesser General Public
+    License as published by the Free Software Foundation; either
+    version 2.1 of the License, or (at your option) any later version.
+
+    This library is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+    Lesser General Public License for more details.
+
+    You should have received a copy of the GNU Lesser General Public
+    License along with this library; if not, write to the Free Software
+    Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+    02110-1301  USA
+
+ */
+
+/*
+
+    These files are distributed with VIPS - http://www.vips.ecs.soton.ac.uk
+
+ */
+
+#ifndef VIPS_QUANTISE_H
+#define VIPS_QUANTISE_H
+
+#ifdef __cplusplus
+extern "C" {
+#endif /*__cplusplus*/
+
+#if defined(HAVE_IMAGEQUANT)
+#define HAVE_QUANTIZATION
+
+#include <libimagequant.h>
+
+#define VipsQuantiseAttr liq_attr
+#define VipsQuantiseImage liq_image
+#define VipsQuantiseResult liq_result
+#define VipsQuantisePalette liq_palette
+#define VipsQuantiseError liq_error
+
+#elif defined(HAVE_QUANTIZR)
+#define HAVE_QUANTIZATION
+
+#include <quantizr.h>
+
+#define VipsQuantiseAttr QuantizrOptions
+#define VipsQuantiseImage QuantizrImage
+#define VipsQuantiseResult QuantizrResult
+#define VipsQuantisePalette QuantizrPalette
+#define VipsQuantiseError QuantizrError
+#endif
+
+#ifdef HAVE_QUANTIZATION
+VipsQuantiseAttr* vips__quantise_attr_create();
+VipsQuantiseError vips__quantise_set_max_colors(VipsQuantiseAttr* attr, int colors);
+VipsQuantiseError vips__quantise_set_quality(VipsQuantiseAttr* attr, int minimum, int maximum);
+VipsQuantiseError vips__quantise_set_speed(VipsQuantiseAttr* attr, int speed);
+VipsQuantiseImage* vips__quantise_image_create_rgba(const VipsQuantiseAttr *attr, const void *bitmap, int width, int height, double gamma);
+VipsQuantiseError vips__quantise_image_quantize(VipsQuantiseImage *const input_image, VipsQuantiseAttr *const options, VipsQuantiseResult **result_output);
+VipsQuantiseError vips__quantise_set_dithering_level(VipsQuantiseResult *res, float dither_level);
+const VipsQuantisePalette* vips__quantise_get_palette(VipsQuantiseResult *result);
+VipsQuantiseError vips__quantise_write_remapped_image(VipsQuantiseResult *result, VipsQuantiseImage *input_image, void *buffer, size_t buffer_size);
+void vips__quantise_result_destroy(VipsQuantiseResult *result);
+void vips__quantise_image_destroy(VipsQuantiseImage *img);
+void vips__quantise_attr_destroy(VipsQuantiseAttr *attr);
+#endif /*HAVE_QUANTIZATION*/
+
+int vips__quantise_image( VipsImage *in,
+	VipsImage **index_out, VipsImage **palette_out,
+	int colours, int Q, double dither, int effort,
+	gboolean threshold_alpha );
+
+#ifdef __cplusplus
+}
+#endif /*__cplusplus*/
+
+#endif /*VIPS_QUANTISE_H*/

--- a/libvips/foreign/vipspng.c
+++ b/libvips/foreign/vipspng.c
@@ -133,6 +133,7 @@
 #include <vips/debug.h>
 
 #include "pforeign.h"
+#include "quantise.h"
 
 #include <png.h>
 
@@ -1072,7 +1073,7 @@ write_vips( Write *write,
 		return( -1 );
 	}
 
-#ifdef HAVE_IMAGEQUANT
+#ifdef HAVE_QUANTIZATION
 	/* Enable image quantisation to paletted 8bpp PNG if colours is set.
 	 */
 	if( palette ) 
@@ -1081,7 +1082,7 @@ write_vips( Write *write,
 	if( palette )
 		g_warning( "%s",
 			_( "ignoring palette (no quantisation support)" ) );
-#endif /*HAVE_IMAGEQUANT*/
+#endif /*HAVE_QUANTIZATION*/
 
 	interlace_type = interlace ? PNG_INTERLACE_ADAM7 : PNG_INTERLACE_NONE;
 
@@ -1181,7 +1182,7 @@ write_vips( Write *write,
 			return( -1 );
 	}
 
-#ifdef HAVE_IMAGEQUANT
+#ifdef HAVE_QUANTIZATION
 	if( palette ) {
 		VipsImage *im_index;
 		VipsImage *im_palette;
@@ -1244,7 +1245,7 @@ write_vips( Write *write,
 		write->memory = im_index;
 		in = write->memory;
 	}
-#endif /*HAVE_IMAGEQUANT*/
+#endif /*HAVE_QUANTIZATION*/
 
 	png_write_info( write->pPng, write->pInfo );
 


### PR DESCRIPTION
Hey!

I have an image quantization lib named Quantizr that was mentioned in https://github.com/libvips/libvips/issues/2531#issuecomment-966998106. It's not as advanced as libimagequant yet it does its work and it's licensed under MIT. We use it with imgproxy for more than a year, so it's field-tested.

Today I made some improvements, so now it's almost as fast as libimagequant:

Quantizr:
```
$ time vips copy /images/earth.gif[n=-1] x.gif

real	0m1.155s
user	0m0.970s
sys	0m0.066s
```

libimagequant:
```
$ time vips copy /images/earth.gif[n=-1] x.gif

real	0m1.152s
user	0m0.964s
sys	0m0.074s
```

Currently, Quantizr can mimic libimagequant so that we can build libvips with it. Yet this can be easily broken by using a LIQ func that Quantizr doesn't have. Considering this and the fact that Quantizr was developed to be used with libvips in the first place, I'd like to add its first-class support to libvips.

I added an abstraction over quantization API as you did for *Magick.