### PR TITLE
Private fontmap

### DIFF
--- a/libvips/create/text.c
+++ b/libvips/create/text.c
@@ -120,7 +120,10 @@ typedef VipsCreateClass VipsTextClass;
 
 G_DEFINE_TYPE( VipsText, vips_text, VIPS_TYPE_CREATE );
 
-/* These are expensive. Have one shared between libvips threads.
+/* These are expensive and do not unref cleanly on many platforms. We keep a
+ * single value for libvips and reuse it behind a lock.
+ *
+ * Have one shared between libvips threads.
  */
 static PangoFontMap *vips_text_fontmap = NULL;
 
@@ -372,9 +375,11 @@ vips_text_autofit( VipsText *text )
 }
 
 static void *
-vips_text_fontmap_init( void *dummy )
+vips_text_init_once( void *client )
 {
+	vips_text_lock = vips_g_mutex_new();
 	vips_text_fontmap = pango_cairo_font_map_new();
+	vips_text_fontfiles = g_hash_table_new( g_str_hash, g_str_equal );
 
 	return( NULL );
 }
@@ -395,8 +400,6 @@ vips_text_build( VipsObject *object )
 	cairo_t *cr;
 	cairo_status_t status;
 
-	VIPS_ONCE( &once, vips_text_fontmap_init, NULL );
-
 	if( VIPS_OBJECT_CLASS( vips_text_parent_class )->build( object ) )
 		return( -1 );
 
@@ -406,13 +409,15 @@ vips_text_build( VipsObject *object )
 		return( -1 );
 	}
 
+	VIPS_ONCE( &once, vips_text_init_once, NULL );
+
 	text->context = pango_font_map_create_context( vips_text_fontmap );
 
+	/* Because we set resolution on vips_text_fontmap and that's shared
+	 * between all vips_text instances, we must lock all the way to the
+	 * end of text rendering.
+	 */
 	g_mutex_lock( vips_text_lock ); 
-
-	if( !vips_text_fontfiles )
-		vips_text_fontfiles = 
-			g_hash_table_new( g_str_hash, g_str_equal );
 
 #ifdef HAVE_FONTCONFIG
 	if( text->fontfile &&
@@ -441,24 +446,27 @@ vips_text_build( VipsObject *object )
 			_( "ignoring fontfile (no fontconfig support)" ) );
 #endif /*HAVE_FONTCONFIG*/
 
-	g_mutex_unlock( vips_text_lock );
-
 	/* If our caller set height and not dpi, we adjust dpi until 
 	 * we get a fit.
 	 */
 	if( vips_object_argument_isset( object, "height" ) &&
 		!vips_object_argument_isset( object, "dpi" ) ) {
-		if( vips_text_autofit( text ) )
+		if( vips_text_autofit( text ) ) {
+			g_mutex_unlock( vips_text_lock );
 			return( -1 );
+		}
 	}
 
 	/* Layout. Can fail for "", for example.
 	 */
-	if( vips_text_get_extents( text, &extents ) )
+	if( vips_text_get_extents( text, &extents ) ) {
+		g_mutex_unlock( vips_text_lock );
 		return( -1 );
+	}
 
 	if( extents.width == 0 || 
 		extents.height == 0 ) {
+		g_mutex_unlock( vips_text_lock );
 		vips_error( class->nickname, "%s", _( "no text to render" ) );
 		return( -1 );
 	}
@@ -473,8 +481,10 @@ vips_text_build( VipsObject *object )
 	image->Yoffset = extents.top;
 
 	if( vips_image_pipelinev( image, VIPS_DEMAND_STYLE_ANY, NULL ) ||
-		vips_image_write_prepare( image ) ) 
+		vips_image_write_prepare( image ) ) {
+		g_mutex_unlock( vips_text_lock );
 		return( -1 );
+	}
 
 	surface = cairo_image_surface_create_for_data( 
 		VIPS_IMAGE_ADDR( image, 0, 0 ), 
@@ -485,6 +495,7 @@ vips_text_build( VipsObject *object )
 	status = cairo_surface_status( surface );
 	if( status ) {
 		cairo_surface_destroy( surface );
+		g_mutex_unlock( vips_text_lock );
 		vips_error( class->nickname,
 			"%s", cairo_status_to_string( status ) );
 		return( -1 );
@@ -498,6 +509,8 @@ vips_text_build( VipsObject *object )
 	pango_cairo_show_layout( cr, text->layout );
 
 	cairo_destroy( cr );
+
+	g_mutex_unlock( vips_text_lock );
 
 	if( text->rgba ) {
 		int y;
@@ -528,24 +541,11 @@ vips_text_build( VipsObject *object )
 	return( 0 );
 }
 
-static void *
-vips_text_make_lock( void *client )
-{
-	if( !vips_text_lock ) 
-		vips_text_lock = vips_g_mutex_new();
-
-	return( NULL );
-}
-
 static void
 vips_text_class_init( VipsTextClass *class )
 {
 	GObjectClass *gobject_class = G_OBJECT_CLASS( class );
 	VipsObjectClass *vobject_class = VIPS_OBJECT_CLASS( class );
-
-	static GOnce once = G_ONCE_INIT;
-
-	VIPS_ONCE( &once, vips_text_make_lock, NULL );
 
 	gobject_class->dispose = vips_text_dispose;
 	gobject_class->set_property = vips_object_set_property;


### PR DESCRIPTION
Use a private fontmap in `vips_text()` to avoid clashes with other pangocairo users in the same process.

See https://github.com/libvips/libvips/issues/3275

This is against 8.14, but maybe should be master? Or not. It needs a changelog note too, and I guess a version bump somewhere.