### PR TITLE
Ensure EXIF is at least 4 bytes before inspection

### DIFF
--- a/libvips/foreign/exif.c
+++ b/libvips/foreign/exif.c
@@ -167,6 +167,10 @@ vips_exif_load_data_without_fix( const void *data, size_t length )
 	/* exif_data_load_data() only allows uint for length. Limit it to less
 	 * than that: 2**20 should be enough for anyone.
 	 */
+	if( length < 4 ) {
+		vips_error( "exif", "%s", _( "exif too small" ) );
+		return( NULL );
+	}
 	if( length > 1 << 20 ) {
 		vips_error( "exif", "%s", _( "exif too large" ) ); 
 		return( NULL );


### PR DESCRIPTION
Fixes https://bugs.chromium.org/p/oss-fuzz/issues/detail?id=52606

This was exposed by me in https://github.com/libvips/libvips/pull/3100, sorry.