### PR TITLE
Ensure consistent formatting of `->format_table`

### DIFF
--- a/libvips/arithmetic/abs.c
+++ b/libvips/arithmetic/abs.c
@@ -244,8 +244,8 @@ vips_abs_buffer( VipsArithmetic *arithmetic,
 /* Format doesn't change with abs, other than complex -> real.
  */
 static const VipsBandFormat vips_abs_format_table[10] = {
-/* UC  C   US  S   UI  I   F   X   D   DX */
-   UC, C,  US, S,  UI, I,  F,  F,  D,  D 
+	/* Band format:  UC  C  US  S  UI  I  F  X  D  DX */
+	/* Promotion: */ UC, C, US, S, UI, I, F, F, D, D
 };
 
 static void

--- a/libvips/arithmetic/add.c
+++ b/libvips/arithmetic/add.c
@@ -158,8 +158,8 @@ add_buffer( VipsArithmetic *arithmetic, VipsPel *out, VipsPel **in, int width )
  * match the case statement in add_buffer() above.
  */
 static const VipsBandFormat vips_add_format_table[10] = {
-/* UC  C   US  S   UI  I  F  X  D  DX */
-   US, S,  UI, I,  UI, I, F, X, D, DX
+	/* Band format:  UC  C  US  S  UI  I  F  X  D  DX */
+	/* Promotion: */ US, S, UI, I, UI, I, F, X, D, DX
 };
 
 static void

--- a/libvips/arithmetic/boolean.c
+++ b/libvips/arithmetic/boolean.c
@@ -224,8 +224,8 @@ vips_boolean_buffer( VipsArithmetic *arithmetic,
 /* Type conversions for boolean. 
  */
 static const VipsBandFormat vips_boolean_format_table[10] = {
-/* UC  C   US  S   UI  I   F   X   D   DX */
-   UC, C,  US, S,  UI, I,  I,  I,  I,  I,
+	/* Band format:  UC  C  US  S  UI  I  F  X  D  DX */
+	/* Promotion: */ UC, C, US, S, UI, I, I, I, I, I
 };
 
 static void

--- a/libvips/arithmetic/complex.c
+++ b/libvips/arithmetic/complex.c
@@ -234,8 +234,8 @@ vips_complex_buffer( VipsArithmetic *arithmetic,
 #define DX VIPS_FORMAT_DPCOMPLEX
 
 static const VipsBandFormat vips_complex_format_table[10] = {
-/* UC  C   US  S   UI  I   F   X   D   DX */
-   X,  X,  X,  X,  X,  X,  X,  X,  DX, DX 
+	/* Band format:  UC C  US S  UI I  F  X  D   DX */
+	/* Promotion: */ X, X, X, X, X, X, X, X, DX, DX
 };
 
 static void
@@ -527,8 +527,8 @@ vips_complex2_buffer( VipsArithmetic *arithmetic,
 #define DX VIPS_FORMAT_DPCOMPLEX
 
 static const VipsBandFormat vips_complex2_format_table[10] = {
-/* UC  C   US  S   UI  I   F   X   D   DX */
-   X,  X,  X,  X,  X,  X,  X,  X,  DX, DX 
+	/* Band format:  UC C  US S  UI I  F  X  D   DX */
+	/* Promotion: */ X, X, X, X, X, X, X, X, DX, DX
 };
 
 static void
@@ -741,8 +741,8 @@ vips_complexget_buffer( VipsArithmetic *arithmetic,
 #define DX VIPS_FORMAT_DPCOMPLEX
 
 static const VipsBandFormat vips_complexget_format_table[10] = {
-/* UC  C   US  S   UI  I   F   X   D   DX */
-   UC, C,  US, S,  UI, I,  F,  F,  D,  D
+	/* Band format:  UC  C  US  S  UI  I  F  X  D  DX */
+	/* Promotion: */ UC, C, US, S, UI, I, F, F, D, D
 };
 
 static void
@@ -951,9 +951,9 @@ vips_complexform_buffer( VipsArithmetic *arithmetic,
 /* Type promotion for form complex. Sign and value preserving. Make sure 
  * these match the case statement in complexform_buffer() above.
  */
-static int vips_complexform_format_table[10] = {
-/* UC  C   US  S   UI  I  F  X  D  DX */
-   X,  X,  X,  X,  X,  X, X, X, DX,DX
+static VipsBandFormat vips_complexform_format_table[10] = {
+	/* Band format:  UC C  US S  UI I  F  X  D   DX */
+	/* Promotion: */ X, X, X, X, X, X, X, X, DX, DX
 };
 
 static void

--- a/libvips/arithmetic/divide.c
+++ b/libvips/arithmetic/divide.c
@@ -210,9 +210,9 @@ vips_divide_buffer( VipsArithmetic *arithmetic,
 /* Type promotion for division. Sign and value preserving. Make sure 
  * these match the case statement in divide_buffer() above.
  */
-static int vips_divide_format_table[10] = {
-/* UC  C   US  S   UI  I  F  X  D  DX */
-   F,  F,  F,  F,  F,  F, F, X, D, DX
+static VipsBandFormat vips_divide_format_table[10] = {
+	/* Band format:  UC C  US S  UI I  F  X  D  DX */
+	/* Promotion: */ F, F, F, F, F, F, F, X, D, DX
 };
 
 static void

--- a/libvips/arithmetic/hist_find.c
+++ b/libvips/arithmetic/hist_find.c
@@ -386,8 +386,8 @@ vips_hist_find_scan( VipsStatistic *statistic, void *seq,
 /* Type mapping: go to uchar or ushort.
  */
 static const VipsBandFormat vips_hist_find_format_table[10] = {
-/* UC   C  US   S  UI   I   F   X   D  DX */
-   UC, UC, US, US, US, US, US, US, US, US
+	/* Band format:  UC  C   US  S   UI  I   F   X   D   DX */
+	/* Promotion: */ UC, UC, US, US, US, US, US, US, US, US
 };
 
 static void

--- a/libvips/arithmetic/hist_find_indexed.c
+++ b/libvips/arithmetic/hist_find_indexed.c
@@ -130,8 +130,8 @@ histogram_new( VipsHistFindIndexed *indexed )
 /* Type mapping: go to uchar or ushort.
  */
 static const VipsBandFormat vips_hist_find_indexed_format[10] = {
-/* UC   C  US   S  UI   I   F   X   D  DX */
-   UC, UC, US, US, US, US, US, US, US, US
+	/* Band format:  UC  C   US  S   UI  I   F   X   D   DX */
+	/* Promotion: */ UC, UC, US, US, US, US, US, US, US, US
 };
 
 static int

--- a/libvips/arithmetic/hist_find_ndim.c
+++ b/libvips/arithmetic/hist_find_ndim.c
@@ -286,8 +286,8 @@ vips_hist_find_ndim_scan( VipsStatistic *statistic, void *seq,
 /* Type mapping: go to uchar or ushort.
  */
 static const VipsBandFormat vips_hist_find_ndim_format_table[10] = {
-/* UC   C  US   S  UI   I   F   X  D   DX */
-   UC, UC, US, US, US, US, US, US, US, US
+	/* Band format:  UC  C   US  S   UI  I   F   X   D   DX */
+	/* Promotion: */ UC, UC, US, US, US, US, US, US, US, US
 };
 
 static void

--- a/libvips/arithmetic/hough.c
+++ b/libvips/arithmetic/hough.c
@@ -152,8 +152,8 @@ vips_hough_scan( VipsStatistic *statistic,
 /* Input image is cast to this format.
  */
 static const VipsBandFormat vips_hough_format_table[10] = {
-/* UC   C  US   S  UI   I   F   X   D  DX */
-   UC, UC, UC, UC, UC, UC, UC, UC, UC, UC
+	/* Band format:  UC  C   US  S   UI  I   F   X   D   DX */
+	/* Promotion: */ UC, UC, UC, UC, UC, UC, UC, UC, UC, UC
 };
 
 static void

--- a/libvips/arithmetic/invert.c
+++ b/libvips/arithmetic/invert.c
@@ -151,8 +151,8 @@ vips_invert_buffer( VipsArithmetic *arithmetic,
 /* Format doesn't change with invert.
  */
 static const VipsBandFormat vips_invert_format_table[10] = {
-/* UC  C   US  S   UI  I   F   X   D   DX */
-   UC, C,  US, S,  UI, I,  F,  X,  D,  DX 
+	/* Band format:  UC  C  US  S  UI  I  F  X  D  DX */
+	/* Promotion: */ UC, C, US, S, UI, I, F, X, D, DX
 };
 
 static void

--- a/libvips/arithmetic/linear.c
+++ b/libvips/arithmetic/linear.c
@@ -401,8 +401,8 @@ vips_linear_buffer( VipsArithmetic *arithmetic,
 /* Format doesn't change with linear.
  */
 static const VipsBandFormat vips_linear_format_table[10] = {
-/* UC  C   US  S   UI  I   F   X   D   DX */
-   F,  F,  F,  F,  F,  F,  F,  X,  D,  DX 
+	/* Band format:  UC C  US S  UI I  F  X  D  DX */
+	/* Promotion: */ F, F, F, F, F, F, F, X, D, DX
 };
 
 static void

--- a/libvips/arithmetic/math.c
+++ b/libvips/arithmetic/math.c
@@ -206,8 +206,8 @@ vips_math_buffer( VipsArithmetic *arithmetic,
 #define DX VIPS_FORMAT_DPCOMPLEX
 
 static const VipsBandFormat vips_math_format_table[10] = {
-/* UC  C   US  S   UI  I   F   X   D   DX */
-   F,  F,  F,  F,  F,  F,  F,  X,  D,  DX 
+	/* Band format:  UC C  US S  UI I  F  X  D  DX */
+	/* Promotion: */ F, F, F, F, F, F, F, X, D, DX
 };
 
 static void

--- a/libvips/arithmetic/math2.c
+++ b/libvips/arithmetic/math2.c
@@ -206,9 +206,9 @@ vips_math2_buffer( VipsArithmetic *arithmetic,
 
 /* Type promotion for math2. Keep in sync with math2_buffer() above.
  */
-static int vips_math2_format_table[10] = {
-/* UC  C   US  S   UI  I   F   X   D   DX */
-   F,  F,  F,  F,  F,  F,  F,  X,  D,  DX 
+static const VipsBandFormat vips_math2_format_table[10] = {
+	/* Band format:  UC C  US S  UI I  F  X  D  DX */
+	/* Promotion: */ F, F, F, F, F, F, F, X, D, DX
 };
 
 static void

--- a/libvips/arithmetic/multiply.c
+++ b/libvips/arithmetic/multiply.c
@@ -158,9 +158,9 @@ vips_multiply_buffer( VipsArithmetic *arithmetic,
 /* Type promotion for multiplication. Sign and value preserving. Make sure 
  * these match the case statement in multiply_buffer() above.
  */
-static int vips_multiply_format_table[10] = {
-/* UC  C   US  S   UI  I  F  X  D  DX */
-   US, S,  UI, I,  UI, I, F, X, D, DX
+static const VipsBandFormat vips_multiply_format_table[10] = {
+	/* Band format:  UC  C  US  S  UI  I  F  X  D  DX */
+	/* Promotion: */ US, S, UI, I, UI, I, F, X, D, DX
 };
 
 static void

--- a/libvips/arithmetic/project.c
+++ b/libvips/arithmetic/project.c
@@ -87,8 +87,8 @@ G_DEFINE_TYPE( VipsProject, vips_project, VIPS_TYPE_STATISTIC );
 #define N VIPS_FORMAT_NOTSET
 
 static const VipsBandFormat vips_project_format_table[10] = {
-/* UC   C  US   S  UI   I   F   X   D  DX */
-   UI,  I, UI,  I, UI,  I,  D,  N,  D, N
+	/* Band format:  UC  C  US  S  UI  I  F  X  D  DX */
+	/* Promotion: */ UI, I, UI, I, UI, I, D, N, D, N
 };
 
 static Histogram *

--- a/libvips/arithmetic/relational.c
+++ b/libvips/arithmetic/relational.c
@@ -198,8 +198,8 @@ vips_relational_buffer( VipsArithmetic *arithmetic,
 #define DX VIPS_FORMAT_DPCOMPLEX
 
 static const VipsBandFormat vips_relational_format_table[10] = {
-/* UC  C   US  S   UI  I   F   X   D   DX */
-   UC, UC, UC, UC, UC, UC, UC, UC, UC, UC
+	/* Band format:  UC  C   US  S   UI  I   F   X   D   DX */
+	/* Promotion: */ UC, UC, UC, UC, UC, UC, UC, UC, UC, UC
 };
 
 static void

--- a/libvips/arithmetic/remainder.c
+++ b/libvips/arithmetic/remainder.c
@@ -154,9 +154,9 @@ vips_remainder_buffer( VipsArithmetic *arithmetic,
 
 /* Type promotion for remainder. Keep in sync with remainder_buffer() above.
  */
-static int vips_remainder_format_table[10] = {
-/* UC  C   US  S   UI  I  F  X  D  DX */
-   UC, C,  US, S,  UI, I, F, X, D, DX
+static const VipsBandFormat vips_remainder_format_table[10] = {
+	/* Band format:  UC  C  US  S  UI  I  F  X  D  DX */
+	/* Promotion: */ UC, C, US, S, UI, I, F, X, D, DX
 };
 
 static void

--- a/libvips/arithmetic/round.c
+++ b/libvips/arithmetic/round.c
@@ -143,8 +143,8 @@ vips_round_buffer( VipsArithmetic *arithmetic,
 #define DX VIPS_FORMAT_DPCOMPLEX
 
 static const VipsBandFormat vips_round_format_table[10] = {
-/* UC  C   US  S   UI  I   F   X   D   DX */
-   UC, C,  US, S,  UI, I,  F,  X,  D,  DX 
+	/* Band format:  UC  C  US  S  UI  I  F  X  D  DX */
+	/* Promotion: */ UC, C, US, S, UI, I, F, X, D, DX
 };
 
 static void

--- a/libvips/arithmetic/sign.c
+++ b/libvips/arithmetic/sign.c
@@ -138,8 +138,8 @@ vips_sign_buffer( VipsArithmetic *arithmetic,
 #define DX VIPS_FORMAT_DPCOMPLEX
 
 static const VipsBandFormat vips_sign_format_table[10] = {
-/* UC  C   US  S   UI  I   F   X   D   DX */
-   C,  C,  C,  C,  C,  C,  C,  X,  C,  DX 
+	/* Band format:  UC C  US S  UI I  F  X  D  DX */
+	/* Promotion: */ C, C, C, C, C, C, C, X, C, DX
 };
 
 static void

--- a/libvips/arithmetic/subtract.c
+++ b/libvips/arithmetic/subtract.c
@@ -148,8 +148,8 @@ vips_subtract_buffer( VipsArithmetic *arithmetic,
  * match the case statement in vips_subtract_buffer() above.
  */
 static const VipsBandFormat vips_subtract_format_table[10] = {
-/* UC  C   US  S   UI  I  F  X  D  DX */
-   S,  S,  I,  I,  I,  I, F, X, D, DX
+	/* Band format:  UC C  US S  UI I  F  X  D  DX */
+	/* Promotion: */ S, S, I, I, I, I, F, X, D, DX
 };
 
 static void

--- a/libvips/arithmetic/sum.c
+++ b/libvips/arithmetic/sum.c
@@ -127,8 +127,8 @@ sum_buffer( VipsArithmetic *arithmetic, VipsPel *out, VipsPel **in, int width )
  * match the case statement in sum_buffer() above.
  */
 static const VipsBandFormat vips_sum_format_table[10] = {
-/* UC  C   US  S   UI  I  F  X  D  DX */
-   UI, I,  UI, I,  UI, I, F, X, D, DX
+	/* Band format:  UC  C  US  S  UI  I  F  X  D  DX */
+	/* Promotion: */ UI, I, UI, I, UI, I, F, X, D, DX
 };
 
 static void

--- a/libvips/conversion/bandbool.c
+++ b/libvips/conversion/bandbool.c
@@ -190,8 +190,8 @@ vips_bandbool_buffer( VipsBandarySequence *seq,
 /* Format conversions for boolean. 
  */
 static const VipsBandFormat vips_bandbool_format_table[10] = {
-/* UC  C   US  S   UI  I   F   X   D   DX */
-   UC, C,  US, S,  UI, I,  I,  I,  I,  I,
+	/* Band format:  UC  C  US  S  UI  I  F  X  D  DX */
+	/* Promotion: */ UC, C, US, S, UI, I, I, I, I, I
 };
 
 static void

--- a/libvips/conversion/gamma.c
+++ b/libvips/conversion/gamma.c
@@ -69,16 +69,16 @@ G_DEFINE_TYPE( VipsGamma, vips_gamma, VIPS_TYPE_CONVERSION );
 /* For each input format, what we normalise the pow() about.
  */
 static double vips_gamma_maxval[10] = {
-/* UC  */	UCHAR_MAX,
-/* C   */	SCHAR_MAX,
-/* US  */	USHRT_MAX,
-/* S   */	SHRT_MAX,
-/* UI  */	UINT_MAX,
-/* I  */	INT_MAX,
-/* F  */	1.0,
-/* X  */	1.0,
-/* D  */	1.0,
-/* DX */	1.0
+	/* UC */ UCHAR_MAX,
+	/* C  */ SCHAR_MAX,
+	/* US */ USHRT_MAX,
+	/* S  */ SHRT_MAX,
+	/* UI */ UINT_MAX,
+	/* I  */ INT_MAX,
+	/* F  */ 1.0,
+	/* X  */ 1.0,
+	/* D  */ 1.0,
+	/* DX */ 1.0
 };
 
 static int

--- a/libvips/convolution/fastcor.c
+++ b/libvips/convolution/fastcor.c
@@ -200,9 +200,9 @@ vips_fastcor_correlation( VipsCorrelation *correlation,
 /* Type promotion for multiplication. Sign and value preserving. Make sure 
  * these match the case statement in multiply_buffer() above.
  */
-static int vips_fastcor_format_table[10] = {
-/* UC  C   US  S   UI  I  F  X  D  DX */
-   UI, UI, UI, UI, UI, UI,F, X, D, DX
+static const VipsBandFormat vips_fastcor_format_table[10] = {
+	/* Band format:  UC  C   US  S   UI  I   F  X  D  DX */
+	/* Promotion: */ UI, UI, UI, UI, UI, UI, F, X, D, DX
 };
 
 static void

--- a/libvips/convolution/spcor.c
+++ b/libvips/convolution/spcor.c
@@ -300,9 +300,9 @@ vips_spcor_correlation( VipsCorrelation *correlation,
 #define D VIPS_FORMAT_DOUBLE
 #define DX VIPS_FORMAT_DPCOMPLEX
 
-static int vips_spcor_format_table[10] = {
-/* UC  C   US  S   UI  I  F  X  D  DX */
-   F,  F,  F,  F,  F,  F, F, F, F, F
+static const VipsBandFormat vips_spcor_format_table[10] = {
+	/* Band format:  UC C  US S  UI I  F  X  D  DX */
+	/* Promotion: */ F, F, F, F, F, F, F, F, F, F
 };
 
 static void

--- a/libvips/foreign/cgifsave.c
+++ b/libvips/foreign/cgifsave.c
@@ -770,8 +770,12 @@ vips_foreign_save_cgif_build( VipsObject *object )
 static const char *vips__save_cgif_suffs[] = { ".gif", NULL };
 
 #define UC VIPS_FORMAT_UCHAR
-static int bandfmt_gif[10] = {
-	UC, UC, UC, UC, UC, UC, UC, UC, UC, UC
+
+/* Type promotion for save ... just always go to uchar.
+ */
+static VipsBandFormat bandfmt_gif[10] = {
+	/* Band format:  UC  C   US  S   UI  I   F   X   D   DX */
+	/* Promotion: */ UC, UC, UC, UC, UC, UC, UC, UC, UC, UC
 };
 
 static void

--- a/libvips/foreign/dzsave.c
+++ b/libvips/foreign/dzsave.c
@@ -2644,9 +2644,9 @@ vips_foreign_save_dz_build( VipsObject *object )
 #define D VIPS_FORMAT_DOUBLE
 #define DX VIPS_FORMAT_DPCOMPLEX
 
-static int bandfmt_dz[10] = {
-/* UC  C   US  S   UI  I   F   X   D   DX */
-   UC, C,  US, S,  UI, I,  F,  F,  D,  D
+static VipsBandFormat bandfmt_dz[10] = {
+	/* Band format:  UC  C  US  S  UI  I  F  X  D  DX */
+	/* Promotion: */ UC, C, US, S, UI, I, F, F, D, D
 };
 
 static const char *dz_suffs[] = { ".dz", ".szi", NULL };

--- a/libvips/foreign/fitssave.c
+++ b/libvips/foreign/fitssave.c
@@ -109,9 +109,9 @@ vips_foreign_save_fits_build( VipsObject *object )
 #define D VIPS_FORMAT_DOUBLE
 #define DX VIPS_FORMAT_DPCOMPLEX
 
-static int bandfmt_fits[10] = {
-/* UC  C   US  S   UI  I   F   X   D   DX */
-   UC, UC, US, US, UI, UI, F,  X,  D,  DX
+static VipsBandFormat bandfmt_fits[10] = {
+	/* Band format:  UC  C   US  S   UI  I   F  X  D  DX */
+	/* Promotion: */ UC, UC, US, US, UI, UI, F, X, D, DX
 };
 
 static void

--- a/libvips/foreign/foreign.c
+++ b/libvips/foreign/foreign.c
@@ -1748,9 +1748,9 @@ vips_foreign_save_build( VipsObject *object )
 #define D VIPS_FORMAT_DOUBLE
 #define DX VIPS_FORMAT_DPCOMPLEX
 
-static int vips_foreign_save_format_table[10] = {
-// UC  C   US  S   UI  I  F  X  D  DX 
-   UC, C,  US, S,  UI, I, F, X, D, DX
+static VipsBandFormat vips_foreign_save_format_table[10] = {
+	/* Band format:  UC  C  US  S  UI  I  F  X  D  DX */
+	/* Promotion: */ UC, C, US, S, UI, I, F, X, D, DX
 };
 
 static void

--- a/libvips/foreign/heifsave.c
+++ b/libvips/foreign/heifsave.c
@@ -577,9 +577,12 @@ vips_foreign_save_heif_build( VipsObject *object )
 #define UC VIPS_FORMAT_UCHAR
 #define US VIPS_FORMAT_USHORT
 
-static int vips_heif_bandfmt[10] = {
-/* UC  C   US  S   UI  I   F   X   D   DX */
-   UC, UC, US, US, US, US, US, US, US, US
+/* Except for 8-bit inputs, we send everything else to 16. We decide on 8-bit
+ * vs. 12 bit save based on Type in_build(), see above.
+ */
+static VipsBandFormat vips_heif_bandfmt[10] = {
+	/* Band format:  UC  C   US  S   UI  I   F   X   D   DX */
+	/* Promotion: */ UC, UC, US, US, US, US, US, US, US, US
 };
 
 static void

--- a/libvips/foreign/jpegsave.c
+++ b/libvips/foreign/jpegsave.c
@@ -118,9 +118,9 @@ G_DEFINE_ABSTRACT_TYPE( VipsForeignSaveJpeg, vips_foreign_save_jpeg,
 
 /* Type promotion for save ... just always go to uchar.
  */
-static int bandfmt_jpeg[10] = {
-     /* UC  C   US  S   UI  I   F   X   D   DX */
-	UC, UC, UC, UC, UC, UC, UC, UC, UC, UC
+static VipsBandFormat bandfmt_jpeg[10] = {
+	/* Band format:  UC  C   US  S   UI  I   F   X   D   DX */
+	/* Promotion: */ UC, UC, UC, UC, UC, UC, UC, UC, UC, UC
 };
 
 static int

--- a/libvips/foreign/jxlsave.c
+++ b/libvips/foreign/jxlsave.c
@@ -484,9 +484,9 @@ vips_foreign_save_jxl_build( VipsObject *object )
 
 /* Type promotion for save ... unsigned ints + float + double.
  */
-static int bandfmt_jxl[10] = {
-     /* UC   C  US   S  UI   I  F  X  D DX */
-	UC, UC, US, US,  F,  F, F, F, F, F
+static VipsBandFormat bandfmt_jxl[10] = {
+	/* Band format:  UC  C   US  S   UI I  F  X  D DX */
+	/* Promotion: */ UC, UC, US, US, F, F, F, F, F, F
 };
 
 static void

--- a/libvips/foreign/matrixsave.c
+++ b/libvips/foreign/matrixsave.c
@@ -153,9 +153,9 @@ vips_foreign_save_matrix_build( VipsObject *object )
 #define D VIPS_FORMAT_DOUBLE
 #define DX VIPS_FORMAT_DPCOMPLEX
 
-static int bandfmt_matrix[10] = {
-/* UC  C   US  S   UI  I  F  X  D  DX */
-   D,  D,  D,  D,  D,  D, D, D, D, D
+static VipsBandFormat bandfmt_matrix[10] = {
+	/* Band format:  UC  C  US S  UI I  F  X  D  DX */
+	/* Promotion: */ D,  D, D, D, D, D, D, D, D, D
 };
 
 static const char *vips_foreign_save_matrix_suffs[] = {

--- a/libvips/foreign/niftisave.c
+++ b/libvips/foreign/niftisave.c
@@ -407,9 +407,9 @@ vips_foreign_save_nifti_build( VipsObject *object )
 #define D VIPS_FORMAT_DOUBLE
 #define DX VIPS_FORMAT_DPCOMPLEX
 
-static int vips_nifti_bandfmt[10] = {
-/* UC  C   US  S   UI  I   F   X   D   DX */
-   UC, C,  US, S,  UI, I,  F,  X,  D,  DX
+static VipsBandFormat vips_nifti_bandfmt[10] = {
+	/* Band format:  UC  C  US  S  UI  I  F  X  D  DX */
+	/* Promotion: */ UC, C, US, S, UI, I, F, X, D, DX
 };
 
 static void

--- a/libvips/foreign/pngsave.c
+++ b/libvips/foreign/pngsave.c
@@ -182,9 +182,9 @@ vips_foreign_save_png_build( VipsObject *object )
 /* Except for 8-bit inputs, we send everything else to 16. We decide on png8
  * vs. png16 based on Type in_build(), see above.
  */
-static int bandfmt_png[10] = {
-/* UC  C   US  S   UI  I   F   X   D   DX */
-   UC, UC, US, US, US, US, US, US, US, US
+static VipsBandFormat bandfmt_png[10] = {
+	/* Band format:  UC  C   US  S   UI  I   F   X   D   DX */
+	/* Promotion: */ UC, UC, US, US, US, US, US, US, US, US
 };
 
 static void

--- a/libvips/foreign/ppmsave.c
+++ b/libvips/foreign/ppmsave.c
@@ -444,9 +444,9 @@ vips_foreign_save_ppm_build( VipsObject *object )
 #define D VIPS_FORMAT_DOUBLE
 #define DX VIPS_FORMAT_DPCOMPLEX
 
-static int bandfmt_ppm[10] = {
-/* UC  C   US  S   UI  I   F   X   D   DX */
-   UC, UC, US, US, UI, UI, F,  F,  F,  F
+static VipsBandFormat bandfmt_ppm[10] = {
+	/* Band format:  UC  C   US  S   UI  I   F  X  D  DX */
+	/* Promotion: */ UC, UC, US, US, UI, UI, F, F, F, F
 };
 
 static void

--- a/libvips/foreign/radsave.c
+++ b/libvips/foreign/radsave.c
@@ -76,9 +76,9 @@ G_DEFINE_ABSTRACT_TYPE( VipsForeignSaveRad, vips_foreign_save_rad,
 #define D VIPS_FORMAT_DOUBLE
 #define DX VIPS_FORMAT_DPCOMPLEX
 
-static int vips_foreign_save_rad_format_table[10] = {
-/* UC  C   US  S   UI  I   F   X   D   DX */
-   F,  F,  F,  F,  F,  F,  F,  F,  F,  F
+static VipsBandFormat vips_foreign_save_rad_format_table[10] = {
+	/* Band format:  UC C  US S  UI I  F  X  D  DX */
+	/* Promotion: */ F, F, F, F, F, F, F, F, F, F
 };
 
 static void

--- a/libvips/foreign/spngsave.c
+++ b/libvips/foreign/spngsave.c
@@ -650,14 +650,15 @@ vips_foreign_save_spng_build( VipsObject *object )
 	return( 0 );
 }
 
-/* Except for 8-bit inputs, we send everything else to 16. We decide on spng8
- * vs. spng16 based on Type in_build(), see above.
- */
 #define UC VIPS_FORMAT_UCHAR
 #define US VIPS_FORMAT_USHORT
-static int bandfmt_spng[10] = {
-/* UC  C   US  S   UI  I   F   X   D   DX */
-   UC, UC, US, US, US, US, US, US, US, US
+
+/* Except for 8-bit inputs, we send everything else to 16. We decide on png8
+ * vs. png16 based on Type in_build(), see above.
+ */
+static VipsBandFormat bandfmt_spng[10] = {
+	/* Band format:  UC  C   US  S   UI  I   F   X   D   DX */
+	/* Promotion: */ UC, UC, US, US, US, US, US, US, US, US
 };
 
 static void

--- a/libvips/foreign/tiffsave.c
+++ b/libvips/foreign/tiffsave.c
@@ -137,9 +137,9 @@ vips_foreign_save_tiff_dispose( GObject *gobject )
 
 /* Type promotion for jpeg-in-tiff save ... just always go to uchar.
  */
-static int bandfmt_jpeg[10] = {
-/* UC  C   US  S   UI  I   F   X   D   DX */
-   UC, UC, UC, UC, UC, UC, UC, UC, UC, UC
+static VipsBandFormat bandfmt_jpeg[10] = {
+	/* Band format:  UC  C   US  S   UI  I   F   X   D   DX */
+	/* Promotion: */ UC, UC, UC, UC, UC, UC, UC, UC, UC, UC
 };
 
 static int

--- a/libvips/foreign/vips2magick.c
+++ b/libvips/foreign/vips2magick.c
@@ -445,9 +445,9 @@ static const char *vips__save_magick_gif_suffs[] = { ".gif", NULL };
 #define F VIPS_FORMAT_FLOAT
 #define D VIPS_FORMAT_DOUBLE
 
-static int bandfmt_magick[10] = {
-/* UC  C   US  S   UI  I   F   X   D   DX */
-   UC, UC, US, US, UI, UI, F,  F,  D,  D
+static VipsBandFormat bandfmt_magick[10] = {
+	/* Band format:  UC  C   US  S   UI  I   F  X  D  DX */
+	/* Promotion: */ UC, UC, US, US, UI, UI, F, F, D, D
 };
 
 static void

--- a/libvips/foreign/webpsave.c
+++ b/libvips/foreign/webpsave.c
@@ -724,9 +724,9 @@ static const char *vips__save_webp_suffs[] = { ".webp", NULL };
 
 /* Type promotion for save ... just always go to uchar.
  */
-static int bandfmt_webp[10] = {
-/* UC  C   US  S   UI  I   F   X   D   DX */
-   UC, UC, UC, UC, UC, UC, UC, UC, UC, UC
+static VipsBandFormat bandfmt_webp[10] = {
+	/* Band format:  UC  C   US  S   UI  I   F   X   D   DX */
+	/* Promotion: */ UC, UC, UC, UC, UC, UC, UC, UC, UC, UC
 };
 
 static void

--- a/libvips/histogram/hist_cum.c
+++ b/libvips/histogram/hist_cum.c
@@ -134,8 +134,8 @@ vips_hist_cum_process( VipsHistogram *histogram,
 #define DX VIPS_FORMAT_DPCOMPLEX
 
 static const VipsBandFormat vips_hist_cum_format_table[10] = {
-/* UC  C   US  S   UI  I   F   X   D   DX */
-   UI, I,  UI, I,  UI, I,  F,  F,  D,  D 
+	/* Band format:  UC  C  US  S  UI  I  F  X  D  DX */
+	/* Promotion: */ UI, I, UI, I, UI, I, F, F, D, D
 };
 
 static void

--- a/libvips/histogram/maplut.c
+++ b/libvips/histogram/maplut.c
@@ -498,9 +498,9 @@ vips_maplut_stop( void *vseq, void *a, void *b )
 
 /* Type mapping: go to uchar / ushort / uint to make an index. 
  */
-static int bandfmt_maplut[10] = {
-/* UC   C  US   S  UI   I   F   X  D   DX */
-   UC, UC, US, US, UI, UI, UI, UI, UI, UI
+static const VipsBandFormat bandfmt_maplut[10] = {
+	/* Band format:  UC  C   US  S   UI  I   F   X   D   DX */
+	/* Promotion: */ UC, UC, US, US, UI, UI, UI, UI, UI, UI
 };
 
 /* Repack lut into a set of band arrays. If we're just passing one band of the


### PR DESCRIPTION
Also, ensure it's declared as a `VipsBandFormat` array instead of an `int` array. Note that it can only be declared const outside the `foreign/` directory, see for example:
https://github.com/libvips/libvips/blob/25444cd9275a154f4f24f071bdfdcd996529d117/libvips/include/vips/foreign.h#L378
https://github.com/libvips/libvips/blob/25444cd9275a154f4f24f071bdfdcd996529d117/libvips/arithmetic/parithmetic.h#L92
According to https://stackoverflow.com/a/5083976, it would not be an ABI/API break to change it to const-qualified type, but reverting back to non-const would be. I can open a new PR for that, if desired.

_Split out from #3125._