### PR TITLE
libnsgif: Update to latest upstream.

### DIFF
--- a/libvips/foreign/libnsgif/README-ns.md
+++ b/libvips/foreign/libnsgif/README-ns.md
@@ -49,10 +49,15 @@ Now you can load the GIF source data into the nsgif object with
 
 This scans the source data and decodes information about each frame, however
 it doesn't decode any of the bitmap data for the frames. The client may call
-`nsgif_data_scan()` multiple times as source data is fetched. Once the
-function has returned `NSGIF_OK` it has enough data to display at least one
-frame. The early frames can be decoded before the later frames are scanned.
-Frames have to be scanned before they can be decoded.
+`nsgif_data_scan()` multiple times as source data is fetched. The early frames
+can be decoded before the later frames are scanned. Frames have to be scanned
+before they can be decoded.
+
+This function will sometimes return an error. That is OK, and even expected.
+It is fine to proceed to decoding any frames that are available after a scan.
+Some errors indicate that there is a flaw in the source GIF data (not at all
+uncommon, GIF is an ancient format that has had many broken encoders), or that
+it has reached the end of the source data.
 
 > **Note**: The client must not free the data until after calling
 > `nsgif_destroy()`. You can move the data, e.g. if you realloc to a bigger

--- a/libvips/foreign/libnsgif/README.md
+++ b/libvips/foreign/libnsgif/README.md
@@ -8,7 +8,7 @@ but within the libvips build system.
 Run `./update.sh` to update this copy of libnsgif from the upstream repo. It
 will also patch libnsgif.c to prevent it modifying the input.
 
-Last updated 3 Mar 2022.
+Last updated 8 Mar 2022.
 
 # To do
 

--- a/libvips/foreign/libnsgif/nsgif.h
+++ b/libvips/foreign/libnsgif/nsgif.h
@@ -284,7 +284,7 @@ typedef struct nsgif_info {
 	uint32_t height;
 	/** number of frames decoded */
 	uint32_t frame_count;
-	/** number of times to loop animation */
+	/** number of times to play animation (zero means loop forever) */
 	int loop_max;
 	/** number of animation loops so far */
 	int loop_count;


### PR DESCRIPTION
Fixes loop_max, and adds support for "ANIMEXTS1.0".

See #2709.