### PR TITLE
dzsave: add missing include directive for errno/EEXIST

### DIFF
--- a/libvips/foreign/dzsave.c
+++ b/libvips/foreign/dzsave.c
@@ -176,6 +176,7 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
+#include <errno.h>
 
 #include <vips/vips.h>
 #include <vips/internal.h>


### PR DESCRIPTION
Resolves: #3024.

> **Note**: this PR targets the [`8.13`](https://github.com/libvips/libvips/tree/8.13) branch.