### PR TITLE
Windows: don't set create time on invalid/special file descriptors

### DIFF
--- a/libvips/iofuncs/util.c
+++ b/libvips/iofuncs/util.c
@@ -586,6 +586,12 @@ vips__set_create_time( int fd )
 	SYSTEMTIME st;
 	FILETIME ft;
 
+	/* Create time cannot be set on invalid or stream
+	 * (stdin, stdout, stderr) file descriptors.
+	 */
+	if( fd < 3 )
+		return;
+
 	if( (handle = (HANDLE) _get_osfhandle( fd )) == INVALID_HANDLE_VALUE )
 		return;
 	GetSystemTime( &st );
@@ -635,7 +641,7 @@ vips__fopen( const char *filename, const char *mode )
 	fp = g_fopen( filename, mode );
 
 #ifdef G_OS_WIN32
-	if( mode[0] == 'w' )
+	if( fp && mode[0] == 'w' )
 		vips__set_create_time( _fileno( fp ) ); 
 #endif /*G_OS_WIN32*/
 


### PR DESCRIPTION
Calling `vips__set_create_time` with a file descriptor value less than 3 appears to end the process when run on Windows.

Having read https://docs.microsoft.com/en-us/cpp/c-runtime-library/reference/get-osfhandle?view=msvc-170 my understanding is:

* If you pass -1 to `_get_osfhandle` it can crash.
* If you pass 0, 1 or 2 to `_get_osfhandle` it can return a "valid" handle of -2 (note this is not the same as an `INVALID_HANDLE_VALUE` of -1) then `SetFileTime` can crash.

Originally reported at https://github.com/lovell/sharp/issues/2999