### PR TITLE
remove duplicated vips_dbuf_destroy declaration in headers,

### DIFF
--- a/libvips/include/vips/dbuf.h
+++ b/libvips/include/vips/dbuf.h
@@ -62,8 +62,6 @@ typedef struct _VipsDbuf {
 } VipsDbuf; 
 
 VIPS_API
-void vips_dbuf_destroy( VipsDbuf *dbuf );
-VIPS_API
 void vips_dbuf_init( VipsDbuf *dbuf );
 VIPS_API
 gboolean vips_dbuf_minimum_size( VipsDbuf *dbuf, size_t size );


### PR DESCRIPTION
Hi,

I'm trying to write a libvips binding for deno, so have to map all functions.

the following declaration in `dbuf.h` is present 2 times:

```C
VIPS_API
void vips_dbuf_destroy( VipsDbuf *dbuf );
```

that the only duplicate exported C API.
