### PR TITLE
Allow to modify/create EXIF OffsetTime* tags

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -1469,8 +1469,16 @@ if test x"$with_libexif" != x"no"; then
      PACKAGES_USED="$PACKAGES_USED libexif"
 
      # 0.6.22 adds a couple of EXIF 2.3 ASCII tags
-     PKG_CHECK_MODULES(EXIF_2_3_ASCII_TAGS, libexif >= 0.6.22,
-       [AC_DEFINE(HAVE_EXIF_2_3_ASCII_TAGS,1,[define if your libexif has EXIF 2.3 ASCII tags.])
+     PKG_CHECK_MODULES(EXIF_0_6_22, libexif >= 0.6.22,
+       [AC_DEFINE(HAVE_EXIF_0_6_22,1,[define if you have libexif >= 0.6.22])
+       ],
+       [:
+       ]
+     )
+
+     # 0.6.23 adds some OffsetTime* ASCII tags
+     PKG_CHECK_MODULES(EXIF_0_6_23, libexif >= 0.6.23,
+       [AC_DEFINE(HAVE_EXIF_0_6_23,1,[define if you have libexif >= 0.6.23])
        ],
        [:
        ]

--- a/libvips/foreign/exif.c
+++ b/libvips/foreign/exif.c
@@ -777,12 +777,17 @@ tag_is_ascii( ExifTag tag )
 		tag == EXIF_TAG_SUB_SEC_TIME ||
 		tag == EXIF_TAG_SUB_SEC_TIME_ORIGINAL ||
 		tag == EXIF_TAG_SUB_SEC_TIME_DIGITIZED
-#ifdef HAVE_EXIF_2_3_ASCII_TAGS
+#ifdef HAVE_EXIF_0_6_22
 		|| tag == EXIF_TAG_CAMERA_OWNER_NAME
 		|| tag == EXIF_TAG_BODY_SERIAL_NUMBER
 		|| tag == EXIF_TAG_LENS_MAKE
 		|| tag == EXIF_TAG_LENS_MODEL
 		|| tag == EXIF_TAG_LENS_SERIAL_NUMBER
+#endif
+#ifdef HAVE_EXIF_0_6_23
+		|| tag == EXIF_TAG_OFFSET_TIME
+		|| tag == EXIF_TAG_OFFSET_TIME_ORIGINAL
+		|| tag == EXIF_TAG_OFFSET_TIME_DIGITIZED
 #endif
 		);
 }

--- a/meson.build
+++ b/meson.build
@@ -269,7 +269,11 @@ if libexif_dep.found()
     endif
     # 0.6.22 adds a couple of EXIF 2.3 ASCII tags
     if libexif_dep.version().version_compare('>=0.6.22')
-        cfg_var.set('HAVE_EXIF_2_3_ASCII_TAGS', '1')
+        cfg_var.set('HAVE_EXIF_0_6_22', '1')
+    endif
+    # 0.6.23 adds some OffsetTime* ASCII tags
+    if libexif_dep.version().version_compare('>=0.6.23')
+        cfg_var.set('HAVE_EXIF_0_6_23', '1')
     endif
 endif
 


### PR DESCRIPTION
Available since libexif 0.6.23.

Noticed this while working on PR https://github.com/libexif/libexif/pull/85.

Context: https://github.com/libvips/libvips/pull/2795.