### PR TITLE
webpsave: add parameter for mixed encoding

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -21,6 +21,7 @@
 - add "gap" option to vips_reduce[hv]() and vips_resize() [kleisauke]
 - add "ceil" option to vips_shrink() [kleisauke]
 - quality improvements for image resizing [kleisauke]
+- add "mixed" to webpsave [dloebl]
 
 26/11/21 started 8.12.3
 - better arg checking for vips_hist_find_ndim() [travisbell]

--- a/libvips/foreign/pforeign.h
+++ b/libvips/foreign/pforeign.h
@@ -214,7 +214,7 @@ int vips__webp_write_target( VipsImage *image, VipsTarget *target,
 	int Q, gboolean lossless, VipsForeignWebpPreset preset,
 	gboolean smart_subsample, gboolean near_lossless,
 	int alpha_q, int effort,
-	gboolean min_size, int kmin, int kmax,
+	gboolean min_size, gboolean mixed, int kmin, int kmax,
 	gboolean strip, const char *profile );
 
 extern const char *vips_foreign_nifti_suffs[];

--- a/libvips/foreign/vips2webp.c
+++ b/libvips/foreign/vips2webp.c
@@ -87,6 +87,7 @@ typedef struct {
 	int alpha_q;
 	int effort;
 	gboolean min_size;
+	gboolean mixed;
 	int kmin;
 	int kmax;
 	gboolean strip;
@@ -148,7 +149,7 @@ vips_webp_write_init( VipsWebPWrite *write, VipsImage *image,
 	int Q, gboolean lossless, VipsForeignWebpPreset preset,
 	gboolean smart_subsample, gboolean near_lossless,
 	int alpha_q, int effort,
-	gboolean min_size, int kmin, int kmax,
+	gboolean min_size, gboolean mixed, int kmin, int kmax,
 	gboolean strip, const char *profile )
 {
 	write->image = NULL;
@@ -160,6 +161,7 @@ vips_webp_write_init( VipsWebPWrite *write, VipsImage *image,
 	write->alpha_q = alpha_q;
 	write->effort = effort;
 	write->min_size = min_size;
+	write->mixed = mixed;
 	write->kmin = kmin;
 	write->kmax = kmax;
 	write->strip = strip;
@@ -314,7 +316,7 @@ write_webp_anim( VipsWebPWrite *write, VipsImage *image, int page_height )
 	}
 
 	anim_config.minimize_size = write->min_size;
-	anim_config.allow_mixed = write->min_size;
+	anim_config.allow_mixed = write->mixed;
 	anim_config.kmin = write->kmin;
 	anim_config.kmax = write->kmax;
 
@@ -555,14 +557,14 @@ vips__webp_write_target( VipsImage *image, VipsTarget *target,
 	int Q, gboolean lossless, VipsForeignWebpPreset preset,
 	gboolean smart_subsample, gboolean near_lossless,
 	int alpha_q, int effort,
-	gboolean min_size, int kmin, int kmax,
+	gboolean min_size, gboolean mixed, int kmin, int kmax,
 	gboolean strip, const char *profile )
 {
 	VipsWebPWrite write;
 
 	if( vips_webp_write_init( &write, image,
 		Q, lossless, preset, smart_subsample, near_lossless,
-		alpha_q, effort, min_size, kmin, kmax, strip,
+		alpha_q, effort, min_size, mixed, kmin, kmax, strip,
 		profile ) )
 		return( -1 );
 

--- a/libvips/foreign/webpsave.c
+++ b/libvips/foreign/webpsave.c
@@ -550,7 +550,7 @@ vips_foreign_save_webp_mime_init( VipsForeignSaveWebpMime *mime )
  * * @alpha_q: %gint, set alpha quality in lossless mode
  * * @effort: %gint, level of CPU effort to reduce file size
  * * @min_size: %gboolean, minimise size
- * * @mixed: %gboolean, allow mixed encoding
+ * * @mixed: %gboolean, allow both lossy and lossless encoding
  * * @kmin: %gint, minimum number of frames between keyframes
  * * @kmax: %gint, maximum number of frames between keyframes
  * * @strip: %gboolean, remove all metadata from image
@@ -584,6 +584,9 @@ vips_foreign_save_webp_mime_init( VipsForeignSaveWebpMime *mime )
  * keyframes. Setting 0 means only keyframes. @kmin sets the minimum number of
  * frames between frames. Setting 0 means no keyframes. By default, keyframes
  * are disabled.
+ *
+ * For animated webp output, @mixed tries to improve the file size by mixing
+ * both lossy and lossless encoding.
  *
  * Use @profile to give the name of a profile to be embedded in the file.
  * This does not affect the pixels which are written, just the way 
@@ -629,7 +632,7 @@ vips_webpsave( VipsImage *in, const char *filename, ... )
  * * @alpha_q: %gint, set alpha quality in lossless mode
  * * @effort: %gint, level of CPU effort to reduce file size
  * * @min_size: %gboolean, minimise size
- * * @mixed: %gboolean, allow mixed encoding
+ * * @mixed: %gboolean, allow both lossy and lossless encoding
  * * @kmin: %gint, minimum number of frames between keyframes
  * * @kmax: %gint, maximum number of frames between keyframes
  * * @strip: %gboolean, remove all metadata from image
@@ -688,6 +691,7 @@ vips_webpsave_buffer( VipsImage *in, void **buf, size_t *len, ... )
  * * @alpha_q: %gint, set alpha quality in lossless mode
  * * @effort: %gint, level of CPU effort to reduce file size
  * * @min_size: %gboolean, minimise size
+ * * @mixed: %gboolean, allow both lossy and lossless encoding
  * * @kmin: %gint, minimum number of frames between keyframes
  * * @kmax: %gint, maximum number of frames between keyframes
  * * @strip: %gboolean, remove all metadata from image
@@ -728,6 +732,7 @@ vips_webpsave_mime( VipsImage *in, ... )
  * * @alpha_q: %gint, set alpha quality in lossless mode
  * * @effort: %gint, level of CPU effort to reduce file size
  * * @min_size: %gboolean, minimise size
+ * * @mixed: %gboolean, allow both lossy and lossless encoding
  * * @kmin: %gint, minimum number of frames between keyframes
  * * @kmax: %gint, maximum number of frames between keyframes
  * * @strip: %gboolean, remove all metadata from image

--- a/libvips/foreign/webpsave.c
+++ b/libvips/foreign/webpsave.c
@@ -95,6 +95,10 @@ typedef struct _VipsForeignSaveWebp {
 	 */
 	gboolean min_size;
 
+	/* Allow mixed encoding (might reduce file size)
+	 */
+	gboolean mixed;
+
 	/* Min between key frames.
 	 */
 	int kmin;
@@ -226,6 +230,13 @@ vips_foreign_save_webp_class_init( VipsForeignSaveWebpClass *class )
 		VIPS_ARGUMENT_OPTIONAL_INPUT | VIPS_ARGUMENT_DEPRECATED,
 		G_STRUCT_OFFSET( VipsForeignSaveWebp, effort ),
 		0, 6, 4 );
+
+	VIPS_ARG_BOOL( class, "mixed", 22,
+		_( "Mixed encoding" ),
+		_( "Allow mixed encoding (might reduce file size)" ),
+		VIPS_ARGUMENT_OPTIONAL_INPUT,
+		G_STRUCT_OFFSET( VipsForeignSaveWebp, mixed ),
+		FALSE );
 }
 
 static void
@@ -269,7 +280,7 @@ vips_foreign_save_webp_target_build( VipsObject *object )
 		webp->Q, webp->lossless, webp->preset,
 		webp->smart_subsample, webp->near_lossless,
 		webp->alpha_q, webp->effort,
-		webp->min_size, webp->kmin, webp->kmax,
+		webp->min_size, webp->mixed, webp->kmin, webp->kmax,
 		save->strip, webp->profile ) )
 		return( -1 );
 
@@ -337,7 +348,7 @@ vips_foreign_save_webp_file_build( VipsObject *object )
 		webp->Q, webp->lossless, webp->preset,
 		webp->smart_subsample, webp->near_lossless,
 		webp->alpha_q, webp->effort,
-		webp->min_size, webp->kmin, webp->kmax,
+		webp->min_size, webp->mixed, webp->kmin, webp->kmax,
 		save->strip, webp->profile ) ) {
 		VIPS_UNREF( target );
 		return( -1 );
@@ -409,7 +420,7 @@ vips_foreign_save_webp_buffer_build( VipsObject *object )
 		webp->Q, webp->lossless, webp->preset,
 		webp->smart_subsample, webp->near_lossless,
 		webp->alpha_q, webp->effort,
-		webp->min_size, webp->kmin, webp->kmax,
+		webp->min_size, webp->mixed, webp->kmin, webp->kmax,
 		save->strip, webp->profile ) ) {
 		VIPS_UNREF( target );
 		return( -1 );
@@ -483,7 +494,7 @@ vips_foreign_save_webp_mime_build( VipsObject *object )
 		webp->Q, webp->lossless, webp->preset,
 		webp->smart_subsample, webp->near_lossless,
 		webp->alpha_q, webp->effort,
-		webp->min_size, webp->kmin, webp->kmax,
+		webp->min_size, webp->mixed, webp->kmin, webp->kmax,
 		save->strip, webp->profile ) ) {
 		VIPS_UNREF( target );
 		return( -1 );
@@ -539,6 +550,7 @@ vips_foreign_save_webp_mime_init( VipsForeignSaveWebpMime *mime )
  * * @alpha_q: %gint, set alpha quality in lossless mode
  * * @effort: %gint, level of CPU effort to reduce file size
  * * @min_size: %gboolean, minimise size
+ * * @mixed: %gboolean, allow mixed encoding
  * * @kmin: %gint, minimum number of frames between keyframes
  * * @kmax: %gint, maximum number of frames between keyframes
  * * @strip: %gboolean, remove all metadata from image
@@ -617,6 +629,7 @@ vips_webpsave( VipsImage *in, const char *filename, ... )
  * * @alpha_q: %gint, set alpha quality in lossless mode
  * * @effort: %gint, level of CPU effort to reduce file size
  * * @min_size: %gboolean, minimise size
+ * * @mixed: %gboolean, allow mixed encoding
  * * @kmin: %gint, minimum number of frames between keyframes
  * * @kmax: %gint, maximum number of frames between keyframes
  * * @strip: %gboolean, remove all metadata from image


### PR DESCRIPTION
We noticed that the `allow_mixed` flag in combination with the `min_size` flag can substantially degrade the encoding time of animated WebP without much improvement on the file size. Allow passing the `allow_mixed` value with a new parameter in `webpsave`.

**Example animation:**
[earth.gif](https://upload.wikimedia.org/wikipedia/commons/2/2c/Rotating_earth_%28large%29.gif)
libwebp version: `v1.2.2`

**Old default `min-size=TRUE` behaviour:**
```
$ time vips copy earth.gif[n=-1] min_mixed.webp[min-size=true,mixed=true]
6.743s
```

**New default `min-size=TRUE` behaviour:**
```
$ time vips copy earth.gif[n=-1] min.webp[min-size=true,mixed=false]
0.758s
```

```
$ du -h min_mixed.webp min.webp
256K	min_mixed.webp
256K	min.webp
```

/cc @gurpreetg