### PR TITLE
nsgifload: Fix gif decoding issue.

### DIFF
--- a/libvips/foreign/nsgifload.c
+++ b/libvips/foreign/nsgifload.c
@@ -324,7 +324,8 @@ vips_foreign_load_nsgif_header( VipsForeignLoad *load )
 #ifdef VERBOSE
 	print_animation( gif->anim, gif->info );
 #endif /*VERBOSE*/
-	if( result != NSGIF_OK ) {
+	if( result != NSGIF_OK &&
+		load->fail_on >= VIPS_FAIL_ON_WARNING ) {
 		vips_foreign_load_nsgif_error( gif, result ); 
 		return( -1 );
 	}


### PR DESCRIPTION
The nsgif_data_scan() call returns an error code that says
if anything was wrong with the source data.

It is not unusual for there to be bad stuff in a GIF, so we
only need to worry if we failed to find any frames.

Fixes #2698.