### PR TITLE
text: use MT-safe `pango_cairo_font_map_get_default`

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -1221,7 +1221,7 @@ AC_ARG_WITH([pangocairo],
     [build without pangocairo (default: test)]))
 
 if test x"$with_pangocairo" != x"no"; then
-  PKG_CHECK_MODULES(PANGOCAIRO, pangocairo,
+  PKG_CHECK_MODULES(PANGOCAIRO, pangocairo >= 1.32.6,
     [AC_DEFINE(HAVE_PANGOCAIRO,1,[define if you have pangocairo installed.])
      with_pangocairo=yes
      PACKAGES_USED="$PACKAGES_USED pangocairo"
@@ -1241,7 +1241,7 @@ AC_ARG_WITH([fontconfig],
     [build without fontconfig (default: test)]))
 
 if test x"$with_pangocairo" != x"no" -a x"$with_fontconfig" != x"no"; then
-  PKG_CHECK_MODULES(FONTCONFIG, fontconfig pangoft2 >= 1.4,
+  PKG_CHECK_MODULES(FONTCONFIG, fontconfig pangoft2 >= 1.32.6,
     [AC_DEFINE(HAVE_FONTCONFIG,1,[define if you have fontconfig installed.])
      with_fontconfig=yes
      PACKAGES_USED="$PACKAGES_USED fontconfig pangoft2"

--- a/meson.build
+++ b/meson.build
@@ -329,7 +329,7 @@ if libwebp_dep.found()
     cfg_var.set('HAVE_LIBWEBP', '1')
 endif
 
-pangocairo_dep = dependency('pangocairo', required: get_option('pangocairo'))
+pangocairo_dep = dependency('pangocairo', version: '>=1.32.6', required: get_option('pangocairo'))
 if pangocairo_dep.found()
     libvips_deps += pangocairo_dep
     cfg_var.set('HAVE_PANGOCAIRO', '1')
@@ -338,7 +338,7 @@ endif
 fontconfig_dep = dependency('fontconfig', required: get_option('fontconfig'))
 if fontconfig_dep.found() and pangocairo_dep.found()
     libvips_deps += fontconfig_dep
-    libvips_deps += dependency('pangoft2', version: '>=1.4')
+    libvips_deps += dependency('pangoft2', version: '>=1.32.6')
     cfg_var.set('HAVE_FONTCONFIG', '1')
 endif
 


### PR DESCRIPTION
> Note that since Pango 1.32.6, the default fontmap is per-thread. Each thread gets its own default fontmap. In this way, PangoCairo can be used safely from multiple threads.
> https://docs.gtk.org/PangoCairo/type_func.FontMap.get_default.html

Depends on: #2847.