### PR TITLE
CI: upgrade runner to Ubuntu 22.04

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,14 +10,14 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - name: "Linux x64 (Ubuntu 20.04) - GCC 9"
-            os: ubuntu-20.04
+          - name: "Linux x64 (Ubuntu 22.04) - GCC 11"
+            os: ubuntu-22.04
             build: { cc: gcc, cxx: g++, linker: ld }
             shell: bash
 
-          - name: "Linux x64 (Ubuntu 20.04) - Clang 13 with ASan and UBSan"
-            os: ubuntu-20.04
-            build: { cc: clang-13, cxx: clang++-13, linker: ld.lld-13, sanitize: true }
+          - name: "Linux x64 (Ubuntu 22.04) - Clang 14 with ASan and UBSan"
+            os: ubuntu-22.04
+            build: { cc: clang-14, cxx: clang++-14, linker: ld.lld-14, sanitize: true }
             shell: bash
 
           - name: "macOS (11.6) - Xcode 13.2.1"
@@ -51,18 +51,11 @@ jobs:
         if: runner.os == 'Linux'
         run: sudo -E apt-get update -qq -o Acquire::Retries=3
 
-      - name: Add Ubuntu PPAs
-        if: runner.os == 'Linux'
-        run: |
-          sudo add-apt-repository ppa:strukturag/libde265
-          sudo add-apt-repository ppa:strukturag/libheif
-          sudo add-apt-repository ppa:lovell/cgif
-
       - name: Install Ubuntu dependencies
         if: runner.os == 'Linux'
         run:
           sudo -E apt-get install --fix-missing -qq -o Acquire::Retries=3
-            ninja-build 
+            meson
             python3-pip python3-setuptools python3-wheel
             libfftw3-dev libexif-dev libjpeg-turbo8-dev
             libpng-dev libwebp-dev libtiff5-dev
@@ -73,24 +66,17 @@ jobs:
             libopenslide-dev libffi-dev libopenjp2-7-dev
             libimagequant-dev libcgif-dev
 
-      - name: Install recent meson 
-        if: runner.os == 'Linux'
-        run:
-          sudo pip3 install meson
-
       - name: Install macOS dependencies
         if: runner.os == 'macOS'
         run: |
           brew install meson ninja fftw fontconfig glib libexif libgsf little-cms2 orc pango
           brew install cfitsio libheif libimagequant libjpeg-turbo libmatio librsvg libspng libtiff openexr openjpeg openslide poppler webp cgif
 
-      - name: Install Clang 13
-        if: runner.os == 'Linux' && matrix.build.cc == 'clang-13'
-        run: |
-          wget -O - https://apt.llvm.org/llvm-snapshot.gpg.key | sudo apt-key add -
-          sudo add-apt-repository -y "deb http://apt.llvm.org/$(lsb_release -sc)/ llvm-toolchain-$(lsb_release -sc)-13 main"
-          sudo -E apt-get install --fix-missing -qq -o Acquire::Retries=3 \
-            clang-13 libomp-13-dev lld-13 llvm-13
+      - name: Install Clang 14
+        if: runner.os == 'Linux' && matrix.build.cc == 'clang-14'
+        run:
+          sudo -E apt-get install --fix-missing -qq -o Acquire::Retries=3
+            clang-14 libomp-14-dev lld-14 llvm-14
 
       - name: Prepare Ubuntu environment
         if: runner.os == 'Linux'
@@ -105,7 +91,7 @@ jobs:
       - name: Prepare sanitizers
         if: matrix.build.sanitize
         env:
-          LLVM_PREFIX: /usr/lib/llvm-13
+          LLVM_PREFIX: /usr/lib/llvm-14
         run: |
           ASAN_DSO=`$CC -print-file-name=libclang_rt.asan-x86_64.so`
           echo "LDSHARED=$CC -shared" >> $GITHUB_ENV

--- a/suppressions/lsan.supp
+++ b/suppressions/lsan.supp
@@ -1,6 +1,6 @@
 leak:python3
 leak:bash
 leak:libfontconfig.so
-leak:libIlmImf-2_3.so
-leak:libIlmThread-2_3.so
+leak:libIlmImf-2_5.so
+leak:libIlmThread-2_5.so
 leak:libx265.so

--- a/test/test_formats.sh
+++ b/test/test_formats.sh
@@ -200,6 +200,16 @@ fi
 
 if test_supported matload; then
 	test_loader $matlab_ref $matlab matlab 0
+
+	# test blocked and untrusted
+	printf "testing VIPS_BLOCK_UNTRUSTED with matio ... "
+	export VIPS_BLOCK_UNTRUSTED=1
+	if vips matload $matlab $tmp/block.png; then
+		echo "failed to block matload"
+		exit 1
+	fi
+	echo "ok"
+	unset VIPS_BLOCK_UNTRUSTED
 fi
 
 if test_supported dzsave; then
@@ -207,16 +217,3 @@ if test_supported dzsave; then
 	test_saver copy $image .dz
 	test_saver copy $image .dz[container=zip]
 fi
-
-# test blocked and untrusted
-if test_supported magicksave; then
-	printf "testing VIPS_BLOCK_UNTRUSTED with imagemagick ... "
-  export VIPS_BLOCK_UNTRUSTED=1
-  if vips magicksave $matlab $tmp/block.png; then
-		echo "failed to block imagemagick"
-		exit 1
-  fi
-	echo "ok"
-  unset VIPS_BLOCK_UNTRUSTED
-fi
-


### PR DESCRIPTION
- Compile with GCC 11 and Clang 14.
- Remove redundant PPAs.
- Use system provided Meson.
- Update LeakSanitizer suppressions.

Note that this GitHub Actions runner is still in beta phase, so we might have to wait.