### PR TITLE
cgifsave: Make loop counts more accurate

### DIFF
--- a/libvips/foreign/cgifsave.c
+++ b/libvips/foreign/cgifsave.c
@@ -63,6 +63,7 @@ typedef struct _VipsForeignSaveCgif {
 	int effort;
 	int bitdepth;
 	double maxerror;
+	gboolean noloop;
 	VipsTarget *target;
 
 	/* Derived write params.
@@ -309,7 +310,7 @@ vips_foreign_save_cgif_write_frame( VipsForeignSaveCgif *cgif )
 	 */
 	if( !cgif->cgif_context ) {
 		cgif->cgif_config.pGlobalPalette = cgif->palette_rgb;
-		cgif->cgif_config.attrFlags = CGIF_ATTR_IS_ANIMATED;
+		cgif->cgif_config.attrFlags = CGIF_ATTR_IS_ANIMATED | ( cgif->noloop ? CGIF_ATTR_NO_LOOP : 0 );
 		cgif->cgif_config.width = frame_rect->width;
 		cgif->cgif_config.height = frame_rect->height;
 		cgif->cgif_config.numGlobalPaletteEntries = cgif->lp->count;
@@ -612,6 +613,13 @@ vips_foreign_save_cgif_class_init( VipsForeignSaveCgifClass *class )
 		VIPS_ARGUMENT_OPTIONAL_INPUT,
 		G_STRUCT_OFFSET( VipsForeignSaveCgif, maxerror ),
 		0, 32, 0.0 );
+
+	VIPS_ARG_BOOL( class, "noloop", 14,
+		_( "No loop" ),
+		_( "Disables looping" ),
+		VIPS_ARGUMENT_OPTIONAL_INPUT,
+		G_STRUCT_OFFSET( VipsForeignSaveCgif, noloop ),
+		FALSE );
 }
 
 static void

--- a/libvips/foreign/cgifsave.c
+++ b/libvips/foreign/cgifsave.c
@@ -63,7 +63,6 @@ typedef struct _VipsForeignSaveCgif {
 	int effort;
 	int bitdepth;
 	double maxerror;
-	gboolean noloop;
 	VipsTarget *target;
 
 	/* Derived write params.
@@ -311,11 +310,11 @@ vips_foreign_save_cgif_write_frame( VipsForeignSaveCgif *cgif )
 	 */
 	if( !cgif->cgif_context ) {
 		cgif->cgif_config.pGlobalPalette = cgif->palette_rgb;
-		cgif->cgif_config.attrFlags = CGIF_ATTR_IS_ANIMATED | ( cgif->noloop ? CGIF_ATTR_NO_LOOP : 0 );
+		cgif->cgif_config.attrFlags = CGIF_ATTR_IS_ANIMATED | ( cgif->loop == 1 ? CGIF_ATTR_NO_LOOP : 0 );
 		cgif->cgif_config.width = frame_rect->width;
 		cgif->cgif_config.height = frame_rect->height;
 		cgif->cgif_config.numGlobalPaletteEntries = cgif->lp->count;
-		cgif->cgif_config.numLoops = cgif->loop;
+		cgif->cgif_config.numLoops = cgif->loop > 1 ? cgif->loop - 1 : cgif->loop;
 		cgif->cgif_config.pWriteFn = vips__cgif_write;
 		cgif->cgif_config.pContext = (void *) cgif->target;
 
@@ -614,13 +613,6 @@ vips_foreign_save_cgif_class_init( VipsForeignSaveCgifClass *class )
 		VIPS_ARGUMENT_OPTIONAL_INPUT,
 		G_STRUCT_OFFSET( VipsForeignSaveCgif, maxerror ),
 		0, 32, 0.0 );
-
-	VIPS_ARG_BOOL( class, "noloop", 14,
-		_( "No loop" ),
-		_( "Disables looping" ),
-		VIPS_ARGUMENT_OPTIONAL_INPUT,
-		G_STRUCT_OFFSET( VipsForeignSaveCgif, noloop ),
-		FALSE );
 }
 
 static void

--- a/libvips/foreign/cgifsave.c
+++ b/libvips/foreign/cgifsave.c
@@ -310,11 +310,19 @@ vips_foreign_save_cgif_write_frame( VipsForeignSaveCgif *cgif )
 	 */
 	if( !cgif->cgif_context ) {
 		cgif->cgif_config.pGlobalPalette = cgif->palette_rgb;
+#ifdef HAVE_CGIF_ATTR_NO_LOOP
 		cgif->cgif_config.attrFlags = CGIF_ATTR_IS_ANIMATED | ( cgif->loop == 1 ? CGIF_ATTR_NO_LOOP : 0 );
+#else
+		cgif->cgif_config.attrFlags = CGIF_ATTR_IS_ANIMATED;
+#endif/*HAVE_CGIF_ATTR_NO_LOOP*/
 		cgif->cgif_config.width = frame_rect->width;
 		cgif->cgif_config.height = frame_rect->height;
 		cgif->cgif_config.numGlobalPaletteEntries = cgif->lp->count;
+#ifdef HAVE_CGIF_ATTR_NO_LOOP
 		cgif->cgif_config.numLoops = cgif->loop > 1 ? cgif->loop - 1 : cgif->loop;
+#else
+		cgif->cgif_config.numLoops = cgif->loop;
+#endif/*HAVE_CGIF_ATTR_NO_LOOP*/
 		cgif->cgif_config.pWriteFn = vips__cgif_write;
 		cgif->cgif_config.pContext = (void *) cgif->target;
 

--- a/libvips/foreign/libnsgif/gif.c
+++ b/libvips/foreign/libnsgif/gif.c
@@ -799,7 +799,8 @@ static nsgif_error nsgif__parse_extension_application(
 	if ((data[1] == 0x0b) &&
 	    (strncmp((const char *)data + 2, "NETSCAPE2.0", 11) == 0) &&
 	    (data[13] == 0x03) && (data[14] == 0x01)) {
-		gif->info.loop_max = data[15] | (data[16] << 8);
+		int loop = data[15] | (data[16] << 8);
+		gif->info.loop_max = loop > 0 ? loop + 1 : loop;
 	}
 
 	return NSGIF_OK;

--- a/libvips/foreign/libnsgif/gif.c
+++ b/libvips/foreign/libnsgif/gif.c
@@ -799,8 +799,7 @@ static nsgif_error nsgif__parse_extension_application(
 	if ((data[1] == 0x0b) &&
 	    (strncmp((const char *)data + 2, "NETSCAPE2.0", 11) == 0) &&
 	    (data[13] == 0x03) && (data[14] == 0x01)) {
-		int loop = data[15] | (data[16] << 8);
-		gif->info.loop_max = loop > 0 ? loop + 1 : loop;
+		gif->info.loop_max = data[15] | (data[16] << 8);
 	}
 
 	return NSGIF_OK;

--- a/meson.build
+++ b/meson.build
@@ -238,6 +238,9 @@ if quantisation_package.found()
     if cgif_dep.found()
         libvips_deps += cgif_dep
         cfg_var.set('HAVE_CGIF', '1')
+        if cc.compiles('#include <cgif.h>\nint i = CGIF_ATTR_NO_LOOP;', name: 'Has CGIF_ATTR_NO_LOOP', dependencies: cgif_dep)
+            cfg_var.set('HAVE_CGIF_ATTR_NO_LOOP', '1')
+        endif
     endif
 endif
 


### PR DESCRIPTION
See dloebl/cgif#46 and dloebl/cgif#48.

This fixes cgifsave to make the libvips `loop` property specify the number of iterations instead of the number of times an animation loops. Depends on (the currently unreleased) CGIF version 0.3.0.