### PR TITLE
doc: add missing files and use full paths

### DIFF
--- a/cplusplus/meson.build
+++ b/cplusplus/meson.build
@@ -59,6 +59,6 @@ if get_option('doxygen')
         output: 'html',
         command: [doxygen, doxyfile],
         install: true,
-        install_dir: get_option('prefix') / get_option('datadir') / 'doc' / 'libvips-doc'
+        install_dir: get_option('prefix') / get_option('datadir') / 'doc' / 'vips-doc'
     )
 endif

--- a/doc/meson.build
+++ b/doc/meson.build
@@ -1,4 +1,4 @@
-private_headers = [
+private_libvips_headers = [
     'include/vips/almostdeprecated.h',
     'include/vips/deprecated.h',
     'include/vips/vips7compat.h',
@@ -34,7 +34,11 @@ private_headers = [
     'foreign/jpeg.h',
     'foreign/magick.h',
     'foreign/pforeign.h',
+    'foreign/quantise.h',
     'foreign/tiff.h',
+    'foreign/libnsgif/lzw.h',
+    'foreign/libnsgif/nsgif.h',
+    'foreign/libnsgif/test/cli.h',
     'freqfilt/pfreqfilt.h',
     'histogram/hist_unary.h',
     'histogram/phistogram.h',
@@ -46,6 +50,11 @@ private_headers = [
     'resample/presample.h',
     'resample/templates.h'
 ]
+
+private_headers = []
+foreach private_libvips_header : private_libvips_headers
+    private_headers += [join_paths(meson.project_source_root(), 'libvips', private_libvips_header)]
+endforeach
 
 markdown_content_files = files(
     'How-it-works.md',
@@ -109,7 +118,10 @@ docpath = get_option('prefix') / get_option('datadir') / 'gtk-doc' / 'html'
 gnome.gtkdoc('libvips',
     mode: 'none',
     main_xml: 'libvips-docs.xml.in',
-    src_dir: include_directories('../libvips'),
+    src_dir: [
+        join_paths(meson.project_source_root(), 'libvips'),
+        join_paths(meson.project_build_root(), 'libvips'),
+    ],
     dependencies: libvips_dep,
     scan_args: [
       '--ignore-headers=' + ' '.join(private_headers),


### PR DESCRIPTION
It seems that `private_headers` didn't work for out-of-tree builds.
This PR makes it use full paths and adds a few missing files.

Should fix the following errors when building with gtk-doc enabled:

<details>
  <summary>Details</summary>

```
/usr/bin/ld: libvips-scan.o: in function `main':
libvips-scan.c:(.text.startup+0x98): undefined reference to `vips_arithmetic_get_type'
/usr/bin/ld: libvips-scan.c:(.text.startup+0xe0): undefined reference to `vips_bandary_get_type'
/usr/bin/ld: libvips-scan.c:(.text.startup+0xec): undefined reference to `vips_binary_get_type'
/usr/bin/ld: libvips-scan.c:(.text.startup+0x134): undefined reference to `vips_colour_code_get_type'
/usr/bin/ld: libvips-scan.c:(.text.startup+0x140): undefined reference to `vips_colour_difference_get_type'
/usr/bin/ld: libvips-scan.c:(.text.startup+0x14c): undefined reference to `vips_colour_get_type'
/usr/bin/ld: libvips-scan.c:(.text.startup+0x158): undefined reference to `vips_colour_transform_get_type'
/usr/bin/ld: libvips-scan.c:(.text.startup+0x1b8): undefined reference to `vips_conversion_get_type'
/usr/bin/ld: libvips-scan.c:(.text.startup+0x1c4): undefined reference to `vips_convolution_get_type'
/usr/bin/ld: libvips-scan.c:(.text.startup+0x1d0): undefined reference to `vips_correlation_get_type'
/usr/bin/ld: libvips-scan.c:(.text.startup+0x1dc): undefined reference to `vips_create_get_type'
/usr/bin/ld: libvips-scan.c:(.text.startup+0x218): undefined reference to `vips_draw_get_type'
/usr/bin/ld: libvips-scan.c:(.text.startup+0x224): undefined reference to `vips_drawink_get_type'
/usr/bin/ld: libvips-scan.c:(.text.startup+0x3bc): undefined reference to `vips_format_get_type'
/usr/bin/ld: libvips-scan.c:(.text.startup+0x3c8): undefined reference to `vips_freqfilt_get_type'
/usr/bin/ld: libvips-scan.c:(.text.startup+0x3d4): undefined reference to `vips_hist_unary_get_type'
/usr/bin/ld: libvips-scan.c:(.text.startup+0x3e0): undefined reference to `vips_histogram_get_type'
/usr/bin/ld: libvips-scan.c:(.text.startup+0x3ec): undefined reference to `vips_hough_get_type'
/usr/bin/ld: libvips-scan.c:(.text.startup+0x488): undefined reference to `vips_mask_butterworth_get_type'
/usr/bin/ld: libvips-scan.c:(.text.startup+0x494): undefined reference to `vips_mask_gaussian_get_type'
/usr/bin/ld: libvips-scan.c:(.text.startup+0x4a0): undefined reference to `vips_mask_get_type'
/usr/bin/ld: libvips-scan.c:(.text.startup+0x4ac): undefined reference to `vips_mask_ideal_get_type'
/usr/bin/ld: libvips-scan.c:(.text.startup+0x4b8): undefined reference to `vips_morphology_get_type'
/usr/bin/ld: libvips-scan.c:(.text.startup+0x4c4): undefined reference to `vips_nary_get_type'
/usr/bin/ld: libvips-scan.c:(.text.startup+0x5f0): undefined reference to `vips_point_get_type'
/usr/bin/ld: libvips-scan.c:(.text.startup+0x644): undefined reference to `vips_resample_get_type'
/usr/bin/ld: libvips-scan.c:(.text.startup+0x6b0): undefined reference to `vips_statistic_get_type'
/usr/bin/ld: libvips-scan.c:(.text.startup+0x704): undefined reference to `vips_unary_const_get_type'
/usr/bin/ld: libvips-scan.c:(.text.startup+0x710): undefined reference to `vips_unary_get_type'
collect2: error: ld returned 1 exit status
```
</details>