### PR TITLE
Ensure compatibility with libheif > 1.14.2

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -2,6 +2,7 @@ TBD 8.14.2
 
 - use a private fontmap in vips_text() [jcupitt]
 - increase sanity checks on TIFF tile dimensions [lovell]
+- ensure compatibility with libheif > 1.14.2 [kleisauke]
 
 9/1/23 8.14.1
 

--- a/libvips/foreign/foreign.c
+++ b/libvips/foreign/foreign.c
@@ -3147,18 +3147,15 @@ vips_foreign_operation_init( void )
 	vips_foreign_save_nifti_get_type(); 
 #endif /*HAVE_NIFTI*/
 
-#if defined(HAVE_HEIF_DECODER) && !defined(HEIF_MODULE)
+#if defined(HAVE_HEIF) && !defined(HEIF_MODULE)
 	vips_foreign_load_heif_file_get_type(); 
 	vips_foreign_load_heif_buffer_get_type(); 
 	vips_foreign_load_heif_source_get_type(); 
-#endif /*defined(HAVE_HEIF_DECODER) && !defined(HEIF_MODULE)*/
-
-#if defined(HAVE_HEIF_ENCODER) && !defined(HEIF_MODULE)
 	vips_foreign_save_heif_file_get_type(); 
 	vips_foreign_save_heif_buffer_get_type(); 
 	vips_foreign_save_heif_target_get_type(); 
 	vips_foreign_save_avif_target_get_type();
-#endif /*defined(HAVE_HEIF_ENCODER) && !defined(HEIF_MODULE)*/
+#endif /*defined(HAVE_HEIF) && !defined(HEIF_MODULE)*/
 
 	vips__foreign_load_operation = 
 		g_quark_from_static_string( "vips-foreign-load-operation" ); 

--- a/libvips/foreign/heifload.c
+++ b/libvips/foreign/heifload.c
@@ -76,7 +76,7 @@
 
 /* These are shared with the encoder.
  */
-#if defined(HAVE_HEIF_DECODER) || defined(HAVE_HEIF_ENCODER)
+#ifdef HAVE_HEIF
 
 #include "pforeign.h"
 
@@ -97,10 +97,6 @@ const char *vips__heif_suffs[] = {
 	".avif",
 	NULL 
 };
-
-#endif /*defined(HAVE_HEIF_DECODER) || defined(HAVE_HEIF_ENCODER)*/
-
-#ifdef HAVE_HEIF_DECODER
 
 #include <libheif/heif.h>
 
@@ -1409,7 +1405,7 @@ vips_foreign_load_heif_source_init( VipsForeignLoadHeifSource *source )
 {
 }
 
-#endif /*HAVE_HEIF_DECODER*/
+#endif /*HAVE_HEIF*/
 
 /* The C API wrappers are defined in foreign.c.
  */

--- a/libvips/foreign/heifsave.c
+++ b/libvips/foreign/heifsave.c
@@ -55,7 +55,7 @@
 #endif /*HAVE_CONFIG_H*/
 #include <glib/gi18n-lib.h>
 
-#ifdef HAVE_HEIF_ENCODER
+#ifdef HAVE_HEIF
 
 #include <stdio.h>
 #include <stdlib.h>
@@ -927,7 +927,7 @@ vips_foreign_save_avif_target_init( VipsForeignSaveAvifTarget *target )
 	heif->compression = VIPS_FOREIGN_HEIF_COMPRESSION_AV1;
 }
 
-#endif /*HAVE_HEIF_ENCODER*/
+#endif /*HAVE_HEIF*/
 
 /* The C API wrappers are defined in foreign.c.
  */

--- a/libvips/module/heif.c
+++ b/libvips/module/heif.c
@@ -47,7 +47,7 @@
 #include <vips/debug.h>
 #include <vips/internal.h>
 
-#if (defined(HAVE_HEIF_DECODER) || defined(HAVE_HEIF_ENCODER)) && defined(HEIF_MODULE)
+#if defined(HAVE_HEIF) && defined(HEIF_MODULE)
 
 /* This is called on module load.
  */
@@ -66,20 +66,15 @@ g_module_check_init( GModule *module )
 	extern GType vips_foreign_save_heif_target_get_type( void ); 
 	extern GType vips_foreign_save_avif_target_get_type( void ); 
 
-#ifdef HAVE_HEIF_DECODER
 	vips_foreign_load_heif_file_get_type(); 
 	vips_foreign_load_heif_buffer_get_type(); 
 	vips_foreign_load_heif_source_get_type(); 
-#endif /*HAVE_HEIF_DECODER*/
-
-#ifdef HAVE_HEIF_ENCODER
 	vips_foreign_save_heif_file_get_type(); 
 	vips_foreign_save_heif_buffer_get_type(); 
 	vips_foreign_save_heif_target_get_type(); 
 	vips_foreign_save_avif_target_get_type(); 
-#endif /*HAVE_HEIF_ENCODER*/
 
 	return( NULL );
 }
 
-#endif /*(defined(HAVE_HEIF_DECODER) || defined(HAVE_HEIF_ENCODER)) && defined(HEIF_MODULE)*/
+#endif /*defined(HAVE_HEIF) && defined(HEIF_MODULE)*/

--- a/meson.build
+++ b/meson.build
@@ -452,12 +452,7 @@ if libheif_dep.found()
     else
         libvips_deps += libheif_dep
     endif
-    if libheif_dep.get_variable(pkgconfig: 'builtin_h265_decoder', internal: 'builtin_h265_decoder', default_value: 'no') != 'no' or libheif_dep.get_variable(pkgconfig: 'builtin_avif_decoder', internal: 'builtin_avif_decoder', default_value: 'no') != 'no'
-        cfg_var.set('HAVE_HEIF_DECODER', '1')
-    endif
-    if libheif_dep.get_variable(pkgconfig: 'builtin_h265_encoder', internal: 'builtin_h265_encoder', default_value: 'no') != 'no' or libheif_dep.get_variable(pkgconfig: 'builtin_avif_encoder', internal: 'builtin_avif_encoder', default_value: 'no') != 'no'
-        cfg_var.set('HAVE_HEIF_ENCODER', '1')
-    endif
+    cfg_var.set('HAVE_HEIF', '1')
     if cc.has_function('heif_image_handle_get_raw_color_profile', prefix: '#include <libheif/heif.h>', dependencies: libheif_dep)
         cfg_var.set('HAVE_HEIF_COLOR_PROFILE', '1')
     endif


### PR DESCRIPTION
See: https://github.com/strukturag/libheif/issues/758

> **Note**: this PR targets the [`8.14`](https://github.com/libvips/libvips/tree/8.14) branch.