### PR TITLE
colour: manually inline vips_col_scRGB2XYZ logic, ~2x faster

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -4,6 +4,7 @@
 	* use with (un)premultiply for ~10% perf gain on AVX CPUs
 - dedupe FITS header write [ewelot]
 - add fast path to extract_band and bandjoin for uchar images [lovell]
+- inline scRGB to XYZ colourspace conversion, ~2x faster [lovell]
 
 TBD 8.14.2
 

--- a/libvips/colour/scRGB2XYZ.c
+++ b/libvips/colour/scRGB2XYZ.c
@@ -67,15 +67,21 @@ vips_scRGB2XYZ_line( VipsColour *colour, VipsPel *out, VipsPel **in, int width )
 		float G = p[1];
 		float B = p[2];
 
-		float X, Y, Z;
+		/* Manually inlined logic from the vips_col_scRGB2XYZ function
+		 * as the original is defined in a separate file and is part of
+		 * the public API so a compiler will not inline.
+		 */
+		q[0] = VIPS_D65_Y0 * 0.4124 * R +
+			VIPS_D65_Y0 * 0.3576 * G +
+			VIPS_D65_Y0 * 0.18056 * B;
+		q[1] = VIPS_D65_Y0 * 0.2126 * R +
+			VIPS_D65_Y0 * 0.7152 * G +
+			VIPS_D65_Y0 * 0.07220 * B;
+		q[2] = VIPS_D65_Y0 * 0.0193 * R +
+			VIPS_D65_Y0 * 0.1192 * G +
+			VIPS_D65_Y0 * 0.9505 * B;
 
 		p += 3;
-
-		vips_col_scRGB2XYZ( R, G, B, &X, &Y, &Z );
-
-		q[0] = X;
-		q[1] = Y;
-		q[2] = Z;
 		q += 3;
 	}
 }


### PR DESCRIPTION
Even at `-O3` it looks like gcc will not inline the call to `vips_col_scRGB2XYZ()`, which I think is due to the function being part of the external/public API, plus is defined in a separate source file.

By manually "inlining" the logic, the performance of almost all RGB colour transformations involving an ICC profile should be improved as XYZ is commonly used for the connection space.

Before:
```
46,873,827 (20.74%)  ../libvips/colour/LabQ2sRGB.c:vips_col_scRGB2XYZ [/usr/local/lib/x86_64-linux-gnu/libvips.so.42.17.0]
24,180,156 (10.70%)  ../libvips/colour/scRGB2XYZ.c:vips_scRGB2XYZ_line [/usr/local/lib/x86_64-linux-gnu/libvips.so.42.17.0]
```
After:
```
33,794,761 (18.18%)  ../libvips/colour/scRGB2XYZ.c:vips_scRGB2XYZ_line [/usr/local/lib/x86_64-linux-gnu/libvips.so.42.17.0]
```

As an aside, I also tested various options for `VIPS_TARGET_CLONES` on the `vips_scRGB2XYZ_line()` function. Adding a clone for `avx` improves performance by another ~9%, but I haven't included it here as inlining the logic has already provided such a big jump.