### PR TITLE
CI: remove redundant glib-utils dependency

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -69,7 +69,7 @@ jobs:
       - name: Install macOS dependencies
         if: runner.os == 'macOS'
         run: |
-          brew install meson ninja fftw fontconfig glib glib-utils libexif libgsf little-cms2 orc pango
+          brew install meson ninja fftw fontconfig glib libexif libgsf little-cms2 orc pango
           brew install cfitsio libheif libimagequant libjpeg-turbo libmatio librsvg libspng libtiff openexr openjpeg openslide poppler webp cgif
 
       - name: Install Clang 14


### PR DESCRIPTION
The GLib utilities, which was split into its own `glib-utils`
formula has been merged back into `glib`, see:
https://github.com/Homebrew/homebrew-core/pull/108307

This reverts commit a846de017d9f369ea3cdd1b0f5510bebbb71b5c7.