### PR TITLE
Don't fail if PNG contains too many text chunks

### DIFF
--- a/libvips/foreign/spngload.c
+++ b/libvips/foreign/spngload.c
@@ -258,9 +258,9 @@ vips_foreign_load_png_set_header( VipsForeignLoadPng *png, VipsImage *image )
 		 */
 
 		if( !png->unlimited && n_text > MAX_PNG_TEXT_CHUNKS ) {
-			vips_error( class->nickname, 
-				"%s", _( "too many text chunks" ) );
-			return( -1 );
+			g_warning(_( "%d text chunks, only %d text chunks will be loaded" ),
+					n_text, MAX_PNG_TEXT_CHUNKS );
+			n_text = MAX_PNG_TEXT_CHUNKS;
 		}
 
 		text = VIPS_ARRAY( VIPS_OBJECT( png ), 

--- a/libvips/foreign/vipspng.c
+++ b/libvips/foreign/vipspng.c
@@ -581,10 +581,9 @@ png2vips_header( Read *read, VipsImage *out )
 		 */
 		if( !read->unlimited && 
 			num_text > MAX_PNG_TEXT_CHUNKS ) {
-			vips_error( "vipspng", 
-				_( "%d text chunks, image blocked" ),
-			       num_text );
-			return( -1 );
+			g_warning(_( "%d text chunks, only %d text chunks will be loaded" ),
+					num_text, MAX_PNG_TEXT_CHUNKS );
+			num_text = MAX_PNG_TEXT_CHUNKS;
 		}
 
 		for( i = 0; i < num_text; i++ ) 


### PR DESCRIPTION
Hey!

One of imgproxy users gave me a sample of proper PNG with 61 text chunks that expectedly is rejected by vips. First I was going to increase the text chunks limit. But then I thought that we already loaded text chunks at the moment of their number check. So if we have too many text chunks, we can just throw a warning, get the maximum allowed text chunks, and set them to the vips image. It doesn't seem to me that we SHOULD return an error in this case.

WDYT?