### PR TITLE
spngsave: fix transparency

### DIFF
--- a/libvips/foreign/spngsave.c
+++ b/libvips/foreign/spngsave.c
@@ -406,14 +406,9 @@ vips_foreign_save_spng_write( VipsForeignSaveSpng *spng, VipsImage *in )
 			entry->blue = p[2];
 			plte.n_entries += 1;
 
-			/* Quantizr and libimagequant sort the pallette
-			 * by transparency, so trns.type3_alpha[] and
-			 * plte.entries[] will use the same indexing.
-			 */
-			g_assert( i == 0 || p[3] >= p[-1] );
+			trns.type3_alpha[i] = p[3];
 			if( p[3] != 255 ) {
-				trns.type3_alpha[trns.n_type3_entries] = p[3];
-				trns.n_type3_entries += 1;
+				trns.n_type3_entries = i+1;
 			}
 		}
 


### PR DESCRIPTION
Fixes https://github.com/lovell/sharp/issues/3395

LIQ may not sort the palette by alpha properly so the current way of filling `trns` may not work in some cases. This PR makes libvips fill `trns.type3_alpha` for every palette entry but update `trns.n_type3_entries` only when the palette entry has transparency. Thus we don't care if the palette is sorted by alpha or not.