### PR TITLE
doc: ensure `pandoc-docbook-template.docbook` is distributed

### DIFF
--- a/doc/Makefile.am
+++ b/doc/Makefile.am
@@ -180,10 +180,11 @@ include gtk-doc.make
 # Other files to distribute
 # e.g. EXTRA_DIST += version.xml.in
 EXTRA_DIST += \
-        ${markdown_content_files} \
+	${markdown_content_files} \
 	gen-function-list.py \
 	images \
-	meson.build
+	meson.build \
+	pandoc-docbook-template.docbook
 
 # Files not to distribute
 # for --rebuild-types in $(SCAN_OPTIONS), e.g. $(DOC_MODULE).types


### PR DESCRIPTION
Since that is also used by Meson (when configuring with `-Dgtk_doc=true`
and when pandoc is available).