### PR TITLE
cplusplus: silence missing sentinel warning

### DIFF
--- a/cplusplus/VImage.cpp
+++ b/cplusplus/VImage.cpp
@@ -733,7 +733,7 @@ VImage::write_to_buffer( const char *suffix, void **buf, size_t *size,
 				set( "in", *this )->
 				set( "target", target ) );
 
-		g_object_get( target.get_target(), "blob", &blob, NULL );
+		g_object_get( target.get_target(), "blob", &blob, (void *) NULL );
 	}
 	else if( (operation_name = vips_foreign_find_save_buffer( filename )) ) {
 		call_option_string( operation_name, option_string,


### PR DESCRIPTION
Spotted this warning when compiling the latest 8.12.

```
VImage.cpp: In member function 'void vips::VImage::write_to_buffer(const char*, void**, size_t*, vips::VOption*) const':
VImage.cpp:736:58: warning: missing sentinel in function call [-Wformat=]
  736 |   g_object_get( target.get_target(), "blob", &blob, NULL );
      |                                                          ^
```
Low priority, and same fix as https://github.com/libvips/libvips/pull/668 etc.