### PR TITLE
Prefer to use `flags |=` everywhere

### DIFF
--- a/libvips/foreign/csvload.c
+++ b/libvips/foreign/csvload.c
@@ -657,7 +657,7 @@ vips_foreign_load_csv_source_class_init( VipsForeignLoadCsvFileClass *class )
 	object_class->nickname = "csvload_source";
 	object_class->build = vips_foreign_load_csv_source_build;
 
-	operation_class->flags = VIPS_OPERATION_NOCACHE;
+	operation_class->flags |= VIPS_OPERATION_NOCACHE;
 
 	load_class->is_a_source = vips_foreign_load_csv_source_is_a_source;
 

--- a/libvips/foreign/fitsload.c
+++ b/libvips/foreign/fitsload.c
@@ -188,7 +188,7 @@ vips_foreign_load_fits_class_init( VipsForeignLoadFitsClass *class )
 	/* cfitsio has not been fuzzed, so should not be used with
 	 * untrusted input unless you are very careful.
 	 */
-	operation_class->flags = VIPS_OPERATION_UNTRUSTED;
+	operation_class->flags |= VIPS_OPERATION_UNTRUSTED;
 
 	/* is_a() is not that quick ... lower the priority.
 	 */
@@ -332,7 +332,7 @@ vips_foreign_load_fits_source_class_init(
 	object_class->description = _( "load FITS from a source" );
 	object_class->build = vips_foreign_load_fits_source_build;
 
-	operation_class->flags = VIPS_OPERATION_NOCACHE;
+	operation_class->flags |= VIPS_OPERATION_NOCACHE;
 
 	load_class->is_a_source = 
 		vips_foreign_load_fits_source_is_a_source;

--- a/libvips/foreign/fitssave.c
+++ b/libvips/foreign/fitssave.c
@@ -133,7 +133,7 @@ vips_foreign_save_fits_class_init( VipsForeignSaveFitsClass *class )
 	/* cfitsio has not been fuzzed, so should not be used with
 	 * untrusted input unless you are very careful.
 	 */
-	operation_class->flags = VIPS_OPERATION_UNTRUSTED;
+	operation_class->flags |= VIPS_OPERATION_UNTRUSTED;
 
 	foreign_class->suffs = vips__fits_suffs;
 

--- a/libvips/foreign/heifload.c
+++ b/libvips/foreign/heifload.c
@@ -1391,7 +1391,7 @@ vips_foreign_load_heif_source_class_init(
 	object_class->nickname = "heifload_source";
 	object_class->build = vips_foreign_load_heif_source_build;
 
-	operation_class->flags = VIPS_OPERATION_NOCACHE;
+	operation_class->flags |= VIPS_OPERATION_NOCACHE;
 
 	load_class->is_a_source = vips_foreign_load_heif_source_is_a_source;
 

--- a/libvips/foreign/heifsave.c
+++ b/libvips/foreign/heifsave.c
@@ -868,7 +868,7 @@ vips_foreign_save_avif_target_class_init(
 
 	/* Hide from UI.
 	 */
-	operation_class->flags = VIPS_OPERATION_DEPRECATED;
+	operation_class->flags |= VIPS_OPERATION_DEPRECATED;
 }
 
 static void

--- a/libvips/foreign/jp2kload.c
+++ b/libvips/foreign/jp2kload.c
@@ -1279,7 +1279,7 @@ vips_foreign_load_jp2k_source_class_init(
 	object_class->nickname = "jp2kload_source";
 	object_class->build = vips_foreign_load_jp2k_source_build;
 
-	operation_class->flags = VIPS_OPERATION_NOCACHE;
+	operation_class->flags |= VIPS_OPERATION_NOCACHE;
 
 	load_class->is_a_source = vips_foreign_load_jp2k_is_a_source;
 

--- a/libvips/foreign/jpegload.c
+++ b/libvips/foreign/jpegload.c
@@ -260,7 +260,7 @@ vips_foreign_load_jpeg_source_class_init(
 	object_class->description = _( "load image from jpeg source" );
 	object_class->build = vips_foreign_load_jpeg_source_build;
 
-	operation_class->flags = VIPS_OPERATION_NOCACHE;
+	operation_class->flags |= VIPS_OPERATION_NOCACHE;
 
 	load_class->is_a_source = vips_foreign_load_jpeg_source_is_a_source;
 

--- a/libvips/foreign/jxlload.c
+++ b/libvips/foreign/jxlload.c
@@ -918,7 +918,7 @@ vips_foreign_load_jxl_source_class_init( VipsForeignLoadJxlSourceClass *class )
 	object_class->nickname = "jxlload_source";
 	object_class->build = vips_foreign_load_jxl_source_build;
 
-	operation_class->flags = VIPS_OPERATION_NOCACHE;
+	operation_class->flags |= VIPS_OPERATION_NOCACHE;
 
 	load_class->is_a_source = vips_foreign_load_jxl_is_a_source;
 

--- a/libvips/foreign/magick6load.c
+++ b/libvips/foreign/magick6load.c
@@ -114,7 +114,7 @@ vips_foreign_load_magick_class_init( VipsForeignLoadMagickClass *class )
 
 	/* Don't cache magickload: it can gobble up memory and disc. 
 	 */
-	operation_class->flags = VIPS_OPERATION_NOCACHE;
+	operation_class->flags |= VIPS_OPERATION_NOCACHE;
 
 	/* *magick is fuzzed, but it's such a huge thing it's safer to
 	 * disable it.

--- a/libvips/foreign/magick7load.c
+++ b/libvips/foreign/magick7load.c
@@ -355,7 +355,7 @@ vips_foreign_load_magick7_class_init( VipsForeignLoadMagick7Class *class )
 
 	/* Don't cache magickload: it can gobble up memory and disc. 
 	 */
-	operation_class->flags = VIPS_OPERATION_NOCACHE;
+	operation_class->flags |= VIPS_OPERATION_NOCACHE;
 
 	/* *magick is fuzzed, but it's such a huge thing it's safer to
 	 * disable it.

--- a/libvips/foreign/matrixload.c
+++ b/libvips/foreign/matrixload.c
@@ -458,7 +458,7 @@ vips_foreign_load_matrix_source_class_init(
 	object_class->nickname = "matrixload_source";
 	object_class->build = vips_foreign_load_matrix_source_build;
 
-	operation_class->flags = VIPS_OPERATION_NOCACHE;
+	operation_class->flags |= VIPS_OPERATION_NOCACHE;
 
 	load_class->is_a_source = vips_foreign_load_matrix_source_is_a_source;
 

--- a/libvips/foreign/niftiload.c
+++ b/libvips/foreign/niftiload.c
@@ -595,7 +595,7 @@ vips_foreign_load_nifti_class_init( VipsForeignLoadNiftiClass *class )
 	/* nificlib has not been fuzzed, so should not be used with
 	 * untrusted input unless you are very careful.
 	 */
-	operation_class->flags = VIPS_OPERATION_UNTRUSTED;
+	operation_class->flags |= VIPS_OPERATION_UNTRUSTED;
 
 	/* is_a() is not that quick ... lower the priority.
 	 */
@@ -783,7 +783,7 @@ vips_foreign_load_nifti_source_class_init(
 	object_class->description = _( "load NIfTI volumes" );
 	object_class->build = vips_foreign_load_nifti_source_build;
 
-	operation_class->flags = VIPS_OPERATION_NOCACHE;
+	operation_class->flags |= VIPS_OPERATION_NOCACHE;
 
 	load_class->is_a_source = 
 		vips_foreign_load_nifti_source_is_a_source;

--- a/libvips/foreign/niftisave.c
+++ b/libvips/foreign/niftisave.c
@@ -432,7 +432,7 @@ vips_foreign_save_nifti_class_init( VipsForeignSaveNiftiClass *class )
 	/* nificlib has not been fuzzed, so should not be used with
 	 * untrusted input unless you are very careful.
 	 */
-	operation_class->flags = VIPS_OPERATION_UNTRUSTED;
+	operation_class->flags |= VIPS_OPERATION_UNTRUSTED;
 
 	foreign_class->suffs = vips_foreign_nifti_suffs;
 

--- a/libvips/foreign/nsgifload.c
+++ b/libvips/foreign/nsgifload.c
@@ -826,7 +826,7 @@ vips_foreign_load_nsgif_source_class_init(
 	object_class->description = _( "load gif from source" );
 	object_class->build = vips_foreign_load_nsgif_source_build;
 
-	operation_class->flags = VIPS_OPERATION_NOCACHE;
+	operation_class->flags |= VIPS_OPERATION_NOCACHE;
 
 	load_class->is_a_source = vips_foreign_load_nsgif_is_a_source;
 

--- a/libvips/foreign/openslideload.c
+++ b/libvips/foreign/openslideload.c
@@ -859,6 +859,7 @@ vips_foreign_load_openslide_class_init( VipsForeignLoadOpenslideClass *class )
 {
 	GObjectClass *gobject_class = G_OBJECT_CLASS( class );
 	VipsObjectClass *object_class = (VipsObjectClass *) class;
+	VipsOperationClass *operation_class = VIPS_OPERATION_CLASS( class );
 	VipsForeignClass *foreign_class = (VipsForeignClass *) class;
 	VipsForeignLoadClass *load_class = (VipsForeignLoadClass *) class;
 
@@ -878,6 +879,16 @@ vips_foreign_load_openslide_class_init( VipsForeignLoadOpenslideClass *class )
 	 * JPEGs.
 	 */
 	foreign_class->priority = 100;
+
+	/* libopenslide does not try to recover from errors, so it's not safe 
+	 * to cache.
+	 */
+	operation_class->flags |= VIPS_OPERATION_NOCACHE;
+
+	/* openslide has not been fuzzed and is largly unmaintained, so should 
+	 * not be used with untrusted input unless you are very careful.
+	 */
+	operation_class->flags |= VIPS_OPERATION_UNTRUSTED;
 
 	load_class->get_flags_filename = 
 		vips_foreign_load_openslide_get_flags_filename;
@@ -1053,7 +1064,6 @@ vips_foreign_load_openslide_source_class_init(
 {
 	GObjectClass *gobject_class = G_OBJECT_CLASS( class );
 	VipsObjectClass *object_class = (VipsObjectClass *) class;
-	VipsOperationClass *operation_class = VIPS_OPERATION_CLASS( class );
 	VipsForeignLoadClass *load_class = (VipsForeignLoadClass *) class;
 
 	gobject_class->set_property = vips_object_set_property;
@@ -1062,16 +1072,6 @@ vips_foreign_load_openslide_source_class_init(
 	object_class->nickname = "openslideload_source";
 	object_class->description = _( "load source with OpenSlide" );
 	object_class->build = vips_foreign_load_openslide_source_build;
-
-	/* libopenslide does not try to recover from errors, so it's not safe 
-	 * to cache.
-	 */
-	operation_class->flags = VIPS_OPERATION_NOCACHE;
-
-	/* openslide has not been fuzzed and is largly unmaintained, so should 
-	 * not be used with untrusted input unless you are very careful.
-	 */
-	operation_class->flags |= VIPS_OPERATION_UNTRUSTED;
 
 	load_class->is_a_source = 
 		vips_foreign_load_openslide_source_is_a_source;

--- a/libvips/foreign/pdfiumload.c
+++ b/libvips/foreign/pdfiumload.c
@@ -967,7 +967,7 @@ vips_foreign_load_pdf_source_class_init(
 	object_class->description = _( "load PDF from source" );
 	object_class->build = vips_foreign_load_pdf_source_build;
 
-	operation_class->flags = VIPS_OPERATION_NOCACHE;
+	operation_class->flags |= VIPS_OPERATION_NOCACHE;
 
 	load_class->is_a_source = vips_foreign_load_pdf_source_is_a_source;
 

--- a/libvips/foreign/pngload.c
+++ b/libvips/foreign/pngload.c
@@ -233,7 +233,7 @@ vips_foreign_load_png_source_class_init( VipsForeignLoadPngSourceClass *class )
 	object_class->description = _( "load png from source" );
 	object_class->build = vips_foreign_load_png_source_build;
 
-	operation_class->flags = VIPS_OPERATION_NOCACHE;
+	operation_class->flags |= VIPS_OPERATION_NOCACHE;
 
 	load_class->is_a_source = vips_foreign_load_png_source_is_a_source;
 

--- a/libvips/foreign/popplerload.c
+++ b/libvips/foreign/popplerload.c
@@ -846,7 +846,7 @@ vips_foreign_load_pdf_source_class_init(
 	object_class->description = _( "load PDF from source" );
 	object_class->build = vips_foreign_load_pdf_source_build;
 
-	operation_class->flags = VIPS_OPERATION_NOCACHE;
+	operation_class->flags |= VIPS_OPERATION_NOCACHE;
 
 	load_class->is_a_source = vips_foreign_load_pdf_source_is_a_source;
 

--- a/libvips/foreign/ppmload.c
+++ b/libvips/foreign/ppmload.c
@@ -886,7 +886,7 @@ vips_foreign_load_ppm_source_class_init( VipsForeignLoadPpmFileClass *class )
 	object_class->nickname = "ppmload_source";
 	object_class->build = vips_foreign_load_ppm_source_build;
 
-	operation_class->flags = VIPS_OPERATION_NOCACHE;
+	operation_class->flags |= VIPS_OPERATION_NOCACHE;
 
 	load_class->is_a_source = vips_foreign_load_ppm_is_a_source;
 

--- a/libvips/foreign/ppmsave.c
+++ b/libvips/foreign/ppmsave.c
@@ -641,7 +641,7 @@ vips_foreign_save_pbm_target_class_init(
 
 	/* Hide from UI.
 	 */
-	operation_class->flags = VIPS_OPERATION_DEPRECATED;
+	operation_class->flags |= VIPS_OPERATION_DEPRECATED;
 }
 
 static void
@@ -673,7 +673,7 @@ vips_foreign_save_pgm_target_class_init(
 
 	/* Hide from UI.
 	 */
-	operation_class->flags = VIPS_OPERATION_DEPRECATED;
+	operation_class->flags |= VIPS_OPERATION_DEPRECATED;
 }
 
 static void
@@ -705,7 +705,7 @@ vips_foreign_save_pfm_target_class_init(
 
 	/* Hide from UI.
 	 */
-	operation_class->flags = VIPS_OPERATION_DEPRECATED;
+	operation_class->flags |= VIPS_OPERATION_DEPRECATED;
 }
 
 static void

--- a/libvips/foreign/radload.c
+++ b/libvips/foreign/radload.c
@@ -199,7 +199,7 @@ vips_foreign_load_rad_source_class_init( VipsForeignLoadRadSourceClass *class )
 	object_class->description = _( "load rad from source" );
 	object_class->build = vips_foreign_load_rad_source_build;
 
-	operation_class->flags = VIPS_OPERATION_NOCACHE;
+	operation_class->flags |= VIPS_OPERATION_NOCACHE;
 
 	load_class->is_a_source = vips_foreign_load_rad_source_is_a_source;
 

--- a/libvips/foreign/spngload.c
+++ b/libvips/foreign/spngload.c
@@ -748,7 +748,7 @@ vips_foreign_load_png_source_class_init( VipsForeignLoadPngSourceClass *class )
 	object_class->description = _( "load png from source" );
 	object_class->build = vips_foreign_load_png_source_build;
 
-	operation_class->flags = VIPS_OPERATION_NOCACHE;
+	operation_class->flags |= VIPS_OPERATION_NOCACHE;
 
 	load_class->is_a_source = vips_foreign_load_png_source_is_a_source;
 

--- a/libvips/foreign/svgload.c
+++ b/libvips/foreign/svgload.c
@@ -691,7 +691,7 @@ vips_foreign_load_svg_class_init( VipsForeignLoadSvgClass *class )
 	/* librsvg has not been fuzzed, so should not be used with
 	 * untrusted input unless you are very careful.
 	 */
-	operation_class->flags = VIPS_OPERATION_UNTRUSTED;
+	operation_class->flags |= VIPS_OPERATION_UNTRUSTED;
 
 	/* is_a() is not that quick ... lower the priority.
 	 */
@@ -814,7 +814,7 @@ vips_foreign_load_svg_source_class_init( VipsForeignLoadSvgSourceClass *class )
 	object_class->nickname = "svgload_source";
 	object_class->description = _( "load svg from source" );
 
-	operation_class->flags = VIPS_OPERATION_NOCACHE;
+	operation_class->flags |= VIPS_OPERATION_NOCACHE;
 
 	load_class->is_a_source = vips_foreign_load_svg_source_is_a_source;
 	load_class->header = vips_foreign_load_svg_source_header;

--- a/libvips/foreign/tiffload.c
+++ b/libvips/foreign/tiffload.c
@@ -282,7 +282,7 @@ vips_foreign_load_tiff_source_class_init(
 	object_class->description = _( "load tiff from source" );
 	object_class->build = vips_foreign_load_tiff_source_build;
 
-	operation_class->flags = VIPS_OPERATION_NOCACHE;
+	operation_class->flags |= VIPS_OPERATION_NOCACHE;
 
 	load_class->is_a_source = vips_foreign_load_tiff_source_is_a_source;
 

--- a/libvips/foreign/vips2magick.c
+++ b/libvips/foreign/vips2magick.c
@@ -470,7 +470,7 @@ vips_foreign_save_magick_class_init( VipsForeignSaveMagickClass *class )
 	/* *magick is fuzzed, but it's such a huge thing it's safer to
 	 * disable it.
 	 */
-	operation_class->flags = VIPS_OPERATION_UNTRUSTED;
+	operation_class->flags |= VIPS_OPERATION_UNTRUSTED;
 
 	/* We need to be well to the back of the queue since vips's
 	 * dedicated savers are usually preferable.
@@ -686,7 +686,7 @@ vips_foreign_save_magick_bmp_file_class_init(
 
 	/* Hide from UI.
 	 */
-	operation_class->flags = VIPS_OPERATION_DEPRECATED;
+	operation_class->flags |= VIPS_OPERATION_DEPRECATED;
 }
 
 static void
@@ -719,7 +719,7 @@ vips_foreign_save_magick_bmp_buffer_class_init(
 
 	/* Hide from UI.
 	 */
-	operation_class->flags = VIPS_OPERATION_DEPRECATED;
+	operation_class->flags |= VIPS_OPERATION_DEPRECATED;
 }
 
 static void
@@ -752,7 +752,7 @@ vips_foreign_save_magick_gif_file_class_init(
 
 	/* Hide from UI.
 	 */
-	operation_class->flags = VIPS_OPERATION_DEPRECATED;
+	operation_class->flags |= VIPS_OPERATION_DEPRECATED;
 }
 
 static void
@@ -785,7 +785,7 @@ vips_foreign_save_magick_gif_buffer_class_init(
 
 	/* Hide from UI.
 	 */
-	operation_class->flags = VIPS_OPERATION_DEPRECATED;
+	operation_class->flags |= VIPS_OPERATION_DEPRECATED;
 }
 
 static void

--- a/libvips/foreign/vipsload.c
+++ b/libvips/foreign/vipsload.c
@@ -302,7 +302,7 @@ vips_foreign_load_vips_source_class_init( VipsForeignLoadVipsClass *class )
 	object_class->description = _( "load vips from source" );
 	object_class->build = vips_foreign_load_vips_source_build;
 
-	operation_class->flags = VIPS_OPERATION_NOCACHE;
+	operation_class->flags |= VIPS_OPERATION_NOCACHE;
 
 	load_class->is_a_source = 
 		vips_foreign_load_vips_source_is_a_source;

--- a/libvips/foreign/webpload.c
+++ b/libvips/foreign/webpload.c
@@ -264,7 +264,7 @@ vips_foreign_load_webp_source_class_init(
 	object_class->description = _( "load webp from source" );
 	object_class->build = vips_foreign_load_webp_source_build;
 
-	operation_class->flags = VIPS_OPERATION_NOCACHE;
+	operation_class->flags |= VIPS_OPERATION_NOCACHE;
 
 	load_class->is_a_source = vips__iswebp_source; 
 

--- a/libvips/iofuncs/system.c
+++ b/libvips/iofuncs/system.c
@@ -271,7 +271,7 @@ vips_system_class_init( VipsSystemClass *class )
 
 	/* Commands can have side-effects, so don't cache them. 
 	 */
-	operation_class->flags = VIPS_OPERATION_NOCACHE;
+	operation_class->flags |= VIPS_OPERATION_NOCACHE;
 
 	VIPS_ARG_BOXED( class, "in", 0, 
 		_( "Input" ), 

--- a/libvips/resample/thumbnail.c
+++ b/libvips/resample/thumbnail.c
@@ -949,7 +949,7 @@ vips_thumbnail_class_init( VipsThumbnailClass *class )
 	/* We mustn't cache these calls, since we open the file or buffer in 
 	 * sequential mode.
 	 */
-	operation_class->flags = VIPS_OPERATION_NOCACHE;
+	operation_class->flags |= VIPS_OPERATION_NOCACHE;
 
 	VIPS_ARG_IMAGE( class, "out", 2, 
 		_( "Output" ), 


### PR DESCRIPTION
Use the bitwise OR assignment operator to ensure that derived
classes does not overwrite the flags from the base class. Also,
move the flags from `openslideload_source` to its base class.