### PR TITLE
Set memory (image volume) limit for fuzzing.

### DIFF
--- a/fuzz/gifsave_buffer_fuzzer.cc
+++ b/fuzz/gifsave_buffer_fuzzer.cc
@@ -1,9 +1,13 @@
 #include <vips/vips.h>
 
+// Unpublised libjxl API.
+void SetDecoderMemoryLimitBase_(size_t memory_limit_base);
+
 extern "C" int
 LLVMFuzzerInitialize( int *argc, char ***argv )
 {
 	vips_concurrency_set( 1 );
+	SetDecoderMemoryLimitBase_(1 << 20);
 	return( 0 );
 }
 

--- a/fuzz/jpegsave_buffer_fuzzer.cc
+++ b/fuzz/jpegsave_buffer_fuzzer.cc
@@ -1,9 +1,13 @@
 #include <vips/vips.h>
 
+// Unpublised libjxl API.
+void SetDecoderMemoryLimitBase_(size_t memory_limit_base);
+
 extern "C" int
 LLVMFuzzerInitialize( int *argc, char ***argv )
 {
 	vips_concurrency_set( 1 );
+	SetDecoderMemoryLimitBase_(1 << 20);
 	return( 0 );
 }
 

--- a/fuzz/jpegsave_file_fuzzer.cc
+++ b/fuzz/jpegsave_file_fuzzer.cc
@@ -1,9 +1,13 @@
 #include <vips/vips.h>
 
+// Unpublised libjxl API.
+void SetDecoderMemoryLimitBase_(size_t memory_limit_base);
+
 extern "C" int
 LLVMFuzzerInitialize( int *argc, char ***argv )
 {
 	vips_concurrency_set( 1 );
+	SetDecoderMemoryLimitBase_(1 << 20);
 	return( 0 );
 }
 

--- a/fuzz/mosaic_fuzzer.cc
+++ b/fuzz/mosaic_fuzzer.cc
@@ -8,10 +8,14 @@ struct mosaic_opt {
 	guint16 ysec;
 } __attribute__ ((packed));
 
+// Unpublised libjxl API.
+void SetDecoderMemoryLimitBase_(size_t memory_limit_base);
+
 extern "C" int
 LLVMFuzzerInitialize( int *argc, char ***argv )
 {
 	vips_concurrency_set( 1 );
+	SetDecoderMemoryLimitBase_(1 << 20);
 	return( 0 );
 }
 

--- a/fuzz/pngsave_buffer_fuzzer.cc
+++ b/fuzz/pngsave_buffer_fuzzer.cc
@@ -1,9 +1,13 @@
 #include <vips/vips.h>
 
+// Unpublised libjxl API.
+void SetDecoderMemoryLimitBase_(size_t memory_limit_base);
+
 extern "C" int
 LLVMFuzzerInitialize( int *argc, char ***argv )
 {
 	vips_concurrency_set( 1 );
+	SetDecoderMemoryLimitBase_(1 << 20);
 	return( 0 );
 }
 

--- a/fuzz/sharpen_fuzzer.cc
+++ b/fuzz/sharpen_fuzzer.cc
@@ -1,9 +1,13 @@
 #include <vips/vips.h>
 
+// Unpublised libjxl API.
+void SetDecoderMemoryLimitBase_(size_t memory_limit_base);
+
 extern "C" int
 LLVMFuzzerInitialize( int *argc, char ***argv )
 {
 	vips_concurrency_set( 1 );
+	SetDecoderMemoryLimitBase_(1 << 20);
 	return( 0 );
 }
 

--- a/fuzz/smartcrop_fuzzer.cc
+++ b/fuzz/smartcrop_fuzzer.cc
@@ -1,9 +1,13 @@
 #include <vips/vips.h>
 
+// Unpublised libjxl API.
+void SetDecoderMemoryLimitBase_(size_t memory_limit_base);
+
 extern "C" int
 LLVMFuzzerInitialize( int *argc, char ***argv )
 {
 	vips_concurrency_set( 1 );
+	SetDecoderMemoryLimitBase_(1 << 20);
 	return( 0 );
 }
 

--- a/fuzz/thumbnail_fuzzer.cc
+++ b/fuzz/thumbnail_fuzzer.cc
@@ -1,9 +1,13 @@
 #include <vips/vips.h>
 
+// Unpublised libjxl API.
+void SetDecoderMemoryLimitBase_(size_t memory_limit_base);
+
 extern "C" int
 LLVMFuzzerInitialize( int *argc, char ***argv )
 {
 	vips_concurrency_set( 1 );
+	SetDecoderMemoryLimitBase_(1 << 20);
 	return( 0 );
 }
 

--- a/fuzz/webpsave_buffer_fuzzer.cc
+++ b/fuzz/webpsave_buffer_fuzzer.cc
@@ -1,9 +1,13 @@
 #include <vips/vips.h>
 
+// Unpublised libjxl API.
+void SetDecoderMemoryLimitBase_(size_t memory_limit_base);
+
 extern "C" int
 LLVMFuzzerInitialize( int *argc, char ***argv )
 {
 	vips_concurrency_set( 1 );
+	SetDecoderMemoryLimitBase_(1 << 20);
 	return( 0 );
 }
 


### PR DESCRIPTION
This should resolve OOMs / timeouts in JXL decoder.