### PR TITLE
Fix minimum libheif version

### DIFF
--- a/libvips/convolution/meson.build
+++ b/libvips/convolution/meson.build
@@ -23,7 +23,6 @@ convolution_headers = files(
 
 libvips_sources += convolution_sources
 
-
 convolution_lib = static_library('convolution',
     convolution_sources,
     convolution_headers,

--- a/meson.build
+++ b/meson.build
@@ -108,7 +108,7 @@ endif
 vector_arithmetic_check = '''
 typedef float v4f __attribute__((vector_size(4 * sizeof(float)),aligned(16)));
 int main(void) {
-    v4f f = {1, 2, 3, 4}; f *= 12.0; 
+    v4f f = {1, 2, 3, 4}; f *= 12.0;
     v4f g = {5, 6, 7, 8}; f = g > 0 ? g : -1 * g;
 }
 '''
@@ -188,7 +188,7 @@ if magick_found
     if magick7
         cfg_var.set('HAVE_MAGICK7', '1')
     else
-        # come here for imagemagick6, and graphicsmagick1.x, which also uses 
+        # come here for imagemagick6, and graphicsmagick1.x, which also uses
         # the im6 API
         cfg_var.set('HAVE_MAGICK6', '1')
         if cc.has_member('struct _ImageInfo', 'number_scenes', prefix: magick_include, dependencies: magick_dep)
@@ -288,13 +288,12 @@ if libexif_dep.found()
     endif
 endif
 
-
 libjpeg_dep = dependency('libjpeg', required: get_option('jpeg'))
 if libjpeg_dep.found()
     libvips_deps += libjpeg_dep
     cfg_var.set('HAVE_JPEG', '1')
     # features like trellis quant are exposed as extension parameters ...
-    # mozjpeg 3.2 and later have #define JPEG_C_PARAM_SUPPORTED, but we must 
+    # mozjpeg 3.2 and later have #define JPEG_C_PARAM_SUPPORTED, but we must
     # work with earlier versions
     if cc.has_function('jpeg_c_bool_param_supported', prefix: '#include <stdio.h>\n#include <jpeglib.h>', dependencies: libjpeg_dep)
         cfg_var.set('HAVE_JPEG_EXT_PARAMS', '1')
@@ -328,7 +327,6 @@ if not spng_found
         endif
     endif
 endif
-
 
 # libwebp ... target 0.6+ to reduce complication
 # webp has the stuff for handling metadata in two separate libraries -- we
@@ -442,8 +440,7 @@ if pdfium_dep.found()
     cfg_var.set('HAVE_PDFIUM', '1')
 endif
 
-
-libheif_dep = dependency('libheif', version: '>=0.4.11', required: get_option('heif'))
+libheif_dep = dependency('libheif', version: '>=1.3.0', required: get_option('heif'))
 libheif_module = false
 if libheif_dep.found()
     libheif_module = modules_enabled and not get_option('heif-module').disabled()
@@ -453,14 +450,16 @@ if libheif_dep.found()
         libvips_deps += libheif_dep
     endif
     cfg_var.set('HAVE_HEIF', '1')
+    # added in 1.6.0
     if cc.has_function('heif_image_handle_get_raw_color_profile', prefix: '#include <libheif/heif.h>', dependencies: libheif_dep)
         cfg_var.set('HAVE_HEIF_COLOR_PROFILE', '1')
     endif
-    if cc.has_member('struct heif_decoding_options', 'convert_hdr_to_8bit', prefix: '#include <libheif/heif.h>', dependencies: libheif_dep)
-        cfg_var.set('HAVE_HEIF_DECODING_OPTIONS_CONVERT_HDR_TO_8BIT', '1')
-    endif
     if cc.has_function('heif_context_set_maximum_image_size_limit', prefix: '#include <libheif/heif.h>', dependencies: libheif_dep)
         cfg_var.set('HAVE_HEIF_SET_MAX_IMAGE_SIZE_LIMIT', '1')
+    endif
+    # added in 1.7.0
+    if cc.has_member('struct heif_decoding_options', 'convert_hdr_to_8bit', prefix: '#include <libheif/heif.h>', dependencies: libheif_dep)
+        cfg_var.set('HAVE_HEIF_DECODING_OPTIONS_CONVERT_HDR_TO_8BIT', '1')
     endif
     # heif_main_brand added in 1.4.0, but heif_avif appeared in 1.7 ... just check
     # the libheif version number since testing for enums is annoying


### PR DESCRIPTION
Looks like a copy-paste error (i.e. `orc-0.4` has this minimal version). In-line with the previous Autotools build system, see commit: 0617165c669e94eb3fa0f7b56516f0074089461a.

> **Note**: this PR targets the [`8.14`](https://github.com/libvips/libvips/tree/8.14) branch.