### PR TITLE
vipsload: sanity check resolution

### DIFF
--- a/libvips/iofuncs/vips.c
+++ b/libvips/iofuncs/vips.c
@@ -358,8 +358,8 @@ vips__read_header_bytes( VipsImage *im, unsigned char *from )
 	/* We read xres/yres as floats to a staging area, then copy to double
 	 * in the main fields.
 	 */
-	im->Xres = im->Xres_float;
-	im->Yres = im->Yres_float;
+	im->Xres = VIPS_MAX( 0, im->Xres_float );
+	im->Yres = VIPS_MAX( 0, im->Yres_float );
 
 	/* Some protection against malicious files. We also check predicted
 	 * (based on these values) against real file length, see below. 


### PR DESCRIPTION
Fixes https://bugs.chromium.org/p/oss-fuzz/issues/detail?id=46009 (when compiled with debug assertions).

Before:
```
$ vipsheader -a fail.v

(vipsheader:15655): VIPS-WARNING **: 10:35:38.096: error reading vips image metadata: VipsImage: XML parse error

sanity failure: VipsImage (0x558a4f1da330) bad resolution

**
VIPS:ERROR:../libvips/iofuncs/image.c:3619:vips_image_pio_input: assertion failed: (vips_object_sanity( VIPS_OBJECT( image ) ))
Bail out! VIPS:ERROR:../libvips/iofuncs/image.c:3619:vips_image_pio_input: assertion failed: (vips_object_sanity( VIPS_OBJECT( image ) ))
Aborted (core dumped)
```

After:
```
$ vipsheader -a fail.v
vipsheader: VipsImage: invalid resolution
VipsImage: unable to read header for "fail.v"
```
