### PR TITLE
thumbnail: avoid upsizing via libwebp

### DIFF
--- a/libvips/resample/thumbnail.c
+++ b/libvips/resample/thumbnail.c
@@ -604,8 +604,16 @@ vips_thumbnail_open( VipsThumbnail *thumbnail )
 				thumbnail->input_width, 
 				thumbnail->input_height );
 	}
+	else if( vips_isprefix( "VipsForeignLoadWebp", thumbnail->loader ) ) {
+		factor = vips_thumbnail_calculate_common_shrink( thumbnail, 
+			thumbnail->input_width, 
+			thumbnail->page_height );
+
+		/* Avoid upsizing via libwebp.
+		 */
+		factor = VIPS_MAX( 1.0, factor );
+	}
 	else if( vips_isprefix( "VipsForeignLoadPdf", thumbnail->loader ) ||
-		vips_isprefix( "VipsForeignLoadWebp", thumbnail->loader ) ||
 		vips_isprefix( "VipsForeignLoadSvg", thumbnail->loader ) ) 
 		factor = vips_thumbnail_calculate_common_shrink( thumbnail, 
 			thumbnail->input_width, 


### PR DESCRIPTION
Test case:
```bash
$ vips black x.webp 100 100
$ vipsthumbnail x.webp -s 16384x
```

Context: https://github.com/lovell/sharp/issues/3262.