### PR TITLE
Refine header inclusion to allow better introspection generation

### DIFF
--- a/libvips/Vips-8.0.metadata
+++ b/libvips/Vips-8.0.metadata
@@ -1,0 +1,7 @@
+Object.new_from_string skip
+Object.print_summary_class skip
+ArgumentClass.object_class skip
+class_find skip
+ClassMapFn.cls type="void*"
+ArgumentClassMapFn.object_class type="void*"
+ArgumentTable type="GLib.HashTable<GLib.ParamSpec,Vips.Argument?>"

--- a/libvips/include/vips/arithmetic.h
+++ b/libvips/include/vips/arithmetic.h
@@ -34,6 +34,9 @@
 #ifndef VIPS_ARITHMETIC_H
 #define VIPS_ARITHMETIC_H
 
+#include <glib.h>
+#include <vips/image.h>
+
 #ifdef __cplusplus
 extern "C" {
 #endif /*__cplusplus*/

--- a/libvips/include/vips/buf.h
+++ b/libvips/include/vips/buf.h
@@ -31,11 +31,12 @@
 #ifndef VIPS_BUF_H
 #define VIPS_BUF_H
 
+#include <glib.h>
+#include <glib-object.h>
+
 #ifdef __cplusplus
 extern "C" {
 #endif /*__cplusplus*/
-
-#include <vips/vips.h>
 
 /* A string in the process of being written to ... multiple calls to 
  * vips_buf_append add to it. On overflow append "..." and block further 
@@ -85,8 +86,8 @@ gboolean vips_buf_appendg( VipsBuf *buf, double g );
 gboolean vips_buf_appendd( VipsBuf *buf, int d );
 int vips_buf_len( VipsBuf *buf );
 
-#endif /*VIPS_BUF_H*/
-
 #ifdef __cplusplus
 }
 #endif /*__cplusplus*/
+
+#endif /*VIPS_BUF_H*/

--- a/libvips/include/vips/connection.h
+++ b/libvips/include/vips/connection.h
@@ -33,6 +33,12 @@
 #ifndef VIPS_CONNECTION_H
 #define VIPS_CONNECTION_H
 
+#include <glib.h>
+#include <glib-object.h>
+#include <gio/gio.h>
+#include <vips/object.h>
+#include <vips/type.h>
+
 #ifdef __cplusplus
 extern "C" {
 #endif /*__cplusplus*/

--- a/libvips/include/vips/draw.h
+++ b/libvips/include/vips/draw.h
@@ -34,6 +34,10 @@
 #ifndef VIPS_DRAW_H
 #define VIPS_DRAW_H
 
+#include <glib.h>
+#include <glib-object.h>
+#include <vips/object.h>
+
 #ifdef __cplusplus
 extern "C" {
 #endif /*__cplusplus*/

--- a/libvips/include/vips/foreign.h
+++ b/libvips/include/vips/foreign.h
@@ -32,6 +32,11 @@
 #ifndef VIPS_FOREIGN_H
 #define VIPS_FOREIGN_H
 
+#include <glib.h>
+#include <glib-object.h>
+#include <vips/object.h>
+#include <vips/operation.h>
+
 #ifdef __cplusplus
 extern "C" {
 #endif /*__cplusplus*/

--- a/libvips/include/vips/image.h
+++ b/libvips/include/vips/image.h
@@ -36,6 +36,13 @@
 #ifndef VIPS_IMAGE_H
 #define VIPS_IMAGE_H
 
+#include <glib.h>
+#include <glib-object.h>
+#include <vips/object.h>
+#include <vips/connection.h>
+#include <vips/rect.h>
+#include <vips/region.h>
+
 #ifdef __cplusplus
 extern "C" {
 #endif /*__cplusplus*/

--- a/libvips/include/vips/object.h
+++ b/libvips/include/vips/object.h
@@ -31,6 +31,11 @@
 #ifndef VIPS_OBJECT_H
 #define VIPS_OBJECT_H
 
+#include <glib.h>
+#include <glib-object.h>
+#include <vips/buf.h>
+#include <vips/basic.h>
+
 #ifdef __cplusplus
 extern "C" {
 #endif /*__cplusplus*/

--- a/libvips/include/vips/operation.h
+++ b/libvips/include/vips/operation.h
@@ -31,6 +31,12 @@
 #ifndef VIPS_OPERATION_H
 #define VIPS_OPERATION_H
 
+#include <glib.h>
+#include <glib-object.h>
+#include <vips/object.h>
+#include <vips/buf.h>
+#include <vips/basic.h>
+
 #ifdef __cplusplus
 extern "C" {
 #endif /*__cplusplus*/

--- a/libvips/include/vips/rect.h
+++ b/libvips/include/vips/rect.h
@@ -31,6 +31,8 @@
 #ifndef VIPS_RECT_H
 #define VIPS_RECT_H
 
+#include <glib.h>
+
 #ifdef __cplusplus
 extern "C" {
 #endif /*__cplusplus*/

--- a/libvips/include/vips/region.h
+++ b/libvips/include/vips/region.h
@@ -36,6 +36,13 @@
 #ifndef VIPS_REGION_H
 #define VIPS_REGION_H
 
+#include <glib.h>
+#include <glib-object.h>
+#include <vips/object.h>
+#include <vips/image.h>
+#include <vips/rect.h>
+#include <vips/private.h>
+
 #ifdef __cplusplus
 extern "C" {
 #endif /*__cplusplus*/

--- a/libvips/iofuncs/image.c
+++ b/libvips/iofuncs/image.c
@@ -1751,7 +1751,7 @@ vips_image_new_mode( const char *filename, const char *mode )
 }
 
 /**
- * vips_image_new_memory: (constructor)
+ * vips_image_new_memory: (skip)
  *
  * vips_image_new_memory() creates a new #VipsImage which, when written to, will
  * create a memory image. 
@@ -2374,7 +2374,7 @@ vips_image_new_matrix_from_array( int width, int height,
 }
 
 /**
- * vips_image_matrix_from_array: (constructor)
+ * vips_image_matrix_from_array: (skip)
  * @width: image width
  * @height: image height
  * @array: (array length=size) (transfer none): array of elements


### PR DESCRIPTION
The headers need to be self-contained for the introspection parser
to work correctly. The entry for external users remains vips/vips.h