### PR TITLE
svgload: recognize dimensions for SVGs without width/height

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -1041,23 +1041,6 @@ if test x"$with_rsvg" != x"no"; then
     AC_DEFINE(HAVE_RSVG,1,[define if you have librsvg-2.0 >= 2.40.3 and cairo >= 1.2 installed.])
     with_rsvg=yes
     PACKAGES_USED="$PACKAGES_USED librsvg-2.0 cairo"
-
-    # 2.46 for rsvg_handle_render_document
-    PKG_CHECK_MODULES(RSVG_HANDLE_RENDER_DOCUMENT, librsvg-2.0 >= 2.46,
-      [AC_DEFINE(HAVE_RSVG_HANDLE_RENDER_DOCUMENT,1,[define if your librsvg has rsvg_handle_render_document().])
-      ],
-      [:
-      ]
-    )
-
-    # 2.52 for rsvg_handle_get_intrinsic_size_in_pixels
-    PKG_CHECK_MODULES(HAVE_RSVG_HANDLE_GET_INTRINSIC_SIZE_IN_PIXELS, librsvg-2.0 >= 2.52,
-      [AC_DEFINE(HAVE_RSVG_HANDLE_GET_INTRINSIC_SIZE_IN_PIXELS,1,[define if your librsvg has rsvg_handle_get_intrinsic_size_in_pixels().])
-      ],
-      [:
-      ]
-    )
-
   ], [
     AC_MSG_WARN([librsvg-2.0 >= 2.40.3 or cairo >= 1.2 not found; disabling SVG load via rsvg])
     with_rsvg=no

--- a/meson.build
+++ b/meson.build
@@ -358,14 +358,6 @@ if librsvg_dep.found() and cairo_dep.found()
     libvips_deps += librsvg_dep
     libvips_deps += cairo_dep
     cfg_var.set('HAVE_RSVG', '1')
-    # 2.46 for rsvg_handle_render_document
-    if librsvg_dep.version().version_compare('>=2.46')
-        cfg_var.set('HAVE_RSVG_HANDLE_RENDER_DOCUMENT', '1')
-    endif
-    # 2.52 for rsvg_handle_get_intrinsic_size_in_pixels
-    if librsvg_dep.version().version_compare('>=2.52')
-        cfg_var.set('HAVE_RSVG_HANDLE_GET_INTRINSIC_SIZE_IN_PIXELS', '1')
-    endif
 endif
 
 openslide_dep = dependency('openslide', version: '>=3.3.0', required: get_option('openslide'))

--- a/test/test-suite/test_foreign.py
+++ b/test/test-suite/test_foreign.py
@@ -995,6 +995,27 @@ class TestForeign:
         assert abs(im.width * 2 - x.width) < 2
         assert abs(im.height * 2 - x.height) < 2
 
+        with pytest.raises(pyvips.error.Error):
+            svg = b'<svg viewBox="0 0 0 0"></svg>'
+            im = pyvips.Image.new_from_buffer(svg, "")
+
+        # recognize dimensions for SVGs without width/height
+        svg = b'<svg viewBox="0 0 100 100"></svg>'
+        im = pyvips.Image.new_from_buffer(svg, "")
+        assert im.width == 100
+        assert im.height == 100
+
+        svg = b'<svg><rect width="100" height="100" /></svg>'
+        im = pyvips.Image.new_from_buffer(svg, "")
+        assert im.width == 100
+        assert im.height == 100
+
+        # width and height of 0.5 is valid
+        svg = b'<svg width="0.5" height="0.5"></svg>'
+        im = pyvips.Image.new_from_buffer(svg, "")
+        assert im.width == 1
+        assert im.height == 1
+
     def test_csv(self):
         self.save_load("%s.csv", self.mono)
 


### PR DESCRIPTION
Rather than defaulting to 1928x1080. Also, prefer to use the
`LIBRSVG_CHECK_VERSION` macro instead of our configure checks.