### PR TITLE
Allow to modify/create EXIF 2.3 ASCII tags

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -1467,6 +1467,14 @@ if test x"$with_libexif" != x"no"; then
     [AC_DEFINE(HAVE_EXIF,1,[define if you have libexif >= 0.6 installed.])
      with_libexif=yes
      PACKAGES_USED="$PACKAGES_USED libexif"
+
+     # 0.6.22 adds a couple of EXIF 2.3 ASCII tags
+     PKG_CHECK_MODULES(EXIF_2_3_ASCII_TAGS, libexif >= 0.6.22,
+       [AC_DEFINE(HAVE_EXIF_2_3_ASCII_TAGS,1,[define if your libexif has EXIF 2.3 ASCII tags.])
+       ],
+       [:
+       ]
+     )
     ],
     [AC_MSG_WARN([libexif >= 0.6 not found; disabling exif support])
      with_libexif=no

--- a/libvips/foreign/exif.c
+++ b/libvips/foreign/exif.c
@@ -776,7 +776,15 @@ tag_is_ascii( ExifTag tag )
 		tag == EXIF_TAG_DATE_TIME_DIGITIZED ||
 		tag == EXIF_TAG_SUB_SEC_TIME ||
 		tag == EXIF_TAG_SUB_SEC_TIME_ORIGINAL ||
-		tag == EXIF_TAG_SUB_SEC_TIME_DIGITIZED );
+		tag == EXIF_TAG_SUB_SEC_TIME_DIGITIZED
+#ifdef HAVE_EXIF_2_3_ASCII_TAGS
+		|| tag == EXIF_TAG_CAMERA_OWNER_NAME
+		|| tag == EXIF_TAG_BODY_SERIAL_NUMBER
+		|| tag == EXIF_TAG_LENS_MAKE
+		|| tag == EXIF_TAG_LENS_MODEL
+		|| tag == EXIF_TAG_LENS_SERIAL_NUMBER
+#endif
+		);
 }
 
 static gboolean

--- a/meson.build
+++ b/meson.build
@@ -267,6 +267,10 @@ if libexif_dep.found()
         # libexif includes don't need libexif prefix
         cfg_var.set('UNTAGGED_EXIF', '1')
     endif
+    # 0.6.22 adds a couple of EXIF 2.3 ASCII tags
+    if libexif_dep.version().version_compare('>=0.6.22')
+        cfg_var.set('HAVE_EXIF_2_3_ASCII_TAGS', '1')
+    endif
 endif
 
 

--- a/test/test-suite/test_foreign.py
+++ b/test/test-suite/test_foreign.py
@@ -344,6 +344,29 @@ class TestForeign:
             im = pyvips.Image.new_from_buffer(buf, "")
             exif_removed(im)
 
+    @skip_if_no("jpegsave")
+    @pytest.mark.xfail(raises=AttributeError, reason="requires libexif >= 0.6.22")
+    def test_jpegsave_exif_2_3_ascii(self):
+        def exif_valid(im):
+            assert im.get("exif-ifd2-CameraOwnerName").find("ASCII, 14 components, 14 bytes") != -1
+            assert im.get("exif-ifd2-BodySerialNumber").find("ASCII, 14 components, 14 bytes") != -1
+            assert im.get("exif-ifd2-LensMake").find("ASCII, 14 components, 14 bytes") != -1
+            assert im.get("exif-ifd2-LensModel").find("ASCII, 14 components, 14 bytes") != -1
+            assert im.get("exif-ifd2-LensSerialNumber").find("ASCII, 14 components, 14 bytes") != -1
+
+        # first make sure we have exif support
+        im = pyvips.Image.new_from_file(JPEG_FILE)
+        if im.get_typeof("exif-ifd0-Orientation") != 0:
+            x = im.copy()
+            x.set_type(pyvips.GValue.gstr_type, "exif-ifd2-CameraOwnerName", "hello ( there")
+            x.set_type(pyvips.GValue.gstr_type, "exif-ifd2-BodySerialNumber", "hello ( there")
+            x.set_type(pyvips.GValue.gstr_type, "exif-ifd2-LensMake", "hello ( there")
+            x.set_type(pyvips.GValue.gstr_type, "exif-ifd2-LensModel", "hello ( there")
+            x.set_type(pyvips.GValue.gstr_type, "exif-ifd2-LensSerialNumber", "hello ( there")
+            buf = x.jpegsave_buffer()
+            y = pyvips.Image.new_from_buffer(buf, "")
+            exif_valid(y)
+
     @skip_if_no("jpegload")
     def test_truncated(self):
         # This should open (there's enough there for the header)

--- a/test/test-suite/test_foreign.py
+++ b/test/test-suite/test_foreign.py
@@ -345,7 +345,7 @@ class TestForeign:
             exif_removed(im)
 
     @skip_if_no("jpegsave")
-    @pytest.mark.xfail(raises=AttributeError, reason="requires libexif >= 0.6.22")
+    @pytest.mark.xfail(raises=pyvips.error.Error, reason="requires libexif >= 0.6.22")
     def test_jpegsave_exif_2_3_ascii(self):
         def exif_valid(im):
             assert im.get("exif-ifd2-CameraOwnerName").find("ASCII, 14 components, 14 bytes") != -1


### PR DESCRIPTION
Make `tag_is_ascii` aware of the EXIF 2.3 ASCII tags that are
available since libexif 0.6.22.

See: https://github.com/kleisauke/net-vips/issues/167