### PR TITLE
Mention mozjpeg as the best libjpeg option

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,7 +129,8 @@ so make sure that is working.
 
 ### libjpeg
 
-The IJG JPEG library. Use the `-turbo` version if you can. 
+Anything that is compatible with the IJG JPEG library. Use `mozjpeg` if you
+can. Another option is `libjpeg-turbo`. 
 
 ### libexif
 


### PR DESCRIPTION
Just a quick suggestion to make it more clear how the `libjpeg` dependency works.

The most important change is recommending `mozjpeg`, because it is the package that will give you access to the most features and the best compression. Before, it seemed like `libjpeg-turbo` was the best option.

Another little detail I put in there, is just to make it clear that you can use any lib which supports the standard IJG JPEG library interface. As a new user, I was confused by the original wording, and thought I had to use the IJG library.