### PR TITLE
Fix build with `-Dwebp=disabled`

### DIFF
--- a/libvips/foreign/webpsave.c
+++ b/libvips/foreign/webpsave.c
@@ -71,8 +71,6 @@
 #endif /*HAVE_CONFIG_H*/
 #include <glib/gi18n-lib.h>
 
-#ifdef HAVE_LIBWEBP
-
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
@@ -81,6 +79,8 @@
 #include <vips/internal.h>
 
 #include "pforeign.h"
+
+#ifdef HAVE_LIBWEBP
 
 #include <webp/encode.h>
 #include <webp/types.h>


### PR DESCRIPTION
<details>
    <summary>Details</summary>

```
../libvips/foreign/webpsave.c:1153:16: error: unknown type name 'VipsImage'
vips_webpsave( VipsImage *in, const char *filename, ... )
               ^
../libvips/foreign/webpsave.c:1159:11: warning: implicit declaration of function 'vips_call_split' is invalid in C99 [-Wimplicit-function-declaration]
        result = vips_call_split( "webpsave", ap, in, filename );
                 ^
../libvips/foreign/webpsave.c:1199:23: error: unknown type name 'VipsImage'
vips_webpsave_buffer( VipsImage *in, void **buf, size_t *len, ... )
                      ^
../libvips/foreign/webpsave.c:1202:2: error: use of undeclared identifier 'VipsArea'
        VipsArea *area;
        ^
../libvips/foreign/webpsave.c:1202:12: error: use of undeclared identifier 'area'; did you mean 'free'?
        VipsArea *area;
                  ^~~~
                  free
/usr/include/stdlib.h:555:13: note: 'free' declared here
extern void free (void *__ptr) __THROW;
            ^
../libvips/foreign/webpsave.c:1205:2: error: use of undeclared identifier 'area'
        area = NULL;
        ^
../libvips/foreign/webpsave.c:1208:11: warning: implicit declaration of function 'vips_call_split' is invalid in C99 [-Wimplicit-function-declaration]
        result = vips_call_split( "webpsave_buffer", ap, in, &area );
                 ^
../libvips/foreign/webpsave.c:1208:56: error: use of undeclared identifier 'area'; did you mean 'free'?
        result = vips_call_split( "webpsave_buffer", ap, in, &area );
                                                              ^~~~
                                                              free
/usr/include/stdlib.h:555:13: note: 'free' declared here
extern void free (void *__ptr) __THROW;
            ^
../libvips/foreign/webpsave.c:1212:3: error: use of undeclared identifier 'area'; did you mean 'free'?
                area ) {
                ^~~~
                free
/usr/include/stdlib.h:555:13: note: 'free' declared here
extern void free (void *__ptr) __THROW;
            ^
../libvips/foreign/webpsave.c:1212:3: warning: address of function 'free' will always evaluate to 'true' [-Wpointer-bool-conversion]
                area ) {
                ^~~~
../libvips/foreign/webpsave.c:1212:3: note: prefix with the address-of operator to silence this warning
                area ) {
                ^
                &
../libvips/foreign/webpsave.c:1214:11: error: use of undeclared identifier 'area'
                        *buf = area->data;
                               ^
../libvips/foreign/webpsave.c:1215:4: error: use of undeclared identifier 'area'
                        area->free_fn = NULL;
                        ^
../libvips/foreign/webpsave.c:1218:11: error: use of undeclared identifier 'area'
                        *len = area->length;
                               ^
../libvips/foreign/webpsave.c:1220:3: warning: implicit declaration of function 'vips_area_unref' is invalid in C99 [-Wimplicit-function-declaration]
                vips_area_unref( area );
                ^
../libvips/foreign/webpsave.c:1220:20: error: use of undeclared identifier 'area'; did you mean 'free'?
                vips_area_unref( area );
                                 ^~~~
                                 free
/usr/include/stdlib.h:555:13: note: 'free' declared here
extern void free (void *__ptr) __THROW;
            ^
../libvips/foreign/webpsave.c:1254:21: error: unknown type name 'VipsImage'
vips_webpsave_mime( VipsImage *in, ... )
                    ^
../libvips/foreign/webpsave.c:1260:11: warning: implicit declaration of function 'vips_call_split' is invalid in C99 [-Wimplicit-function-declaration]
        result = vips_call_split( "webpsave_mime", ap, in );
                 ^
../libvips/foreign/webpsave.c:1295:23: error: unknown type name 'VipsImage'
vips_webpsave_target( VipsImage *in, VipsTarget *target, ... )
                      ^
../libvips/foreign/webpsave.c:1295:38: error: unknown type name 'VipsTarget'
vips_webpsave_target( VipsImage *in, VipsTarget *target, ... )
                                     ^
../libvips/foreign/webpsave.c:1301:11: warning: implicit declaration of function 'vips_call_split' is invalid in C99 [-Wimplicit-function-declaration]
        result = vips_call_split( "webpsave_target", ap, in, target );
                 ^
6 warnings and 14 errors generated.
```
</details>