### PR TITLE
tweak libnsgif to allow truncated frames

### DIFF
--- a/libvips/foreign/libnsgif/nsgif.h
+++ b/libvips/foreign/libnsgif/nsgif.h
@@ -359,6 +359,8 @@ typedef struct nsgif_info {
 	uint32_t height;
 	/** number of frames decoded */
 	uint32_t frame_count;
+	/** number of frames partially decoded */
+	uint32_t frame_count_partial;
 	/** number of times to play animation (zero means loop forever) */
 	int loop_max;
 	/** background colour in same pixel format as \ref nsgif_bitmap_t. */


### PR DESCRIPTION
- move frame_count_partial into the public info struct so apps can decide how to handle truncated final frames

- allow decode of truncated frames by ignoring EOF from the LZW decompressor

- allow decode of frames with "display" set false (is this a good idea? dunno! I expect there's a better fix)

see https://github.com/libvips/libvips/issues/3134