### PR TITLE
nsgif: try to recover after LZW_EOI_CODE

### DIFF
--- a/libvips/foreign/libnsgif/gif.c
+++ b/libvips/foreign/libnsgif/gif.c
@@ -471,7 +471,7 @@ static nsgif_error nsgif__decode_complex(
 			while (available == 0) {
 				if (res != LZW_OK) {
 					/* Unexpected end of frame, try to recover */
-					if (res == LZW_OK_EOD) {
+					if (res == LZW_OK_EOD || res == LZW_EOI_CODE) {
 						ret = NSGIF_OK;
 					} else {
 						ret = nsgif__error_from_lzw(res);
@@ -557,7 +557,7 @@ static nsgif_error nsgif__decode_simple(
 		frame_data += written;
 		if (res != LZW_OK) {
 			/* Unexpected end of frame, try to recover */
-			if (res == LZW_OK_EOD) {
+			if (res == LZW_OK_EOD || res == LZW_EOI_CODE) {
 				ret = NSGIF_OK;
 			} else {
 				ret = nsgif__error_from_lzw(res);

--- a/libvips/foreign/libnsgif/patches/try-to-recover-after-LZW_EOI_CODE.patch
+++ b/libvips/foreign/libnsgif/patches/try-to-recover-after-LZW_EOI_CODE.patch
@@ -1,0 +1,20 @@
+--- libnsgif/gif.c
++++ gif.c
+@@ -471,7 +471,7 @@ static nsgif_error nsgif__decode_complex(
+ 			while (available == 0) {
+ 				if (res != LZW_OK) {
+ 					/* Unexpected end of frame, try to recover */
+-					if (res == LZW_OK_EOD) {
++					if (res == LZW_OK_EOD || res == LZW_EOI_CODE) {
+ 						ret = NSGIF_OK;
+ 					} else {
+ 						ret = nsgif__error_from_lzw(res);
+@@ -557,7 +557,7 @@ static nsgif_error nsgif__decode_simple(
+ 		frame_data += written;
+ 		if (res != LZW_OK) {
+ 			/* Unexpected end of frame, try to recover */
+-			if (res == LZW_OK_EOD) {
++			if (res == LZW_OK_EOD || res == LZW_EOI_CODE) {
+ 				ret = NSGIF_OK;
+ 			} else {
+ 				ret = nsgif__error_from_lzw(res);


### PR DESCRIPTION
Here's an issue with a GIF sample that can't be loaded because of the `NSGIF_ERR_DATA_FRAME` error: https://github.com/imgproxy/imgproxy/issues/842. I found that it is caused by `LZW_EOI_CODE`, and it seems like we can try to recover after it as we do with `LZW_OK_EOD`. I've tried to process the sample from the issue with this patch applied and everything worked fine.