### PR TITLE
pngsave: ensure 8-bit palette images can be created

### DIFF
--- a/libvips/foreign/pngsave.c
+++ b/libvips/foreign/pngsave.c
@@ -145,9 +145,9 @@ vips_foreign_save_png_build( VipsObject *object )
 		png->bitdepth < 8 )
 		png->palette = TRUE;
 
-        /* Disable palettization for >8 bit save.
-         */
-        if( png->bitdepth >= 8 )
+	/* Disable palettization for >8 bit save.
+	 */
+	if( png->bitdepth > 8 )
 		png->palette = FALSE;
 
 	if( vips__png_write_target( in, png->target,

--- a/libvips/foreign/spngsave.c
+++ b/libvips/foreign/spngsave.c
@@ -613,9 +613,9 @@ vips_foreign_save_spng_build( VipsObject *object )
 		spng->bitdepth < 8 )
 		spng->palette = TRUE;
 
-        /* Disable palettization for >8 bit save.
-         */
-        if( spng->bitdepth >= 8 )
+	/* Disable palettization for >8 bit save.
+	 */
+	if( spng->bitdepth > 8 )
 		spng->palette = FALSE;
 
 	if( vips_foreign_save_spng_write( spng, in ) ) {


### PR DESCRIPTION
This PR ensures the logic matches the comment and, I think, intended behaviour. (It also fixes comment indentation.)

It targets the 8.13 branch as this appears to be a bug introduced in v8.13.1 via commit https://github.com/libvips/libvips/commit/198920398509465ab00e7c6f5584fd345bda20e7

Reported downstream at https://github.com/lovell/sharp/issues/3357