### PR TITLE
cgifsave: fill transparent pixels with zeroes

### DIFF
--- a/libvips/foreign/cgifsave.c
+++ b/libvips/foreign/cgifsave.c
@@ -237,7 +237,8 @@ vips_foreign_save_cgif_write_frame( VipsForeignSaveCgif *cgif )
 	 */
 	p = frame_bytes;
 	for( i = 0; i < n_pels; i++ ) {
-		p[3] = p[3] >= 128 ? 255 : 0;
+		if (p[3] >= 128) p[3] = 255;
+		else memset(p, 0, 4);
 		p += 4;
 	}
 


### PR DESCRIPTION
Hey!

When we make pixels fully transparent in `cgifsave` it's better to fill them with zeroes. This removes nasty artifacts when saving resized GIF with transparency. Also this reduces the number of colors in the image and helps a quantizer to build a better palette.