### PR TITLE
Ensure compatibility with nip2

### DIFF
--- a/libvips/include/vips/vips7compat.h
+++ b/libvips/include/vips/vips7compat.h
@@ -581,10 +581,11 @@ size_t im_ref_string_get_length( const GValue *value );
 #define IM_MICRO_VERSION VIPS_MICRO_VERSION
 
 #if defined(G_PLATFORM_WIN32) || defined(G_WITH_CYGWIN)
-#define IM_EXEEXT ".exe"
+#define VIPS_EXEEXT ".exe"
 #else /* !defined(G_PLATFORM_WIN32) && !defined(G_WITH_CYGWIN) */
-#define IM_EXEEXT ""
+#define VIPS_EXEEXT ""
 #endif /* defined(G_PLATFORM_WIN32) || defined(G_WITH_CYGWIN) */
+#define IM_EXEEXT VIPS_EXEEXT
 
 #define IM_SIZEOF_HEADER VIPS_SIZEOF_HEADER
 


### PR DESCRIPTION
nip2 uses the `VIPS_EXEEXT` definition.
```c
main.c:1086:34: error: ‘VIPS_EXEEXT’ undeclared (first use in this function); did you mean ‘IM_EXEEXT’?
 1086 |         setenvf( "EXEEXT", "%s", VIPS_EXEEXT );
      |                                  ^~~~~~~~~~~
      |                                  IM_EXEEXT
```
_Split out from #2688._