### PR TITLE
jxl: remove support for never-implemented JXL_TYPE_UINT32

### DIFF
--- a/libvips/foreign/jxlload.c
+++ b/libvips/foreign/jxlload.c
@@ -350,10 +350,6 @@ vips_foreign_load_jxl_print_format( JxlPixelFormat *format )
 		printf( "JXL_TYPE_UINT16" );
 		break;
 
-	case JXL_TYPE_UINT32: 
-		printf( "JXL_TYPE_UINT32" );
-		break;
-
 	case JXL_TYPE_FLOAT: 
 		printf( "JXL_TYPE_FLOAT" );
 		break;
@@ -420,10 +416,6 @@ vips_foreign_load_jxl_set_header( VipsForeignLoadJxl *jxl, VipsImage *out )
 
 	case JXL_TYPE_UINT16:
 		format = VIPS_FORMAT_USHORT;
-		break;
-
-	case JXL_TYPE_UINT32:
-		format = VIPS_FORMAT_UINT;
 		break;
 
 	case JXL_TYPE_FLOAT:
@@ -551,8 +543,6 @@ vips_foreign_load_jxl_header( VipsForeignLoad *load )
 			if( jxl->info.exponent_bits_per_sample > 0 ||
 				jxl->info.alpha_exponent_bits > 0 )
 				jxl->format.data_type = JXL_TYPE_FLOAT;
-			else if( jxl->info.bits_per_sample > 16 )
-				jxl->format.data_type = JXL_TYPE_UINT32;
 			else if( jxl->info.bits_per_sample > 8 )
 				jxl->format.data_type = JXL_TYPE_UINT16;
 			else

--- a/libvips/foreign/jxlsave.c
+++ b/libvips/foreign/jxlsave.c
@@ -182,10 +182,6 @@ vips_foreign_save_jxl_print_format( JxlPixelFormat *format )
 		printf( "JXL_TYPE_UINT16" );
 		break;
 
-	case JXL_TYPE_UINT32: 
-		printf( "JXL_TYPE_UINT32" );
-		break;
-
 	case JXL_TYPE_FLOAT: 
 		printf( "JXL_TYPE_FLOAT" );
 		break;
@@ -279,12 +275,6 @@ vips_foreign_save_jxl_build( VipsObject *object )
 		jxl->info.bits_per_sample = 16;
 		jxl->info.exponent_bits_per_sample = 0;
 		jxl->format.data_type = JXL_TYPE_UINT16;
-		break;
-
-	case VIPS_FORMAT_UINT:
-		jxl->info.bits_per_sample = 32;
-		jxl->info.exponent_bits_per_sample = 0;
-		jxl->format.data_type = JXL_TYPE_UINT32;
 		break;
 
 	case VIPS_FORMAT_FLOAT:
@@ -445,9 +435,9 @@ vips_foreign_save_jxl_build( VipsObject *object )
 
 /* Type promotion for save ... unsigned ints + float + double.
  */
-static int bandfmt_jpeg[10] = {
+static int bandfmt_jxl[10] = {
      /* UC   C  US   S  UI   I  F  X  D DX */
-	UC, UC, US, US, UI, UI, F, F, F, F
+	UC, UC, US, US,  F,  F, F, F, F, F
 };
 
 static void
@@ -475,7 +465,7 @@ vips_foreign_save_jxl_class_init( VipsForeignSaveJxlClass *class )
 	foreign_class->suffs = vips__jxl_suffs;
 
 	save_class->saveable = VIPS_SAVEABLE_ANY;
-	save_class->format_table = bandfmt_jpeg;
+	save_class->format_table = bandfmt_jxl;
 
 	VIPS_ARG_INT( class, "tier", 10, 
 		_( "Tier" ), 


### PR DESCRIPTION
This was removed via https://github.com/libjxl/libjxl/pull/1337

Technically it has been deprecated, but can be considered as good as gone due to not being included in the official spec.



