### PR TITLE
Remove unneeded adapter function for Emscripten

### DIFF
--- a/libvips/conversion/extract.c
+++ b/libvips/conversion/extract.c
@@ -172,14 +172,6 @@ vips_extract_area_build( VipsObject *object )
 	return( 0 );
 }
 
-#ifdef __EMSCRIPTEN__
-static void
-vips_crop_class_intern_init_adapter( gpointer class, void *dummy )
-{
-	vips_extract_area_class_intern_init( class );
-}
-#endif
-
 static void
 vips_extract_area_class_init( VipsExtractAreaClass *class )
 {
@@ -290,11 +282,7 @@ vips_crop_get_type( void )
 		GType new_type = g_type_register_static_simple(	VIPS_TYPE_CONVERSION,
 			g_intern_static_string( "crop" ),
 			sizeof( VipsExtractAreaClass ),
-#ifdef __EMSCRIPTEN__
-			(GClassInitFunc) vips_crop_class_intern_init_adapter,
-#else
 			(GClassInitFunc)(void (*)(void)) vips_extract_area_class_intern_init,
-#endif
 			sizeof( VipsExtractArea ),
 #ifdef __EMSCRIPTEN__
 			(GInstanceInitFunc) vips_crop_init_adapter,


### PR DESCRIPTION
The `*_class_intern_init` functions have already been patched within wasm-vips to include the missing `class_data` member, see: https://github.com/kleisauke/wasm-vips/blob/v0.0.3/build/patches/glib-function-pointers.patch#L2661-L2680
So, this adapter function was not needed.

As an aside, I'm investigating integrating the necessary WebAssembly patches of GLib upstream. Although, GLib has a hard requirement with function pointer conversions, which will not work on WASM, see:
https://gitlab.gnome.org/GNOME/glib/-/blob/2.73.2/docs/toolchain-requirements.md#function-pointer-conversions
https://stackoverflow.com/a/14044244

Hopefully they will loosen that requirement.

> **Note**: this PR targets the [`8.13`](https://github.com/libvips/libvips/tree/8.13) branch.