### PR TITLE
colour: add AVX-specific XYZ2Lab implementation, ~10% faster

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -2,6 +2,7 @@
 
 - add support for target_clones attribute [lovell]
 	* use with (un)premultiply for ~10% perf gain on AVX CPUs
+	* use with XYZ to LAB colourspace conversion for ~10% perf gain on AVX CPUs
 - dedupe FITS header write [ewelot]
 - add fast path to extract_band and bandjoin for uchar images [lovell]
 

--- a/libvips/colour/XYZ2Lab.c
+++ b/libvips/colour/XYZ2Lab.c
@@ -90,6 +90,8 @@ typedef VipsColourTransformClass VipsXYZ2LabClass;
 
 G_DEFINE_TYPE( VipsXYZ2Lab, vips_XYZ2Lab, VIPS_TYPE_COLOUR_TRANSFORM );
 
+static GOnce table_init_once = G_ONCE_INIT;
+
 static void *
 table_init( void *client )
 {
@@ -111,10 +113,6 @@ static void
 vips_col_XYZ2Lab_helper( VipsXYZ2Lab *XYZ2Lab,
 	float X, float Y, float Z, float *L, float *a, float *b )
 {
-	static GOnce once = G_ONCE_INIT;
-
-	VIPS_ONCE( &once, table_init, NULL );
-
 	float nX, nY, nZ;
 	int i;
 	float f;
@@ -145,6 +143,7 @@ vips_col_XYZ2Lab_helper( VipsXYZ2Lab *XYZ2Lab,
 
 /* Process a buffer of data.
  */
+VIPS_TARGET_CLONES("default,avx")
 static void
 vips_XYZ2Lab_line( VipsColour *colour, VipsPel *out, VipsPel **in, int width )
 {
@@ -153,6 +152,8 @@ vips_XYZ2Lab_line( VipsColour *colour, VipsPel *out, VipsPel **in, int width )
 	float *q = (float *) out;
 
 	int x;
+
+	VIPS_ONCE( &table_init_once, table_init, NULL );
 
 	for( x = 0; x < width; x++ ) {
 		float X, Y, Z;
@@ -189,6 +190,8 @@ void
 vips_col_XYZ2Lab( float X, float Y, float Z, float *L, float *a, float *b )
 {
 	VipsXYZ2Lab XYZ2Lab;
+
+	VIPS_ONCE( &table_init_once, table_init, NULL );
 
 	XYZ2Lab.X0 = VIPS_D65_X0;
 	XYZ2Lab.Y0 = VIPS_D65_Y0;


### PR DESCRIPTION
The XYZ to LAB conversion is most commonly used for colour difference calculations and is often their bottleneck. It is also used for the smartcrop and sharpen operations. ICC profile transforms can use LAB as the connection space, although XYZ is usually fast/good enough.

Before:
```
127,870,765 (55.01%)  ../libvips/colour/XYZ2Lab.c:vips_XYZ2Lab_line [/usr/local/lib/x86_64-linux-gnu/libvips.so.42.17.0]
```
After:
```
115,085,981 (52.39%)  ../libvips/colour/XYZ2Lab.c:vips_XYZ2Lab_line.avx.0 [/usr/local/lib/x86_64-linux-gnu/libvips.so.42.17.0]
```

This adds up to ~4KB to the binary size (debug build, worst case).

This PR also moves the `GOnce` status to live in same scope as the lookup table it protects, which helps provide a small speed-up as its status no longer has to be checked for every pixel when converting a line.