### PR TITLE
test: allow `svgload` suite to be run with resvg

### DIFF
--- a/test/test-suite/test_foreign.py
+++ b/test/test-suite/test_foreign.py
@@ -1085,22 +1085,22 @@ class TestForeign:
         assert abs(im.height * 2 - x.height) < 2
 
         with pytest.raises(pyvips.error.Error):
-            svg = b'<svg viewBox="0 0 0 0"></svg>'
+            svg = b'<svg xmlns="http://www.w3.org/2000/svg" width="0" height="0"></svg>'
             im = pyvips.Image.new_from_buffer(svg, "")
 
         # recognize dimensions for SVGs without width/height
-        svg = b'<svg viewBox="0 0 100 100"></svg>'
+        svg = b'<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100"></svg>'
         im = pyvips.Image.new_from_buffer(svg, "")
         assert im.width == 100
         assert im.height == 100
 
-        svg = b'<svg><rect width="100" height="100" /></svg>'
+        svg = b'<svg xmlns="http://www.w3.org/2000/svg"><rect width="100" height="100" /></svg>'
         im = pyvips.Image.new_from_buffer(svg, "")
         assert im.width == 100
         assert im.height == 100
 
         # width and height of 0.5 is valid
-        svg = b'<svg width="0.5" height="0.5"></svg>'
+        svg = b'<svg xmlns="http://www.w3.org/2000/svg" width="0.5" height="0.5"></svg>'
         im = pyvips.Image.new_from_buffer(svg, "")
         assert im.width == 1
         assert im.height == 1


### PR DESCRIPTION
resvg is slightly stricter regarding SVG parsing and requires that SVG images to have the `xmlns="http://www.w3.org/2000/svg"` namespace, see:
https://github.com/RazrFalcon/resvg/issues/192#issuecomment-569467534

This was noticed on the wasm-vips testsuite. The upcoming v0.0.5 release would likely ship with optional/experimental SVG load support via resvg, see:
https://github.com/kleisauke/wasm-vips/pull/40
https://github.com/kleisauke/libvips/pull/2