### PR TITLE
Inverted order of TIFF tag writing when saving multi-page subifd pyramids

### DIFF
--- a/libvips/foreign/vips2tiff.c
+++ b/libvips/foreign/vips2tiff.c
@@ -822,7 +822,12 @@ wtiff_write_header( Wtiff *wtiff, Layer *layer )
 	else
 		TIFFSetField( tif, TIFFTAG_ROWSPERSTRIP, wtiff->tileh );
 
-	if( wtiff->toilet_roll ) {
+
+	if( layer->above ) 
+		/* Pyramid layer.
+		 */
+		TIFFSetField( tif, TIFFTAG_SUBFILETYPE, FILETYPE_REDUCEDIMAGE );
+	else if( wtiff->toilet_roll ) {
 		/* One page of many.
 		 */
 		TIFFSetField( tif, TIFFTAG_SUBFILETYPE, FILETYPE_PAGE );
@@ -831,10 +836,6 @@ wtiff_write_header( Wtiff *wtiff, Layer *layer )
 			wtiff->page_number, wtiff->n_pages );
 	}
 
-	if( layer->above ) 
-		/* Pyramid layer.
-		 */
-		TIFFSetField( tif, TIFFTAG_SUBFILETYPE, FILETYPE_REDUCEDIMAGE );
 
 	/* Sample format.
 	 *

--- a/libvips/foreign/vips2tiff.c
+++ b/libvips/foreign/vips2tiff.c
@@ -822,11 +822,6 @@ wtiff_write_header( Wtiff *wtiff, Layer *layer )
 	else
 		TIFFSetField( tif, TIFFTAG_ROWSPERSTRIP, wtiff->tileh );
 
-	if( layer->above ) 
-		/* Pyramid layer.
-		 */
-		TIFFSetField( tif, TIFFTAG_SUBFILETYPE, FILETYPE_REDUCEDIMAGE );
-
 	if( wtiff->toilet_roll ) {
 		/* One page of many.
 		 */
@@ -835,6 +830,11 @@ wtiff_write_header( Wtiff *wtiff, Layer *layer )
 		TIFFSetField( tif, TIFFTAG_PAGENUMBER, 
 			wtiff->page_number, wtiff->n_pages );
 	}
+
+	if( layer->above ) 
+		/* Pyramid layer.
+		 */
+		TIFFSetField( tif, TIFFTAG_SUBFILETYPE, FILETYPE_REDUCEDIMAGE );
 
 	/* Sample format.
 	 *


### PR DESCRIPTION
This ensures that subifd pyramid layers are correctly tagged as reduced-image subfile type and not as pages when creating a multi-page image stack. With the previous tag writing order, the reduced-image subfile type was being over-written.