### PR TITLE
Introduce support for target_clones attribute, apply to (un)premultiply for ~10% perf improvement

### DIFF
--- a/libvips/conversion/premultiply.c
+++ b/libvips/conversion/premultiply.c
@@ -121,6 +121,7 @@ G_DEFINE_TYPE( VipsPremultiply, vips_premultiply, VIPS_TYPE_CONVERSION );
 	} \
 }
 
+VIPS_TARGET_CLONES("default,avx")
 static int
 vips_premultiply_gen( VipsRegion *or, void *vseq, void *a, void *b,
 	gboolean *stop )

--- a/libvips/conversion/unpremultiply.c
+++ b/libvips/conversion/unpremultiply.c
@@ -174,6 +174,7 @@ G_DEFINE_TYPE( VipsUnpremultiply, vips_unpremultiply, VIPS_TYPE_CONVERSION );
 	} \
 }
 
+VIPS_TARGET_CLONES("default,avx")
 static int
 vips_unpremultiply_gen( VipsRegion *or, void *vseq, void *a, void *b,
 	gboolean *stop )

--- a/libvips/include/vips/util.h
+++ b/libvips/include/vips/util.h
@@ -215,6 +215,16 @@ G_STMT_START { \
  */
 #define VIPS_PATH_MAX (4096)
 
+/* Create multiple copies of a function targeted at groups of SIMD intrinsics,
+ * with the most suitable selected at runtime via dynamic dispatch.
+ */
+#if defined( HAVE_TARGET_CLONES )
+	#define VIPS_TARGET_CLONES( TARGETS ) \
+		__attribute__(( target_clones( TARGETS ) ))
+#else
+	#define VIPS_TARGET_CLONES( TARGETS )
+#endif
+
 VIPS_API
 const char *vips_enum_string( GType enm, int value );
 VIPS_API

--- a/libvips/include/vips/util.h
+++ b/libvips/include/vips/util.h
@@ -218,7 +218,7 @@ G_STMT_START { \
 /* Create multiple copies of a function targeted at groups of SIMD intrinsics,
  * with the most suitable selected at runtime via dynamic dispatch.
  */
-#if defined( HAVE_TARGET_CLONES )
+#ifdef HAVE_TARGET_CLONES
 	#define VIPS_TARGET_CLONES( TARGETS ) \
 		__attribute__(( target_clones( TARGETS ) ))
 #else

--- a/meson.build
+++ b/meson.build
@@ -131,6 +131,20 @@ if cpp.compiles(vector_arithmetic_check, name: 'Has vector arithmetic', dependen
     endif
 endif
 
+# HAVE_TARGET_CLONES
+target_clones_check = '''
+static int __attribute__((target_clones("default,avx")))
+has_target_clones(void) {
+    return 0;
+}
+int main(void) {
+    return has_target_clones();
+}
+'''
+if cc.compiles(target_clones_check, args: '-Werror', name: 'Has target_clones attribute')
+    cfg_var.set('HAVE_TARGET_CLONES', '1')
+endif
+
 func_names = [ 'vsnprintf', '_aligned_malloc', 'posix_memalign', 'memalign', 'cbrt', 'hypot', 'atan2', 'asinh' ]
 foreach func_name : func_names
     if cc.has_function(func_name, dependencies: m_dep)


### PR DESCRIPTION
This rather neat compiler feature requires gcc 6+ or clang 14+ as well as glibc 2.23+ at build time, hence this PR adds feature detection. It slightly increases binary size so is best to use sparingly.

It works well for functions with inner loops that are already auto-vectorised. I happen to know vips_(un)premultiply falls into this category, and was pleased to discover this feature provides a ~10% performance improvement on AVX+ CPUs (premultiply is a regularly used code path e.g. when resizing and compositing RGBA images).

I also tested these functions with an AVX2-specific clone but that provided no further benefits over AVX.

There will probably be a few other relatively hot functions that are "low hanging fruit" for this feature, but I wanted to start small.

Some stats gathered via callgrind when processing a 1 megapixel RGBA image.

premultiply before
```
68,225,088 (34.58%)  build/../libvips/conversion/premultiply.c:vips_premultiply_gen [/usr/local/lib/x86_64-linux-gnu/libvips.so.42.16.1]
```
premultiply after
```
60,327,528 (31.77%)  build/../libvips/conversion/premultiply.c:vips_premultiply_gen.avx.0 [/usr/local/lib/x86_64-linux-gnu/libvips.so.42.16.1]
```
unpremultiply before
```
62,865,351 (32.68%)  build/../libvips/conversion/unpremultiply.c:vips_unpremultiply_gen [/usr/local/lib/x86_64-linux-gnu/libvips.so.42.16.1]
```
unpremultiply after
```
56,683,775 (30.51%)  build/../libvips/conversion/unpremultiply.c:vips_unpremultiply_gen.avx.0 [/usr/local/lib/x86_64-linux-gnu/libvips.so.42.16.1]
```
binary size (debug build)
```
before: 9025480
after:  9051920
```