### PR TITLE
Update LibNSGIF to latest upstream

### DIFF
--- a/libvips/foreign/libnsgif/README.md
+++ b/libvips/foreign/libnsgif/README.md
@@ -8,7 +8,7 @@ but within the libvips build system.
 Run `./update.sh` to update this copy of libnsgif from the upstream repo. It
 will also patch libnsgif.c to prevent it modifying the input.
 
-Last updated 15 Apr 2022.
+Last updated 8 May 2022.
 
 # To do
 

--- a/libvips/foreign/nsgifload.c
+++ b/libvips/foreign/nsgifload.c
@@ -201,6 +201,7 @@ print_frame( const nsgif_frame_info_t *frame_info )
 
 	printf( "frame_info:\n" );
 	printf( "  display = %d\n", frame_info->display );
+	printf( "  local_palette = %d\n", frame_info->local_palette );
 	printf( "  transparency = %d\n", frame_info->transparency );
 	printf( "  disposal = %d (%s)\n", 
 		frame_info->disposal, 
@@ -222,6 +223,7 @@ print_animation( nsgif_t *anim, const nsgif_info_t *info )
 	printf( "  width = %d\n", info->width );
 	printf( "  height = %d\n", info->height );
 	printf( "  frame_count = %d\n", info->frame_count );
+	printf( "  global_palette = %d\n", info->global_palette );
 	printf( "  loop_max = %d\n", info->loop_max );
 	printf( "  background = %d %d %d %d\n",
 		bg[0], bg[1], bg[2], bg[3] );


### PR DESCRIPTION
This adds access to palette info, as required by #2576.

The upstream test decoder also has a new `-p` option to save images of the palettes.