### PR TITLE
Remove even pixel check for J2K subsample_mode auto

### DIFF
--- a/libvips/foreign/jp2ksave.c
+++ b/libvips/foreign/jp2ksave.c
@@ -795,8 +795,6 @@ vips_foreign_save_jp2k_build( VipsObject *object )
 		jp2k->subsample =
 			!jp2k->lossless &&
 			jp2k->Q < 90 &&
-			save->ready->Xsize % 2 == 0 &&
-			save->ready->Ysize % 2 == 0 &&
 			(save->ready->Type == VIPS_INTERPRETATION_sRGB ||
 			 save->ready->Type == VIPS_INTERPRETATION_RGB16) &&
 			save->ready->Bands == 3;


### PR DESCRIPTION
Having a different colorspace and chroma subsampling just because the source image happens to be an even or odd number of pixels is surprising and hard to debug, so let's remove it.

See https://github.com/libvips/libvips/issues/2965#issuecomment-1201354156 for discussion.