### PR TITLE
nsgifload: avoid using sequential flags

### DIFF
--- a/libvips/foreign/nsgifload.c
+++ b/libvips/foreign/nsgifload.c
@@ -259,7 +259,8 @@ vips_foreign_load_nsgif_set_header( VipsForeignLoadNsgif *gif,
 		gif->has_transparency ? 4 : 3,
 		VIPS_FORMAT_UCHAR, VIPS_CODING_NONE,
 		VIPS_INTERPRETATION_sRGB, 1.0, 1.0 );
-	vips_image_pipelinev( image, VIPS_DEMAND_STYLE_FATSTRIP, NULL );
+	if( vips_image_pipelinev( image, VIPS_DEMAND_STYLE_FATSTRIP, NULL ) )
+		return( -1 );
 
 	/* Only set page-height if we have more than one page, or this could
 	 * accidentally turn into an animated image later.
@@ -440,7 +441,8 @@ vips_foreign_load_nsgif_header( VipsForeignLoad *load )
 
 	gif->gif_delay = gif->delay[0] / 10;
 
-	vips_foreign_load_nsgif_set_header( gif, load->out );
+	if( vips_foreign_load_nsgif_set_header( gif, load->out ) )
+		return( -1 );
 
 	return( 0 );
 }

--- a/libvips/foreign/nsgifload.c
+++ b/libvips/foreign/nsgifload.c
@@ -173,13 +173,13 @@ vips_foreign_load_nsgif_dispose( GObject *gobject )
 static VipsForeignFlags
 vips_foreign_load_nsgif_get_flags_filename( const char *filename )
 {
-	return( VIPS_FOREIGN_SEQUENTIAL );
+	return( 0 );
 }
 
 static VipsForeignFlags
 vips_foreign_load_nsgif_get_flags( VipsForeignLoad *load )
 {
-	return( VIPS_FOREIGN_SEQUENTIAL );
+	return( 0 );
 }
 
 static gboolean

--- a/libvips/foreign/nsgifload.c
+++ b/libvips/foreign/nsgifload.c
@@ -511,30 +511,6 @@ vips_foreign_load_nsgif_generate( VipsRegion *or,
 	return( 0 );
 }
 
-int
-vips_foreign_load_nsgif_tile_height( VipsForeignLoadNsgif *gif ) 
-{
-	int height = gif->info->height;
-
-	int i;
-
-	/* First, check the perfect size.
-         */
-	if( height % 16 == 0 )
-		return( 16 );
-
-	/* Next, check larger and smaller sizes.
-         */
-	for( i = 1; i < 16; i++ ) {
-		if( height % (16 + i) == 0 )
-			return( 16 + i );
-		if( height % (16 - i) == 0 )
-			return( 16 - i );
-	}
-
-	return( 1 );
-}
-
 static int
 vips_foreign_load_nsgif_load( VipsForeignLoad *load )
 {
@@ -555,8 +531,7 @@ vips_foreign_load_nsgif_load( VipsForeignLoad *load )
 	if( vips_image_generate( t[0],
 		NULL, vips_foreign_load_nsgif_generate, NULL, gif, NULL ) ||
 		vips_sequential( t[0], &t[1],
-			"tile_height", 
-				vips_foreign_load_nsgif_tile_height( gif ),
+			"tile_height", VIPS__FATSTRIP_HEIGHT,
 			NULL ) ||
 		vips_image_write( t[1], load->real ) )
 		return( -1 );


### PR DESCRIPTION
It cannot be considered sequential since the entire source is mapped into memory. This corresponds to `webpload`, whose semantics are the same.

This also means that we can revert commit ce31c04cd28ab4d2c2872dd94d69b8e337ad0738. I verified that this does not cause any regressions using the test image and program mentioned in #2996.

Setup:
```console
$ gcc -O3 vipsgiftest.c `pkg-config vips --cflags --libs`
$ sha256sum animated_gif20.gif
58bb2293ff14273e37277a4f5b5f39f9f430d85b96b2728a133b5a99fb7d27a2  animated_gif20.gif
```

Before ([`master`](https://github.com/libvips/libvips/tree/master) branch - commit 4611651d90d5afe3f8628be2735a1d35be32f3b2):
```console
$ /usr/bin/time -f %M:%e ./a.out animated_gif20.gif x.gif
306912:5.54
```

Commit 0f1de55ccbb818f985039b912bb2ac6c31f64bff:
```console
$ /usr/bin/time -f %M:%e ./a.out animated_gif20.gif x.gif
304400:5.62
```

Commit 0abe70eee2eb6176fa68fbefdf9aee493546c6c8:
```console
$ /usr/bin/time -f %M:%e ./a.out animated_gif20.gif x.gif
304388:5.59
```

So, slightly lower memory use, similar performance. This was tested with cgif v0.3.0 and libimagequant v2.17.0, as provided by Fedora 37.

/cc @DarthSim