### PR TITLE
heifsave: make it possible to use a specific encoder

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -25,6 +25,7 @@ master
 - add @wrap to vips_text()
 - GIF load supports truncated frames [tlsa]
 - EXIF support for PNG load and save
+- add "encoder" to heifsave [dloebl]
 
 9/11/22 started 8.13.4
 - missing include in mosaic_fuzzer [ServOKio]

--- a/libvips/foreign/foreign.c
+++ b/libvips/foreign/foreign.c
@@ -2250,6 +2250,7 @@ vips_heifload_source( VipsSource *source, VipsImage **out, ... )
  * * @compression: #VipsForeignHeifCompression, write with this compression
  * * @effort: %gint, encoding effort
  * * @subsample_mode: #VipsForeignSubsample, chroma subsampling mode
+ * * @encoder: %gchararray, select encoder to use
  *
  * Write a VIPS image to a file in HEIF format. 
  *
@@ -2270,6 +2271,8 @@ vips_heifload_source( VipsSource *source, VipsImage **out, ... )
  *
  * Use @bitdepth to set the bitdepth of the output file. HEIC supports at
  * least 8, 10 and 12 bits; other codecs may support more or fewer options.
+ *
+ * Use @encoder if you want to use a specific encoder (e.g. aom, svt etc).
  *
  * See also: vips_image_write_to_file(), vips_heifload().
  *
@@ -2303,6 +2306,7 @@ vips_heifsave( VipsImage *in, const char *filename, ... )
  * * @compression: #VipsForeignHeifCompression, write with this compression
  * * @effort: %gint, encoding effort
  * * @subsample_mode: #VipsForeignSubsample, chroma subsampling mode
+ * * @encoder: %gchararray, select encoder to use
  *
  * As vips_heifsave(), but save to a memory buffer. 
  *
@@ -2356,6 +2360,7 @@ vips_heifsave_buffer( VipsImage *in, void **buf, size_t *len, ... )
  * * @compression: #VipsForeignHeifCompression, write with this compression
  * * @effort: %gint, encoding effort
  * * @subsample_mode: #VipsForeignSubsample, chroma subsampling mode
+ * * @encoder: %gchararray, select encoder to use
  *
  * As vips_heifsave(), but save to a target.
  *

--- a/libvips/foreign/foreign.c
+++ b/libvips/foreign/foreign.c
@@ -2250,7 +2250,7 @@ vips_heifload_source( VipsSource *source, VipsImage **out, ... )
  * * @compression: #VipsForeignHeifCompression, write with this compression
  * * @effort: %gint, encoding effort
  * * @subsample_mode: #VipsForeignSubsample, chroma subsampling mode
- * * @encoder: %gchararray, select encoder to use
+ * * @encoder: #VipsForeignHeifEncoder, select encoder to use
  *
  * Write a VIPS image to a file in HEIF format. 
  *
@@ -2306,7 +2306,7 @@ vips_heifsave( VipsImage *in, const char *filename, ... )
  * * @compression: #VipsForeignHeifCompression, write with this compression
  * * @effort: %gint, encoding effort
  * * @subsample_mode: #VipsForeignSubsample, chroma subsampling mode
- * * @encoder: %gchararray, select encoder to use
+ * * @encoder: #VipsForeignHeifEncoder, select encoder to use
  *
  * As vips_heifsave(), but save to a memory buffer. 
  *
@@ -2360,7 +2360,7 @@ vips_heifsave_buffer( VipsImage *in, void **buf, size_t *len, ... )
  * * @compression: #VipsForeignHeifCompression, write with this compression
  * * @effort: %gint, encoding effort
  * * @subsample_mode: #VipsForeignSubsample, chroma subsampling mode
- * * @encoder: %gchararray, select encoder to use
+ * * @encoder: #VipsForeignHeifEncoder, select encoder to use
  *
  * As vips_heifsave(), but save to a target.
  *

--- a/libvips/foreign/foreign.c
+++ b/libvips/foreign/foreign.c
@@ -2259,7 +2259,7 @@ vips_heifload_source( VipsSource *source, VipsImage **out, ... )
  *
  * Set @lossless %TRUE to switch to lossless compression.
  *
- * Use @compression to set the encoder e.g. HEVC, AVC, AV1. It defaults to AV1
+ * Use @compression to set the compression format e.g. HEVC, AVC, AV1 to use. It defaults to AV1
  * if the target filename ends with ".avif", otherwise HEVC.
  *
  * Use @effort to control the CPU effort spent improving compression.
@@ -2272,7 +2272,7 @@ vips_heifload_source( VipsSource *source, VipsImage **out, ... )
  * Use @bitdepth to set the bitdepth of the output file. HEIC supports at
  * least 8, 10 and 12 bits; other codecs may support more or fewer options.
  *
- * Use @encoder if you want to use a specific encoder (e.g. aom, svt etc).
+ * Use @encoder to set the encode library to use, e.g. aom, SVT-AV1, rav1e etc.
  *
  * See also: vips_image_write_to_file(), vips_heifload().
  *

--- a/libvips/foreign/heifsave.c
+++ b/libvips/foreign/heifsave.c
@@ -669,8 +669,8 @@ vips_foreign_save_heif_class_init( VipsForeignSaveHeifClass *class )
 		0, 9, 5 );
 
 	VIPS_ARG_STRING( class, "encoder", 18,
-		_( "encoder" ),
-		_( "select encoder to use" ),
+		_( "Encoder" ),
+		_( "Select encoder to use" ),
 		VIPS_ARGUMENT_OPTIONAL_INPUT,
 		G_STRUCT_OFFSET( VipsForeignSaveHeif, selected_encoder ),
 		"" );

--- a/libvips/foreign/heifsave.c
+++ b/libvips/foreign/heifsave.c
@@ -473,24 +473,31 @@ vips_foreign_save_heif_build( VipsObject *object )
 	/* Try to find the selected encoder.
 	 */
 	if( heif->selected_encoder != VIPS_FOREIGN_HEIF_ENCODER_AUTO ) {
-		const int count = heif_context_get_encoder_descriptors( heif->ctx,
-					(enum heif_compression_format) heif->compression,
-					vips_enum_nick( VIPS_TYPE_FOREIGN_HEIF_ENCODER, heif->selected_encoder ),
-					&out_encoder, 1 );
+		const int count = heif_context_get_encoder_descriptors(
+			heif->ctx,
+			(enum heif_compression_format) heif->compression,
+			vips_enum_nick( VIPS_TYPE_FOREIGN_HEIF_ENCODER,
+				heif->selected_encoder ),
+			&out_encoder, 1 );
 
 		if( count > 0 ) {
 			error = heif_context_get_encoder( heif->ctx,
 				out_encoder, &heif->encoder );
-		} else {
-			g_warning( "heifsave: could not find selected encoder %s", vips_enum_nick( VIPS_TYPE_FOREIGN_HEIF_ENCODER, heif->selected_encoder ) );
+		}
+		else {
+			g_warning(
+			"heifsave: could not find selected encoder %s",
+			vips_enum_nick( VIPS_TYPE_FOREIGN_HEIF_ENCODER,
+				heif->selected_encoder ) );
 		}
 	}
+
 	/* Fallback to default encoder.
 	 */
-	if( heif->encoder == NULL ) {
+	if( !heif->encoder ) {
 		error = heif_context_get_encoder_for_format( heif->ctx,
-				(enum heif_compression_format) heif->compression,
-				&heif->encoder );
+			(enum heif_compression_format) heif->compression,
+			&heif->encoder );
 	}
 
 	if( error.code ) {

--- a/libvips/foreign/heifsave.c
+++ b/libvips/foreign/heifsave.c
@@ -99,6 +99,10 @@ typedef struct _VipsForeignSaveHeif {
 	 */
 	VipsForeignSubsample subsample_mode;
 
+	/* Encoder to use. For instance: aom, svt etc.
+	 */
+	gchararray selected_encoder;
+
 	/* The image we save. This is a copy of save->ready since we need to
 	 * be able to update the metadata.
 	 */
@@ -438,6 +442,7 @@ vips_foreign_save_heif_build( VipsObject *object )
 	struct heif_error error;
 	struct heif_writer writer;
 	char *chroma;
+	const struct heif_encoder_descriptor* out_encoder;
 
 	if( VIPS_OBJECT_CLASS( vips_foreign_save_heif_parent_class )->
 		build( object ) )
@@ -465,9 +470,21 @@ vips_foreign_save_heif_build( VipsObject *object )
                         heif->image->Type == VIPS_INTERPRETATION_GREY16 ? 
                                 12 : 8;
 
-	error = heif_context_get_encoder_for_format( heif->ctx, 
-		(enum heif_compression_format) heif->compression, 
-		&heif->encoder );
+	/* Try to find the selected encoder.
+	 */
+	const int count = heif_context_get_encoder_descriptors( heif->ctx,
+				(enum heif_compression_format) heif->compression,
+				heif->selected_encoder,
+				&out_encoder, 1 );
+	if( count > 0 ) {
+		error = heif_context_get_encoder( heif->ctx,
+				out_encoder, &heif->encoder );
+	} else {
+		error = heif_context_get_encoder_for_format( heif->ctx,
+				(enum heif_compression_format) heif->compression,
+				&heif->encoder );
+	}
+
 	if( error.code ) {
 		if( error.code == heif_error_Unsupported_filetype ) 
 			vips_error( "heifsave", 
@@ -651,6 +668,12 @@ vips_foreign_save_heif_class_init( VipsForeignSaveHeifClass *class )
 		G_STRUCT_OFFSET( VipsForeignSaveHeif, speed ),
 		0, 9, 5 );
 
+	VIPS_ARG_STRING( class, "encoder", 18,
+		_( "encoder" ),
+		_( "select encoder to use" ),
+		VIPS_ARGUMENT_OPTIONAL_INPUT,
+		G_STRUCT_OFFSET( VipsForeignSaveHeif, selected_encoder ),
+		"" );
 }
 
 static void

--- a/libvips/include/vips/foreign.h
+++ b/libvips/include/vips/foreign.h
@@ -964,6 +964,28 @@ typedef enum {
 	VIPS_FOREIGN_HEIF_COMPRESSION_LAST
 } VipsForeignHeifCompression;
 
+/**
+ * VipsForeignHeifEncoder:
+ * @VIPS_FOREIGN_HEIF_ENCODER_AUTO: auto
+ * @VIPS_FOREIGN_HEIF_ENCODER_AOM: aom
+ * @VIPS_FOREIGN_HEIF_ENCODER_RAV1E: RAV1E
+ * @VIPS_FOREIGN_HEIF_ENCODER_SVT: SVT-AV1
+ * @VIPS_FOREIGN_HEIF_ENCODER_X265: x265
+ *
+ * The selected encoder to use.
+ * If libheif hasn't been compiled with the selected encoder,
+ * we will fallback to the default encoder for the compression format.
+ *
+ */
+typedef enum {
+	VIPS_FOREIGN_HEIF_ENCODER_AUTO,
+	VIPS_FOREIGN_HEIF_ENCODER_AOM,
+	VIPS_FOREIGN_HEIF_ENCODER_RAV1E,
+	VIPS_FOREIGN_HEIF_ENCODER_SVT,
+	VIPS_FOREIGN_HEIF_ENCODER_X265,
+	VIPS_FOREIGN_HEIF_ENCODER_LAST
+} VipsForeignHeifEncoder;
+
 #ifdef __cplusplus
 }
 #endif /*__cplusplus*/


### PR DESCRIPTION
[libheif](https://github.com/strukturag/libheif) supports various backends: For instance `aom`, `svt` and `rav1e` for AV1 encoding.
As of now, we use the first encoder we find (default encoder). However, in some cases it's useful to force [libheif](https://github.com/strukturag/libheif)  to use a different encoder (e.g. `svt` instead of `aom`).
Make it possible to specify the encoder to use (e.g. `aom`, `svt` etc).

**Question to the reviewer:**
~~Do we want to add a list of encoders to libvips or is it fine to just pass a string to libheif directly (as in this PR with the `encoder` parameter)?~~