### PR TITLE
Add fast path to extract_band and bandjoin for single uchar, up to ~60% faster for 1 and 3 channels

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -3,6 +3,7 @@
 - add support for target_clones attribute [lovell]
 	* use with (un)premultiply for ~10% perf gain on AVX CPUs
 - increase sanity checks on TIFF tile dimensions [lovell]
+- add fast path to extract_band and bandjoin for uchar images [lovell]
 
 9/1/23 8.14.1
 

--- a/libvips/conversion/bandjoin.c
+++ b/libvips/conversion/bandjoin.c
@@ -135,7 +135,7 @@ vips_bandjoin_buffer( VipsBandarySequence *seq,
 				q1 += ops;
 			}
 
-			q += 3;
+			q += ips;
 		}
 		else {
 			for( x = 0; x < width; x++ ) {

--- a/libvips/conversion/bandjoin.c
+++ b/libvips/conversion/bandjoin.c
@@ -123,7 +123,7 @@ vips_bandjoin_buffer( VipsBandarySequence *seq,
 				q1 += ops;
 			}
 
-			q += 1;
+			q += ips;
 		}
 		else if( ips == 3 ) {
 			for( x = 0; x < width; x++ ) {

--- a/libvips/conversion/bandjoin.c
+++ b/libvips/conversion/bandjoin.c
@@ -131,7 +131,7 @@ vips_bandjoin_buffer( VipsBandarySequence *seq,
 				q1[1] = p1[1];
 				q1[2] = p1[2];
 
-				p1 += 3;
+				p1 += ips;
 				q1 += ops;
 			}
 

--- a/libvips/conversion/bandjoin.c
+++ b/libvips/conversion/bandjoin.c
@@ -116,15 +116,38 @@ vips_bandjoin_buffer( VipsBandarySequence *seq,
 		q1 = q;
 		p1 = p[i];
 
-		for( x = 0; x < width; x++ ) {
-			for( z = 0; z < ips; z++ )
-				q1[z] = p1[z];
+		if( ips == 1 ) {
+			for( x = 0; x < width; x++ ) {
+				q1[0] = p1[x];
 
-			p1 += ips;
-			q1 += ops;
+				q1 += ops;
+			}
+
+			q += 1;
 		}
+		else if( ips == 3 ) {
+			for( x = 0; x < width; x++ ) {
+				q1[0] = p1[0];
+				q1[1] = p1[1];
+				q1[2] = p1[2];
 
-		q += ips;
+				p1 += 3;
+				q1 += ops;
+			}
+
+			q += 3;
+		}
+		else {
+			for( x = 0; x < width; x++ ) {
+				for( z = 0; z < ips; z++ )
+					q1[z] = p1[z];
+
+				p1 += ips;
+				q1 += ops;
+			}
+
+			q += ips;
+		}
 	}
 }
 

--- a/libvips/conversion/extract.c
+++ b/libvips/conversion/extract.c
@@ -355,17 +355,26 @@ vips_extract_band_buffer( VipsBandarySequence *seq,
 	int ips = VIPS_IMAGE_SIZEOF_PEL( im );
 	const int ops = VIPS_IMAGE_SIZEOF_PEL( conversion->out );
 
-	VipsPel *p, *q;
+	VipsPel * restrict p;
+	VipsPel * restrict q;
 	int x, z;
 
 	p = in[0] + extract->band * es;
 	q = out;
-	for( x = 0; x < width; x++ ) {
-		for( z = 0; z < ops; z++ )
-			q[z] = p[z];
+	if( ops == 1 ) {
+		for( x = 0; x < width; x++ ) {
+			q[x] = p[0];
+			p += ips;
+		}
+	}
+	else {
+		for( x = 0; x < width; x++ ) {
+			for( z = 0; z < ops; z++ )
+				q[z] = p[z];
 
-		p += ips;
-		q += ops;
+			p += ips;
+			q += ops;
+		}
 	}
 }
 


### PR DESCRIPTION
Such images are common and using these two functions for single channel remove/add is also common.

Removing the inner `z` loop allows the compiler to auto-vectorise the outer `x` loop.

Here are some `callgrind` stats for extracting a single channel from a 3 channel 1.4 megapixel image:

Before:
```
28,466,438 (19.51%)  ../libvips/conversion/extract.c:vips_extract_band_buffer [/usr/local/lib/x86_64-linux-gnu/libvips.so.42.17.0]
```
After:
```
 8,568,560 ( 6.80%)  ../libvips/conversion/extract.c:vips_extract_band_buffer [/usr/local/lib/x86_64-linux-gnu/libvips.so.42.17.0]
```

...and some stats for joining a channel to the same 3 channel image:

Before:
```
71,131,060 (36.56%)  ../libvips/conversion/bandjoin.c:vips_bandjoin_buffer [/usr/local/lib/x86_64-linux-gnu/libvips.so.42.17.0]
```

After:
```
51,234,183 (29.32%)  ../libvips/conversion/bandjoin.c:vips_bandjoin_buffer [/usr/local/lib/x86_64-linux-gnu/libvips.so.42.17.0]
```

I haven't done it here, but it might be worth adding a fast path for 3 channel joining (`ips == 3`) as well as 1 channel, as RGB+A is a common scenario. Happy to add to this PR or as a follow-up.

There is already a fast path for `vips_bandjoin_const` and this approach keeps things consistent.

https://github.com/libvips/libvips/blob/07d3a53f0d29fa5e611ed372b879117bb53af3de/libvips/conversion/bandjoin.c#L328
