### PR TITLE
tiff2vips: avoid `g_assert_not_reached` in the default clause

### DIFF
--- a/libvips/foreign/tiff2vips.c
+++ b/libvips/foreign/tiff2vips.c
@@ -1937,13 +1937,15 @@ rtiff_decompress_jpeg_run( Rtiff *rtiff, j_decompress_ptr cinfo,
                 bytes_per_pixel = 3;
                 break;
 
+        case PHOTOMETRIC_MINISWHITE:
         case PHOTOMETRIC_MINISBLACK:
                 cinfo->jpeg_color_space = JCS_GRAYSCALE;
                 bytes_per_pixel = 1;
                 break;
 
         default:
-                g_assert_not_reached();
+                cinfo->jpeg_color_space = JCS_UNKNOWN;
+                bytes_per_pixel = 1;
                 break;
         }
 


### PR DESCRIPTION
Since that could terminate the application in debug builds. Also, add the missing case clause for `PHOTOMETRIC_MINISWHITE`, see:
https://gitlab.com/libtiff/libtiff/-/blob/4c3ddd99b6efbdca9d0f2e91a53671edb0656fd7/libtiff/tif_jpeg.c#L1706-1731

Resolves: https://bugs.chromium.org/p/oss-fuzz/issues/detail?id=51013.