### PR TITLE
exif: ensure prefix is present before parsing

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -2,6 +2,7 @@
 - improve rules for 16-bit heifsave [johntrunc]
 - improve libspng pallette write [kleisauke]
 - improve libspng pallette sort [DarthSim]
+- ensure EXIF has prefix before parsing [lovell]
 
 5/9/22 started 8.13.2
 - in dzsave, add add missing include directive for errno/EEXIST [kleisauke]

--- a/libvips/foreign/exif.c
+++ b/libvips/foreign/exif.c
@@ -178,7 +178,17 @@ vips_exif_load_data_without_fix( const void *data, size_t length )
 	}
 
 	exif_data_unset_option( ed, EXIF_DATA_OPTION_FOLLOW_SPECIFICATION );
-	exif_data_load_data( ed, data, length );
+	if( !vips_isprefix( "Exif", (char *) data ) ) {
+		/* Ensure "Exif" prefix as loaders may not provide it.
+		 */
+		void* data_with_prefix;
+		data_with_prefix = g_malloc0( length + 6 );
+		memcpy( data_with_prefix, "Exif\0\0", 6 );
+		memcpy( data_with_prefix + 6, data, length );
+		exif_data_load_data( ed, data_with_prefix, length + 6 );
+		g_free( data_with_prefix );
+	} else
+		exif_data_load_data( ed, data, length );
 
 	return( ed );
 }
@@ -1391,7 +1401,7 @@ vips__exif_update( VipsImage *image )
 			(void *) &data, &length ) )
 			return( -1 );
 
-		if( !(ed = exif_data_new_from_data( data, length )) )
+		if( !(ed = vips_exif_load_data_without_fix( data, length )) )
 			return( -1 );
 	}
 	else  {
@@ -1401,11 +1411,12 @@ vips__exif_update( VipsImage *image )
 			EXIF_DATA_OPTION_FOLLOW_SPECIFICATION );
 		exif_data_set_data_type( ed, EXIF_DATA_TYPE_COMPRESSED );
 		exif_data_set_byte_order( ed, EXIF_BYTE_ORDER_INTEL );
-	
-		/* Create the mandatory EXIF fields with default data.
-		 */
-		exif_data_fix( ed );
 	}
+
+	/* Make sure all required fields are there before we attach the vips
+	 * metadata.
+	 */
+	exif_data_fix( ed );
 
 	/* Update EXIF tags from the image metadata.
 	 */


### PR DESCRIPTION
It looks like some newer Apple devices are attaching EXIF to images without the `Exif\0\0` prefix, however libexif still requires it due to JPEG/JFIF/APP1 marker heritage.

There's an upstream issue about this at https://github.com/libexif/libexif/issues/58

Originally reported at https://github.com/lovell/sharp/issues/3412

Before:
```
exif-data: 2402 bytes of binary data
exif-ifd0-XResolution: 72009/1000 (72.009, Rational, 1 components, 8 bytes)
exif-ifd0-YResolution: 72009/1000 (72.009, Rational, 1 components, 8 bytes)
exif-ifd0-ResolutionUnit: 2 (Inch, Short, 1 components, 2 bytes)
exif-ifd2-ExifVersion: Exif Version 2.1 (Exif Version 2.1, Undefined, 4 components, 4 bytes)
exif-ifd2-FlashpixVersion: FlashPix Version 1.0 (FlashPix Version 1.0, Undefined, 4 components, 4 bytes)
exif-ifd2-ColorSpace: 65535 (Uncalibrated, Short, 1 components, 2 bytes)
```

After:
```
exif-data: 2402 bytes of binary data
exif-ifd0-Make: Apple (Apple, ASCII, 6 components, 6 bytes)
exif-ifd0-Model: iPhone 11 Pro Max (iPhone 11 Pro Max, ASCII, 18 components, 18 bytes)
exif-ifd0-Orientation: 1 (Top-left, Short, 1 components, 2 bytes)
exif-ifd0-XResolution: 72/1 (72, Rational, 1 components, 8 bytes)
exif-ifd0-YResolution: 72/1 (72, Rational, 1 components, 8 bytes)
exif-ifd0-ResolutionUnit: 2 (Inch, Short, 1 components, 2 bytes)
exif-ifd0-Software: 15.5 (15.5, ASCII, 5 components, 5 bytes)
exif-ifd0-DateTime: 2022:07:08 13:00:46 (2022:07:08 13:00:46, ASCII, 20 components, 20 bytes)
exif-ifd2-ExposureTime: 1/122 (1/122 sec., Rational, 1 components, 8 bytes)
exif-ifd2-FNumber: 12/5 (f/2.4, Rational, 1 components, 8 bytes)
exif-ifd2-ExposureProgram: 2 (Normal programme, Short, 1 components, 2 bytes)
exif-ifd2-ISOSpeedRatings: 25 (25, Short, 1 components, 2 bytes)
exif-ifd2-ExifVersion: Exif Version 2.32 (Exif Version 2.32, Undefined, 4 components, 4 bytes)
exif-ifd2-DateTimeOriginal: 2022:07:08 13:00:46 (2022:07:08 13:00:46, ASCII, 20 components, 20 bytes)
exif-ifd2-DateTimeDigitized: 2022:07:08 13:00:46 (2022:07:08 13:00:46, ASCII, 20 components, 20 bytes)
exif-ifd2-OffsetTime: +01:00 (+01:00, ASCII, 7 components, 7 bytes)
exif-ifd2-OffsetTimeOriginal: +01:00 (+01:00, ASCII, 7 components, 7 bytes)
exif-ifd2-OffsetTimeDigitized: +01:00 (+01:00, ASCII, 7 components, 7 bytes)
exif-ifd2-ComponentsConfiguration: Y Cb Cr - (Y Cb Cr -, Undefined, 4 components, 4 bytes)
exif-ifd2-ShutterSpeedValue: 68321/9857 (6.93 EV (1/122 sec.), SRational, 1 components, 8 bytes)
exif-ifd2-ApertureValue: 4845/1918 (2.53 EV (f/2.4), Rational, 1 components, 8 bytes)
exif-ifd2-BrightnessValue: 35212/4987 (7.06 EV (457.43 cd/m^2), SRational, 1 components, 8 bytes)
exif-ifd2-ExposureBiasValue: 0/1 (0.00 EV, SRational, 1 components, 8 bytes)
exif-ifd2-MeteringMode: 5 (Pattern, Short, 1 components, 2 bytes)
exif-ifd2-Flash: 16 (Flash did not fire, compulsory flash mode, Short, 1 components, 2 bytes)
exif-ifd2-FocalLength: 77/50 (1.5 mm, Rational, 1 components, 8 bytes)
exif-ifd2-SubjectArea: 2015 1511 2324 1392 (Within rectangle (width 2324, height 1392) around (x,y) = (2015,1511), Short, 4 components, 8 bytes)
exif-ifd2-MakerNote: 1236 bytes undefined data (1236 bytes undefined data, Undefined, 1236 components, 1236 bytes)
exif-ifd2-SubsecTime: 520 (520, ASCII, 4 components, 4 bytes)
exif-ifd2-SubSecTimeOriginal: 520 (520, ASCII, 4 components, 4 bytes)
exif-ifd2-SubSecTimeDigitized: 520 (520, ASCII, 4 components, 4 bytes)
exif-ifd2-FlashpixVersion: FlashPix Version 1.0 (FlashPix Version 1.0, Undefined, 4 components, 4 bytes)
exif-ifd2-ColorSpace: 1 (sRGB, Short, 1 components, 2 bytes)
exif-ifd2-PixelXDimension: 288 (288, Long, 1 components, 4 bytes)
exif-ifd2-PixelYDimension: 279 (279, Long, 1 components, 4 bytes)
exif-ifd2-SensingMethod: 2 (One-chip colour area sensor, Short, 1 components, 2 bytes)
exif-ifd2-SceneType: Directly photographed (Directly photographed, Undefined, 1 components, 1 bytes)
exif-ifd2-ExposureMode: 0 (Auto exposure, Short, 1 components, 2 bytes)
exif-ifd2-WhiteBalance: 0 (Auto white balance, Short, 1 components, 2 bytes)
exif-ifd2-DigitalZoomRatio: 1512/1325 (1.1411, Rational, 1 components, 8 bytes)
exif-ifd2-FocalLengthIn35mmFilm: 15 (15, Short, 1 components, 2 bytes)
exif-ifd2-SceneCaptureType: 0 (Standard, Short, 1 components, 2 bytes)
exif-ifd2-LensSpecification: 807365/524263 6/1 9/5 12/5 (1.540000,  6, 1.8, 2.4, Rational, 4 components, 32 bytes)
exif-ifd2-LensMake: Apple (Apple, ASCII, 6 components, 6 bytes)
exif-ifd2-LensModel: iPhone 11 Pro Max back triple camera 1.54mm f/2.4 (iPhone 11 Pro Max back triple camera 1.54mm f/2.4, ASCII, 50 components, 50 bytes)
exif-ifd2-CompositeImage: 2 (2, Short, 1 components, 2 bytes)
exif-ifd3-GPSLatitudeRef: N (N, ASCII, 2 components, 2 bytes)
exif-ifd3-GPSLatitude: 55/1 14/1 2461/100 (55, 14, 24.61, Rational, 3 components, 24 bytes)
exif-ifd3-GPSLongitudeRef: W (W, ASCII, 2 components, 2 bytes)
exif-ifd3-GPSLongitude: 6/1 30/1 3820/100 ( 6, 30, 38.20, Rational, 3 components, 24 bytes)
exif-ifd3-GPSAltitudeRef: Sea level (Sea level, Byte, 1 components, 1 bytes)
exif-ifd3-GPSAltitude: 52037/8161 (6.3763, Rational, 1 components, 8 bytes)
exif-ifd3-GPSSpeedRef: K (K, ASCII, 2 components, 2 bytes)
exif-ifd3-GPSSpeed: 0/1 ( 0, Rational, 1 components, 8 bytes)
exif-ifd3-GPSImgDirectionRef: T (T, ASCII, 2 components, 2 bytes)
exif-ifd3-GPSImgDirection: 130663/487 (268.302, Rational, 1 components, 8 bytes)
exif-ifd3-GPSDestBearingRef: T (T, ASCII, 2 components, 2 bytes)
exif-ifd3-GPSDestBearing: 130663/487 (268.302, Rational, 1 components, 8 bytes)
exif-ifd3-GPSHPositioningError: 7566/1549 (4.8844, Rational, 1 components, 8 bytes)
```
