### PR TITLE
Lower Meson version requirement to 0.55.x

### DIFF
--- a/doc/meson.build
+++ b/doc/meson.build
@@ -51,7 +51,7 @@ private_libvips_headers = [
 
 private_headers = []
 foreach private_libvips_header : private_libvips_headers
-    private_headers += [join_paths(meson.project_source_root(), 'libvips', private_libvips_header)]
+    private_headers += [join_paths(project_source_root, 'libvips', private_libvips_header)]
 endforeach
 
 markdown_content_files = files(
@@ -137,8 +137,8 @@ gnome.gtkdoc('libvips',
     mode: 'none',
     main_xml: 'libvips-docs.xml.in',
     src_dir: [
-        join_paths(meson.project_source_root(), 'libvips'),
-        join_paths(meson.project_build_root(), 'libvips'),
+        join_paths(project_source_root, 'libvips'),
+        join_paths(project_build_root, 'libvips'),
     ],
     dependencies: libvips_dep,
     scan_args: [

--- a/meson.build
+++ b/meson.build
@@ -1,6 +1,6 @@
 project('vips', 'c', 'cpp',
     version: '8.14.1',
-    meson_version: '>=0.56',
+    meson_version: '>=0.55',
     default_options: [
         # this is what glib uses (one of our required deps), so we use it too
         'c_std=gnu99',
@@ -70,6 +70,10 @@ nodelete_link_args = cc.get_supported_link_arguments('-Wl,-z,nodelete')
 
 prefix_dir = get_option('prefix')
 lib_dir = prefix_dir / get_option('libdir')
+
+project_source_root = meson.current_source_dir()
+project_build_root = meson.current_build_dir()
+
 if gmodule_dep.found() and gmodule_dep.get_variable(pkgconfig: 'gmodule_supported') == 'true'
     # Disable modules by default when building static libraries
     modules_enabled = get_option('modules').enabled() or get_option('default_library') == 'shared'

--- a/test/meson.build
+++ b/test/meson.build
@@ -1,6 +1,6 @@
 variables_data = configuration_data()
-variables_data.set('abs_top_srcdir', meson.project_source_root())
-variables_data.set('abs_top_builddir', meson.project_build_root())
+variables_data.set('abs_top_srcdir', project_source_root)
+variables_data.set('abs_top_builddir', project_build_root)
 variables_data.set('PYTHON', pymod.find_installation().full_path())
 
 variables_sh = configure_file(


### PR DESCRIPTION
Allowing libvips to be compiled on RHEL 7 (and its derivatives). Tested with:
```console
$ pip3 install meson==0.55.0
$ meson setup full_build -Ddoxygen=true -Dgtk_doc=true -Dvapi=true
$ meson compile -Cfull_build
$ meson install -Cfull_build
```

See: https://github.com/libvips/libvips/issues/2879#issuecomment-1368742798.

> **Note**: this PR targets the [`8.14`](https://github.com/libvips/libvips/tree/8.14) branch.