### PR TITLE
SubIFD offsets should only be added if smaller pyramid layers actually exist

### DIFF
--- a/libvips/foreign/vips2tiff.c
+++ b/libvips/foreign/vips2tiff.c
@@ -2128,11 +2128,14 @@ wtiff_page_start( Wtiff *wtiff )
 		 */
 		for( n_layers = 0, p = wtiff->layer->below; p; p = p->below )
 			n_layers += 1;
-		subifd_offsets = VIPS_ARRAY( NULL, n_layers, toff_t );
-		memset( subifd_offsets, 0, n_layers * sizeof( toff_t ) );
-		TIFFSetField( wtiff->layer->tif, TIFFTAG_SUBIFD, 
-			n_layers, subifd_offsets );
-		g_free( subifd_offsets );
+
+		if( n_layers > 0 ){
+		  subifd_offsets = VIPS_ARRAY( NULL, n_layers, toff_t );
+		  memset( subifd_offsets, 0, n_layers * sizeof( toff_t ) );
+		  TIFFSetField( wtiff->layer->tif, TIFFTAG_SUBIFD,
+			  n_layers, subifd_offsets );
+		  g_free( subifd_offsets );
+		}
 	}
 
 	return( 0 );


### PR DESCRIPTION
For images that are smaller than the tile size, empty SubIFD offsets get added resulting in corrupted TIFF files