### PR TITLE
Fix build when the webpsave feature is disabled

### DIFF
--- a/libvips/foreign/webpsave.c
+++ b/libvips/foreign/webpsave.c
@@ -71,8 +71,6 @@
 #endif /*HAVE_CONFIG_H*/
 #include <glib/gi18n-lib.h>
 
-#ifdef HAVE_LIBWEBP
-
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
@@ -81,6 +79,8 @@
 #include <vips/internal.h>
 
 #include "pforeign.h"
+
+#ifdef HAVE_LIBWEBP
 
 #include <webp/encode.h>
 #include <webp/types.h>


### PR DESCRIPTION
**Before:**
```
$ meson setup build -Dwebp=disabled
$ meson compile -C build

[..]
../libvips/foreign/webpsave.c:1254:21: error: unknown type name 'VipsImage'
vips_webpsave_mime( VipsImage *in, ... )
                    ^
../libvips/foreign/webpsave.c:1260:11: error: implicit declaration of function 'vips_call_split' is invalid in C99 [-Werror,-Wimplicit-function-declaration]
        result = vips_call_split( "webpsave_mime", ap, in );
                 ^
../libvips/foreign/webpsave.c:1295:23: error: unknown type name 'VipsImage'
vips_webpsave_target( VipsImage *in, VipsTarget *target, ... )
                      ^
../libvips/foreign/webpsave.c:1295:38: error: unknown type name 'VipsTarget'
vips_webpsave_target( VipsImage *in, VipsTarget *target, ... )
                                     ^
../libvips/foreign/webpsave.c:1301:11: error: implicit declaration of function 'vips_call_split' is invalid in C99 [-Werror,-Wimplicit-function-declaration]
        result = vips_call_split( "webpsave_target", ap, in, target );
                 ^
1 warning and 19 errors generated.
[69/505] Compiling C object libvips/deprecated/libdeprecated.a.p/freq_dispatch.c.o
ninja: build stopped: subcommand failed.
```

**After:**
```
$ meson setup build -Dwebp=disabled
$ meson compile -C build

[..]
[505/505] Linking target cplusplus/libvips-cpp.42.dylib
```