### PR TITLE
cgifsave: avoid size issue

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -82,9 +82,7 @@ jobs:
         if: runner.os == 'macOS'
         run: |
           brew install meson ninja fftw fontconfig glib libexif libgsf little-cms2 orc pango
-          brew install cfitsio libheif libimagequant libjpeg-turbo libmatio librsvg libspng libtiff openexr openjpeg openslide poppler webp
-          brew tap lovell/cgif-packaging https://github.com/lovell/cgif-packaging.git
-          brew install --build-bottle lovell/cgif-packaging/cgif
+          brew install cfitsio libheif libimagequant libjpeg-turbo libmatio librsvg libspng libtiff openexr openjpeg openslide poppler webp cgif
 
       - name: Install Clang 13
         if: runner.os == 'Linux' && matrix.build.cc == 'clang-13'

--- a/configure.ac
+++ b/configure.ac
@@ -1493,8 +1493,8 @@ AC_ARG_WITH([cgif],
   AS_HELP_STRING([--without-cgif], [build without cgif (default: test)]))
 
 if test x"$quantisation_package" != x"" && test x"$with_cgif" != x"no"; then
-  PKG_CHECK_MODULES(CGIF, cgif,
-    [AC_DEFINE(HAVE_CGIF,1,[define if you have cgif installed.])
+  PKG_CHECK_MODULES(CGIF, cgif >= 0.2.0,
+    [AC_DEFINE(HAVE_CGIF,1,[define if you have cgif >= 0.2.0 installed.])
       with_cgif=yes
       PACKAGES_USED="$PACKAGES_USED cgif"
     ],

--- a/libvips/foreign/cgifsave.c
+++ b/libvips/foreign/cgifsave.c
@@ -62,7 +62,7 @@ typedef struct _VipsForeignSaveCgif {
 	double dither;
 	int effort;
 	int bitdepth;
-	int maxerror;
+	double maxerror;
 	VipsTarget *target;
 
 	/* Derived write params.
@@ -599,12 +599,12 @@ vips_foreign_save_cgif_class_init( VipsForeignSaveCgifClass *class )
 		G_STRUCT_OFFSET( VipsForeignSaveCgif, bitdepth ),
 		1, 8, 8 );
 
-	VIPS_ARG_INT( class, "maxerror", 13,
+	VIPS_ARG_DOUBLE( class, "maxerror", 13,
 		_( "Max. error for lossy transparency setting"),
 		_( "Maximum pixel error to allow when identifying areas as identical (inter frame)" ),
 		VIPS_ARGUMENT_OPTIONAL_INPUT,
 		G_STRUCT_OFFSET( VipsForeignSaveCgif, maxerror ),
-		0, 32, 6 );
+		0, 32, 0.0 );
 }
 
 static void
@@ -613,7 +613,7 @@ vips_foreign_save_cgif_init( VipsForeignSaveCgif *gif )
 	gif->dither = 1.0;
 	gif->effort = 7;
 	gif->bitdepth = 8;
-	gif->maxerror = 6;
+	gif->maxerror = 0.0;
 }
 
 typedef struct _VipsForeignSaveCgifTarget {

--- a/libvips/foreign/cgifsave.c
+++ b/libvips/foreign/cgifsave.c
@@ -385,8 +385,8 @@ vips_foreign_save_cgif_write_frame( VipsForeignSaveCgif *cgif )
 		/* Keep head frame_bytes in memory for transparency trick
 		*  which avoids the size explosion (#2576).
 		*/
-		cgif->frame_bytes_head = g_malloc0(4 * frame_rect->width * frame_rect->height);
-		memcpy(cgif->frame_bytes_head, frame_bytes, 4 * frame_rect->width * frame_rect->height);
+		cgif->frame_bytes_head = g_malloc( 4 * n_pels );
+		memcpy( cgif->frame_bytes_head, frame_bytes, 4 * n_pels );
 	}
 
 	return( 0 );

--- a/libvips/foreign/cgifsave.c
+++ b/libvips/foreign/cgifsave.c
@@ -286,8 +286,6 @@ vips_foreign_save_cgif_write_frame( VipsForeignSaveCgif *cgif )
 	if( !cgif->cgif_context ) {
 		cgif->cgif_config.pGlobalPalette = cgif->palette_rgb;
 		cgif->cgif_config.attrFlags = CGIF_ATTR_IS_ANIMATED;
-		cgif->cgif_config.attrFlags |= 
-			cgif->has_transparency ? CGIF_ATTR_HAS_TRANSPARENCY : 0;
 		cgif->cgif_config.width = frame_rect->width;
 		cgif->cgif_config.height = frame_rect->height;
 		cgif->cgif_config.numGlobalPaletteEntries = cgif->lp->count;
@@ -297,12 +295,6 @@ vips_foreign_save_cgif_write_frame( VipsForeignSaveCgif *cgif )
 
 		cgif->cgif_context = cgif_newgif( &cgif->cgif_config );
 	}
-
-	/* Reset global transparency flag.
-	 */
-	cgif->cgif_config.attrFlags = 
-		(cgif->cgif_config.attrFlags & ~CGIF_ATTR_HAS_TRANSPARENCY) |
-		(cgif->has_transparency ? CGIF_ATTR_HAS_TRANSPARENCY : 0);
 
 	/* Write frame to cgif.
 	 */
@@ -316,6 +308,14 @@ vips_foreign_save_cgif_write_frame( VipsForeignSaveCgif *cgif )
 		CGIF_FRAME_GEN_USE_TRANSPARENCY | 
 		CGIF_FRAME_GEN_USE_DIFF_WINDOW;
 	frame_config.attrFlags = 0;
+
+	/* Switch per-frame alpha channel on.
+	 * Index 0 is used for pixels with alpha channel.
+	 */
+	if( cgif->has_transparency ) {
+		frame_config.attrFlags |= CGIF_FRAME_ATTR_HAS_ALPHA;
+		frame_config.transIndex = 0;
+	}
 
 	/* Do the transparency trick (only possible when no alpha channel present)
 	*/

--- a/meson.build
+++ b/meson.build
@@ -234,7 +234,7 @@ endif
 
 cgif_dep = disabler()
 if quantisation_package.found()
-    cgif_dep = dependency('cgif', required: get_option('cgif'))
+    cgif_dep = dependency('cgif', version: '>=0.2.0', required: get_option('cgif'))
     if cgif_dep.found()
         libvips_deps += cgif_dep
         cfg_var.set('HAVE_CGIF', '1')


### PR DESCRIPTION
Avoid size issues when resizing GIF animations with a static background. The trick is to restore the original transparency setting after quantization and dithering.
**Background:** Keeping many pixels at the transparency index can reduce the size a lot and is the reason why the original animations in (#2576) are quite small in terms of bytes despite their huge width/height. The current resizing and subsequent color quantization method puts the focus on image quality but can make this transparency optimization less effective.

The suggested fix depends on dloebl/cgif#38 and cgif 0.2.0 to be released:

**Results:**
`$ vipsthumbnail --size 200 city.gif[n=-1] -o vips_city.gif`
`$ vipsthumbnail --size 1400 watch.gif[n=-1] -o vips_watch.gif`
`$ du -h vips_*`
**`2.2M vips_city.gif`
`812K vips_watch.gif`**

The size is still larger than before, as the transparency setting is changed by the resizing. However, the two animations are probably extreme cases and the size problem is mitigated quite a bit with this change.
I've visualized the transparency setting for the resized city GIF and the original (green means that a pixel is identical to the frame before):
**Resized:**
![out](https://user-images.githubusercontent.com/34104349/150117814-27d6c607-b24a-4f7e-8b76-159527b25619.gif)
**Original:**
![sorg](https://user-images.githubusercontent.com/34104349/150118018-6e6a1892-c096-4553-90a2-4bc96da2cf99.gif)

One can see some "kernels" (in the resized image). I guess these come from the interpolation method and illustrate where the remaining increase in size comes from. To further improve the size it could be interesting to have a "transparency-friendly" resize method (which keeps identical areas identical). For instance, nearest-neighbor resizing would be "transparency-friendly" but is of course not ideal in terms of quality. An alternative would be to determine transparent areas in a lossy way in cgifsave (I think @jcupitt once mentioned such a low-pass filter). So the problem is finding the right balance between quality and size.

Please let me know if there are changes required on this PR.