### PR TITLE
cgifsave: add support for interlaced GIF write

### DIFF
--- a/libvips/foreign/cgifsave.c
+++ b/libvips/foreign/cgifsave.c
@@ -83,6 +83,7 @@ typedef struct _VipsForeignSaveCgif {
 	int bitdepth;
 	double interframe_maxerror;
 	gboolean reoptimise;
+	gboolean interlace;
 	double interpalette_maxerror;
 	VipsTarget *target;
 
@@ -601,6 +602,16 @@ vips_foreign_save_cgif_write_frame( VipsForeignSaveCgif *cgif )
 		frame_config.numLocalPaletteEntries = n_colours;
 	}
 
+	/* Write an interlaced GIF, if requested.
+	*/
+	if( cgif->interlace ) {
+#ifdef HAVE_CGIF_FRAME_ATTR_INTERLACED
+		frame_config.attrFlags |= CGIF_FRAME_ATTR_INTERLACED;
+#else /*!HAVE_CGIF_FRAME_ATTR_INTERLACED*/
+		vips_error( class->nickname, "%s", _( "cgif >= v0.3.0 required for interlaced GIF write" ) );
+#endif /*HAVE_CGIF_FRAME_ATTR_INTERLACED*/
+	}
+
 	/* Write frame to cgif.
 	 */
 	frame_config.pImageData = cgif->index;
@@ -893,6 +904,14 @@ vips_foreign_save_cgif_class_init( VipsForeignSaveCgifClass *class )
 		VIPS_ARGUMENT_OPTIONAL_INPUT,
 		G_STRUCT_OFFSET( VipsForeignSaveCgif, interpalette_maxerror ),
 		0, 256, 3.0 );
+
+	VIPS_ARG_BOOL( class, "interlace", 16,
+		_( "Interlaced" ),
+		_( "Generate an interlaced (progressive) GIF" ),
+		VIPS_ARGUMENT_OPTIONAL_INPUT,
+		G_STRUCT_OFFSET( VipsForeignSaveCgif, interlace ),
+		FALSE );
+
 }
 
 static void
@@ -903,6 +922,7 @@ vips_foreign_save_cgif_init( VipsForeignSaveCgif *gif )
 	gif->bitdepth = 8;
 	gif->interframe_maxerror = 0.0;
 	gif->reoptimise = FALSE;
+	gif->interlace = FALSE;
 	gif->interpalette_maxerror = 3.0;
 	gif->mode = VIPS_FOREIGN_SAVE_CGIF_MODE_GLOBAL;
 }
@@ -1087,6 +1107,7 @@ vips_foreign_save_cgif_buffer_init( VipsForeignSaveCgifBuffer *buffer )
  * * @bitdepth: %gint, number of bits per pixel
  * * @interframe_maxerror: %gdouble, maximum inter-frame error for transparency
  * * @reoptimise: %gboolean, reoptimise colour palettes
+ * * @interlace: %gboolean, write an interlaced (progressive) GIF
  * * @interpalette_maxerror: %gdouble, maximum inter-palette error for palette
  *   reusage
  *
@@ -1109,6 +1130,10 @@ vips_foreign_save_cgif_buffer_init( VipsForeignSaveCgifBuffer *buffer )
  * If @reoptimise is TRUE, new palettes will be generated. Use
  * @interpalette_maxerror to set the threshold below which one of the previously
  * generated palettes will be reused.
+ *
+ * If @interlace is TRUE, the GIF file will be interlaced (progressive GIF).
+ * These files may be better for display over a slow network
+ * conection, but need more memory to encode.
  *
  * See also: vips_image_new_from_file().
  *
@@ -1141,6 +1166,7 @@ vips_gifsave( VipsImage *in, const char *filename, ... )
  * * @bitdepth: %gint, number of bits per pixel
  * * @interframe_maxerror: %gdouble, maximum inter-frame error for transparency
  * * @reoptimise: %gboolean, reoptimise colour palettes
+ * * @interlace: %gboolean, write an interlaced (progressive) GIF
  * * @interpalette_maxerror: %gdouble, maximum inter-palette error for palette
  *   reusage
  *
@@ -1195,6 +1221,7 @@ vips_gifsave_buffer( VipsImage *in, void **buf, size_t *len, ... )
  * * @bitdepth: %gint, number of bits per pixel
  * * @interframe_maxerror: %gdouble, maximum inter-frame error for transparency
  * * @reoptimise: %gboolean, reoptimise colour palettes
+ * * @interlace: %gboolean, write an interlaced (progressive) GIF
  * * @interpalette_maxerror: %gdouble, maximum inter-palette error for palette
  *   reusage
  *

--- a/libvips/foreign/cgifsave.c
+++ b/libvips/foreign/cgifsave.c
@@ -608,7 +608,7 @@ vips_foreign_save_cgif_write_frame( VipsForeignSaveCgif *cgif )
 #ifdef HAVE_CGIF_FRAME_ATTR_INTERLACED
 		frame_config.attrFlags |= CGIF_FRAME_ATTR_INTERLACED;
 #else /*!HAVE_CGIF_FRAME_ATTR_INTERLACED*/
-		vips_error( class->nickname, "%s", _( "cgif >= v0.3.0 required for interlaced GIF write" ) );
+		g_warning( "%s: cgif >= v0.3.0 required for interlaced GIF write", class->nickname );
 #endif /*HAVE_CGIF_FRAME_ATTR_INTERLACED*/
 	}
 

--- a/meson.build
+++ b/meson.build
@@ -259,6 +259,9 @@ if quantisation_package.found()
         if cc.compiles('#include <cgif.h>\nint i = CGIF_ATTR_NO_LOOP;', name: 'Has CGIF_ATTR_NO_LOOP', dependencies: cgif_dep)
             cfg_var.set('HAVE_CGIF_ATTR_NO_LOOP', '1')
         endif
+        if cc.compiles('#include <cgif.h>\nint i = CGIF_FRAME_ATTR_INTERLACED;', name: 'Has CGIF_FRAME_ATTR_INTERLACED', dependencies: cgif_dep)
+            cfg_var.set('HAVE_CGIF_FRAME_ATTR_INTERLACED', '1')
+        endif
     endif
 endif
 

--- a/test/test-suite/test_foreign.py
+++ b/test/test-suite/test_foreign.py
@@ -1472,6 +1472,13 @@ class TestForeign:
         # FIXME ... this requires cgif0.3 or later for fixed loop support
         # assert x1.get("loop") == x2.get("loop")
 
+        # Interlaced write
+        x1 = pyvips.Image.new_from_file(GIF_ANIM_FILE, n=-1)
+        b1 = x1.gifsave_buffer(interlace=False)
+        b2 = x1.gifsave_buffer(interlace=True)
+        # Interlaced GIFs are usually larger in file size
+        assert len(b2) >= len(b1)
+
         # Reducing dither will typically reduce file size (and quality)
         little_dither = self.colour.gifsave_buffer(dither=0.1, effort=1)
         large_dither = self.colour.gifsave_buffer(dither=0.9, effort=1)

--- a/test/test-suite/test_foreign.py
+++ b/test/test-suite/test_foreign.py
@@ -1473,10 +1473,13 @@ class TestForeign:
         # assert x1.get("loop") == x2.get("loop")
 
         # Interlaced write
-        x1 = pyvips.Image.new_from_file(GIF_ANIM_FILE, n=-1)
+        x1 = pyvips.Image.new_from_file(GIF_FILE, n=-1)
         b1 = x1.gifsave_buffer(interlace=False)
         b2 = x1.gifsave_buffer(interlace=True)
         # Interlaced GIFs are usually larger in file size
+        # FIXME ... cgif v0.3 or later required for interlaced write.
+        # If interlaced write is not supported b2 and b1 are expected to be
+        # of the same file size.
         assert len(b2) >= len(b1)
 
         # Reducing dither will typically reduce file size (and quality)


### PR DESCRIPTION
cgif >= [v0.3.0](https://github.com/dloebl/cgif/releases/tag/V0.3.0) supports writing interlaced (progressive) GIFs. Add support for interlaced GIF write in libvips.
**Note:** As of now, cgif requires more memory for writing interlaced GIFs (tracked by https://github.com/dloebl/cgif/issues/52).