### PR TITLE
jxlsave: avoid using deprecated functions

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -847,6 +847,13 @@ if test x"$with_libjxl" != x"no"; then
      with_libjxl=yes
      AS_IF([test x"$with_libjxl_module" = x"no"],
        [PACKAGES_USED="$PACKAGES_USED libjxl"])
+
+     PKG_CHECK_MODULES(LIBJXL_0_7, libjxl >= 0.7,
+       [AC_DEFINE(HAVE_LIBJXL_0_7,1,[define if you have libjxl >= 0.7])
+       ],
+       [:
+       ]
+     )
     ],
     [AS_IF([test x"$with_libjxl" = x"test"],
        AC_MSG_WARN([libjxl not found; disabling libjxl support]),

--- a/libvips/foreign/jxlsave.c
+++ b/libvips/foreign/jxlsave.c
@@ -229,7 +229,7 @@ vips_foreign_save_jxl_build( VipsObject *object )
 	VipsForeignSaveJxl *jxl = (VipsForeignSaveJxl *) object;
 	VipsImage **t = (VipsImage **) vips_object_local_array( object, 5 );
 
-#if HAVE_LIBJXL_0_7
+#ifdef HAVE_LIBJXL_0_7
 	JxlEncoderFrameSettings *frame_settings;
 #else
 	JxlEncoderOptions *frame_settings;
@@ -419,7 +419,7 @@ vips_foreign_save_jxl_build( VipsObject *object )
 	if( vips_image_wio_input( in ) )
 		return( -1 );
 
-#if HAVE_LIBJXL_0_7
+#ifdef HAVE_LIBJXL_0_7
 	frame_settings = JxlEncoderFrameSettingsCreate( jxl->encoder, NULL );
 	JxlEncoderFrameSettingsSetOption( frame_settings, 
 		JXL_ENC_FRAME_SETTING_DECODING_SPEED, jxl->tier );

--- a/meson.build
+++ b/meson.build
@@ -484,6 +484,9 @@ if libjxl_found
     if cc.has_function('JxlEncoderInitBasicInfo', prefix: '#include <jxl/encode.h>', dependencies: libjxl_dep)
         cfg_var.set('HAVE_LIBJXL_JXLENCODERINITBASICINFO', '1')
     endif
+    if libjxl_dep.version().version_compare('>=0.7')
+        cfg_var.set('HAVE_LIBJXL_0_7', '1')
+    endif
 endif
 
 libpoppler_dep = dependency('poppler-glib', version: '>=0.16.0', required: get_option('poppler'))


### PR DESCRIPTION
The upcoming libjxl 0.7 has deprecated a number of functions.

> **Note**: this PR targets the [`8.13`](https://github.com/libvips/libvips/tree/8.13) branch.