### PR TITLE
Minor doc improvements

### DIFF
--- a/doc/Examples.md
+++ b/doc/Examples.md
@@ -17,7 +17,7 @@ in the API.  It's also a useful source of examples.
 
 # Average a region of interest box on an image
 
-``` python
+```python
 #!/usr/bin/python3
 
 import sys
@@ -124,20 +124,20 @@ To test it, first make a large 1-bit image. This command will take the
 green channel and write as a 1-bit fax image. `wtc.jpg` is a test 10,000
 x 10,000 jpeg:
 
-```
+```bash
 $ vips extract_band wtc.jpg x.tif[squash,compression=ccittfax4,strip] 1
 ```
 
 Now make 1,000 copies of that image in a subdirectory:
 
-```
+```bash
 $ mkdir test
 $ for i in {1..1000}; do cp x.tif test/$i.tif; done
 ```
 
 And run this Python program on them:
 
-```
+```bash
 $ time python try255.py x.tif[squash,compression=ccittfax4,strip,bigtiff] test/*
 real	1m59.924s
 user	4m5.388s
@@ -152,7 +152,7 @@ If you wanted to handle transparency, or if you wanted mixed CMYK and RGB
 images, you'd need to do some more work to convert them all into the same
 colourspace before inserting them.
 
-``` python
+```python
 #!/usr/bin/python3
 #file try255.py
 

--- a/doc/Examples.xml
+++ b/doc/Examples.xml
@@ -121,20 +121,20 @@ vi.write_to_file(sys.argv[2])
   <para>
     To test it, first make a large 1-bit image. This command will take the green channel and write as a 1-bit fax image. <literal>wtc.jpg</literal> is a test 10,000 x 10,000 jpeg:
   </para>
-  <programlisting>
+  <programlisting language="bash">
 $ vips extract_band wtc.jpg x.tif[squash,compression=ccittfax4,strip] 1
 </programlisting>
   <para>
     Now make 1,000 copies of that image in a subdirectory:
   </para>
-  <programlisting>
+  <programlisting language="bash">
 $ mkdir test
 $ for i in {1..1000}; do cp x.tif test/$i.tif; done
 </programlisting>
   <para>
     And run this Python program on them:
   </para>
-  <programlisting>
+  <programlisting language="bash">
 $ time python try255.py x.tif[squash,compression=ccittfax4,strip,bigtiff] test/*
 real    1m59.924s
 user    4m5.388s

--- a/doc/How-it-opens-files.md
+++ b/doc/How-it-opens-files.md
@@ -85,7 +85,7 @@ two.
 
 Imagine how this command might be executed:
 
-```
+```bash
 $ vips flip fred.jpg jim.jpg vertical
 ```
 
@@ -99,7 +99,7 @@ before it can run the flip operation.
 However many useful operations do not require true random access.  For
 example:
 
-```
+```bash
 $ vips shrink fred.png jim.png 10 10
 ```
 

--- a/doc/How-it-opens-files.xml
+++ b/doc/How-it-opens-files.xml
@@ -63,7 +63,7 @@
   <para>
     Imagine how this command might be executed:
   </para>
-  <programlisting>
+  <programlisting language="bash">
 $ vips flip fred.jpg jim.jpg vertical
 </programlisting>
   <para>
@@ -75,7 +75,7 @@ $ vips flip fred.jpg jim.jpg vertical
   <para>
     However many useful operations do not require true random access.  For example:
   </para>
-  <programlisting>
+  <programlisting language="bash">
 $ vips shrink fred.png jim.png 10 10
 </programlisting>
   <para>

--- a/doc/How-it-works.md
+++ b/doc/How-it-works.md
@@ -36,7 +36,7 @@ VipsImage *image = vips_image_new_from_file( filename, NULL );
 VipsRegion *region = vips_region_new( image );
 
 // ask for a 100x100 pixel region at 0x0 (top left)
-VipsRect r = { left: 0, top: 0, width: 100, height: 100 };
+VipsRect r = { .left = 0, .top = 0, .width = 100, .height = 100 };
 if( vips_region_prepare( region, &r ) ) 
   vips_error( ... );
 

--- a/doc/How-it-works.xml
+++ b/doc/How-it-works.xml
@@ -33,7 +33,7 @@ VipsImage *image = vips_image_new_from_file( filename, NULL );
 VipsRegion *region = vips_region_new( image );
 
 // ask for a 100x100 pixel region at 0x0 (top left)
-VipsRect r = { left: 0, top: 0, width: 100, height: 100 };
+VipsRect r = { .left = 0, .top = 0, .width = 100, .height = 100 };
 if( vips_region_prepare( region, &amp;r ) ) 
   vips_error( ... );
 

--- a/doc/Making-image-pyramids.md
+++ b/doc/Making-image-pyramids.md
@@ -21,7 +21,7 @@ but that's very simple to use. This page concentrates on the DeepZoom builder.
 
 Run dzsave with no arguments to see a summary:
 
-```bash
+```
 $ vips dzsave
 save image to deepzoom file
 usage:

--- a/doc/Making-image-pyramids.md
+++ b/doc/Making-image-pyramids.md
@@ -21,7 +21,7 @@ but that's very simple to use. This page concentrates on the DeepZoom builder.
 
 Run dzsave with no arguments to see a summary:
 
-```
+```bash
 $ vips dzsave
 save image to deepzoom file
 usage:
@@ -72,7 +72,7 @@ by using `.dz` or `.szi` as an output file suffix.
 The `--layout` option sets the basic mode of operation. With no
 `--layout`, dzsave writes DeepZoom pyramids. For example:
 
-```
+```bash
 $ vips dzsave huge.tif mydz
 ```
 
@@ -83,7 +83,7 @@ metadata. 
 You can use the `--suffix` option to control how tiles are written. For
 example:
 
-```
+```bash
 $ vips dzsave huge.tif mydz --suffix .jpg[Q=90]
 ```
 
@@ -95,7 +95,7 @@ for details.
 
 Use `--layout zoomify` to put dzsave into zoomify mode. For example:
 
-```
+```bash
 $ vips dzsave huge.tif myzoom --layout zoomify
 ```
 
@@ -111,7 +111,7 @@ Use `--layout google` to write Google maps-style pyramids. These are
 compatible with <ulink url="http://leafletjs.com">Leaflet</ulink>. For
 example:
 
-```
+```bash
 $ vips dzsave wtc.tif gmapdir --layout google
 ```
 
@@ -132,7 +132,7 @@ centred.
 
 For example:
 
-```
+```bash
 $ vips dzsave wtc.tif gmapdir --layout google --background 0 --centre
 ```
 
@@ -157,7 +157,7 @@ You can use `--container` to set the container type. Normally dzsave will
 write a tree of directories, but with `--container zip` you'll get a zip file
 instead. Use .zip as the directory suffix to turn on zip format automatically:
 
-```
+```bash
 $ vips dzsave wtc.tif mypyr.zip
 ```
 
@@ -174,7 +174,7 @@ You can use `.dz` as a filename suffix, meaning send the image to
 `vips_dzsave()`. This means you can write the output of any vips operation to a
 pyramid. For example:
 
-```
+```bash
 $ vips extract_area huge.svs mypy.dz[layout=google] 100 100 10000 10000
 ```
 
@@ -186,7 +186,7 @@ build a pyramid in Google layout using just those pixels.
 If you are working from OpenSlide images, you can use the shrink-on-load
 feature of many of those formats. For example:
 
-```
+```bash
 $ vips dzsave CMU-1.mrxs[level=1] x
 ```
 

--- a/doc/Making-image-pyramids.xml
+++ b/doc/Making-image-pyramids.xml
@@ -20,7 +20,7 @@
 <para>
   Run dzsave with no arguments to see a summary:
 </para>
-<programlisting>
+<programlisting language="bash">
 $ vips dzsave
 save image to deepzoom file
 usage:
@@ -70,7 +70,7 @@ operation flags: sequential nocache
   <para>
     The <literal>--layout</literal> option sets the basic mode of operation. With no <literal>--layout</literal>, dzsave writes DeepZoom pyramids. For example:
   </para>
-  <programlisting>
+  <programlisting language="bash">
 $ vips dzsave huge.tif mydz
 </programlisting>
   <para>
@@ -79,7 +79,7 @@ $ vips dzsave huge.tif mydz
   <para>
     You can use the <literal>--suffix</literal> option to control how tiles are written. For example:
   </para>
-  <programlisting>
+  <programlisting language="bash">
 $ vips dzsave huge.tif mydz --suffix .jpg[Q=90]
 </programlisting>
   <para>
@@ -91,7 +91,7 @@ $ vips dzsave huge.tif mydz --suffix .jpg[Q=90]
   <para>
     Use <literal>--layout zoomify</literal> to put dzsave into zoomify mode. For example:
   </para>
-  <programlisting>
+  <programlisting language="bash">
 $ vips dzsave huge.tif myzoom --layout zoomify
 </programlisting>
   <para>
@@ -106,7 +106,7 @@ $ vips dzsave huge.tif myzoom --layout zoomify
   <para>
     Use <literal>--layout google</literal> to write Google maps-style pyramids. These are compatible with <ulink url="http://leafletjs.com">Leaflet</ulink>. For example:
   </para>
-  <programlisting>
+  <programlisting language="bash">
 $ vips dzsave wtc.tif gmapdir --layout google
 </programlisting>
   <para>
@@ -124,7 +124,7 @@ $ vips dzsave wtc.tif gmapdir --layout google
   <para>
     For example:
   </para>
-  <programlisting>
+  <programlisting language="bash">
 $ vips dzsave wtc.tif gmapdir --layout google --background 0 --centre
 </programlisting>
 </refsect3>
@@ -142,7 +142,7 @@ $ vips dzsave wtc.tif gmapdir --layout google --background 0 --centre
   <para>
     You can use <literal>--container</literal> to set the container type. Normally dzsave will write a tree of directories, but with <literal>--container zip</literal> you’ll get a zip file instead. Use .zip as the directory suffix to turn on zip format automatically:
   </para>
-  <programlisting>
+  <programlisting language="bash">
 $ vips dzsave wtc.tif mypyr.zip
 </programlisting>
   <para>
@@ -157,7 +157,7 @@ $ vips dzsave wtc.tif mypyr.zip
   <para>
     You can use <literal>.dz</literal> as a filename suffix, meaning send the image to <literal>vips_dzsave()</literal>. This means you can write the output of any vips operation to a pyramid. For example:
   </para>
-  <programlisting>
+  <programlisting language="bash">
 $ vips extract_area huge.svs mypy.dz[layout=google] 100 100 10000 10000
 </programlisting>
   <para>
@@ -166,7 +166,7 @@ $ vips extract_area huge.svs mypy.dz[layout=google] 100 100 10000 10000
   <para>
     If you are working from OpenSlide images, you can use the shrink-on-load feature of many of those formats. For example:
   </para>
-  <programlisting>
+  <programlisting language="bash">
 $ vips dzsave CMU-1.mrxs[level=1] x
 </programlisting>
   <para>

--- a/doc/Making-image-pyramids.xml
+++ b/doc/Making-image-pyramids.xml
@@ -20,7 +20,7 @@
 <para>
   Run dzsave with no arguments to see a summary:
 </para>
-<programlisting language="bash">
+<programlisting>
 $ vips dzsave
 save image to deepzoom file
 usage:

--- a/doc/Using-vipsthumbnail.md
+++ b/doc/Using-vipsthumbnail.md
@@ -206,7 +206,7 @@ optimizer.
 
 Check the image write operations to see all the possible options. For example:
 
-```bash
+```
 $ vips jpegsave
 save image to jpeg file
 usage:
@@ -245,7 +245,7 @@ saving.
 
 For example:
 
-```bash
+```
 $ vipsthumbnail 42-32157534.jpg
 $ ls -l tn_42-32157534.jpg
 -rw-r–r– 1 john john 6682 Nov 12 21:27 tn_42-32157534.jpg
@@ -253,7 +253,7 @@ $ ls -l tn_42-32157534.jpg
 
 `strip` almost halves the size of the thumbnail:
 
-```bash
+```
 $ vipsthumbnail 42-32157534.jpg -o x.jpg[optimize_coding,strip]
 $ ls -l x.jpg
 -rw-r–r– 1 john john 3600 Nov 12 21:27 x.jpg
@@ -269,7 +269,7 @@ This can save several kb per thumbnail.
 
 For example:
 
-```bash
+```
 $ vipsthumbnail shark.jpg
 $ ls -l tn_shark.jpg 
 -rw-r–r– 1 john john 7295 Nov  9 14:33 tn_shark.jpg
@@ -278,7 +278,7 @@ $ ls -l tn_shark.jpg
 Now transform to sRGB and don't attach a profile (you can also use `strip`,
 though that will remove *all* metadata from the image):
 
-```bash
+```
 $ vipsthumbnail shark.jpg --export-profile srgb -o tn_shark.jpg[profile=none]
 $ ls -l tn_shark.jpg 
 -rw-r–r– 1 john john 4229 Nov  9 14:33 tn_shark.jpg

--- a/doc/Using-vipsthumbnail.md
+++ b/doc/Using-vipsthumbnail.md
@@ -25,7 +25,7 @@ $image->writeToFile("my-thumbnail.jpg");
 
 You can also call `thumbnail_source` from the CLI, for example:
 
-```
+```bash
 $ cat k2.jpg | \
     vips thumbnail_source [descriptor=0] .jpg[Q=90] 128 | \
     cat > x.jpg
@@ -52,7 +52,7 @@ is running. 
 
 `vipsthumbnail` can process many images in one command. For example:
 
-```
+```bash
 $ vipsthumbnail *.jpg
 ```
 
@@ -64,7 +64,7 @@ where thumbnails are written.
 speedup by running several `vipsthumbnail`s in parallel, depending on how
 much load you want to put on your system. For example:
 
-```
+```bash
 $ parallel vipsthumbnail ::: *.jpg
 ```
 
@@ -73,14 +73,14 @@ $ parallel vipsthumbnail ::: *.jpg
 You can set the bounding box of the generated thumbnail with the `--size`
 option. For example:
 
-```
+```bash
 $ vipsthumbnail shark.jpg --size 200x100
 ```
 
 Use a single number to set a square bounding box. You can omit either number
 but keep the x to mean resize just based on that axis, for example:
 
-```
+```bash
 $ vipsthumbnail shark.jpg --size 200x
 ```
 
@@ -99,7 +99,7 @@ the aspect ratio.
 You can use the `--smartcrop` option to crop to fill the box instead. Excess
 pixels are trimmed away using the strategy you set. For example:
 
-```
+```bash
 $ vipsthumbnail owl.jpg --smartcrop attention -s 128
 ```
 
@@ -126,7 +126,7 @@ to the voltage that should be applied to the electron gun in a CRT display.
 `vipsthumbnail` has an option to perform image shrinking in linear space, that
 is, a colourspace where values are proportional to photon numbers. For example:
 
-```
+```bash
 $ vipsthumbnail fred.jpg --linear
 ```
 
@@ -137,7 +137,7 @@ photons. This can make linear light thumbnailing of large images extremely slow.
 
 For example, for a 10,000 x 10,000 pixel JPEG I see:
 
-```
+```bash
 $ time vipsthumbnail wtc.jpg 
 real	0m0.317s
 user	0m0.292s
@@ -154,7 +154,7 @@ You set the thumbnail write parameters with the `-o`
 option. This is a pattern which the input filename is pasted into to
 produce the output filename. For example:
 
-```
+```bash
 $ vipsthumbnail fred.jpg jim.tif -o tn_%s.jpg
 ```
 
@@ -167,7 +167,7 @@ If the pattern given to `-o` is an absolute path, any path components are
 dropped from the input filenames. This lets you write all of your thumbnails
 to a specific directory, if you want. For example:
 
-```
+```bash
 $ vipsthumbnail fred.jpg ../jim.tif -o /mythumbs/tn_%s.jpg
 ```
 
@@ -177,7 +177,7 @@ images are in different directories.
 Conversely, if `-o` is set to a relative path, any path component from the
 input file is prepended. For example:
 
-```
+```bash
 $ vipsthumbnail fred.jpg ../jim.tif -o mythumbs/tn_%s.jpg
 ```
 
@@ -188,7 +188,7 @@ their current directory.
 
 You can use `-o` to specify the thumbnail image format too. For example: 
 
-```
+```bash
 $ vipsthumbnail fred.jpg ../jim.tif -o tn_%s.png
 ```
 
@@ -197,7 +197,7 @@ Will write thumbnails in PNG format.
 You can give options to the image write operation as a list of comma-separated
 arguments in square brackets. For example:
 
-```
+```bash
 $ vipsthumbnail fred.jpg ../jim.tif -o tn_%s.jpg[Q=90,optimize_coding]
 ```
 
@@ -206,7 +206,7 @@ optimizer.
 
 Check the image write operations to see all the possible options. For example:
 
-```
+```bash
 $ vips jpegsave
 save image to jpeg file
 usage:
@@ -245,7 +245,7 @@ saving.
 
 For example:
 
-```
+```bash
 $ vipsthumbnail 42-32157534.jpg
 $ ls -l tn_42-32157534.jpg
 -rw-r–r– 1 john john 6682 Nov 12 21:27 tn_42-32157534.jpg
@@ -253,7 +253,7 @@ $ ls -l tn_42-32157534.jpg
 
 `strip` almost halves the size of the thumbnail:
 
-```
+```bash
 $ vipsthumbnail 42-32157534.jpg -o x.jpg[optimize_coding,strip]
 $ ls -l x.jpg
 -rw-r–r– 1 john john 3600 Nov 12 21:27 x.jpg
@@ -269,7 +269,7 @@ This can save several kb per thumbnail.
 
 For example:
 
-```
+```bash
 $ vipsthumbnail shark.jpg
 $ ls -l tn_shark.jpg 
 -rw-r–r– 1 john john 7295 Nov  9 14:33 tn_shark.jpg
@@ -278,7 +278,7 @@ $ ls -l tn_shark.jpg
 Now transform to sRGB and don't attach a profile (you can also use `strip`,
 though that will remove *all* metadata from the image):
 
-```
+```bash
 $ vipsthumbnail shark.jpg --export-profile srgb -o tn_shark.jpg[profile=none]
 $ ls -l tn_shark.jpg 
 -rw-r–r– 1 john john 4229 Nov  9 14:33 tn_shark.jpg
@@ -294,7 +294,7 @@ embedded one. For example, perhaps you somehow know that a JPG is in Adobe98
 space, even though it has no embedded profile. 
 
 
-```
+```bash
 $ vipsthumbnail kgdev.jpg --input-profile /my/profiles/a98.icm 
 ```
 
@@ -302,7 +302,7 @@ $ vipsthumbnail kgdev.jpg --input-profile /my/profiles/a98.icm
 
 Putting all this together, I suggest this as a sensible set of options:
 
-```
+```bash
 $ vipsthumbnail fred.jpg \
     --size 128 \
     --export-profile srgb \

--- a/doc/Using-vipsthumbnail.xml
+++ b/doc/Using-vipsthumbnail.xml
@@ -24,7 +24,7 @@ $image-&gt;writeToFile(&quot;my-thumbnail.jpg&quot;);
 <para>
   You can also call <literal>thumbnail_source</literal> from the CLI, for example:
 </para>
-<programlisting>
+<programlisting language="bash">
 $ cat k2.jpg | \
     vips thumbnail_source [descriptor=0] .jpg[Q=90] 128 | \
     cat &gt; x.jpg
@@ -52,7 +52,7 @@ $ cat k2.jpg | \
   <para>
     <literal>vipsthumbnail</literal> can process many images in one command. For example:
   </para>
-  <programlisting>
+  <programlisting language="bash">
 $ vipsthumbnail *.jpg
 </programlisting>
   <para>
@@ -61,7 +61,7 @@ $ vipsthumbnail *.jpg
   <para>
     <literal>vipsthumbnail</literal> will process images one after the other. You can get a good speedup by running several <literal>vipsthumbnail</literal>s in parallel, depending on how much load you want to put on your system. For example:
   </para>
-  <programlisting>
+  <programlisting language="bash">
 $ parallel vipsthumbnail ::: *.jpg
 </programlisting>
 </refsect3>
@@ -70,13 +70,13 @@ $ parallel vipsthumbnail ::: *.jpg
   <para>
     You can set the bounding box of the generated thumbnail with the <literal>--size</literal> option. For example:
   </para>
-  <programlisting>
+  <programlisting language="bash">
 $ vipsthumbnail shark.jpg --size 200x100
 </programlisting>
   <para>
     Use a single number to set a square bounding box. You can omit either number but keep the x to mean resize just based on that axis, for example:
   </para>
-  <programlisting>
+  <programlisting language="bash">
 $ vipsthumbnail shark.jpg --size 200x
 </programlisting>
   <para>
@@ -94,7 +94,7 @@ $ vipsthumbnail shark.jpg --size 200x
   <para>
     <literal>vipsthumbnail</literal> normally shrinks images to fit within the box set by <literal>--size</literal>. You can use the <literal>--smartcrop</literal> option to crop to fill the box instead. Excess pixels are trimmed away using the strategy you set. For example:
   </para>
-  <programlisting>
+  <programlisting language="bash">
 $ vipsthumbnail owl.jpg --smartcrop attention -s 128
 </programlisting>
   <para>
@@ -129,7 +129,7 @@ $ vipsthumbnail owl.jpg --smartcrop attention -s 128
   <para>
     <literal>vipsthumbnail</literal> has an option to perform image shrinking in linear space, that is, a colourspace where values are proportional to photon numbers. For example:
   </para>
-  <programlisting>
+  <programlisting language="bash">
 $ vipsthumbnail fred.jpg --linear
 </programlisting>
   <para>
@@ -138,7 +138,7 @@ $ vipsthumbnail fred.jpg --linear
   <para>
     For example, for a 10,000 x 10,000 pixel JPEG I see:
   </para>
-  <programlisting>
+  <programlisting language="bash">
 $ time vipsthumbnail wtc.jpg 
 real    0m0.317s
 user    0m0.292s
@@ -154,7 +154,7 @@ sys 0m0.016s
   <para>
     You set the thumbnail write parameters with the <literal>-o</literal> option. This is a pattern which the input filename is pasted into to produce the output filename. For example:
   </para>
-  <programlisting>
+  <programlisting language="bash">
 $ vipsthumbnail fred.jpg jim.tif -o tn_%s.jpg
 </programlisting>
   <para>
@@ -163,7 +163,7 @@ $ vipsthumbnail fred.jpg jim.tif -o tn_%s.jpg
   <para>
     If the pattern given to <literal>-o</literal> is an absolute path, any path components are dropped from the input filenames. This lets you write all of your thumbnails to a specific directory, if you want. For example:
   </para>
-  <programlisting>
+  <programlisting language="bash">
 $ vipsthumbnail fred.jpg ../jim.tif -o /mythumbs/tn_%s.jpg
 </programlisting>
   <para>
@@ -172,7 +172,7 @@ $ vipsthumbnail fred.jpg ../jim.tif -o /mythumbs/tn_%s.jpg
   <para>
     Conversely, if <literal>-o</literal> is set to a relative path, any path component from the input file is prepended. For example:
   </para>
-  <programlisting>
+  <programlisting language="bash">
 $ vipsthumbnail fred.jpg ../jim.tif -o mythumbs/tn_%s.jpg
 </programlisting>
   <para>
@@ -184,7 +184,7 @@ $ vipsthumbnail fred.jpg ../jim.tif -o mythumbs/tn_%s.jpg
   <para>
     You can use <literal>-o</literal> to specify the thumbnail image format too. For example: 
   </para>
-  <programlisting>
+  <programlisting language="bash">
 $ vipsthumbnail fred.jpg ../jim.tif -o tn_%s.png
 </programlisting>
   <para>
@@ -193,7 +193,7 @@ $ vipsthumbnail fred.jpg ../jim.tif -o tn_%s.png
   <para>
     You can give options to the image write operation as a list of comma-separated arguments in square brackets. For example:
   </para>
-  <programlisting>
+  <programlisting language="bash">
 $ vipsthumbnail fred.jpg ../jim.tif -o tn_%s.jpg[Q=90,optimize_coding]
 </programlisting>
   <para>
@@ -202,7 +202,7 @@ $ vipsthumbnail fred.jpg ../jim.tif -o tn_%s.jpg[Q=90,optimize_coding]
   <para>
     Check the image write operations to see all the possible options. For example:
   </para>
-  <programlisting>
+  <programlisting language="bash">
 $ vips jpegsave
 save image to jpeg file
 usage:
@@ -240,7 +240,7 @@ optional arguments:
   <para>
     For example:
   </para>
-  <programlisting>
+  <programlisting language="bash">
 $ vipsthumbnail 42-32157534.jpg
 $ ls -l tn_42-32157534.jpg
 -rw-r–r– 1 john john 6682 Nov 12 21:27 tn_42-32157534.jpg
@@ -248,7 +248,7 @@ $ ls -l tn_42-32157534.jpg
   <para>
     <literal>strip</literal> almost halves the size of the thumbnail:
   </para>
-  <programlisting>
+  <programlisting language="bash">
 $ vipsthumbnail 42-32157534.jpg -o x.jpg[optimize_coding,strip]
 $ ls -l x.jpg
 -rw-r–r– 1 john john 3600 Nov 12 21:27 x.jpg
@@ -262,7 +262,7 @@ $ ls -l x.jpg
   <para>
     For example:
   </para>
-  <programlisting>
+  <programlisting language="bash">
 $ vipsthumbnail shark.jpg
 $ ls -l tn_shark.jpg 
 -rw-r–r– 1 john john 7295 Nov  9 14:33 tn_shark.jpg
@@ -270,7 +270,7 @@ $ ls -l tn_shark.jpg
   <para>
     Now transform to sRGB and don’t attach a profile (you can also use <literal>strip</literal>, though that will remove <emphasis>all</emphasis> metadata from the image):
   </para>
-  <programlisting>
+  <programlisting language="bash">
 $ vipsthumbnail shark.jpg --export-profile srgb -o tn_shark.jpg[profile=none]
 $ ls -l tn_shark.jpg 
 -rw-r–r– 1 john john 4229 Nov  9 14:33 tn_shark.jpg
@@ -284,7 +284,7 @@ $ ls -l tn_shark.jpg
   <para>
     You can also specify a fallback input profile to use if the image has no embedded one. For example, perhaps you somehow know that a JPG is in Adobe98 space, even though it has no embedded profile.
   </para>
-  <programlisting>
+  <programlisting language="bash">
 $ vipsthumbnail kgdev.jpg --input-profile /my/profiles/a98.icm 
 </programlisting>
 </refsect3>
@@ -293,7 +293,7 @@ $ vipsthumbnail kgdev.jpg --input-profile /my/profiles/a98.icm
   <para>
     Putting all this together, I suggest this as a sensible set of options:
   </para>
-  <programlisting>
+  <programlisting language="bash">
 $ vipsthumbnail fred.jpg \
     --size 128 \
     --export-profile srgb \

--- a/doc/Using-vipsthumbnail.xml
+++ b/doc/Using-vipsthumbnail.xml
@@ -202,7 +202,7 @@ $ vipsthumbnail fred.jpg ../jim.tif -o tn_%s.jpg[Q=90,optimize_coding]
   <para>
     Check the image write operations to see all the possible options. For example:
   </para>
-  <programlisting language="bash">
+  <programlisting>
 $ vips jpegsave
 save image to jpeg file
 usage:
@@ -240,7 +240,7 @@ optional arguments:
   <para>
     For example:
   </para>
-  <programlisting language="bash">
+  <programlisting>
 $ vipsthumbnail 42-32157534.jpg
 $ ls -l tn_42-32157534.jpg
 -rw-r–r– 1 john john 6682 Nov 12 21:27 tn_42-32157534.jpg
@@ -248,7 +248,7 @@ $ ls -l tn_42-32157534.jpg
   <para>
     <literal>strip</literal> almost halves the size of the thumbnail:
   </para>
-  <programlisting language="bash">
+  <programlisting>
 $ vipsthumbnail 42-32157534.jpg -o x.jpg[optimize_coding,strip]
 $ ls -l x.jpg
 -rw-r–r– 1 john john 3600 Nov 12 21:27 x.jpg
@@ -262,7 +262,7 @@ $ ls -l x.jpg
   <para>
     For example:
   </para>
-  <programlisting language="bash">
+  <programlisting>
 $ vipsthumbnail shark.jpg
 $ ls -l tn_shark.jpg 
 -rw-r–r– 1 john john 7295 Nov  9 14:33 tn_shark.jpg
@@ -270,7 +270,7 @@ $ ls -l tn_shark.jpg
   <para>
     Now transform to sRGB and don’t attach a profile (you can also use <literal>strip</literal>, though that will remove <emphasis>all</emphasis> metadata from the image):
   </para>
-  <programlisting language="bash">
+  <programlisting>
 $ vipsthumbnail shark.jpg --export-profile srgb -o tn_shark.jpg[profile=none]
 $ ls -l tn_shark.jpg 
 -rw-r–r– 1 john john 4229 Nov  9 14:33 tn_shark.jpg

--- a/doc/binding.md
+++ b/doc/binding.md
@@ -206,19 +206,19 @@ You can generate searchable docs from a <code>.gir</code> (the thing that
 is built from scanning libvips and which in turn turn the typelib is 
 made from) with <command>g-ir-doc-tool</command>, for example:
 
-```
+```bash
 $ g-ir-doc-tool --language=Python -o ~/mydocs Vips-8.0.gir
 ```
 
 Then to view them, either:
 
-```
+```bash
 $ yelp ~/mydocs 
 ```
 
 Or perhaps:
 
-```
+```bash
 $ cd ~/mydocs 
 $ yelp-build html .
 ```

--- a/doc/binding.xml
+++ b/doc/binding.xml
@@ -202,19 +202,19 @@ from gi.repository import Vips
   <para>
     You can generate searchable docs from a <code>.gir</code> (the thing that is built from scanning libvips and which in turn turn the typelib is made from) with <command>g-ir-doc-tool</command>, for example:
   </para>
-  <programlisting>
+  <programlisting language="bash">
 $ g-ir-doc-tool --language=Python -o ~/mydocs Vips-8.0.gir
 </programlisting>
   <para>
     Then to view them, either:
   </para>
-  <programlisting>
+  <programlisting language="bash">
 $ yelp ~/mydocs 
 </programlisting>
   <para>
     Or perhaps:
   </para>
-  <programlisting>
+  <programlisting language="bash">
 $ cd ~/mydocs 
 $ yelp-build html .
 </programlisting>

--- a/doc/libvips-from-C++.md
+++ b/doc/libvips-from-C++.md
@@ -14,6 +14,6 @@ C API and adds automatic reference counting, exceptions, operator
 overloads, and automatic constant expansion. 
 
 See the 
-<ulink url="https://libvips.github.io/libvips/API/8.11/cpp">
+<ulink url="https://libvips.github.io/libvips/API/8.12/cpp">
 C++ API documentation</ulink>
 for more details.

--- a/doc/libvips-from-C++.xml
+++ b/doc/libvips-from-C++.xml
@@ -14,7 +14,7 @@
   libvips comes with a convenient C++ API. It is a very thin wrapper over the C API and adds automatic reference counting, exceptions, operator overloads, and automatic constant expansion.
 </para>
 <para>
-  See the <ulink url="https://libvips.github.io/libvips/API/8.11/cpp"> C++ API documentation</ulink> for more details.
+  See the <ulink url="https://libvips.github.io/libvips/API/8.12/cpp"> C++ API documentation</ulink> for more details.
 </para>
 
 


### PR DESCRIPTION
Note that I recently became aware that `bash` is not the correct keyword for shell commands. You have to use `console` for that to ensure that syntax highlighting doesn't match on output. For example:

```bash
$ for i in {1..1000}; do cp x.tif test/$i.tif; done
for i in {1..1000}; do cp x.tif test/$i.tif; done
```
(i.e., triple backtick `bash`)

```console
$ for i in {1..1000}; do cp x.tif test/$i.tif; done
for i in {1..1000}; do cp x.tif test/$i.tif; done
```
(i.e., triple backtick `console`, much nicer)

Unfortunately DocBook (or Pandoc?) does not support that, so commit bed04b85d24ee43005bbe37d89489771b76e883c removes the bash highlighting on output where this is a issue.

_Split out from #3125._