### PR TITLE
spngsave: Don't shift indexed pixels

### DIFF
--- a/libvips/foreign/spngsave.c
+++ b/libvips/foreign/spngsave.c
@@ -270,7 +270,7 @@ vips_foreign_save_spng_pack( VipsForeignSaveSpng *spng,
 	VipsPel *q, VipsPel *p, size_t n )
 {
         int pixel_mask = 8 / spng->bitdepth - 1;
-	int shift = 8 - spng->bitdepth;
+	int shift = spng->palette ? 0 : 8 - spng->bitdepth;
 
         VipsPel bits;
         size_t x;


### PR DESCRIPTION
Hey!

The commit https://github.com/libvips/libvips/commit/ca2796aa7ff75c5bb5a74a1f3a4de9538bb9c45e have broken saving paletted PNGs with low bit-depth (< 8). This happens because palette indexes can't be larger than `1 << bitdepth`, so shifting makes all of them zeroes.

Fixes https://github.com/imgproxy/imgproxy/issues/1013