### PR TITLE
Update to latest libnsgif

### DIFF
--- a/libvips/foreign/libnsgif/README-ns.md
+++ b/libvips/foreign/libnsgif/README-ns.md
@@ -22,14 +22,17 @@ Using
 LibNSGIF allows the client to allocate the bitmap into which the GIF is
 decoded. The client can have an arbitrary bitmap structure, that is simply
 a void pointer to LibNSGIF. The client must provide a callback table for
-interacting with bitmaps. This table must include as a minimum functions to
-create and destroy bitmaps, and a function to get a pointer to the bitmap's
-pixel data buffer.
+interacting with bitmaps, and the required client bitmap pixel format.
+The bitmap table must include as a minimum functions to create and destroy
+bitmaps, and a function to get a pointer to the bitmap's pixel data buffer.
+
+LibNSGIF always decodes to a 32bpp, 8 bits per channel bitmap pixel format,
+however it allows the client to control the colour component ordering.
 
 To load a GIF, first create an nsgif object with `nsgif_create()`.
 
 ```c
-	err = nsgif_create(&bitmap_callbacks, &gif);
+	err = nsgif_create(&bitmap_callbacks, NSGIF_BITMAP_FMT_R8G8B8A8, &gif);
 	if (err != NSGIF_OK) {
 		fprintf(stderr, "%s\n", nsgif_strerror(err));
 		// Handle error

--- a/libvips/foreign/libnsgif/README.md
+++ b/libvips/foreign/libnsgif/README.md
@@ -8,7 +8,7 @@ but within the libvips build system.
 Run `./update.sh` to update this copy of libnsgif from the upstream repo. It
 will also patch libnsgif.c to prevent it modifying the input.
 
-Last updated 8 Mar 2022.
+Last updated 4 Apr 2022.
 
 # To do
 

--- a/libvips/foreign/libnsgif/test/nsgif.c
+++ b/libvips/foreign/libnsgif/test/nsgif.c
@@ -135,15 +135,17 @@ static void warning(const char *context, nsgif_error err)
 
 static void print_gif_info(const nsgif_info_t *info)
 {
+	const uint8_t *bg = (uint8_t *) &info->background;
+
 	fprintf(stdout, "gif:\n");
 	fprintf(stdout, "  width: %"PRIu32"\n", info->width);
 	fprintf(stdout, "  height: %"PRIu32"\n", info->height);
 	fprintf(stdout, "  max-loops: %"PRIu32"\n", info->loop_max);
 	fprintf(stdout, "  frame-count: %"PRIu32"\n", info->frame_count);
 	fprintf(stdout, "  background:\n");
-	fprintf(stdout, "    red: 0x%"PRIx8"\n", info->background[0]);
-	fprintf(stdout, "    green: 0x%"PRIx8"\n", info->background[1]);
-	fprintf(stdout, "    blue: 0x%"PRIx8"\n", info->background[2]);
+	fprintf(stdout, "    red: 0x%"PRIx8"\n", bg[0]);
+	fprintf(stdout, "    green: 0x%"PRIx8"\n", bg[1]);
+	fprintf(stdout, "    blue: 0x%"PRIx8"\n", bg[2]);
 	fprintf(stdout, "  frames:\n");
 }
 
@@ -272,7 +274,7 @@ int main(int argc, char *argv[])
 	}
 
 	/* create our gif animation */
-	err = nsgif_create(&bitmap_callbacks, &gif);
+	err = nsgif_create(&bitmap_callbacks, NSGIF_BITMAP_FMT_R8G8B8A8, &gif);
 	if (err != NSGIF_OK) {
 		warning("nsgif_create", err);
 		return EXIT_FAILURE;

--- a/libvips/foreign/nsgifload.c
+++ b/libvips/foreign/nsgifload.c
@@ -223,7 +223,6 @@ print_animation( nsgif_t *anim, const nsgif_info_t *info )
 	printf( "  height = %d\n", info->height );
 	printf( "  frame_count = %d\n", info->frame_count );
 	printf( "  loop_max = %d\n", info->loop_max );
-	printf( "  loop_count = %d\n", info->loop_count );
 	printf( "  background = %d %d %d %d\n",
 		bg[0], bg[1], bg[2], bg[3] );
 

--- a/libvips/foreign/nsgifload.c
+++ b/libvips/foreign/nsgifload.c
@@ -216,6 +216,7 @@ static void
 print_animation( nsgif_t *anim, const nsgif_info_t *info )
 {
 	int i;
+	const uint8_t *bg = (uint8_t *) &info->background;
 
 	printf( "animation:\n" );
 	printf( "  width = %d\n", info->width );
@@ -224,10 +225,7 @@ print_animation( nsgif_t *anim, const nsgif_info_t *info )
 	printf( "  loop_max = %d\n", info->loop_max );
 	printf( "  loop_count = %d\n", info->loop_count );
 	printf( "  background = %d %d %d %d\n",
-		info->background[0],
-		info->background[1],
-		info->background[2],
-		info->background[3] );
+		bg[0], bg[1], bg[2], bg[3] );
 
 	for( i = 0; i < info->frame_count; i++ ) {
 		printf( "%d ", i );
@@ -242,6 +240,7 @@ vips_foreign_load_nsgif_set_header( VipsForeignLoadNsgif *gif,
 	VipsImage *image )
 {
 	double array[3];
+	const uint8_t *bg;
 
 	VIPS_DEBUG_MSG( "vips_foreign_load_nsgif_set_header:\n" );
 
@@ -265,9 +264,11 @@ vips_foreign_load_nsgif_set_header( VipsForeignLoadNsgif *gif,
 	vips_image_set_array_int( image, "delay", 
 		gif->delay, gif->info->frame_count );
 
-	array[0] = gif->info->background[0];
-	array[1] = gif->info->background[1];
-	array[2] = gif->info->background[2];
+
+	bg = (uint8_t *) &gif->info->background;
+	array[0] = bg[0];
+	array[1] = bg[1];
+	array[2] = bg[2];
 
 	vips_image_set_array_double( image, "background", array, 3 );
 
@@ -557,6 +558,7 @@ vips_foreign_load_nsgif_init( VipsForeignLoadNsgif *gif )
 {
 	nsgif_error result = nsgif_create(
 		&vips_foreign_load_nsgif_bitmap_callbacks,
+		NSGIF_BITMAP_FMT_R8G8B8A8,
 		&gif->anim );
 	if (result != NSGIF_OK) {
 		VipsObjectClass *class = VIPS_OBJECT_GET_CLASS( gif );


### PR DESCRIPTION
The main changes are that now clients can control the pixel format that LibNSGIF decodes to, and some internal state has been removed from the GIF info structure.