### PR TITLE
Fix jpegload pipe

### DIFF
--- a/libvips/foreign/jpeg2vips.c
+++ b/libvips/foreign/jpeg2vips.c
@@ -861,30 +861,6 @@ read_jpeg_image( ReadJpeg *jpeg, VipsImage *out )
 	if( read_jpeg_header( jpeg, t[0] ) )
 		return( -1 );
 
-	{
-		Source *src = (Source *) jpeg->cinfo.src;
-
-		gint64 bytes_in_buffer = src->pub.bytes_in_buffer;
-		gint64 read_position = 
-			vips_source_seek( jpeg->source, 0, SEEK_CUR );
-		gint64 header_length = read_position - bytes_in_buffer;
-
-
-		printf( "read_jpeg_image:\n" );
-		printf( "  %ld bytes still in JPEG read buffer\n",
-			bytes_in_buffer );
-
-		printf( "  source read position = %ld\n",
-			read_position );
-
-		printf( "  JPEG header length = %ld\n",
-			header_length );
-
-		printf( "  next byte to read will be %d\n", 
-			*src->pub.next_input_byte );
-
-	}
-
 	/* Switch to pixel decode.
 	 */
 	if( vips_source_decode( jpeg->source ) )

--- a/libvips/iofuncs/source.c
+++ b/libvips/iofuncs/source.c
@@ -664,13 +664,18 @@ vips_source_decode( VipsSource *source )
 
 	if( !source->decode ) {
 		source->decode = TRUE;
+
 		VIPS_FREEF( g_byte_array_unref, source->sniff ); 
 
 		/* If this is still a pipe source, we can discard the header 
 		 * bytes we saved.
 		 */
-		if( source->is_pipe ) 
+		if( source->is_pipe ) {
+			printf( "vips_source_decode: "
+				"discarding %d bytes of header\n", 
+				source->header_bytes->len );
 			VIPS_FREEF( g_byte_array_unref, source->header_bytes ); 
+		}
 	}
 
 	vips_source_minimise( source );
@@ -1114,6 +1119,9 @@ vips_source_seek( VipsSource *source, gint64 offset, int whence )
 
 	VIPS_DEBUG_MSG( "vips_source_seek: offset = %" G_GINT64_FORMAT 
 		", whence = %d\n", offset, whence );
+
+	if( offset == 0 && whence == SEEK_SET )
+		printf( "vips_source_seek: rewind\n" );
 
 	if( vips_source_unminimise( source ) ||
 		vips_source_test_features( source ) )


### PR DESCRIPTION
We could sometimes free the VipsSource header cache with unused bytes. This patch delays freeing the header cache until we are certain it is exhausted.

See https://github.com/kleisauke/net-vips/issues/155

