### PR TITLE
Allow libjxl 0.6

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -8,7 +8,7 @@ master
 - jp2ksave defaults to chroma subsample off, and jp2 write
 - don't minimise sink_screen input after expose ... improves caching during
   interactive use
-- require libjxl 0.7+
+- require libjxl 0.6+
 - add "interlace" option to GIF save [dloebl]
 - magick load sets "magick-format" metadata [aksdb]
 - add ".pnm" save [ewelot]

--- a/libvips/foreign/jxlsave.c
+++ b/libvips/foreign/jxlsave.c
@@ -229,7 +229,11 @@ vips_foreign_save_jxl_build( VipsObject *object )
 	VipsForeignSaveJxl *jxl = (VipsForeignSaveJxl *) object;
 	VipsImage **t = (VipsImage **) vips_object_local_array( object, 5 );
 
+#ifdef HAVE_LIBJXL_0_7
 	JxlEncoderFrameSettings *frame_settings;
+#else
+	JxlEncoderOptions *frame_settings;
+#endif
 	JxlEncoderStatus status;
 	VipsImage *in;
 	VipsBandFormat format;
@@ -413,6 +417,7 @@ vips_foreign_save_jxl_build( VipsObject *object )
 	if( vips_image_wio_input( in ) )
 		return( -1 );
 
+#ifdef HAVE_LIBJXL_0_7
 	frame_settings = JxlEncoderFrameSettingsCreate( jxl->encoder, NULL );
 	JxlEncoderFrameSettingsSetOption( frame_settings, 
 		JXL_ENC_FRAME_SETTING_DECODING_SPEED, jxl->tier );
@@ -420,6 +425,13 @@ vips_foreign_save_jxl_build( VipsObject *object )
 	JxlEncoderFrameSettingsSetOption( frame_settings, 
 		JXL_ENC_FRAME_SETTING_EFFORT, jxl->effort );
 	JxlEncoderSetFrameLossless( frame_settings, jxl->lossless );
+#else
+	frame_settings = JxlEncoderOptionsCreate( jxl->encoder, NULL );
+	JxlEncoderOptionsSetDecodingSpeed( frame_settings, jxl->tier );
+	JxlEncoderOptionsSetDistance( frame_settings, jxl->distance );
+	JxlEncoderOptionsSetEffort( frame_settings, jxl->effort );
+	JxlEncoderOptionsSetLossless( frame_settings, jxl->lossless );
+#endif
 
 #ifdef DEBUG
 	vips_foreign_save_jxl_print_info( &jxl->info );

--- a/meson.build
+++ b/meson.build
@@ -471,8 +471,8 @@ if libheif_dep.found()
     endif
 endif
 
-libjxl_dep = dependency('libjxl', version: '>=0.7', required: get_option('jpeg-xl'))
-libjxl_threads_dep = dependency('libjxl_threads', version: '>=0.7', required: get_option('jpeg-xl'))
+libjxl_dep = dependency('libjxl', version: '>=0.6', required: get_option('jpeg-xl'))
+libjxl_threads_dep = dependency('libjxl_threads', version: '>=0.6', required: get_option('jpeg-xl'))
 libjxl_found = libjxl_dep.found() and libjxl_threads_dep.found()
 libjxl_module = false
 if libjxl_found
@@ -484,6 +484,9 @@ if libjxl_found
         libvips_deps += libjxl_threads_dep
     endif
     cfg_var.set('HAVE_LIBJXL', '1')
+    if libjxl_dep.version().version_compare('>=0.7')
+        cfg_var.set('HAVE_LIBJXL_0_7', '1')
+    endif
 endif
 
 libpoppler_dep = dependency('poppler-glib', version: '>=0.16.0', required: get_option('poppler'))


### PR DESCRIPTION
This partially reverts commit 0029b3c4.

See: https://github.com/libvips/libvips/commit/0029b3c416de8f520e6282ad5085403a9648a2a7#commitcomment-92398283 and the previous discussion in PR #2539.