### PR TITLE
libnsgif: Update to latest upstream

### DIFF
--- a/libvips/foreign/libnsgif/README.md
+++ b/libvips/foreign/libnsgif/README.md
@@ -8,7 +8,7 @@ but within the libvips build system.
 Run `./update.sh` to update this copy of libnsgif from the upstream repo. It
 will also patch libnsgif.c to prevent it modifying the input.
 
-Last updated 4 Apr 2022.
+Last updated 15 Apr 2022.
 
 # To do
 

--- a/libvips/foreign/libnsgif/gif.c
+++ b/libvips/foreign/libnsgif/gif.c
@@ -471,7 +471,8 @@ static nsgif_error nsgif__decode_complex(
 			while (available == 0) {
 				if (res != LZW_OK) {
 					/* Unexpected end of frame, try to recover */
-					if (res == LZW_OK_EOD) {
+					if (res == LZW_OK_EOD ||
+					    res == LZW_EOI_CODE) {
 						ret = NSGIF_OK;
 					} else {
 						ret = nsgif__error_from_lzw(res);
@@ -524,7 +525,7 @@ static nsgif_error nsgif__decode_simple(
 		uint32_t *restrict frame_data,
 		uint32_t *restrict colour_table)
 {
-	uint32_t pixels = gif->info.width * height;
+	uint32_t pixels;
 	uint32_t written = 0;
 	nsgif_error ret = NSGIF_OK;
 	lzw_result res;
@@ -549,6 +550,7 @@ static nsgif_error nsgif__decode_simple(
 	}
 
 	frame_data += (offset_y * gif->info.width);
+	pixels = gif->info.width * height;
 
 	while (pixels > 0) {
 		res = lzw_decode_map(gif->lzw_ctx,
@@ -557,7 +559,7 @@ static nsgif_error nsgif__decode_simple(
 		frame_data += written;
 		if (res != LZW_OK) {
 			/* Unexpected end of frame, try to recover */
-			if (res == LZW_OK_EOD) {
+			if (res == LZW_OK_EOD || res == LZW_EOI_CODE) {
 				ret = NSGIF_OK;
 			} else {
 				ret = nsgif__error_from_lzw(res);

--- a/libvips/foreign/libnsgif/test/nsgif.c
+++ b/libvips/foreign/libnsgif/test/nsgif.c
@@ -149,11 +149,12 @@ static void print_gif_info(const nsgif_info_t *info)
 	fprintf(stdout, "  frames:\n");
 }
 
-static void print_gif_frame_info(const nsgif_frame_info_t *info)
+static void print_gif_frame_info(const nsgif_frame_info_t *info, uint32_t i)
 {
 	const char *disposal = nsgif_str_disposal(info->disposal);
 
-	fprintf(stdout, "  - disposal-method: %s\n", disposal);
+	fprintf(stdout, "  - frame: %"PRIu32"\n", i);
+	fprintf(stdout, "    disposal-method: %s\n", disposal);
 	fprintf(stdout, "    transparency: %s\n", info->transparency ? "yes" : "no");
 	fprintf(stdout, "    display: %s\n", info->display ? "yes" : "no");
 	fprintf(stdout, "    delay: %"PRIu32"\n", info->delay);
@@ -214,13 +215,15 @@ static void decode(FILE* ppm, const char *name, nsgif_t *gif)
 
 			f_info = nsgif_get_frame_info(gif, frame_new);
 			if (f_info != NULL) {
-				print_gif_frame_info(f_info);
+				print_gif_frame_info(f_info, frame_new);
 			}
 		}
 
 		err = nsgif_frame_decode(gif, frame_new, &bitmap);
 		if (err != NSGIF_OK) {
-			warning("nsgif_decode_frame", err);
+			fprintf(stderr, "Frame %"PRIu32": "
+					"nsgif_decode_frame failed: %s\n",
+					frame_new, nsgif_strerror(err));
 			/* Continue decoding the rest of the frames. */
 
 		} else if (ppm != NULL) {


### PR DESCRIPTION
Includes https://github.com/libvips/libvips/pull/2754 which has been [applied upstream](http://git.netsurf-browser.org/libnsgif.git/commit/?id=aa6e2af43ebb898167f6dc0bb8215eacf0a17389).