### PR TITLE
libnsgif: Update to latest upstream

### DIFF
--- a/libvips/foreign/libnsgif/README.md
+++ b/libvips/foreign/libnsgif/README.md
@@ -8,7 +8,7 @@ but within the libvips build system.
 Run `./update.sh` to update this copy of libnsgif from the upstream repo. It
 will also patch libnsgif.c to prevent it modifying the input.
 
-Last updated 4 Nov 2022.
+Last updated 5 Nov 2022.
 
 # To do
 

--- a/libvips/foreign/libnsgif/gif.c
+++ b/libvips/foreign/libnsgif/gif.c
@@ -1234,7 +1234,7 @@ static nsgif_error nsgif__parse_image_data(
 			/* Check if the frame data runs off the end of the file */
 			if (block_size > len) {
 				frame->lzw_data_length += len;
-				return NSGIF_OK;
+				return NSGIF_ERR_END_OF_DATA;
 			}
 
 			len -= block_size;


### PR DESCRIPTION
Allows clients to know if the scan encountered a truncated image.