### PR TITLE
set some -Ds depending on the release type

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -3,7 +3,9 @@ project('vips', 'c', 'cpp',
     meson_version: '>=0.56',
     default_options: [
         # this is what glib uses (one of our required deps), so we use it too
-        'c_std=gnu99'
+        'c_std=gnu99',
+        # turn off asserts etc. in release mode
+        'b_ndebug=if-release'
     ]
 )
 
@@ -33,16 +35,16 @@ add_project_link_arguments(
     language: 'c',
 )
 
-# in release mode, we automatically turn off cast checks and asserts
+# in release mode, we automatically turn off cast checks and g_assert
 if get_option('buildtype').startswith('release')
-    add_project_arguments('-DNDEBUG', language : ['cpp', 'c'])
     add_project_arguments('-DG_DISABLE_CAST_CHECKS', language : ['cpp', 'c'])
     add_project_arguments('-DG_DISABLE_CHECKS', language : ['cpp', 'c'])
     add_project_arguments('-DG_DISABLE_ASSERT', language : ['cpp', 'c'])
 endif
 
 # in debug mode mode, we automatically enable leak checks and fatal warnings
-if get_option('buildtype').startswith('debug')
+# also true for 'debugoptimized'
+if get_option('debug')
     add_project_arguments('-DDEBUG_FATAL', language : ['cpp', 'c'])
     add_project_arguments('-DDEBUG_LEAK', language : ['cpp', 'c'])
 endif

--- a/meson.build
+++ b/meson.build
@@ -35,14 +35,15 @@ add_project_link_arguments(
     language: 'c',
 )
 
-# in release mode, we automatically turn off cast checks and g_assert
-if get_option('buildtype').startswith('release')
+# if we're optimising (eg. release mode) we turn off cast checks and
+# g_asserts
+if get_option('optimization') in ['2', '3', 's']
     add_project_arguments('-DG_DISABLE_CAST_CHECKS', language : ['cpp', 'c'])
     add_project_arguments('-DG_DISABLE_CHECKS', language : ['cpp', 'c'])
     add_project_arguments('-DG_DISABLE_ASSERT', language : ['cpp', 'c'])
 endif
 
-# in debug mode mode, we automatically enable leak checks and fatal warnings
+# in debug mode we automatically enable leak checks and fatal warnings
 # also true for 'debugoptimized'
 if get_option('debug')
     add_project_arguments('-DDEBUG_FATAL', language : ['cpp', 'c'])

--- a/meson.build
+++ b/meson.build
@@ -33,6 +33,20 @@ add_project_link_arguments(
     language: 'c',
 )
 
+# in release mode, we automatically turn off cast checks and asserts
+if get_option('buildtype').startswith('release')
+    add_project_arguments('-DNDEBUG', language : ['cpp', 'c'])
+    add_project_arguments('-DG_DISABLE_CAST_CHECKS', language : ['cpp', 'c'])
+    add_project_arguments('-DG_DISABLE_CHECKS', language : ['cpp', 'c'])
+    add_project_arguments('-DG_DISABLE_ASSERT', language : ['cpp', 'c'])
+endif
+
+# in debug mode mode, we automatically enable leak checks and fatal warnings
+if get_option('buildtype').startswith('debug')
+    add_project_arguments('-DDEBUG_FATAL', language : ['cpp', 'c'])
+    add_project_arguments('-DDEBUG_LEAK', language : ['cpp', 'c'])
+endif
+
 cc = meson.get_compiler('c')
 cpp = meson.get_compiler('cpp')
 


### PR DESCRIPTION
libvips uses g_assert() quite a bit to check things like pointer bounds,
and this can have a large performance impact.

This PR turns off g_assert() (plus some other things) in release mode,
and enables leak checking (and some other things) in debug mode.

I'm not sure if this is the best way to implement this kind of thing.
Does meson have a more offical path for this?