### PR TITLE
Dedupe fits header

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -2,6 +2,7 @@
 
 - add support for target_clones attribute [lovell]
 	* use with (un)premultiply for ~10% perf gain on AVX CPUs
+- dedupe FITS header write [ewelot]
 
 9/1/23 8.14.1
 

--- a/libvips/foreign/fits.c
+++ b/libvips/foreign/fits.c
@@ -346,12 +346,6 @@ vips_fits_get_header( VipsFits *fits, VipsImage *out )
 	}
 
 	for( i = 0; i < keysexist; i++ ) {
-		/* We try to make key names unique, so when you eg. "add
-		 * a.fits b.fits c.fits" the writer sees all keys from all
-		 * inputs.
-		 */
-		static int key_id = 0;
-
 		char record[81];
 		char vipsname[100];
 
@@ -368,7 +362,7 @@ vips_fits_get_header( VipsFits *fits, VipsImage *out )
 		 * have to include the key index in the vips name we assign.
 		 */
 
-		vips_snprintf( vipsname, 100, "fits-%d", key_id++ );
+		vips_snprintf( vipsname, 100, "fits-%d", i );
 		vips_image_set_string( out, vipsname, record );
 	}
 

--- a/libvips/foreign/fits.c
+++ b/libvips/foreign/fits.c
@@ -68,8 +68,8 @@
  */
 
 /*
- */
 #define VIPS_DEBUG
+ */
 
 #ifdef HAVE_CONFIG_H
 #include <config.h>

--- a/libvips/foreign/fits.c
+++ b/libvips/foreign/fits.c
@@ -92,21 +92,6 @@
 
 #include "pforeign.h"
 
-/*
-
-   	TODO
-
-	- ask Doug for a test colour image
-
-		found WFPC2u5780205r_c0fx.fits on the fits samples page, 
-		but it's tiny
-
-	- test performance
-
-	- vips__fits_read() makes rather ugly bandjoins, fix
-
- */
-
 /* vips only supports 3 dimensions, but we allow up to MAX_DIMENSIONS as long
  * as the higher dimensions are all empty. If you change this value, change
  * fits2vips_get_header() as well.
@@ -361,6 +346,12 @@ vips_fits_get_header( VipsFits *fits, VipsImage *out )
 	}
 
 	for( i = 0; i < keysexist; i++ ) {
+		/* We try to make key names unique, so when you eg. "add
+		 * a.fits b.fits c.fits" the writer sees all keys from all
+		 * inputs.
+		 */
+		static int key_id = 0;
+
 		char record[81];
 		char vipsname[100];
 
@@ -377,7 +368,7 @@ vips_fits_get_header( VipsFits *fits, VipsImage *out )
 		 * have to include the key index in the vips name we assign.
 		 */
 
-		vips_snprintf( vipsname, 100, "fits-%d", i );
+		vips_snprintf( vipsname, 100, "fits-%d", key_id++ );
 		vips_image_set_string( out, vipsname, record );
 	}
 

--- a/libvips/foreign/fits.c
+++ b/libvips/foreign/fits.c
@@ -606,7 +606,8 @@ vips_fits_new_write( VipsImage *in, const char *filename )
 	return( fits );
 }
 
-/* Header fields which cfitsio 4.1 writes for us start like this.
+/* Header fields which cfitsio 4.1 writes for us start like this. It'll use
+ * BZERO and BSCALE for 16- and 32-bit signed data.
  */
 const char *vips_fits_basic[] = {
 	"SIMPLE ",
@@ -616,6 +617,8 @@ const char *vips_fits_basic[] = {
 	"NAXIS2 ",
 	"NAXIS3 ",
 	"EXTEND ",
+	"BZERO ",
+	"BSCALE ",
 	"COMMENT   FITS (Flexible Image Transport System) format",
 	"COMMENT   and Astrophysics', volume 376, page 359; bibcode:",
 };


### PR DESCRIPTION
We mustn't write most FITS header keywords more than once. Something like `vips add a.fits b.fits x.fits` was duplicating header keywords.

See https://github.com/libvips/libvips/issues/3273
