### PR TITLE
Mark Poppler as untrusted

### DIFF
--- a/libvips/foreign/popplerload.c
+++ b/libvips/foreign/popplerload.c
@@ -519,6 +519,7 @@ vips_foreign_load_pdf_class_init( VipsForeignLoadPdfClass *class )
 {
 	GObjectClass *gobject_class = G_OBJECT_CLASS( class );
 	VipsObjectClass *object_class = (VipsObjectClass *) class;
+	VipsOperationClass *operation_class = VIPS_OPERATION_CLASS( class );
 	VipsForeignLoadClass *load_class = (VipsForeignLoadClass *) class;
 
 	gobject_class->dispose = vips_foreign_load_pdf_dispose;
@@ -528,6 +529,10 @@ vips_foreign_load_pdf_class_init( VipsForeignLoadPdfClass *class )
 	object_class->nickname = "pdfload_base";
 	object_class->description = _( "load PDF with libpoppler" );
 	object_class->build = vips_foreign_load_pdf_build;
+
+	/* libpoppler is fuzzed, but not by us.
+	 */
+	operation_class->flags |= VIPS_OPERATION_UNTRUSTED;
 
 	load_class->get_flags_filename = 
 		vips_foreign_load_pdf_get_flags_filename;


### PR DESCRIPTION
`pdfload` using PDFium is continuously fuzzed by OSS-Fuzz, but Poppler not.