### PR TITLE
Doxygen: use SVG for the call graph images

### DIFF
--- a/cplusplus/Doxyfile.in
+++ b/cplusplus/Doxyfile.in
@@ -2461,7 +2461,7 @@ DIRECTORY_GRAPH        = YES
 # The default value is: png.
 # This tag requires that the tag HAVE_DOT is set to YES.
 
-DOT_IMAGE_FORMAT       = png
+DOT_IMAGE_FORMAT       = svg
 
 # If DOT_IMAGE_FORMAT is set to svg, then this option can be set to YES to
 # enable generation of interactive SVG images that allow zooming and panning.


### PR DESCRIPTION
Now that IE is finally gone, all the main browsers support this, which
provides higher quality and smaller sizes.

Inspired by commit https://github.com/libexif/libexif/commit/4a7ab4cc1332afbc63c44a8a96c93421d6aa07a0.