### PR TITLE
cplusplus: remove i18n include

### DIFF
--- a/cplusplus/VConnection.cpp
+++ b/cplusplus/VConnection.cpp
@@ -31,7 +31,6 @@
 #ifdef HAVE_CONFIG_H
 #include <config.h>
 #endif /*HAVE_CONFIG_H*/
-#include <glib/gi18n-lib.h>
 
 #include <vips/vips8>
 

--- a/cplusplus/VError.cpp
+++ b/cplusplus/VError.cpp
@@ -30,7 +30,6 @@
 #ifdef HAVE_CONFIG_H
 #include <config.h>
 #endif /*HAVE_CONFIG_H*/
-#include <glib/gi18n-lib.h>
 
 #include <vips/vips8>
 

--- a/cplusplus/VImage.cpp
+++ b/cplusplus/VImage.cpp
@@ -38,7 +38,6 @@
 #ifdef HAVE_CONFIG_H
 #include <config.h>
 #endif /*HAVE_CONFIG_H*/
-#include <glib/gi18n-lib.h>
 
 #include <vips/vips8>
 

--- a/cplusplus/VInterpolate.cpp
+++ b/cplusplus/VInterpolate.cpp
@@ -31,7 +31,6 @@
 #ifdef HAVE_CONFIG_H
 #include <config.h>
 #endif /*HAVE_CONFIG_H*/
-#include <glib/gi18n-lib.h>
 
 #include <vips/vips8>
 

--- a/cplusplus/VRegion.cpp
+++ b/cplusplus/VRegion.cpp
@@ -3,7 +3,6 @@
 #ifdef HAVE_CONFIG_H
 #include <config.h>
 #endif /*HAVE_CONFIG_H*/
-#include <glib/gi18n-lib.h>
 
 #include <vips/vips8>
 


### PR DESCRIPTION
Since these files doesn't use any i18n features. This makes it easier for downstream projects to consume these files without having to define `GETTEXT_PACKAGE`, see: https://github.com/lovell/sharp/pull/3230#issuecomment-1163484509.

I also thought about guarding this include with `HAVE_CONFIG_H` throughout the codebase. However, that causes compiler errors when individual files are compiled that uses macros from this include directive, for example:
```bash
gcc -S libvips/foreign/exif.c -DGETTEXT_PACKAGE=\"vips8.13\" -DHAVE_EXIF -Ilibvips/include `pkg-config vips --cflags --libs` -lexif
```
(which could be handy to check the assembler output)