### PR TITLE
Swap size_t with gint64 to catch read errors

### DIFF
--- a/libvips/foreign/matrixload.c
+++ b/libvips/foreign/matrixload.c
@@ -422,7 +422,7 @@ static int
 vips_foreign_load_matrix_source_is_a_source( VipsSource *source )
 {
 	unsigned char *data;
-	size_t bytes_read;
+	gint64 bytes_read;
 	char line[80];
 	int width;
 	int height;

--- a/libvips/foreign/svgload.c
+++ b/libvips/foreign/svgload.c
@@ -664,7 +664,7 @@ gboolean
 vips_foreign_load_svg_source_is_a_source( VipsSource *source )
 {
 	unsigned char *data;
-	size_t bytes_read;
+	gint64 bytes_read;
 
 	if( (bytes_read = vips_source_sniff_at_most( source, 
 		&data, SVG_HEADER_SIZE )) <= 0 )


### PR DESCRIPTION
This is similar to commit 5221df224f573653045799fdb98f8fdc19922f2d. Resolves a segfault in `vips_foreign_find_load_source()` when passing a source that returns `-1` during `read()`.
```
Program received signal SIGSEGV, Segmentation fault.
#0  0x00007ffff7c44b20 in vips_strncpy () at /lib64/libvips.so.42
#1  0x00007ffff7ad0a9d in vips_foreign_load_matrix_source_is_a_source () at /lib64/libvips.so.42
#2  0x00007ffff7abe70c in vips_foreign_find_load_source_sub () at /lib64/libvips.so.42
#3  0x00007ffff7c4483d in vips_slist_map2 () at /lib64/libvips.so.42
#4  0x00007ffff7abe66b in vips_foreign_find_load_source () at /lib64/libvips.so.42
```
