### PR TITLE
skip some skippable tests

### DIFF
--- a/test/test_cli.sh
+++ b/test/test_cli.sh
@@ -7,32 +7,6 @@
 
 . ./variables.sh
 
-# is a difference beyond a threshold? return 0 (meaning all ok) or 1 (meaning
-# error, or outside threshold)
-# 
-# use bc since bash does not support fp math
-break_threshold() {
-	diff=$1
-	threshold=$2
-	return $(echo "$diff <= $threshold" | bc -l)
-}
-
-# subtract, look for max difference less than a threshold
-test_difference() {
-	before=$1
-	after=$2
-	threshold=$3
-
-	$vips subtract $before $after $tmp/difference.v
-	$vips abs $tmp/difference.v $tmp/abs.v 
-	dif=$($vips max $tmp/abs.v)
-
-	if break_threshold $dif $threshold; then
-		echo "difference is $dif"
-		exit 1
-	fi
-}
-
 test_rotate() {
 	im=$1
 	inter=$2

--- a/test/test_connections.sh
+++ b/test/test_connections.sh
@@ -12,4 +12,6 @@ if test_supported jpegload_source; then
 
 	# test max difference < 10
 	test_difference $image $tmp/x.png 10
+else
+	exit 77
 fi

--- a/test/test_stall.sh
+++ b/test/test_stall.sh
@@ -14,4 +14,6 @@ if test_supported tiffload; then
 -1 -1 -1
 EOF
 	VIPS_STALL=1 $vips conv $tmp/x.tif $tmp/x2.tif $tmp/mask.con
+else
+	exit 77
 fi

--- a/test/variables.sh.in
+++ b/test/variables.sh.in
@@ -37,6 +37,9 @@ test_supported() {
 break_threshold() {
 	diff=$1
 	threshold=$2
+	if ! command -v bc >/dev/null; then
+		exit 77
+	fi
 	return $(echo "$diff <= $threshold" | bc -l)
 }
 

--- a/test/variables.sh.in
+++ b/test/variables.sh.in
@@ -32,6 +32,8 @@ test_supported() {
 
 # is a difference beyond a threshold? return 0 (meaning all ok) or 1 (meaning
 # error, or outside threshold)
+#
+# use bc since bash does not support fp math
 break_threshold() {
 	diff=$1
 	threshold=$2


### PR DESCRIPTION
There are two types of tests that are implemented here:
- Some tests have an if block, and only run the entire test if some single prerequisite condition is available. This is a simple fix, because the tests are already skipped, but they don't say so. Make these `exit 77` so they are marked as having been skipped.
- Some tests use `bc`, and fail if that is not installed. Make this a bit nicer, and abort the test, marking it as skipped. Oftentimes, `bc` is not installed.