### PR TITLE
Meson: avoid using deprecated feature

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -229,7 +229,7 @@ VIPS_EXEEXT=$EXEEXT
 AC_SUBST(VIPS_EXEEXT)
 
 # cplusplus/Doxyfile.in needs an input and output directory ... they are the
-# same for copnfigure, but meson has separate source and build areas
+# same for configure, but meson has separate source and build areas
 DOXY_INPUT_DIRECTORY=$ac_pwd/$srcdir/cplusplus
 DOXY_OUTPUT_DIRECTORY=$ac_pwd/$srcdir/cplusplus
 AC_SUBST(DOXY_INPUT_DIRECTORY)

--- a/cplusplus/meson.build
+++ b/cplusplus/meson.build
@@ -44,8 +44,7 @@ if get_option('doxygen')
     doxygen_data = configuration_data()
     doxygen_data.set('VIPS_MAJOR_VERSION', version_major)
     doxygen_data.set('VIPS_MINOR_VERSION', version_minor)
-    doxygen_data.set('DOXY_INPUT_DIRECTORY', 
-      join_paths(meson.source_root(), meson.current_source_dir()))
+    doxygen_data.set('DOXY_INPUT_DIRECTORY', meson.current_source_dir())
     doxygen_data.set('DOXY_OUTPUT_DIRECTORY', 'cplusplus')
 
     doxyfile = configure_file(


### PR DESCRIPTION
Fixes the build with `-Ddoxygen=true --fatal-meson-warnings`:
```
cplusplus/meson.build:48: WARNING: Project targeting '>=0.56' but tried to use feature deprecated since '0.56.0': meson.source_root. use meson.project_source_root() or meson.global_source_root() instead.

cplusplus/meson.build:47:17: ERROR: Fatal warnings enabled, aborting
```