### PR TITLE
Minor cleanups

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -304,7 +304,7 @@ EXTRA_LIBS_USED=""
 # Checks for header files.
 AC_HEADER_DIRENT
 AC_HEADER_STDC
-AC_CHECK_HEADERS([errno.h math.h fcntl.h limits.h stdlib.h string.h sys/file.h sys/ioctl.h sys/param.h sys/time.h sys/mman.h sys/types.h sys/stat.h unistd.h io.h direct.h windows.h])
+AC_CHECK_HEADERS([sys/file.h sys/param.h sys/mman.h unistd.h io.h direct.h])
 
 # Checks for typedefs, structures, and compiler characteristics.
 AC_C_RESTRICT

--- a/libvips/colour/icc_transform.c
+++ b/libvips/colour/icc_transform.c
@@ -1437,7 +1437,7 @@ vips_icc_is_compatible_profile( VipsImage *image,
 	return( TRUE ); 
 }
 
-#endif /*HAVE_LCMS*/
+#endif /*HAVE_LCMS2*/
 
 /**
  * vips_icc_import: (method)

--- a/libvips/conversion/conversion.c
+++ b/libvips/conversion/conversion.c
@@ -402,9 +402,6 @@ vips_conversion_operation_init( void )
 	extern GType vips_subsample_get_type( void ); 
 	extern GType vips_msb_get_type( void ); 
 	extern GType vips_byteswap_get_type( void ); 
-#ifdef HAVE_PANGOFT2
-	extern GType vips_text_get_type( void ); 
-#endif /*HAVE_PANGOFT2*/
 	extern GType vips_xyz_get_type( void ); 
 	extern GType vips_falsecolour_get_type( void ); 
 	extern GType vips_gamma_get_type( void ); 
@@ -454,9 +451,6 @@ vips_conversion_operation_init( void )
 	vips_subsample_get_type(); 
 	vips_msb_get_type(); 
 	vips_byteswap_get_type(); 
-#ifdef HAVE_PANGOFT2
-	vips_text_get_type(); 
-#endif /*HAVE_PANGOFT2*/
 	vips_xyz_get_type(); 
 	vips_falsecolour_get_type(); 
 	vips_gamma_get_type(); 

--- a/libvips/include/vips/deprecated.h
+++ b/libvips/include/vips/deprecated.h
@@ -40,14 +40,14 @@ extern "C" {
 
 /* On win32, need to override the wingdi defs for these. Yuk!
  */
-#ifdef HAVE_WINDOWS_H
+#ifdef G_OS_WIN32
 #ifdef RGB
 #undef RGB
 #endif
 #ifdef CMYK
 #undef CMYK
 #endif
-#endif /*HAVE_WINDOWS_H*/
+#endif /*G_OS_WIN32*/
 
 /* Bits per Band */
 #define BBBYTE		8

--- a/libvips/iofuncs/connection.c
+++ b/libvips/iofuncs/connection.c
@@ -50,7 +50,6 @@
 #include <sys/types.h>
 #include <sys/stat.h>
 #include <fcntl.h>
-#include <unistd.h>
 
 #include <vips/vips.h>
 #include <vips/internal.h>

--- a/libvips/iofuncs/sbuf.c
+++ b/libvips/iofuncs/sbuf.c
@@ -50,7 +50,6 @@
 #include <sys/types.h>
 #include <sys/stat.h>
 #include <fcntl.h>
-#include <unistd.h>
 
 #include <vips/vips.h>
 #include <vips/internal.h>

--- a/libvips/iofuncs/source.c
+++ b/libvips/iofuncs/source.c
@@ -69,7 +69,6 @@
 #include <sys/types.h>
 #include <sys/stat.h>
 #include <fcntl.h>
-#include <unistd.h>
 
 #include <vips/vips.h>
 

--- a/libvips/iofuncs/sourcecustom.c
+++ b/libvips/iofuncs/sourcecustom.c
@@ -50,7 +50,6 @@
 #include <sys/types.h>
 #include <sys/stat.h>
 #include <fcntl.h>
-#include <unistd.h>
 
 #include <vips/vips.h>
 #include <vips/internal.h>

--- a/libvips/iofuncs/sourceginput.c
+++ b/libvips/iofuncs/sourceginput.c
@@ -47,7 +47,6 @@
 #include <sys/types.h>
 #include <sys/stat.h>
 #include <fcntl.h>
-#include <unistd.h>
 
 #include <vips/vips.h>
 #include <vips/internal.h>

--- a/libvips/iofuncs/target.c
+++ b/libvips/iofuncs/target.c
@@ -54,7 +54,6 @@
 #include <sys/types.h>
 #include <sys/stat.h>
 #include <fcntl.h>
-#include <unistd.h>
 
 #include <vips/vips.h>
 

--- a/libvips/iofuncs/targetcustom.c
+++ b/libvips/iofuncs/targetcustom.c
@@ -50,7 +50,6 @@
 #include <sys/types.h>
 #include <sys/stat.h>
 #include <fcntl.h>
-#include <unistd.h>
 
 #include <vips/vips.h>
 #include <vips/internal.h>

--- a/meson.build
+++ b/meson.build
@@ -336,10 +336,12 @@ if pangocairo_dep.found()
     cfg_var.set('HAVE_PANGOCAIRO', '1')
 endif
 
+# text rendering with fontconfig requires pangoft2
+pangoft2_dep = dependency('pangoft2', version: '>=1.32.6', required: get_option('fontconfig'))
 fontconfig_dep = dependency('fontconfig', required: get_option('fontconfig'))
-if fontconfig_dep.found() and pangocairo_dep.found()
+if pangoft2_dep.found() and fontconfig_dep.found() and pangocairo_dep.found()
+    libvips_deps += pangoft2_dep
     libvips_deps += fontconfig_dep
-    libvips_deps += dependency('pangoft2', version: '>=1.32.6')
     cfg_var.set('HAVE_FONTCONFIG', '1')
 endif
 
@@ -385,7 +387,6 @@ endif
 lcms_dep = dependency('lcms2', required: get_option('lcms'))
 if lcms_dep.found()
     libvips_deps += lcms_dep
-    cfg_var.set('HAVE_LCMS', '1')
     cfg_var.set('HAVE_LCMS2', '1')
 endif
 
@@ -536,9 +537,6 @@ if cc.has_header('io.h')
 endif
 if cc.has_header('direct.h')
     cfg_var.set('HAVE_DIRECT_H', '1')
-endif
-if cc.has_header('windows.h')
-    cfg_var.set('HAVE_WINDOWS_H', '1')
 endif
 if get_option('deprecated')
     cfg_var.set('ENABLE_DEPRECATED', '1')

--- a/tools/vips.c
+++ b/tools/vips.c
@@ -102,10 +102,6 @@
 #include <vips/vips7compat.h>
 #endif
 
-#ifdef G_OS_WIN32
-#define strcasecmp(a,b) _stricmp(a,b)
-#endif /*G_OS_WIN32*/
-
 static char *main_option_plugin = NULL;
 static gboolean main_option_version;
 

--- a/tools/vipsedit.c
+++ b/tools/vipsedit.c
@@ -57,7 +57,9 @@
 #include <string.h>
 #include <ctype.h>
 #include <sys/types.h>
+#ifdef HAVE_UNISTD_H
 #include <unistd.h>
+#endif /*HAVE_UNISTD_H*/
 #include <locale.h>
 
 #include <vips/vips.h>


### PR DESCRIPTION
- Remove `HAVE_LCMS` definition in favor of `HAVE_LCMS2`.
- Remove `HAVE_WINDOWS_H` definition in favor of `G_OS_WIN32`.
- Remove stray `vips_text_get_type` in `conversion.c`.
- Remove duplicated `unistd.h` include.
- Remove redundant `strcasecmp` definition, we use `g_ascii_strcasecmp` everywhere.
- Remove unnecessary header checks in `configure.ac` and `meson.build`.
- Ensure `unistd.h` include is guarded with `HAVE_UNISTD_H`.
- Fail early when `-Dfontconfig=enabled` and `pangoft2` is not found.