### PR TITLE
add suport for N colour ICC profiles

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -14,6 +14,7 @@ master
 - add ".pnm", save as image format [ewelot]
 - threaded tiff jp2k and jpeg decompress
 - improve speed and efficiency of animated WebP write [dloebl]
+- support for N-colour ICC profiles
 
 5/9/22 started 8.13.2
 - in dzsave, add add missing include directive for errno/EEXIST [kleisauke]

--- a/libvips/colour/icc_transform.c
+++ b/libvips/colour/icc_transform.c
@@ -213,7 +213,7 @@ is_pcs( cmsHPROFILE profile )
 		cmsGetColorSpace( profile ) == cmsSigXYZData ); 
 }
 
-/* Treat these as all forms of CMYK.
+/* Info for all supported lcms profile signatures.
  */
 typedef struct _VipsIccInfo {
         int signature;
@@ -223,6 +223,12 @@ typedef struct _VipsIccInfo {
 } VipsIccInfo;
 
 static VipsIccInfo vips_icc_info_table[] = {
+        { cmsSigGrayData, 1, TYPE_GRAY_8, TYPE_GRAY_16 },
+
+        { cmsSigRgbData, 3, TYPE_RGB_8, TYPE_RGB_16 },
+        { cmsSigLabData, 3, TYPE_Lab_8, TYPE_Lab_16 },
+        { cmsSigXYZData, 3, -1, TYPE_XYZ_16 },
+
         { cmsSigCmykData, 4, TYPE_CMYK_8, TYPE_CMYK_16 },
         { cmsSig4colorData, 4, TYPE_CMYK_8, TYPE_CMYK_16 },
         { cmsSig5colorData, 5, TYPE_CMYK5_8, TYPE_CMYK5_16 },
@@ -256,7 +262,6 @@ vips_icc_build( VipsObject *object )
 	VipsIcc *icc = (VipsIcc *) object;
 
 	cmsUInt32Number flags;
-        VipsIccInfo *info;
 
 	if( icc->depth != 8 &&
 		icc->depth != 16 ) {
@@ -267,87 +272,50 @@ vips_icc_build( VipsObject *object )
 
 	if( icc->in_profile &&
 		code->in ) {
-		switch( cmsGetColorSpace( icc->in_profile ) ) {
-		case cmsSigRgbData:
-			colour->input_bands = 3;
-			code->input_format = 
-				code->in->BandFmt == VIPS_FORMAT_USHORT ? 
-				VIPS_FORMAT_USHORT : VIPS_FORMAT_UCHAR;
-			icc->in_icc_format = 
-				code->in->BandFmt == VIPS_FORMAT_USHORT ? 
-				TYPE_RGB_16 : TYPE_RGB_8;
-			break;
+                int signature;
+                VipsIccInfo *info;
 
+                signature = cmsGetColorSpace( icc->in_profile );
+                if( !(info = vips_icc_info( signature )) ) {
+			vips_error( class->nickname, 
+				_( "unimplemented input color space 0x%x" ), 
+				signature );
+			return( -1 );
+		}
+
+                colour->input_bands = info->bands;
+
+		switch( signature ) {
 		case cmsSigGrayData:
-			colour->input_bands = 1;
 			code->input_format = 
 				code->in->BandFmt == VIPS_FORMAT_USHORT ? 
 				VIPS_FORMAT_USHORT : VIPS_FORMAT_UCHAR;
 			icc->in_icc_format = 
 				code->in->BandFmt == VIPS_FORMAT_USHORT ? 
-				TYPE_GRAY_16 : TYPE_GRAY_8;
+				info->lcms_type16 : info->lcms_type8;
 			break;
 
-		case cmsSigCmykData:
-			colour->input_bands = 4;
+		case cmsSigRgbData:
 			code->input_format = 
 				code->in->BandFmt == VIPS_FORMAT_USHORT ? 
 				VIPS_FORMAT_USHORT : VIPS_FORMAT_UCHAR;
 			icc->in_icc_format = 
 				code->in->BandFmt == VIPS_FORMAT_USHORT ? 
-				TYPE_CMYK_16 : TYPE_CMYK_8;
+				info->lcms_type16 : info->lcms_type8;
 			break;
 
 		case cmsSigLabData:
-			colour->input_bands = 3;
 			code->input_format = VIPS_FORMAT_FLOAT;
 			code->input_interpretation = 
 				VIPS_INTERPRETATION_LAB;
-			icc->in_icc_format = TYPE_Lab_16;
+			icc->in_icc_format = info->lcms_type16;
 			break;
 
 		case cmsSigXYZData:
-			colour->input_bands = 3;
 			code->input_format = VIPS_FORMAT_FLOAT;
-			icc->in_icc_format = TYPE_XYZ_16;
-			break;
-
-		default:
-			vips_error( class->nickname, 
-				_( "unimplemented input color space 0x%x" ), 
-				cmsGetColorSpace( icc->in_profile ) );
-			return( -1 );
-		}
-	}
-
-	if( icc->out_profile ) 
-		switch( cmsGetColorSpace( icc->out_profile ) ) {
-		case cmsSigRgbData:
-			colour->interpretation = 
-				icc->depth == 8 ? 
-				VIPS_INTERPRETATION_sRGB : 
-					VIPS_INTERPRETATION_RGB16;
-			colour->format = 
-				icc->depth == 8 ? 
-				VIPS_FORMAT_UCHAR : VIPS_FORMAT_USHORT;
-			colour->bands = 3;
-			icc->out_icc_format = 
-				icc->depth == 16 ? 
-				TYPE_RGB_16 : TYPE_RGB_8;
-			break;
-
-		case cmsSigGrayData:
-			colour->interpretation = 
-				icc->depth == 8 ? 
-				VIPS_INTERPRETATION_B_W : 
-					VIPS_INTERPRETATION_GREY16;
-			colour->format = 
-				icc->depth == 8 ? 
-				VIPS_FORMAT_UCHAR : VIPS_FORMAT_USHORT;
-			colour->bands = 1;
-			icc->out_icc_format = 
-				icc->depth == 16 ? 
-				TYPE_GRAY_16 : TYPE_GRAY_8;
+			code->input_interpretation = 
+				VIPS_INTERPRETATION_XYZ;
+			icc->in_icc_format = info->lcms_type16;
 			break;
 
 		case cmsSigCmykData:
@@ -362,13 +330,58 @@ vips_icc_build( VipsObject *object )
                         /* Treat as forms of CMYK.
                          */
                         info = vips_icc_info( 
-                                cmsGetColorSpace( icc->out_profile ) );
+                                cmsGetColorSpace( icc->in_profile ) );
 
-			colour->interpretation = VIPS_INTERPRETATION_CMYK;
+			code->input_format = 
+				code->in->BandFmt == VIPS_FORMAT_USHORT ? 
+				VIPS_FORMAT_USHORT : VIPS_FORMAT_UCHAR;
+			icc->in_icc_format = 
+				code->in->BandFmt == VIPS_FORMAT_USHORT ? 
+				info->lcms_type16 : info->lcms_type8;
+			break;
+
+		default:
+			g_assert_not_reached(); 
+			return( -1 );
+		}
+	}
+
+	if( icc->out_profile ) {
+                int signature;
+                VipsIccInfo *info;
+
+                signature = cmsGetColorSpace( icc->out_profile );
+                if( !(info = vips_icc_info( signature )) ) {
+			vips_error( class->nickname, 
+				_( "unimplemented output color space 0x%x" ), 
+				signature );
+			return( -1 );
+		}
+
+                colour->bands = info->bands;
+
+		switch( signature ) {
+		case cmsSigGrayData:
+			colour->interpretation = 
+				icc->depth == 8 ? 
+				VIPS_INTERPRETATION_B_W : 
+					VIPS_INTERPRETATION_GREY16;
 			colour->format = 
 				icc->depth == 8 ? 
 				VIPS_FORMAT_UCHAR : VIPS_FORMAT_USHORT;
-			colour->bands = info->bands;
+			icc->out_icc_format = 
+				icc->depth == 16 ? 
+				info->lcms_type16 : info->lcms_type8;
+			break;
+
+		case cmsSigRgbData:
+			colour->interpretation = 
+				icc->depth == 8 ? 
+				VIPS_INTERPRETATION_sRGB : 
+					VIPS_INTERPRETATION_RGB16;
+			colour->format = 
+				icc->depth == 8 ? 
+				VIPS_FORMAT_UCHAR : VIPS_FORMAT_USHORT;
 			icc->out_icc_format = 
 				icc->depth == 16 ? 
 				info->lcms_type16 : info->lcms_type8;
@@ -377,23 +390,40 @@ vips_icc_build( VipsObject *object )
 		case cmsSigLabData:
 			colour->interpretation = VIPS_INTERPRETATION_LAB;
 			colour->format = VIPS_FORMAT_FLOAT;
-			colour->bands = 3;
-			icc->out_icc_format = TYPE_Lab_16;
+			icc->out_icc_format = info->lcms_type16;
 			break;
 
 		case cmsSigXYZData:
 			colour->interpretation = VIPS_INTERPRETATION_XYZ;
 			colour->format = VIPS_FORMAT_FLOAT;
-			colour->bands = 3;
-			icc->out_icc_format = TYPE_XYZ_16;
+			icc->out_icc_format = info->lcms_type16;
+			break;
+
+		case cmsSigCmykData:
+		case cmsSig5colorData:
+		case cmsSig6colorData:
+		case cmsSig7colorData:
+		case cmsSig8colorData:
+		case cmsSig9colorData:
+		case cmsSig10colorData:
+		case cmsSig11colorData:
+		case cmsSig12colorData:
+                        /* Treat as forms of CMYK.
+                         */
+			colour->interpretation = VIPS_INTERPRETATION_CMYK;
+			colour->format = 
+				icc->depth == 8 ? 
+				VIPS_FORMAT_UCHAR : VIPS_FORMAT_USHORT;
+			icc->out_icc_format = 
+				icc->depth == 16 ? 
+				info->lcms_type16 : info->lcms_type8;
 			break;
 
 		default:
-			vips_error( class->nickname, 
-				_( "unimplemented output color space 0x%x" ), 
-				cmsGetColorSpace( icc->out_profile ) );
+			g_assert_not_reached(); 
 			return( -1 );
 		}
+        }
 
 	/* At least one must be a device profile.
 	 */
@@ -515,166 +545,6 @@ vips_icc_print_profile( const char *name, cmsHPROFILE profile )
 }
 #endif /*DEBUG*/
 
-/* How many bands we expect to see from an image after preprocessing by our
- * parent classes. This is a bit fragile :-( 
- *
- * FIXME ... split the _build() for colour into separate preprocess / process
- * / postprocess phases so we can load profiles after preprocess but before
- * actual processing takes place.
- */
-static int
-vips_image_expected_bands( VipsImage *image )
-{
-	int expected_bands;
-
-	switch( image->Type ) { 
-	case VIPS_INTERPRETATION_B_W:
-	case VIPS_INTERPRETATION_GREY16:
-		expected_bands = 1;
-		break;
-
-	case VIPS_INTERPRETATION_XYZ:
-	case VIPS_INTERPRETATION_LAB:
-	case VIPS_INTERPRETATION_LABQ:
-	case VIPS_INTERPRETATION_RGB:
-	case VIPS_INTERPRETATION_CMC:
-	case VIPS_INTERPRETATION_LCH:
-	case VIPS_INTERPRETATION_LABS:
-	case VIPS_INTERPRETATION_sRGB:
-	case VIPS_INTERPRETATION_YXY:
-	case VIPS_INTERPRETATION_RGB16:
-	case VIPS_INTERPRETATION_scRGB:
-	case VIPS_INTERPRETATION_HSV:
-		expected_bands = 3;
-		break;
-
-	case VIPS_INTERPRETATION_CMYK:
-		expected_bands = 4;
-		break;
-
-	case VIPS_INTERPRETATION_MULTIBAND:
-	case VIPS_INTERPRETATION_HISTOGRAM:
-	case VIPS_INTERPRETATION_MATRIX:
-	case VIPS_INTERPRETATION_FOURIER:
-	default:
-		expected_bands = image->Bands;
-		break;
-	}
-
-	expected_bands = VIPS_MIN( expected_bands, image->Bands );
-
-	return( expected_bands );
-}
-
-static int
-vips_icc_profile_needs_bands( cmsHPROFILE profile )
-{
-	int needs_bands;
-
-	switch( cmsGetColorSpace( profile ) ) {
-	case cmsSigGrayData:
-		needs_bands = 1;
-		break;
-
-	case cmsSigRgbData:
-	case cmsSigLabData:
-	case cmsSigXYZData:
-		needs_bands = 3;
-		break;
-
-	case cmsSigCmykData:
-		needs_bands = 4;
-		break;
-
-	default:
-		needs_bands = -1;
-		break;
-	}
-
-	return( needs_bands );
-}
-
-/* What cmsColorSpaceSignature do we expect this image to be (roughly) after 
- * preprocessing. Again, fragile :( see the FIXME above.
- */
-static cmsColorSpaceSignature
-vips_image_expected_sig( VipsImage *image )
-{
-	cmsColorSpaceSignature expected_sig;
-
-	switch( image->Type ) { 
-	case VIPS_INTERPRETATION_B_W:
-	case VIPS_INTERPRETATION_GREY16:
-		expected_sig = cmsSigGrayData;
-		break;
-
-	case VIPS_INTERPRETATION_LAB:
-	case VIPS_INTERPRETATION_LABQ:
-	case VIPS_INTERPRETATION_LABS:
-		expected_sig = cmsSigLabData;
-		break;
-
-	case VIPS_INTERPRETATION_sRGB:
-	case VIPS_INTERPRETATION_RGB:
-	case VIPS_INTERPRETATION_RGB16:
-	case VIPS_INTERPRETATION_scRGB:
-		expected_sig = cmsSigRgbData;
-		break;
-
-	case VIPS_INTERPRETATION_XYZ:
-		expected_sig = cmsSigXYZData;
-		break;
-
-	case VIPS_INTERPRETATION_CMYK:
-		expected_sig = cmsSigCmykData;
-		break;
-
-	case VIPS_INTERPRETATION_HSV:
-		expected_sig = cmsSigHsvData;
-		break;
-
-	case VIPS_INTERPRETATION_YXY:
-		expected_sig = cmsSigYxyData;
-		break;
-
-	case VIPS_INTERPRETATION_MULTIBAND:
-		/* A generic many-band image. Try to guess from the number of 
-		 * image bands instead.
-		 */
-		switch( image->Bands ) {
-		case 1:
-		case 2:
-			expected_sig = cmsSigGrayData;
-			break;
-
-		case 3:
-			expected_sig = cmsSigRgbData;
-			break;
-
-		case 4:
-		case 5:
-			expected_sig = cmsSigCmykData;
-			break;
-
-		default:
-			expected_sig = -1;
-			break;
-		}
-		break;
-
-	case VIPS_INTERPRETATION_LCH:
-	case VIPS_INTERPRETATION_CMC:
-	case VIPS_INTERPRETATION_HISTOGRAM:
-	case VIPS_INTERPRETATION_MATRIX:
-	case VIPS_INTERPRETATION_FOURIER:
-	default:
-		expected_sig = -1;
-		break;
-	}
-
-	return( expected_sig );
-}
-
 /* Load a profile from a blob and check compatibility with image, intent and
  * direction.
  *
@@ -687,6 +557,7 @@ vips_icc_load_profile_blob( VipsBlob *blob,
 	const void *data;
 	size_t size;
 	cmsHPROFILE profile;
+        VipsIccInfo *info;
 
 #ifdef DEBUG
 	printf( "loading %s profile, intent %s, from blob %p\n", 
@@ -705,20 +576,16 @@ vips_icc_load_profile_blob( VipsBlob *blob,
 	vips_icc_print_profile( "loaded from blob to make", profile );
 #endif /*DEBUG*/
 
-	if( image &&
-		vips_image_expected_bands( image ) != 
-			vips_icc_profile_needs_bands( profile ) ) {
+        if( !(info = vips_icc_info( cmsGetColorSpace( profile ) )) ) {
 		VIPS_FREEF( cmsCloseProfile, profile );
-		g_warning( "%s", _( "profile incompatible with image" ) );
-		return( NULL );
-	}
+		g_warning( "%s", _( "unsupported profile" ) );
+                return( NULL );
+        }
 
 	if( image &&
-		vips_image_expected_sig( image ) != 
-			cmsGetColorSpace( profile ) ) {
+		image->Bands < info->bands ) { 
 		VIPS_FREEF( cmsCloseProfile, profile );
-		g_warning( "%s", 
-			_( "profile colourspace differs from image" ) );
+		g_warning( "%s", _( "profile incompatible with image" ) );
 		return( NULL );
 	}
 
@@ -1433,6 +1300,7 @@ vips_icc_is_compatible_profile( VipsImage *image,
 	const void *data, size_t data_length )
 {
 	cmsHPROFILE profile;
+        VipsIccInfo *info;
 
 	if( !(profile = cmsOpenProfileFromMem( data, data_length )) ) 
 		/* Corrupt profile. 
@@ -1443,13 +1311,16 @@ vips_icc_is_compatible_profile( VipsImage *image,
 	vips_icc_print_profile( "from memory", profile );
 #endif /*DEBUG*/
 
-	if( vips_image_expected_bands( image ) != 
-		vips_icc_profile_needs_bands( profile ) ) {
+        if( !(info = vips_icc_info( cmsGetColorSpace( profile ) )) ) {
+                /* Unsupported profile.
+                 */
 		VIPS_FREEF( cmsCloseProfile, profile );
-		return( FALSE );
-	}
+                return( FALSE );
+        }
 
-	if( vips_image_expected_sig( image ) != cmsGetColorSpace( profile ) ) {
+	if( image->Bands < info->bands ) {
+                /* Too few bands,
+                 */
 		VIPS_FREEF( cmsCloseProfile, profile );
 		return( FALSE );
 	}

--- a/libvips/colour/icc_transform.c
+++ b/libvips/colour/icc_transform.c
@@ -213,58 +213,6 @@ is_pcs( cmsHPROFILE profile )
 		cmsGetColorSpace( profile ) == cmsSigXYZData ); 
 }
 
-typedef struct _VipsIccImportType {
-        cmsColorSpaceSignature signature;
-        VipsBandFormat input_format;
-        int input_bands;
-        guint output_format;
-} VipsIccImportType;
-
-static VipsIccImportType vips_icc_import_table[] = {
-        { cmsSigGrayData, VIPS_FORMAT_UCHAR, 1, TYPE_GRAY_8 },
-        { cmsSigGrayData, VIPS_FORMAT_USHORT, 1, TYPE_GRAY_16 },
-        { cmsSigRgbData, VIPS_FORMAT_UCHAR, 3, TYPE_RGB_8 },
-        { cmsSigRgbData, VIPS_FORMAT_USHORT, 3, TYPE_RGB_16 },
-        { cmsSigLabData, VIPS_FORMAT_FLOAT, 3, TYPE_Lab_16 },
-        { cmsSigXYZData, VIPS_FORMAT_FLOAT, 3, TYPE_XYZ_16 },
-        { cmsSigCmykData, VIPS_FORMAT_UCHAR, 4, TYPE_CMYK_8 },
-        { cmsSigCmykData, VIPS_FORMAT_USHORT, 4, TYPE_CMYK_16 },
-        { cmsSigCmykData, VIPS_FORMAT_UCHAR, 4, TYPE_CMYK_8 },
-        { cmsSig6colorData, VIPS_FORMAT_UCHAR, 6, TYPE_CMYK6_8 },
-        { cmsSig6colorData, VIPS_FORMAT_USHORT, 6, TYPE_CMYK6_16 },
-};
-
-typedef struct _VipsIccExportType {
-        cmsColorSpaceSignature signature;
-        VipsBandFormat output_format;
-        int depth;
-        VipsInterpretation interpretation;
-        guint input_format;
-} VipsIccImportType;
-
-static VipsIccExportType vips_icc_export_table[] = {
-        { cmsSigRgbData, 8,
-                VIPS_INTERPRETATION_sRGB, VIPS_FORMAT_UCHAR, 3, TYPE_RGB_8 },
-        { cmsSigRgbData, 16,
-                VIPS_INTERPRETATION_RGB16, VIPS_FORMAT_USHORT, 3, TYPE_RGB_16 },
-        { cmsSigLabData, 8,
-                VIPS_INTERPRETATION_sRGB, VIPS_FORMAT_UCHAR, 3, TYPE_RGB_8 },
-        { cmsSigRgbData, 16,
-                VIPS_INTERPRETATION_RGB16, VIPS_FORMAT_USHORT, 3, TYPE_RGB_16 },
-
-        { cmsSigGrayData, VIPS_FORMAT_UCHAR, 1, TYPE_GRAY_8 },
-        { cmsSigGrayData, VIPS_FORMAT_USHORT, 1, TYPE_GRAY_16 },
-        { cmsSigRgbData, VIPS_FORMAT_UCHAR, 3, TYPE_RGB_8 },
-        { cmsSigRgbData, VIPS_FORMAT_USHORT, 3, TYPE_RGB_16 },
-        { cmsSigLabData, VIPS_FORMAT_FLOAT, 3, TYPE_Lab_16 },
-        { cmsSigXYZData, VIPS_FORMAT_FLOAT, 3, TYPE_XYZ_16 },
-        { cmsSigCmykData, VIPS_FORMAT_UCHAR, 4, TYPE_CMYK_8 },
-        { cmsSigCmykData, VIPS_FORMAT_USHORT, 4, TYPE_CMYK_16 },
-        { cmsSigCmykData, VIPS_FORMAT_UCHAR, 4, TYPE_CMYK_8 },
-        { cmsSig6colorData, VIPS_FORMAT_UCHAR, 6, TYPE_CMYK6_8 },
-        { cmsSig6colorData, VIPS_FORMAT_USHORT, 6, TYPE_CMYK6_16 },
-};
-
 static int
 vips_icc_build( VipsObject *object )
 {
@@ -274,7 +222,6 @@ vips_icc_build( VipsObject *object )
 	VipsIcc *icc = (VipsIcc *) object;
 
 	cmsUInt32Number flags;
-        int i;
 
 	if( icc->depth != 8 &&
 		icc->depth != 16 ) {
@@ -285,28 +232,57 @@ vips_icc_build( VipsObject *object )
 
 	if( icc->in_profile &&
 		code->in ) {
-                cmsColorSpaceSignature signature = 
-                        cmsGetColorSpace( icc->in_profile );
-                VipsBandFormat input_format = code->in->BandFmt;
+		switch( cmsGetColorSpace( icc->in_profile ) ) {
+		case cmsSigRgbData:
+			colour->input_bands = 3;
+			code->input_format = 
+				code->in->BandFmt == VIPS_FORMAT_USHORT ? 
+				VIPS_FORMAT_USHORT : VIPS_FORMAT_UCHAR;
+			icc->in_icc_format = 
+				code->in->BandFmt == VIPS_FORMAT_USHORT ? 
+				TYPE_RGB_16 : TYPE_RGB_8;
+			break;
 
-                for( i = 0; i < VIPS_NUMBER( vips_icc_import_table ); i++ ) {
-                        VipsIccImportType *type = &vips_icc_import_table[i];
+		case cmsSigGrayData:
+			colour->input_bands = 1;
+			code->input_format = 
+				code->in->BandFmt == VIPS_FORMAT_USHORT ? 
+				VIPS_FORMAT_USHORT : VIPS_FORMAT_UCHAR;
+			icc->in_icc_format = 
+				code->in->BandFmt == VIPS_FORMAT_USHORT ? 
+				TYPE_GRAY_16 : TYPE_GRAY_8;
+			break;
 
-                        if( type->signature == signature &&
-                                type->input_format == input_format )
-                                break;
-                }
+		case cmsSigCmykData:
+			colour->input_bands = 4;
+			code->input_format = 
+				code->in->BandFmt == VIPS_FORMAT_USHORT ? 
+				VIPS_FORMAT_USHORT : VIPS_FORMAT_UCHAR;
+			icc->in_icc_format = 
+				code->in->BandFmt == VIPS_FORMAT_USHORT ? 
+				TYPE_CMYK_16 : TYPE_CMYK_8;
+			break;
 
-                if( i == VIPS_NUMBER( vips_icc_import_table ) ) {
+		case cmsSigLabData:
+			colour->input_bands = 3;
+			code->input_format = VIPS_FORMAT_FLOAT;
+			code->input_interpretation = 
+				VIPS_INTERPRETATION_LAB;
+			icc->in_icc_format = TYPE_Lab_16;
+			break;
+
+		case cmsSigXYZData:
+			colour->input_bands = 3;
+			code->input_format = VIPS_FORMAT_FLOAT;
+			icc->in_icc_format = TYPE_XYZ_16;
+			break;
+
+		default:
 			vips_error( class->nickname, 
 				_( "unimplemented input color space 0x%x" ), 
 				cmsGetColorSpace( icc->in_profile ) );
 			return( -1 );
-                }
-
-                colour->input_format = code->in->BandFmt;
-                colour->input_bands = vips_icc_import_table[i].input_bands;
-                colour->in_icc_format = vips_icc_import_table[i].output_format;
+		}
 	}
 
 	if( icc->out_profile ) 

--- a/libvips/colour/icc_transform.c
+++ b/libvips/colour/icc_transform.c
@@ -326,6 +326,17 @@ vips_icc_build( VipsObject *object )
 				TYPE_CMYK_16 : TYPE_CMYK_8;
 			break;
 
+		case cmsSig6colorData:
+			colour->interpretation = VIPS_INTERPRETATION_CMYK;
+			colour->format = 
+				icc->depth == 8 ? 
+				VIPS_FORMAT_UCHAR : VIPS_FORMAT_USHORT;
+			colour->bands = 6;
+			icc->out_icc_format = 
+				icc->depth == 16 ? 
+				TYPE_CMYK6_16 : TYPE_CMYK6_8;
+			break;
+
 		case cmsSigLabData:
 			colour->interpretation = VIPS_INTERPRETATION_LAB;
 			colour->format = VIPS_FORMAT_FLOAT;


### PR DESCRIPTION
This seems to export to 6clr CMYK correctly. We'll need something fancier for import, and for more generic N colour profiles.

See https://github.com/libvips/libvips/discussions/3045 for a sample 6 clr profile.