### PR TITLE
spngsave: ensure ICC profiles have a name

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -6,6 +6,7 @@
 - reduce latency on dzsave kill [kleisauke]
 - improve text too large check [kleisauke]
 - fix subifd writing for small images [ruven]
+- name ICC profiles in spngsave [lovell]
 
 24/7/22 started 8.13.1
 - fix im7 feature detection in meson

--- a/libvips/foreign/spngsave.c
+++ b/libvips/foreign/spngsave.c
@@ -217,7 +217,7 @@ vips_foreign_save_spng_metadata( VipsForeignSaveSpng *spng, VipsImage *in )
 			"of ICC profile\n", length );
 #endif /*DEBUG*/
 
-		vips_strncpy( iccp.profile_name, "", 
+		vips_strncpy( iccp.profile_name, "icc",
 			sizeof( iccp.profile_name ) );
 		iccp.profile_len = length;
 		iccp.profile = (void *) data;


### PR DESCRIPTION
The PNG spec requires that the iCCP chunk has a profile name with a minumum length of 1 (we use the same "icc" name as pngsave).

http://www.libpng.org/pub/png/spec/1.2/PNG-Chunks.html#C.iCCP

https://github.com/libvips/libvips/blob/4176ab21061f425b4ee274f7f9c6634dacf5ca7c/libvips/foreign/vipspng.c#L1113-L1115

Targets the 8.13 branch as this is a bug fix.

Originally reported at https://github.com/lovell/sharp/issues/3390