### PR TITLE
GObject Introspection: Image unskip constructors (cont. #3079)

### DIFF
--- a/libvips/Vips-8.0.metadata
+++ b/libvips/Vips-8.0.metadata
@@ -10,6 +10,7 @@ ArrayDouble.newv skip=false
 ArrayImage.newv skip=false
 ArrayInt.newv skip=false
 
+Image.*#constructor skip=fase
 Image.*#method skip=false
 Image.eval#virtual_method name="eval_impl"
 Image.invalidate#virtual_method name="invalidate_impl"


### PR DESCRIPTION
Unskips constructors for the Image classes. This, for example, exposes the `from_source` constructor. Continues #3079.

However, generating a vapi with `vapigen Vips-8.0.gir --metadatadir ~/Projects/libvips/libvips/ --library vips` reports:

```
Vips-8.0.gir:5168.7-5170.21: warning: `Image' already contains a definition for `memory'
 5168 |       <constructor name="new_memory"
      |       ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 5169 |                    c:identifier="vips_image_new_memory"
      | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 5170 |                    introspectable="0">
      | ~~~~~~~~~~~~~~~~~~~~~                 
Vips-8.0.gir:4562.7-4562.54: note: previous definition of `memory' was here
 4562 |       <constructor name="memory" c:identifier="vips_image_memory">
      |       ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~            
Vips-8.0.gir:23300.7-23300.54: warning: Creation method of abstract class cannot be public.
23300 |       <constructor name="new" c:identifier="vips_interpolate_new">
      |       ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~            
Vips-8.0.gir:24309.7-24310.73: warning: Creation method of abstract class cannot be public.
24309 |       <constructor name="new_from_string"
      |       ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
24310 |                    c:identifier="vips_object_new_from_string">
      | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
Vips-8.0.gir:25669.7-25669.50: warning: Creation method of abstract class cannot be public.
25669 |       <constructor name="new" c:identifier="vips_operation_new">
      |       ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~              
```

So check this PR, maybe I made a mistake