### PR TITLE
add "configure" operation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 compile
+build
 .pytest_cache
 .dirstamp
 a.out

--- a/ChangeLog
+++ b/ChangeLog
@@ -1,8 +1,6 @@
 21/11/21 started 8.13
 - configure fails for requested but unmet dependencies [remicollet]
 - add support for another quantiser [DarthSim]
-- add "extend", "background" and "premultiplied" to mapim to fix edge
-  antialiasing [GavinJoyce]
 - add support for HDR HEIC and AVIF images
 - add spngsave
 - jpeg2000 load left-justifies bitdepth
@@ -17,6 +15,7 @@
 - add maxerror to gifsave [dloebl]
 - update libnsgif API [tlsa]
 - deprecate "properties" option to dzsave (now always on)
+- add vips_configure() ... set various config options
 
 26/11/21 started 8.12.3
 - better arg checking for hist_find_ndim [travisbell]

--- a/libvips/iofuncs/Makefile.am
+++ b/libvips/iofuncs/Makefile.am
@@ -3,6 +3,7 @@ noinst_LTLIBRARIES = libiofuncs.la
 libiofuncs_la_SOURCES = \
 	ginputsource.c \
 	sourceginput.c \
+	configure.c \
 	connection.c \
 	source.c \
 	sourcecustom.c \

--- a/libvips/iofuncs/configure.c
+++ b/libvips/iofuncs/configure.c
@@ -1,0 +1,177 @@
+/* vips_configure(): set/clear various libvips settings
+ *
+ * 11/04/22
+ * 	- from configure.c
+ */
+
+/*
+
+    This file is part of VIPS.
+    
+    VIPS is free software; you can redistribute it and/or modify
+    it under the terms of the GNU Lesser General Public License as published by
+    the Free Software Foundation; either version 2 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU Lesser General Public License for more details.
+
+    You should have received a copy of the GNU Lesser General Public License
+    along with this program; if not, write to the Free Software
+    Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+    02110-1301  USA
+
+ */
+
+/*
+
+    These files are distributed with VIPS - http://www.vips.ecs.soton.ac.uk
+
+ */
+
+#ifdef HAVE_CONFIG_H
+#include <config.h>
+#endif /*HAVE_CONFIG_H*/
+#include <glib/gi18n-lib.h>
+
+#include <stdio.h>
+#include <stdlib.h>
+
+#ifdef HAVE_UNISTD_H
+#include <unistd.h>
+#endif /*HAVE_UNISTD_H*/
+#include <stdarg.h>
+#include <string.h>
+#include <errno.h>
+
+#include <vips/vips.h>
+#include <vips/internal.h>
+
+typedef struct _VipsConfigure {
+	VipsOperation parent_instance;
+
+	/* Block all untrusted operations.
+	 */
+	gboolean untrusted_block;
+
+	/* Block a specific operation.
+	 */
+	char *operation_block;
+
+	/* Unblock a specific operation.
+	 */
+	char *operation_unblock;
+
+} VipsConfigure;
+
+typedef VipsOperationClass VipsConfigureClass;
+
+G_DEFINE_TYPE( VipsConfigure, vips_configure, VIPS_TYPE_OPERATION );
+
+static int
+vips_configure_build( VipsObject *object )
+{
+	VipsConfigure *configure = (VipsConfigure *) object;
+
+	if( VIPS_OBJECT_CLASS( vips_configure_parent_class )->build( object ) )
+		return( -1 );
+
+	if( vips_object_argument_isset( object, "untrusted_block" ) ) 
+		vips_block_untrusted_set( configure->untrusted_block );
+
+	if( vips_object_argument_isset( object, "operation_block" ) ) 
+		vips_operation_block_set( configure->operation_block, TRUE );
+	if( vips_object_argument_isset( object, "operation_unblock" ) ) 
+		vips_operation_block_set( configure->operation_block, FALSE );
+
+	return( 0 );
+}
+
+static void
+vips_configure_class_init( VipsConfigureClass *class )
+{
+	GObjectClass *gobject_class = G_OBJECT_CLASS( class );
+	VipsObjectClass *vobject_class = VIPS_OBJECT_CLASS( class );
+	VipsOperationClass *operation_class = VIPS_OPERATION_CLASS( class );
+
+	gobject_class->set_property = vips_object_set_property;
+	gobject_class->get_property = vips_object_get_property;
+
+	vobject_class->nickname = "configure";
+	vobject_class->description = _( "set various library options" );
+	vobject_class->build = vips_configure_build;
+
+	/* Commands can have side-effects, so don't cache them. 
+	 */
+	operation_class->flags = VIPS_OPERATION_NOCACHE;
+
+	VIPS_ARG_BOOL( class, "untrusted_block", 2, 
+		_( "Block untrusted" ), 
+		_( "Block all untrusted operations from running" ),
+		VIPS_ARGUMENT_OPTIONAL_INPUT,
+		G_STRUCT_OFFSET( VipsConfigure, untrusted_block ),
+		FALSE );
+
+	VIPS_ARG_STRING( class, "operation_block", 2, 
+		_( "Block operation" ), 
+		_( "Block an operation (and any subclasses) from running" ),
+		VIPS_ARGUMENT_OPTIONAL_INPUT,
+		G_STRUCT_OFFSET( VipsConfigure, operation_block ),
+		NULL );
+
+	VIPS_ARG_STRING( class, "operation_unblock", 2, 
+		_( "Unblock operation" ), 
+		_( "Unblock an operation (and any subclasses) from running" ),
+		VIPS_ARGUMENT_OPTIONAL_INPUT,
+		G_STRUCT_OFFSET( VipsConfigure, operation_unblock ),
+		NULL );
+
+}
+
+static void
+vips_configure_init( VipsConfigure *configure )
+{
+}
+
+/**
+ * vips_configure:
+ * @name: not used
+ * @...: %NULL-terminated list of optional named arguments
+ *
+ * Optional arguments:
+ *
+ * * @untrusted_block: %gboolean, Block all untrusted operations from running
+ * * @operation_block : %gchararray, Block an operation from running
+ * * @operation_unblock : %gchararray, Unblock an operation from running
+ *
+ * vips_configure() can be used to set a number of libvips configure
+ * options.
+ *
+ * If @untrusted_block is set, all libvips operations which have been tagged
+ * as unsafe for untrusted input will be blocked. All subclasses of these
+ * operations are also blocked. See vips_block_untrusted_set().
+ *
+ * If @operation_block is set, the named libvips operation is blocked. All 
+ * subclasses of this operation are also blocked. See
+ * vips_operation_block_set().
+ *
+ * If @operation_unblock is set, the named libvips operation is unblocked. All 
+ * subclasses of this operation are also unblocked. See
+ * vips_operation_block_set().
+ *
+ * Returns: 0 on success, -1 on failure. 
+ */
+int
+vips_configure( const char *name, ... )
+{
+	va_list ap;
+	int result;
+
+	va_start( ap, name );
+	result = vips_call_split( "configure", ap, name );
+	va_end( ap );
+
+	return( result );
+}

--- a/libvips/iofuncs/init.c
+++ b/libvips/iofuncs/init.c
@@ -434,6 +434,7 @@ int
 vips_init( const char *argv0 )
 {
 	extern GType vips_system_get_type( void );
+	extern GType vips_configure_get_type( void );
 	extern GType write_thread_state_get_type( void );
 	extern GType sink_memory_thread_state_get_type( void ); 
 	extern GType render_thread_state_get_type( void ); 
@@ -578,6 +579,7 @@ vips_init( const char *argv0 )
 	/* Start up packages.
 	 */
 	(void) vips_system_get_type();
+	(void) vips_configure_get_type();
 	vips_arithmetic_operation_init();
 	vips_conversion_operation_init();
 	vips_create_operation_init();

--- a/libvips/iofuncs/meson.build
+++ b/libvips/iofuncs/meson.build
@@ -1,6 +1,7 @@
 iofuncs_sources = files(
     'ginputsource.c',
     'sourceginput.c',
+    'configure.c',
     'connection.c',
     'source.c',
     'sourcecustom.c',

--- a/libvips/iofuncs/operation.c
+++ b/libvips/iofuncs/operation.c
@@ -33,6 +33,7 @@
 
 /*
 #define VIPS_DEBUG
+#define DEBUG
  */
 
 #ifdef HAVE_CONFIG_H
@@ -1432,9 +1433,9 @@ vips_operation_block_set_operation( VipsOperationClass *class, gboolean *state )
 {
 	g_assert( VIPS_IS_OPERATION_CLASS( class ) );
 
-#ifdef VIPS_DEBUG
+#ifdef DEBUG
 	if( ((class->flags & VIPS_OPERATION_BLOCKED) != 0) != *state )
-		VIPS_DEBUG_MSG( "vips_operation_block_set_operation: "
+		printf( "vips_operation_block_set_operation: "
 			"setting block state on %s = %d\n", 
 			VIPS_OBJECT_CLASS( class )->nickname, *state );
 #endif


### PR DESCRIPTION
This operation can be used to set various library config options, such
as vips_block_untrusted_set().

Having these options available as an operation makes like simpler for
bindings: they can expose them all via the usual introspection system.

Example:

```python
pyvips.Image.configure(untrusted_block=True)
```