### PR TITLE
text: ensure fontconfig cache of Pango is invalidated

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -1241,10 +1241,10 @@ AC_ARG_WITH([fontconfig],
     [build without fontconfig (default: test)]))
 
 if test x"$with_pangocairo" != x"no" -a x"$with_fontconfig" != x"no"; then
-  PKG_CHECK_MODULES(FONTCONFIG, fontconfig,
+  PKG_CHECK_MODULES(FONTCONFIG, fontconfig pangoft2 >= 1.4,
     [AC_DEFINE(HAVE_FONTCONFIG,1,[define if you have fontconfig installed.])
      with_fontconfig=yes
-     PACKAGES_USED="$PACKAGES_USED fontconfig"
+     PACKAGES_USED="$PACKAGES_USED fontconfig pangoft2"
     ],
     [AC_MSG_WARN([fontconfig not found; disabling fontconfig support])
      with_fontconfig=no

--- a/libvips/create/text.c
+++ b/libvips/create/text.c
@@ -86,6 +86,7 @@
 #include <pango/pangocairo.h>
 
 #ifdef HAVE_FONTCONFIG
+#include <pango/pangofc-fontmap.h>
 #include <fontconfig/fontconfig.h>
 #endif
 
@@ -389,6 +390,13 @@ vips_text_build( VipsObject *object )
 		g_hash_table_insert( vips_text_fontfiles, 
 			text->fontfile,
 			g_strdup( text->fontfile ) );
+
+		/* We need to inform that pango should invalidate its
+		 * fontconfig cache whenever any changes are made.
+		 */
+		if( PANGO_IS_FC_FONT_MAP( vips_text_fontmap ) )
+			pango_fc_font_map_cache_clear(
+				PANGO_FC_FONT_MAP( vips_text_fontmap ) );
 	}
 #else /*!HAVE_FONTCONFIG*/
 	if( text->fontfile )

--- a/meson.build
+++ b/meson.build
@@ -338,6 +338,7 @@ endif
 fontconfig_dep = dependency('fontconfig', required: get_option('fontconfig'))
 if fontconfig_dep.found() and pangocairo_dep.found()
     libvips_deps += fontconfig_dep
+    libvips_deps += dependency('pangoft2', version: '>=1.4')
     cfg_var.set('HAVE_FONTCONFIG', '1')
 endif
 


### PR DESCRIPTION
See: https://gitlab.gnome.org/GNOME/pango/-/issues/551.

Resolves: https://github.com/kleisauke/net-vips/issues/170.