### PR TITLE
move tiff decompress outside lock

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -12,6 +12,7 @@ master
 - add "interlace" option to GIF save [dloebl]
 - magick load sets "magick-format" metadata [aksdb]
 - add ".pnm", save as image format [ewelot]
+- threaded tiff jp2k and jpeg decompress
 
 24/7/22 started 8.13.1
 - fix im7 feature detection in meson

--- a/ChangeLog
+++ b/ChangeLog
@@ -7,7 +7,7 @@ master
 - jp2ksave defaults to chroma subsample off, and jp2 write
 - don't minimise sink_screen input after expose ... improves caching during
   interactive use
-- move tiff jp2k decompress outside the lock
+- move tiff jp2k and jpeg decompress outside the lock
 - require libjxl 0.7+
 - add "interlace" option to GIF save [dloebl]
 - magick load sets "magick-format" metadata [aksdb]

--- a/ChangeLog
+++ b/ChangeLog
@@ -3,6 +3,7 @@ master
 - version bump to 8.14
 - remove autotools
 - jp2ksave defaults to chroma subsample off
+- move tiff jp2k decompress outside the lock
 
 24/7/22 started 8.13.1
 - fix im7 feature detection in meson

--- a/libvips/foreign/jpeg.h
+++ b/libvips/foreign/jpeg.h
@@ -58,6 +58,7 @@ extern "C" {
 #undef FALSE
 #endif /*FALSE*/
 
+#include <setjmp.h>
 #include <jpeglib.h>
 #include <jerror.h>
 

--- a/libvips/foreign/jpeg2vips.c
+++ b/libvips/foreign/jpeg2vips.c
@@ -158,7 +158,6 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
-#include <setjmp.h>
 
 #include <vips/vips.h>
 #include <vips/buf.h>

--- a/libvips/foreign/vips2jpeg.c
+++ b/libvips/foreign/vips2jpeg.c
@@ -144,7 +144,6 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
-#include <setjmp.h>
 #include <math.h>
 
 #include <vips/vips.h>

--- a/libvips/include/vips/memory.h
+++ b/libvips/include/vips/memory.h
@@ -59,10 +59,12 @@ G_STMT_START { \
         } \
 } G_STMT_END
 
+#define VIPS_MALLOC( OBJ, S ) \
+	(vips_malloc( VIPS_OBJECT( OBJ ), S))
 #define VIPS_NEW( OBJ, T ) \
-	((T *) vips_malloc( VIPS_OBJECT( OBJ ), sizeof( T )))
+	((T *) VIPS_MALLOC( OBJ, sizeof( T )))
 #define VIPS_ARRAY( OBJ, N, T ) \
-	((T *) vips_malloc( VIPS_OBJECT( OBJ ), (N) * sizeof( T )))
+	((T *) VIPS_MALLOC( OBJ, (N) * sizeof( T )))
 
 VIPS_API
 void *vips_malloc( VipsObject *object, size_t size );


### PR DESCRIPTION
Most time in TIFF read is spent in decompression. If we move this
outside the lock, we can get a useful speedup.

This commit adds the machinery to move the lock to before decompress, so
jp2k decompression is now threaded.

Before:

```
$ vips copy wtc.jpg x.tif[tile,compression=jp2k]
$ time vips avg x.tif
117.249845
real	0m15.085s
user	0m16.155s
sys	0m0.109s
```

After:

```
$ time vips avg x.tif
117.249845
real	0m1.207s
user	0m18.384s
sys	0m0.369s
```