### PR TITLE
Meson: maintain autotools compatibility on macOS

### DIFF
--- a/cplusplus/meson.build
+++ b/cplusplus/meson.build
@@ -9,6 +9,7 @@ libvips_cpp_lib = library('vips-cpp',
     dependencies: libvips_dep,
     include_directories: libvips_cpp_includedir,
     version: library_version,
+    darwin_versions: darwin_versions,
     gnu_symbol_visibility: 'hidden',
     install: true,
 )

--- a/libvips/meson.build
+++ b/libvips/meson.build
@@ -23,6 +23,7 @@ libvips_lib = library('vips',
     link_whole: libvips_components,
     dependencies: libvips_deps,
     version: library_version,
+    darwin_versions: darwin_versions,
     gnu_symbol_visibility: 'hidden',
     install: true,
 )

--- a/meson.build
+++ b/meson.build
@@ -23,6 +23,7 @@ library_current = 57
 library_age = 15
 library_revision = 0
 library_version = '@0@.@1@.@2@'.format(library_current - library_age, library_age, library_revision)
+darwin_versions = [library_current + 1, '@0@.@1@'.format(library_current + 1, library_revision)]
 
 gnome = import('gnome')
 pymod = import('python')


### PR DESCRIPTION
By setting the correct compatibility/current version.
<details>
  <summary>Details</summary>

Before:
```bash
$ otool -L /usr/local/lib/libvips.42.dylib
/usr/local/lib/libvips.42.dylib:
	/usr/local/lib/libvips.42.dylib (compatibility version 42.0.0, current version 42.0.0)
```
https://github.com/kleisauke/libvips/runs/6845286445#step:15:15

After:
```bash
$ otool -L /usr/local/lib/libvips.42.dylib
/usr/local/lib/libvips.42.dylib:
	/usr/local/lib/libvips.42.dylib (compatibility version 58.0.0, current version 58.0.0)
```
https://github.com/kleisauke/libvips/runs/6845516339#step:15:15

Autotools:
```bash
$ otool -L /usr/local/lib/libvips.42.dylib
/usr/local/lib/libvips.42.dylib:
	/usr/local/lib/libvips.42.dylib (compatibility version 58.0.0, current version 58.0.0)
```
https://github.com/kleisauke/libvips/runs/6845456502#step:15:15

Autotools (v8.12.2 from Homebrew):
```bash
$ otool -L $(brew --prefix vips)/lib/libvips.42.dylib
/usr/local/opt/vips/lib/libvips.42.dylib:
	/usr/local/opt/vips/lib/libvips.42.dylib (compatibility version 57.0.0, current version 57.2.0)
```
https://github.com/kleisauke/libvips/runs/6845530515#step:10:15
</details>