### PR TITLE
jxlsave: correctly mark frame as last

### DIFF
--- a/libvips/foreign/jxlsave.c
+++ b/libvips/foreign/jxlsave.c
@@ -438,6 +438,11 @@ vips_foreign_save_jxl_build( VipsObject *object )
 		return( -1 );
 	}
 
+	/* This function must be called after the final frame and/or box,
+	 * otherwise the codestream will not be encoded correctly.
+	 */
+	JxlEncoderCloseInput( jxl->encoder );
+
 	do {
 		uint8_t *out;
 		size_t avail_out;


### PR DESCRIPTION
It's required to close the input, otherwise the encoder can't
know what the last frame is, resulting in an improper codestream.

Resolves: #2987.

> **Note**: this PR targets the [`8.13`](https://github.com/libvips/libvips/tree/8.13) branch.