### PR TITLE
CI: disable `__tls_get_addr` interception in ASan

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -93,7 +93,9 @@ jobs:
           echo "ASAN_DSO=$ASAN_DSO" >> $GITHUB_ENV
           # Glib is built without -fno-omit-frame-pointer. We need
           # to disable the fast unwinder to get full stacktraces.
-          echo "ASAN_OPTIONS=suppressions=${{ github.workspace }}/suppressions/asan.supp:fast_unwind_on_malloc=0:allocator_may_return_null=1" >> $GITHUB_ENV
+          # FIXME: remove `intercept_tls_get_addr=0`
+          # https://github.com/google/sanitizers/issues/1322
+          echo "ASAN_OPTIONS=suppressions=${{ github.workspace }}/suppressions/asan.supp:fast_unwind_on_malloc=0:allocator_may_return_null=1:intercept_tls_get_addr=0" >> $GITHUB_ENV
           echo "LSAN_OPTIONS=suppressions=${{ github.workspace }}/suppressions/lsan.supp:fast_unwind_on_malloc=0" >> $GITHUB_ENV
           echo "TSAN_OPTIONS=suppressions=${{ github.workspace }}/suppressions/tsan.supp" >> $GITHUB_ENV
           # Ensure UBSan issues causes the program to abort.


### PR DESCRIPTION
It might be the cause of the intermittent ASan failures on CI.

This workaround should be safe, since it has been adopted by many projects, e.g. [Chromium](https://github.com/chromium/chromium/commit/536f57c0fd998ebb788a668544e721fa87d0fd74), [Node.js](https://github.com/nodejs/node/commit/347000ccf8c4705721ff60717b234c75e72183cd) and others.

See: https://github.com/google/sanitizers/issues/1322