### PR TITLE
LSan improvements and fixes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -137,15 +137,15 @@ jobs:
       - name: Build libvips
         run: ninja -C build
 
+      - name: Check libvips
+        run: ninja -C build test
+
       - name: Install libvips
         run: sudo ninja -C build install
 
       - name: Rebuild the shared library cache
         if: runner.os == 'Linux'
         run: sudo ldconfig
-
-      - name: Check libvips
-        run: ninja -C build test
 
       - name: Install pyvips
         run: pip3 install pyvips[test]

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -112,14 +112,17 @@ jobs:
           echo "CPPFLAGS=-g -fsanitize=address,undefined -fno-omit-frame-pointer -fopenmp -DFUZZING_BUILD_MODE_UNSAFE_FOR_PRODUCTION" >> $GITHUB_ENV
           echo "LDFLAGS=-g -fsanitize=address,undefined -shared-libasan -fopenmp=libomp" >> $GITHUB_ENV
           echo "ASAN_DSO=$ASAN_DSO" >> $GITHUB_ENV
-          echo "ASAN_OPTIONS=suppressions=${{ github.workspace }}/suppressions/asan.supp" >> $GITHUB_ENV
+          # Glib is built without -fno-omit-frame-pointer. We need
+          # to disable the fast unwinder to get full stacktraces.
+          echo "ASAN_OPTIONS=suppressions=${{ github.workspace }}/suppressions/asan.supp:fast_unwind_on_malloc=0:allocator_may_return_null=1" >> $GITHUB_ENV
           echo "LSAN_OPTIONS=suppressions=${{ github.workspace }}/suppressions/lsan.supp:fast_unwind_on_malloc=0" >> $GITHUB_ENV
           echo "TSAN_OPTIONS=suppressions=${{ github.workspace }}/suppressions/tsan.supp" >> $GITHUB_ENV
-          echo "UBSAN_OPTIONS=suppressions=${{ github.workspace }}/suppressions/ubsan.supp:halt_on_error=1:abort_on_error=1" >> $GITHUB_ENV
+          # Ensure UBSan issues causes the program to abort.
+          echo "UBSAN_OPTIONS=suppressions=${{ github.workspace }}/suppressions/ubsan.supp:halt_on_error=1:abort_on_error=1:print_stacktrace=1" >> $GITHUB_ENV
           echo "LD_LIBRARY_PATH=$LLVM_PREFIX/lib:`dirname $ASAN_DSO`" >> $GITHUB_ENV
           echo "$LLVM_PREFIX/bin" >> $GITHUB_PATH
-          # workaround for https://github.com/google/sanitizers/issues/89
-          # otherwise libIlmImf-2_3.so ends up as <unknown module>
+          # Workaround for https://github.com/google/sanitizers/issues/89
+          # otherwise libIlmImf-2_3.so ends up as <unknown module>.
           echo "DLCLOSE_PRELOAD=${{ github.workspace }}/dlclose.so" >> $GITHUB_ENV
           echo -e '#include <stdio.h>\nint dlclose(void*handle){return 0;}' | $CC -shared -xc -odlclose.so -
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,7 +10,7 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - name: "Linux x64 (Ubuntu 20.04) - GCC 10"
+          - name: "Linux x64 (Ubuntu 20.04) - GCC 9"
             os: ubuntu-20.04
             build: { cc: gcc, cxx: g++, linker: ld }
             shell: bash
@@ -20,7 +20,7 @@ jobs:
             build: { cc: clang-13, cxx: clang++-13, linker: ld.lld-13, sanitize: true }
             shell: bash
 
-          - name: "macOS (11.5) - Xcode 12.5.1"
+          - name: "macOS (11.6) - Xcode 13.2.1"
             os: macos-11
             build: { cc: clang, cxx: clang++, linker: ld.lld }
             shell: bash

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,9 +15,9 @@ jobs:
             build: { cc: gcc, cxx: g++, linker: ld }
             shell: bash
 
-          - name: "Linux x64 (Ubuntu 20.04) - Clang 12 with ASan and UBSan"
+          - name: "Linux x64 (Ubuntu 20.04) - Clang 13 with ASan and UBSan"
             os: ubuntu-20.04
-            build: { cc: clang-12, cxx: clang++-12, linker: ld.lld-12, sanitize: true }
+            build: { cc: clang-13, cxx: clang++-13, linker: ld.lld-13, sanitize: true }
             shell: bash
 
           - name: "macOS (11.5) - Xcode 12.5.1"
@@ -86,11 +86,13 @@ jobs:
           brew tap lovell/cgif-packaging https://github.com/lovell/cgif-packaging.git
           brew install --build-bottle lovell/cgif-packaging/cgif
 
-      - name: Install Clang 12
-        if: runner.os == 'Linux' && matrix.build.cc == 'clang-12'
-        run:
-          sudo -E apt-get install --fix-missing -qq -o Acquire::Retries=3
-            clang-12 libomp-12-dev lld-12 llvm-12
+      - name: Install Clang 13
+        if: runner.os == 'Linux' && matrix.build.cc == 'clang-13'
+        run: |
+          wget -O - https://apt.llvm.org/llvm-snapshot.gpg.key | sudo apt-key add -
+          sudo add-apt-repository -y "deb http://apt.llvm.org/$(lsb_release -sc)/ llvm-toolchain-$(lsb_release -sc)-13 main"
+          sudo -E apt-get install --fix-missing -qq -o Acquire::Retries=3 \
+            clang-13 libomp-13-dev lld-13 llvm-13
 
       - name: Prepare Ubuntu environment
         if: runner.os == 'Linux'
@@ -105,7 +107,7 @@ jobs:
       - name: Prepare sanitizers
         if: matrix.build.sanitize
         env:
-          LLVM_PREFIX: /usr/lib/llvm-12
+          LLVM_PREFIX: /usr/lib/llvm-13
         run: |
           ASAN_DSO=`$CC -print-file-name=libclang_rt.asan-x86_64.so`
           echo "LDSHARED=$CC -shared" >> $GITHUB_ENV
@@ -128,10 +130,10 @@ jobs:
 
       - name: Configure libvips
         run:
-          meson setup build 
-            -Ddebug=true 
-            -Ddeprecated=false 
-            -Dintrospection=false 
+          meson setup build
+            -Ddebug=true
+            -Ddeprecated=false
+            -Dintrospection=false
           || (cat build/meson-logs/meson-log.txt && exit 1)
 
       - name: Build libvips

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -113,7 +113,7 @@ jobs:
           echo "LDFLAGS=-g -fsanitize=address,undefined -shared-libasan -fopenmp=libomp" >> $GITHUB_ENV
           echo "ASAN_DSO=$ASAN_DSO" >> $GITHUB_ENV
           echo "ASAN_OPTIONS=suppressions=${{ github.workspace }}/suppressions/asan.supp" >> $GITHUB_ENV
-          echo "LSAN_OPTIONS=suppressions=${{ github.workspace }}/suppressions/lsan.supp" >> $GITHUB_ENV
+          echo "LSAN_OPTIONS=suppressions=${{ github.workspace }}/suppressions/lsan.supp:fast_unwind_on_malloc=0" >> $GITHUB_ENV
           echo "TSAN_OPTIONS=suppressions=${{ github.workspace }}/suppressions/tsan.supp" >> $GITHUB_ENV
           echo "UBSAN_OPTIONS=suppressions=${{ github.workspace }}/suppressions/ubsan.supp:halt_on_error=1:abort_on_error=1" >> $GITHUB_ENV
           echo "LD_LIBRARY_PATH=$LLVM_PREFIX/lib:`dirname $ASAN_DSO`" >> $GITHUB_ENV

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -135,17 +135,17 @@ jobs:
           || (cat build/meson-logs/meson-log.txt && exit 1)
 
       - name: Build libvips
-        run: cd build && ninja
-
-      - name: Check libvips
-        run: cd build && ninja test
+        run: ninja -C build
 
       - name: Install libvips
-        run: cd build && sudo ninja install
+        run: sudo ninja -C build install
 
       - name: Rebuild the shared library cache
         if: runner.os == 'Linux'
         run: sudo ldconfig
+
+      - name: Check libvips
+        run: ninja -C build test
 
       - name: Install pyvips
         run: pip3 install pyvips[test]

--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@ of the libvips optional dependencies.
 cd libvips-x.y.x
 meson setup build-dir --prefix=/aaa/bbb/ccc
 cd build-dir
-meson build
+meson compile
 meson test
 meson install
 ```

--- a/fuzz/meson.build
+++ b/fuzz/meson.build
@@ -37,4 +37,7 @@ test(
     depends: [
         fuzz_execs,
     ],
+    # Increase the timeout as running the tests with sanitizers
+    # enabled could be slower than the default 30 seconds.
+    timeout: 60,
 )

--- a/fuzz/test_fuzz.sh
+++ b/fuzz/test_fuzz.sh
@@ -5,11 +5,6 @@ set -e
 
 . ../test/variables.sh
 
-# Glib is built without -fno-omit-frame-pointer. We need
-# to disable the fast unwinder to get full stacktraces.
-export ASAN_OPTIONS="$ASAN_OPTIONS:fast_unwind_on_malloc=0:allocator_may_return_null=1"
-export UBSAN_OPTIONS="$UBSAN_OPTIONS:print_stacktrace=1"
-
 # Hide all warning messages from vips.
 export VIPS_WARNING=0
 

--- a/libvips/iofuncs/init.c
+++ b/libvips/iofuncs/init.c
@@ -962,7 +962,7 @@ static char *
 extract_prefix( const char *dir, const char *name )
 {
 	char edir[VIPS_PATH_MAX];
-	char vname[VIPS_PATH_MAX];
+	static char vname[VIPS_PATH_MAX];
 	int i;
 
 	g_info( "trying for dir = \"%s\", name = \"%s\"", dir, name );
@@ -1011,7 +1011,7 @@ extract_prefix( const char *dir, const char *name )
 
 	g_info( "found \"%s\"", vname );
 
-	return( vips_strdup( NULL, vname ) );
+	return( vname );
 }
 
 /* Search a path for a file ... we overwrite the PATH string passed in.

--- a/suppressions/lsan.supp
+++ b/suppressions/lsan.supp
@@ -1,4 +1,3 @@
-leak:python2.7
 leak:python3
 leak:bash
 leak:libfontconfig.so

--- a/suppressions/lsan.supp
+++ b/suppressions/lsan.supp
@@ -2,7 +2,6 @@ leak:python2.7
 leak:python3
 leak:bash
 leak:libfontconfig.so
-leak:libglib-2.0.so
 leak:libIlmImf-2_3.so
 leak:libIlmThread-2_3.so
 leak:libstdc++.so

--- a/suppressions/lsan.supp
+++ b/suppressions/lsan.supp
@@ -3,3 +3,4 @@ leak:bash
 leak:libfontconfig.so
 leak:libIlmImf-2_3.so
 leak:libIlmThread-2_3.so
+leak:libx265.so

--- a/suppressions/lsan.supp
+++ b/suppressions/lsan.supp
@@ -3,4 +3,3 @@ leak:bash
 leak:libfontconfig.so
 leak:libIlmImf-2_3.so
 leak:libIlmThread-2_3.so
-leak:libstdc++.so

--- a/test/meson.build
+++ b/test/meson.build
@@ -20,7 +20,10 @@ script_tests = [
 foreach script_test : script_tests
     test(script_test,
         files('test_' + script_test + '.sh'),
-        workdir: meson.current_build_dir()
+        workdir: meson.current_build_dir(),
+        # Increase the timeout as running the tests with sanitizers
+        # enabled could be slower than the default 30 seconds.
+        timeout: 60,
     )
 endforeach
 

--- a/test/test_threading.sh
+++ b/test/test_threading.sh
@@ -4,6 +4,13 @@
 
 . ./variables.sh 
 
+exit_code=0
+$vips im_benchmarkn || exit_code=$?
+if [ $exit_code -ne 0 ]; then
+	echo "im_benchmark is not available, skipping test"
+	exit 0
+fi
+
 chain=1
 
 # im_benchmark needs a labq


### PR DESCRIPTION
As discussed in https://gitter.im/libvips/devchat?at=61f6c5059a335454064ac2e0, this PR fixes a small mem leak when the `VIPSHOME` env is not set and the `$libdir/vips-modules-8.13` directory does not exits. It also improves the sanitizer options and suppressions.

This `g_malloc` leak (see CI result of commit f78ce58957cae14e0f2f40e388b4296f213a19d5) was suppressed due to the `libglib-2.0.so` presence in the LSan suppressions. The `fast_unwind_on_malloc=0` wasn't added to the `LSAN_OPTIONS` which caused LSan to fail when unwinding with frame pointers (GLib isn't compiled with `-fno-omit-frame-pointer`) and thus resulted in the error being suppressed.

The last commit (b9d60c196fe66e757542dff48f38b8139d9c24b0) fixes this small leak by avoiding the `vips_strdup` call altogether.