### PR TITLE
Pass close-on-exec flag to lcms for non-Windows OS

### DIFF
--- a/libvips/colour/icc_transform.c
+++ b/libvips/colour/icc_transform.c
@@ -1321,7 +1321,11 @@ vips_icc_ac2rc( VipsImage *in, VipsImage **out, const char *profile_filename )
 	double *mul;
 	int i;
 
+#ifdef G_OS_WIN32
 	if( !(profile = cmsOpenProfileFromFile( profile_filename, "r" )) )
+#else /*!G_OS_WIN32*/
+	if( !(profile = cmsOpenProfileFromFile( profile_filename, "re" )) )
+#endif /*G_OS_WIN32*/
 		return( -1 );
 
 #ifdef DEBUG


### PR DESCRIPTION
This ensures child processes do not inherit open file descriptors and will close a small but long-standing bug reported against sharp over five years ago.

https://github.com/lovell/sharp/issues/674

The change to lcms2 to support this is backwards compatible so the flag will be ignored by existing versions.

https://github.com/mm2/Little-CMS/commit/6ae2e99a3535417ca5c95b602eb61fdd29d294d0

The `fopen()` close-on-exec (`e`) flag will soon be part of the POSIX standard, and is already supported in Linux and BSD. macOS currently ignores it but will have to add support soon to remain POSIX compliant. Only Windows has a problem with it, hence the ifdef wrapper.