### PR TITLE
jxlsave: sync quality to distance calculation with libjxl

### DIFF
--- a/libvips/foreign/jxlsave.c
+++ b/libvips/foreign/jxlsave.c
@@ -249,7 +249,7 @@ vips_foreign_save_jxl_build( VipsObject *object )
 	if( !vips_object_argument_isset( object, "distance" ) ) 
 		jxl->distance = jxl->Q >= 30 ?
 			0.1 + (100 - jxl->Q) * 0.09 :
-			6.4 + pow(2.5, (30 - jxl->Q) / 5.0f) / 6.25f;
+			6.24 + pow(2.5, (30 - jxl->Q) / 5.0f) / 6.25f;
 
 	/* Distance 0 is lossless. libjxl will fail for lossy distance 0.
 	 */


### PR DESCRIPTION
Ensures the quality to distance conversion is continuous at 30.

See:
https://github.com/libjxl/libjxl/commit/ea5fa8074d0146ec0f4388f52990d428ea3b67c3

> **Note**: this PR targets the [`8.13`](https://github.com/libvips/libvips/tree/8.13) branch.