### PR TITLE
Add support for regions in the C++ API

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -9,6 +9,7 @@
 - add meson build system [tintou]
 - improve introspection annotations [tintou]
 - add @unlimited to heifload [lovell]
+- add support for regions in C++ API [shado23]
 
 26/11/21 started 8.12.3
 - better arg checking for hist_find_ndim [travisbell]

--- a/cplusplus/Doxyfile.in
+++ b/cplusplus/Doxyfile.in
@@ -829,6 +829,7 @@ INPUT                  = \
 	@DOXY_INPUT_DIRECTORY@/VError.cpp \
 	@DOXY_INPUT_DIRECTORY@/VImage.cpp \
 	@DOXY_INPUT_DIRECTORY@/VInterpolate.cpp \
+	@DOXY_INPUT_DIRECTORY@/VRegion.cpp \
 	@DOXY_INPUT_DIRECTORY@/vips-operators.cpp \
 	@DOXY_INPUT_DIRECTORY@/include/vips/VConnection8.h \
 	@DOXY_INPUT_DIRECTORY@/include/vips/VError8.h \

--- a/cplusplus/Makefile.am
+++ b/cplusplus/Makefile.am
@@ -11,6 +11,7 @@ lib_LTLIBRARIES = libvips-cpp.la
 libvips_cpp_la_SOURCES = \
 	VImage.cpp \
 	VInterpolate.cpp \
+	VRegion.cpp \
 	VConnection.cpp \
 	VError.cpp 
 

--- a/cplusplus/VImage.cpp
+++ b/cplusplus/VImage.cpp
@@ -778,6 +778,32 @@ VImage::write_to_target( const char *suffix, VTarget target,
 			set( "target", target ) );
 }
 
+VRegion
+VImage::region() const
+{
+	return VRegion::new_from_image( *this );
+}
+
+VRegion
+VImage::region( VipsRect *rect ) const
+{
+	VRegion region = VRegion::new_from_image( *this );
+
+	region.prepare( rect );
+
+	return region;
+}
+
+VRegion
+VImage::region( int left, int top, int width, int height ) const
+{
+	VRegion region = VRegion::new_from_image( *this );
+
+	region.prepare( left, top, width, height );
+
+	return region;
+}
+
 #include "vips-operators.cpp"
 
 std::vector<VImage>

--- a/cplusplus/VRegion.cpp
+++ b/cplusplus/VRegion.cpp
@@ -1,0 +1,28 @@
+// Object part of VRegion class
+
+#ifdef HAVE_CONFIG_H
+#include <config.h>
+#endif /*HAVE_CONFIG_H*/
+#include <vips/intl.h>
+
+#include <vips/vips8>
+
+#include <vips/debug.h>
+
+VIPS_NAMESPACE_START
+
+VRegion
+VRegion::new_from_image( VImage image )
+{
+	VipsRegion *region;
+
+	if( !(region = vips_region_new( image.get_image() )) ) {
+		throw VError();
+	}
+
+	VRegion out( region );
+
+	return( out );
+}
+
+VIPS_NAMESPACE_END

--- a/cplusplus/include/vips/VImage8.h
+++ b/cplusplus/include/vips/VImage8.h
@@ -189,6 +189,7 @@ public:
 
 class VIPS_CPLUSPLUS_API VImage;
 class VIPS_CPLUSPLUS_API VInterpolate;
+class VIPS_CPLUSPLUS_API VRegion;
 class VIPS_CPLUSPLUS_API VSource;
 class VIPS_CPLUSPLUS_API VTarget;
 class VIPS_CPLUSPLUS_API VOption;
@@ -1054,6 +1055,24 @@ public:
 
 		return( result ); 
 	}
+
+	/**
+	 * Acquire VRegion covering the whole image.
+	 */
+	VRegion
+	region() const;
+
+	/**
+	 * Acquire VRegion covering the given VipsRect.
+	 */
+	VRegion
+	region( VipsRect *rect ) const;
+
+	/**
+	 * Acquire VRegion covering the given coordinates.
+	 */
+	VRegion
+	region( int left, int top, int width, int height ) const;
 
 	/**
 	 * Apply a linear transform to an image. For every pixel,

--- a/cplusplus/include/vips/VRegion8.h
+++ b/cplusplus/include/vips/VRegion8.h
@@ -1,0 +1,146 @@
+// VIPS region wrapper
+
+/*
+
+    This file is part of VIPS.
+
+    VIPS is free software; you can redistribute it and/or modify
+    it under the terms of the GNU Lesser General Public License as published by
+    the Free Software Foundation; either version 2 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU Lesser General Public License for more details.
+
+    You should have received a copy of the GNU Lesser General Public License
+    along with this program; if not, write to the Free Software
+    Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+    02110-1301  USA
+
+ */
+
+/*
+
+    These files are distributed with VIPS - http://www.vips.ecs.soton.ac.uk
+
+ */
+
+#ifndef VIPS_VREGION_H
+#define VIPS_VREGION_H
+
+#include <vips/vips.h>
+
+VIPS_NAMESPACE_START
+
+/**
+ * A region of an image. Can be used to access raw pixel data.
+ * */
+class VRegion : public VObject
+{
+public:
+	/**
+	 * Create a VRegion that wraps a VipsRegion object. If steal
+	 * is STEAL, then this VRegion takes over ownership of the libvips
+	 * object and will automatically unref it.
+	 */
+	VRegion( VipsRegion *region, VSteal steal = STEAL ) :
+		VObject( (VipsObject *) region, steal )
+	{
+	}
+
+	/**
+	 * Create a VRegion from an image.
+	 */
+	static VRegion
+	new_from_image( VImage image );
+
+	/**
+	 * Get a pointer to the underlying VipsRegion object.
+	 */
+	VipsRegion *
+	get_region() const
+	{
+		return (VipsRegion *) VObject::get_object();
+	}
+
+	/**
+	 * Prepare the region from VipsRect.
+	 */
+	void
+	prepare( const VipsRect *rect ) const
+	{
+		if ( vips_region_prepare( get_region(), rect ) )
+			throw VError();
+	}
+
+	/**
+	 * Prepare the region from rectangle coordinates.
+	 */
+	void
+	prepare( int left, int top, int width, int height ) const
+	{
+		VipsRect rect = { left, top, width, height };
+
+		prepare( &rect );
+	}
+
+	/**
+	 * Get valid bounds of the region.
+	 */
+	VipsRect
+	valid() const
+	{
+		return get_region()->valid;
+	}
+
+	/**
+	 * Get pointer to the start of the region.
+	 */
+	VipsPel *
+	addr() const
+	{
+		return addr( 0 );
+	}
+
+	/**
+	 * Get pointer at the given index of the region.
+	 */
+	VipsPel *
+	addr( size_t i ) const
+	{
+		return &VIPS_REGION_ADDR_TOPLEFT( get_region() )[i];
+	}
+
+	/**
+	 * Get pointer at the given coordinates of the region.
+	 */
+	VipsPel *
+	addr( int x, int y ) const
+	{
+		return VIPS_REGION_ADDR( get_region(), x, y );
+	}
+
+	/**
+	 * Get VipsPel at the given index of the region.
+	 */
+	VipsPel
+	operator[]( size_t i ) const
+	{
+		return *addr( i );
+	}
+
+	/**
+	 * Get VipsPel at the given coordinates of the region.
+	 */
+	VipsPel
+	operator()( int x, int y ) const
+	{
+		return *addr( x, y );
+	}
+};
+
+VIPS_NAMESPACE_END
+
+#endif /*VIPS_VREGION_H*/

--- a/cplusplus/include/vips/vips8
+++ b/cplusplus/include/vips/vips8
@@ -52,6 +52,7 @@
 #include "VError8.h"
 #include "VImage8.h"
 #include "VInterpolate8.h"
+#include "VRegion8.h"
 #include "VConnection8.h"
 
 #endif /*VIPS_CPLUSPLUS*/

--- a/cplusplus/meson.build
+++ b/cplusplus/meson.build
@@ -3,6 +3,7 @@ subdir('include/vips')
 libvips_cpp_lib = library('vips-cpp',
     'VImage.cpp',
     'VInterpolate.cpp',
+    'VRegion.cpp',
     'VConnection.cpp',
     'VError.cpp',
     dependencies: libvips_dep,


### PR DESCRIPTION
I happened to have a use case where I needed access to the raw pixel data through regions and discovered that the C++ API was missing support for them. 

I've quickly wired up a VRegion wrapper class based on the existing ones, and added a "region" method on VImage.