### PR TITLE
tiff2vips: ensure stdint.h is included for uint32_t type

### DIFF
--- a/libvips/foreign/tiff2vips.c
+++ b/libvips/foreign/tiff2vips.c
@@ -254,6 +254,7 @@
 
 #include <stdio.h>
 #include <stdlib.h>
+#include <stdint.h>
 #include <string.h>
 
 #include <vips/vips.h>


### PR DESCRIPTION
Required since commit https://github.com/libvips/libvips/commit/a7e754162abf8bed28a8ca50c8bb8e42dac97955

```
../libvips/foreign/tiff2vips.c: In function ‘rtiff_decompress_jpeg_run’:
../libvips/foreign/tiff2vips.c:1890:9: error: unknown type name ‘uint32_t’; did you mean ‘u_int32_t’?
 1890 |         uint32_t tables_len;
```