### PR TITLE
cgifsave: reuse global palette, if possible

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -22,6 +22,7 @@
 - add "gap" option to vips_reduce[hv]() and vips_resize() [kleisauke]
 - add "ceil" option to vips_shrink() [kleisauke]
 - quality improvements for image resizing [kleisauke]
+- add reoptimise to gifsave [dloebl]
 
 
 26/11/21 started 8.12.3

--- a/libvips/foreign/cgifsave.c
+++ b/libvips/foreign/cgifsave.c
@@ -615,8 +615,12 @@ vips_foreign_save_cgif_build( VipsObject *object )
 		tmp_image = vips__quantise_image_create_rgba( cgif->attr,
 			tmp_gct, gct_length + 1, 1, 0 );
 
-		vips__quantise_image_quantize( tmp_image,
-			cgif->attr, &cgif->quantisation_result );
+		if( vips__quantise_image_quantize( tmp_image,
+		       cgif->attr, &cgif->quantisation_result ) ) {
+		       vips_error( class->nickname,
+		       	"%s", _( "quantisation failed" ) );
+		       return( -1 );
+		}
 		VIPS_FREE( tmp_gct );
 		VIPS_FREEF( vips__quantise_image_destroy, tmp_image );
 	}

--- a/libvips/foreign/cgifsave.c
+++ b/libvips/foreign/cgifsave.c
@@ -894,6 +894,7 @@ vips_foreign_save_cgif_buffer_init( VipsForeignSaveCgifBuffer *buffer )
  * * @effort: %gint, quantisation CPU effort
  * * @bitdepth: %gint, number of bits per pixel
  * * @maxerror: %gdouble, maximum inter-frame error for transparency
+ * * @reoptimise: %gboolean, reoptimise colour palettes
  *
  * Write to a file in GIF format.
  *
@@ -940,6 +941,7 @@ vips_gifsave( VipsImage *in, const char *filename, ... )
  * * @effort: %gint, quantisation CPU effort
  * * @bitdepth: %gint, number of bits per pixel
  * * @maxerror: %gdouble, maximum inter-frame error for transparency
+ * * @reoptimise: %gboolean, reoptimise colour palettes
  *
  * As vips_gifsave(), but save to a memory buffer.
  *
@@ -991,6 +993,7 @@ vips_gifsave_buffer( VipsImage *in, void **buf, size_t *len, ... )
  * * @effort: %gint, quantisation CPU effort
  * * @bitdepth: %gint, number of bits per pixel
  * * @maxerror: %gdouble, maximum inter-frame error for transparency
+ * * @reoptimise: %gboolean, reoptimise colour palettes
  *
  * As vips_gifsave(), but save to a target.
  *

--- a/libvips/foreign/cgifsave.c
+++ b/libvips/foreign/cgifsave.c
@@ -63,6 +63,7 @@ typedef struct _VipsForeignSaveCgif {
 	int effort;
 	int bitdepth;
 	double maxerror;
+	gboolean reuse_palette;
 	VipsTarget *target;
 
 	/* Derived write params.
@@ -236,7 +237,8 @@ vips_foreign_save_cgif_write_frame( VipsForeignSaveCgif *cgif )
 	cgif->input_image = vips__quantise_image_create_rgba( cgif->attr,
 		frame_bytes, frame_rect->width, frame_rect->height, 0 );
 
-	if( !cgif->gct && vips_image_get_typeof( cgif->in, "gif-palette" ) ) {
+	if( cgif->reuse_palette && !cgif->gct &&
+		vips_image_get_typeof( cgif->in, "gif-palette" ) ) {
 		VipsQuantiseImage *tmp_image;
 		int *tmp_gct;
 
@@ -683,6 +685,14 @@ vips_foreign_save_cgif_class_init( VipsForeignSaveCgifClass *class )
 		VIPS_ARGUMENT_OPTIONAL_INPUT,
 		G_STRUCT_OFFSET( VipsForeignSaveCgif, maxerror ),
 		0, 32, 0.0 );
+
+	VIPS_ARG_BOOL( class, "reuse_palette", 14,
+		_( "Reuse palettes" ),
+		_( "Reuse attached palette. It's faster and the file size \
+is better, but the quality might be reduced" ),
+		VIPS_ARGUMENT_OPTIONAL_INPUT,
+		G_STRUCT_OFFSET( VipsForeignSaveCgif, reuse_palette ),
+		FALSE );
 }
 
 static void
@@ -692,6 +702,7 @@ vips_foreign_save_cgif_init( VipsForeignSaveCgif *gif )
 	gif->effort = 7;
 	gif->bitdepth = 8;
 	gif->maxerror = 0.0;
+	gif->reuse_palette = FALSE;
 }
 
 typedef struct _VipsForeignSaveCgifTarget {

--- a/libvips/foreign/cgifsave.c
+++ b/libvips/foreign/cgifsave.c
@@ -597,7 +597,8 @@ vips_foreign_save_cgif_build( VipsObject *object )
 	vips__quantise_set_speed( cgif->attr, 11 - cgif->effort );
 
 	if( !cgif->reoptimise &&
-		vips_image_get_typeof( cgif->in, "gif-palette" ) ) {
+		vips_image_get_typeof( cgif->in, "gif-palette" ) &&
+		vips_image_get_typeof( cgif->in, "use-lct" ) ) {
 		VipsQuantiseImage *tmp_image;
 		int *tmp_gct;
 

--- a/libvips/foreign/cgifsave.c
+++ b/libvips/foreign/cgifsave.c
@@ -597,8 +597,7 @@ vips_foreign_save_cgif_build( VipsObject *object )
 	vips__quantise_set_speed( cgif->attr, 11 - cgif->effort );
 
 	if( !cgif->reoptimise &&
-		vips_image_get_typeof( cgif->in, "gif-palette" ) &&
-		vips_image_get_typeof( cgif->in, "use-lct" ) ) {
+		vips_image_get_typeof( cgif->in, "gif-palette" ) ) {
 		VipsQuantiseImage *tmp_image;
 		int *tmp_gct;
 

--- a/libvips/foreign/cgifsave.c
+++ b/libvips/foreign/cgifsave.c
@@ -73,8 +73,8 @@ typedef struct _VipsForeignSaveCgif {
 	int *delay;
 	int delay_length;
 	int loop;
-	int *gct;
-	int gct_length;
+	int *global_colour_table;
+	int global_colour_table_length;
 
 	/* We save ->ready a frame at a time, regenerating the 
 	 * palette if we see a significant frame to frame change. 
@@ -251,7 +251,7 @@ vips_foreign_save_cgif_write_frame( VipsForeignSaveCgif *cgif )
 	 *
 	 * frame_sum 0 means no current colourmap.
 	 */
-	if( !cgif->gct ) {
+	if( !cgif->global_colour_table ) {
 		sum = 0;
 		p = frame_bytes;
 		for( i = 0; i < n_pels; i++ ) {
@@ -596,19 +596,24 @@ vips_foreign_save_cgif_build( VipsObject *object )
 		vips_image_get_typeof( cgif->in, "gif-palette" ) ) {
 		VipsQuantiseImage *tmp_image;
 		int *tmp_gct;
+		int *gct;
+		int gct_length;
 
 		vips_image_get_array_int( cgif->in, "gif-palette",
-			&cgif->gct, &cgif->gct_length );
+			&cgif->global_colour_table,
+			&cgif->global_colour_table_length);
+		gct = cgif->global_colour_table;
+		gct_length = cgif->global_colour_table_length;
 
 		/* Attach fake alpha channel.
 		 * That's necessary, because we do not know whether there is an
 		 * alpha channel before processing the animation.
 		 */
-		tmp_gct = g_malloc((cgif->gct_length + 1) * sizeof(int));
-		memcpy(tmp_gct, cgif->gct, cgif->gct_length * sizeof(int));
-		tmp_gct[cgif->gct_length] = 0;
+		tmp_gct = g_malloc((gct_length + 1) * sizeof(int));
+		memcpy(tmp_gct, gct, gct_length * sizeof(int));
+		tmp_gct[gct_length] = 0;
 		tmp_image = vips__quantise_image_create_rgba( cgif->attr,
-			tmp_gct, cgif->gct_length + 1, 1, 0 );
+			tmp_gct, gct_length + 1, 1, 0 );
 
 		/* Quantize attached global palette
 		 */

--- a/libvips/foreign/cgifsave.c
+++ b/libvips/foreign/cgifsave.c
@@ -75,8 +75,6 @@ typedef struct _VipsForeignSaveCgif {
 	int loop;
 	int *gct;
 	int gct_length;
-	int *use_lct;
-	int use_lct_length;
 
 	/* We save ->ready a frame at a time, regenerating the 
 	 * palette if we see a significant frame to frame change. 
@@ -239,6 +237,31 @@ vips_foreign_save_cgif_write_frame( VipsForeignSaveCgif *cgif )
 	cgif->input_image = vips__quantise_image_create_rgba( cgif->attr,
 		frame_bytes, frame_rect->width, frame_rect->height, 0 );
 
+	if( !cgif->reoptimise && !cgif->gct &&
+		vips_image_get_typeof( cgif->in, "gif-palette" ) ) {
+		VipsQuantiseImage *tmp_image;
+		int *tmp_gct;
+
+		vips_image_get_array_int( cgif->in, "gif-palette",
+			&cgif->gct, &cgif->gct_length );
+
+		/* Attach fake alpha channel.
+		 * That's necessary, because we do not know whether there is an
+		 * alpha channel before processing the animation.
+		 */
+		tmp_gct = g_malloc((cgif->gct_length + 1) * sizeof(int));
+		memcpy(tmp_gct, cgif->gct, cgif->gct_length * sizeof(int));
+		tmp_gct[cgif->gct_length] = 0;
+		tmp_image = vips__quantise_image_create_rgba( cgif->attr,
+			tmp_gct, cgif->gct_length + 1, 1, 0 );
+
+		/* Quantize attached global palette
+		 */
+		vips__quantise_image_quantize( tmp_image,
+			cgif->attr, &cgif->quantisation_result );
+		VIPS_FREE( tmp_gct );
+		VIPS_FREEF( vips__quantise_image_destroy, tmp_image );
+	}
 	/* Threshold the alpha channel. It's safe to modify the region since 
 	 * it's a buffer we made.
 	 */
@@ -253,7 +276,7 @@ vips_foreign_save_cgif_write_frame( VipsForeignSaveCgif *cgif )
 	 *
 	 * frame_sum 0 means no current colourmap.
 	 */
-	if( !cgif->gct || ( cgif->use_lct && cgif->use_lct[page_index] ) ) {
+	if( !cgif->gct ) {
 		sum = 0;
 		p = frame_bytes;
 		for( i = 0; i < n_pels; i++ ) {
@@ -293,10 +316,6 @@ vips_foreign_save_cgif_write_frame( VipsForeignSaveCgif *cgif )
 			cgif->n_cmaps_generated += 1;
 #endif/*DEBUG_PERCENT*/
 		}
-	} else {
-		/* Reset frame_sum
-		 */
-		cgif->frame_sum = 0;
 	}
 	/* Dither frame.
 	 */
@@ -595,34 +614,6 @@ vips_foreign_save_cgif_build( VipsObject *object )
 	vips__quantise_set_max_colors( cgif->attr, (1 << cgif->bitdepth) - 1 );
 	vips__quantise_set_quality( cgif->attr, 0, 100 );
 	vips__quantise_set_speed( cgif->attr, 11 - cgif->effort );
-
-	if( !cgif->reoptimise &&
-		vips_image_get_typeof( cgif->in, "gif-palette" ) ) {
-		VipsQuantiseImage *tmp_image;
-		int *tmp_gct;
-
-		vips_image_get_array_int( cgif->in, "gif-palette",
-			&cgif->gct, &cgif->gct_length );
-		vips_image_get_array_int( cgif->in, "use-lct",
-			&cgif->use_lct, &cgif->use_lct_length );
-
-		/* Attach fake alpha channel.
-		 * That's necessary, because we do not know whether there is an
-		 * alpha channel before processing the animation.
-		 */
-		tmp_gct = g_malloc((cgif->gct_length + 1) * sizeof(int));
-		memcpy(tmp_gct, cgif->gct, cgif->gct_length * sizeof(int));
-		tmp_gct[cgif->gct_length] = 0;
-		tmp_image = vips__quantise_image_create_rgba( cgif->attr,
-			tmp_gct, cgif->gct_length + 1, 1, 0 );
-
-		/* Quantize attached global palette
-		 */
-		vips__quantise_image_quantize( tmp_image,
-			cgif->attr, &cgif->quantisation_result );
-		VIPS_FREE( tmp_gct );
-		VIPS_FREEF( vips__quantise_image_destroy, tmp_image );
-	}
 
 	/* Set up cgif on first use.
 	 */

--- a/libvips/foreign/cgifsave.c
+++ b/libvips/foreign/cgifsave.c
@@ -63,7 +63,7 @@ typedef struct _VipsForeignSaveCgif {
 	int effort;
 	int bitdepth;
 	double maxerror;
-	gboolean reuse_palette;
+	gboolean reoptimise;
 	VipsTarget *target;
 
 	/* Derived write params.
@@ -237,7 +237,7 @@ vips_foreign_save_cgif_write_frame( VipsForeignSaveCgif *cgif )
 	cgif->input_image = vips__quantise_image_create_rgba( cgif->attr,
 		frame_bytes, frame_rect->width, frame_rect->height, 0 );
 
-	if( cgif->reuse_palette && !cgif->gct &&
+	if( !cgif->reoptimise && !cgif->gct &&
 		vips_image_get_typeof( cgif->in, "gif-palette" ) ) {
 		VipsQuantiseImage *tmp_image;
 		int *tmp_gct;
@@ -686,12 +686,11 @@ vips_foreign_save_cgif_class_init( VipsForeignSaveCgifClass *class )
 		G_STRUCT_OFFSET( VipsForeignSaveCgif, maxerror ),
 		0, 32, 0.0 );
 
-	VIPS_ARG_BOOL( class, "reuse_palette", 14,
-		_( "Reuse palettes" ),
-		_( "Reuse attached palette. It's faster and the file size \
-is better, but the quality might be reduced" ),
+	VIPS_ARG_BOOL( class, "reoptimise", 14,
+		_( "Reoptimise palettes" ),
+		_( "Reoptimise colour palettes" ),
 		VIPS_ARGUMENT_OPTIONAL_INPUT,
-		G_STRUCT_OFFSET( VipsForeignSaveCgif, reuse_palette ),
+		G_STRUCT_OFFSET( VipsForeignSaveCgif, reoptimise ),
 		FALSE );
 }
 
@@ -702,7 +701,7 @@ vips_foreign_save_cgif_init( VipsForeignSaveCgif *gif )
 	gif->effort = 7;
 	gif->bitdepth = 8;
 	gif->maxerror = 0.0;
-	gif->reuse_palette = FALSE;
+	gif->reoptimise = FALSE;
 }
 
 typedef struct _VipsForeignSaveCgifTarget {

--- a/libvips/foreign/cgifsave.c
+++ b/libvips/foreign/cgifsave.c
@@ -590,7 +590,7 @@ vips_foreign_save_cgif_build( VipsObject *object )
 	vips__quantise_set_quality( cgif->attr, 0, 100 );
 	vips__quantise_set_speed( cgif->attr, 11 - cgif->effort );
 
-	/* Quantize attached global palette (if present)
+	/* Initialise quantization result using global palette.
 	 */
 	if( !cgif->reoptimise &&
 		vips_image_get_typeof( cgif->in, "gif-palette" ) ) {
@@ -615,8 +615,6 @@ vips_foreign_save_cgif_build( VipsObject *object )
 		tmp_image = vips__quantise_image_create_rgba( cgif->attr,
 			tmp_gct, gct_length + 1, 1, 0 );
 
-		/* Quantize attached global palette
-		 */
 		vips__quantise_image_quantize( tmp_image,
 			cgif->attr, &cgif->quantisation_result );
 		VIPS_FREE( tmp_gct );

--- a/libvips/foreign/nsgifload.c
+++ b/libvips/foreign/nsgifload.c
@@ -121,6 +121,11 @@ typedef struct _VipsForeignLoadNsgif {
 	 */
 	int *delay;
 
+	/* Whether a frame uses the global- or a local-palette.
+	 * Array of length @info->frame_count.
+	 */
+	int *use_lct;
+
 	/* A single centisecond value for compatibility.
 	 */
 	int gif_delay;
@@ -128,10 +133,6 @@ typedef struct _VipsForeignLoadNsgif {
 	/* If the GIF contains any frames with transparent elements.
 	 */
 	gboolean has_transparency;
-
-	/* If the GIF has any local palettes.
-	 */
-	gboolean local_palette;
 
 	/* The current frame bitmap and the frame number for it.
 	 */
@@ -165,6 +166,7 @@ vips_foreign_load_nsgif_dispose( GObject *gobject )
 	}
 	VIPS_UNREF( gif->source );
 	VIPS_FREE( gif->delay );
+	VIPS_FREE( gif->use_lct );
 
 	G_OBJECT_CLASS( vips_foreign_load_nsgif_parent_class )->
 		dispose( gobject );
@@ -295,16 +297,17 @@ vips_foreign_load_nsgif_set_header( VipsForeignLoadNsgif *gif,
 	 */
 	vips_image_set_int( image, "gif-delay", gif->gif_delay ); 
 
-	/* If there are no local palettes, we can attach the global palette as
-	 * metadata.
+	/* Attach the global palette (if present).
 	 */
-	if( !gif->local_palette ) {
+	if( gif->info->global_palette ) {
 		size_t entries;
 		uint32_t table[NSGIF_MAX_COLOURS];
 
 		nsgif_global_palette( gif->anim, table, &entries );
 		vips_image_set_array_int( image, "gif-palette", 
-			(const int *) table, entries ); 
+			(const int *) table, entries );
+		vips_image_set_array_int( image, "use-lct",
+			gif->use_lct, gif->info->frame_count );
 	}
 
 	return( 0 );
@@ -357,6 +360,10 @@ vips_foreign_load_nsgif_header( VipsForeignLoad *load )
 
 	/* Check for any transparency.
 	 */
+	VIPS_FREE( gif->use_lct );
+	if( !(gif->use_lct = VIPS_ARRAY( NULL,
+		gif->info->frame_count, int )) )
+		return( -1 );
 	for( i = 0; i < gif->info->frame_count; i++ ) {
 		const nsgif_frame_info_t *frame_info;
 
@@ -364,7 +371,7 @@ vips_foreign_load_nsgif_header( VipsForeignLoad *load )
 			if( frame_info->transparency ) 
 				gif->has_transparency = TRUE;
 			if( frame_info->local_palette ) 
-				gif->local_palette = TRUE;
+				gif->use_lct[i] = TRUE;
 		}
 	}
 


### PR DESCRIPTION
For reference: [2576#comment](https://github.com/libvips/libvips/issues/2576#issuecomment-1121206055)
Reuse the global palette in `gifsave` if it has been attached during `gifload`.
This should both improve the file size and processing time for many GIF -> GIF operations.


@jcupitt **Notes / Questions:**
1. [Quantizing the attached global palette](https://github.com/dloebl/libvips/blob/75b08f3bce9f7a42a60e7859824cabb3c483d549/libvips/foreign/cgifsave.c#L256) to get a `VipsQuantiseResult` feels a bit hacky. Maybe there is a better way to do it?
2. As we probably don't want to enable this new behaviour for any kind of GIF -> GIF operation, should we add a parameter to `gifsave` to enable/disable global palette reuse?
3. Dithering seems to cause colour artifacts with certain GIFs:
$ vipsthumbnail --size 200x [phone.gif](https://user-images.githubusercontent.com/34104349/165298655-f26d5afe-7179-42a5-8029-56490bf6fecf.gif)[n=-1] -o out.gif

**Results:**
GIF used: [earth.gif](https://upload.wikimedia.org/wikipedia/commons/2/2c/Rotating_earth_%28large%29.gif)

**Before:**
`$ time vipsthumbnail --size 200x earth.gif[n=-1] -o old.gif`
`518ms total`

**After:**
`$ time vipsthumbnail --size 200x earth.gif[n=-1] -o new.gif`
`219ms total`

`$ du -h old.gif new.gif` 
`580K	old.gif`
`456K	new.gif`
