### PR TITLE
Fix minimum OpenEXR version

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -406,7 +406,7 @@ if lcms_dep.found()
 endif
 
 # require 1.2.2 since 1.2.1 has a broken ImfCloseTiledInputFile()
-openexr_dep = dependency('OpenEXR', version: '>=0.1.2.2', required: get_option('openexr'))
+openexr_dep = dependency('OpenEXR', version: '>=1.2.2', required: get_option('openexr'))
 if openexr_dep.found()
     libvips_deps += openexr_dep
     cfg_var.set('HAVE_OPENEXR', '1')


### PR DESCRIPTION
In-line with the previous Autotools build system, see:
https://github.com/libvips/libvips/blob/d3a1d4df1b5bf22b193280ad4e6cbca6c390a98d/configure.ac#L802

> **Note**: this PR targets the [`8.14`](https://github.com/libvips/libvips/tree/8.14) branch.