### PR TITLE
webpsave: switch to g_try_malloc() and limit WebP output dimensions

### DIFF
--- a/libvips/foreign/webpsave.c
+++ b/libvips/foreign/webpsave.c
@@ -647,6 +647,13 @@ vips_foreign_save_webp_build( VipsObject *object )
 		build( object ) )
 		return( -1 );
 
+	page_height = vips_image_get_page_height( save->ready );
+	if( save->ready->Xsize > 16383 || page_height > 16383 ) {
+		vips_error( "webpsave", _( "image too large" ) );
+		vips_foreign_save_webp_unset( webp );
+		return( -1 );
+	}
+
 	/* We need a copy of the input image in case we change the metadata
 	 * eg. in vips__exif_update().
 	 */
@@ -654,8 +661,6 @@ vips_foreign_save_webp_build( VipsObject *object )
 		vips_foreign_save_webp_unset( webp );
 		return( -1 );
 	}
-
-	page_height = vips_image_get_page_height( webp->image );
 
 	/* RGB(A) frame as a contiguous buffer.
 	 */

--- a/libvips/foreign/webpsave.c
+++ b/libvips/foreign/webpsave.c
@@ -659,8 +659,13 @@ vips_foreign_save_webp_build( VipsObject *object )
 
 	/* RGB(A) frame as a contiguous buffer.
 	 */
-	webp->frame_bytes = g_malloc( (size_t) webp->image->Bands *
+	webp->frame_bytes = g_try_malloc( (size_t) webp->image->Bands *
 		webp->image->Xsize * page_height );
+	if( webp->frame_bytes == NULL ) {
+		vips_error( "webpsave", _( "out of memory" ) );
+		vips_foreign_save_webp_unset( webp );
+		return( -1 );
+	}
 
 	/* Init generic WebP config
 	 */

--- a/libvips/foreign/webpsave.c
+++ b/libvips/foreign/webpsave.c
@@ -664,10 +664,10 @@ vips_foreign_save_webp_build( VipsObject *object )
 
 	/* RGB(A) frame as a contiguous buffer.
 	 */
-	webp->frame_bytes = g_try_malloc( (size_t) webp->image->Bands *
-		webp->image->Xsize * page_height );
+	size_t frame_size = (size_t) webp->image->Bands * webp->image->Xsize * page_height;
+	webp->frame_bytes = g_try_malloc( frame_size );
 	if( webp->frame_bytes == NULL ) {
-		vips_error( "webpsave", _( "out of memory" ) );
+		vips_error( "webpsave", _( "failed to allocate %zu bytes" ), frame_size );
 		vips_foreign_save_webp_unset( webp );
 		return( -1 );
 	}


### PR DESCRIPTION
Switch from `g_malloc()` to `g_try_malloc()` to avoid that `g_malloc()` aborts the program on error.

**Before:**
```
$ vips black out.webp 10000000 10000000
(vips:27126): GLib-ERROR **: 14:44:37.810: ../glib/gmem.c:136: failed to allocate 300000000000000 bytes
zsh: trace trap (SIGTRAP) vips black out.webp 10000000 10000000
```

**With 0adc6687418803aa86d3b59d62a319aa3b5569e9:**
```
$ vips black out.webp 10000000 10000000
webpsave: out of memory
error buffer: webpsave: out of memory
```

I also added a check for the dimensions limit of WebP (16383 x 16383) with 263476275319844118d8729228a2253c4b06ab16, so that we get a nicer looking error message in this case:
```
$ vips black out.webp 10000000 10000000
webpsave: image too large
error buffer: webpsave: image too large
```
