### PR TITLE
tiffload: increase sanity checks on tile dimensions

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -2,6 +2,7 @@
 
 - add support for target_clones attribute [lovell]
 	* use with (un)premultiply for ~10% perf gain on AVX CPUs
+- increase sanity checks on TIFF tile dimensions [lovell]
 
 9/1/23 8.14.1
 

--- a/libvips/foreign/tiff2vips.c
+++ b/libvips/foreign/tiff2vips.c
@@ -2767,6 +2767,7 @@ rtiff_header_read( Rtiff *rtiff, RtiffHeader *header )
 	guint16 subifd_count;
 	toff_t *subifd_offsets;
 	char *image_description;
+	guint32 max_tile_dimension;
 
 	if( !tfget32( rtiff->tiff, TIFFTAG_IMAGEWIDTH, 
 			&header->width ) ||
@@ -2926,10 +2927,14 @@ rtiff_header_read( Rtiff *rtiff, RtiffHeader *header )
 
 		/* Arbitrary sanity-checking limits.
 		 */
+		max_tile_dimension = VIPS_MIN( 10000, VIPS_ROUND_UP(
+			VIPS_MAX ( header->width, header->height ), 256 ) );
 		if( header->tile_width <= 0 ||
-			header->tile_width > 10000 ||
+			header->tile_width > max_tile_dimension ||
+			header->tile_width % 16 != 0 ||
 			header->tile_height <= 0 ||
-			header->tile_height > 10000 ) {
+			header->tile_height > max_tile_dimension ||
+			header->tile_height % 16 != 0 ) {
 			vips_error( "tiff2vips",
 				"%s", _( "tile size out of range" ) );
 			return( -1 );


### PR DESCRIPTION
TIFF tile dimensions must be a multiple of 16 ~~and no larger than the image to which they belong (AFAIK, TIFF files don't have a "viewport" concept)~~.

Fixes https://bugs.chromium.org/p/oss-fuzz/issues/detail?id=55036 and https://bugs.chromium.org/p/oss-fuzz/issues/detail?id=55148

We might want to backport this to 8.14 also.