### PR TITLE
tiffload: sanitise JPEG dimensions before decompression

### DIFF
--- a/libvips/foreign/tiff2vips.c
+++ b/libvips/foreign/tiff2vips.c
@@ -1949,7 +1949,7 @@ rtiff_decompress_jpeg_run( Rtiff *rtiff, j_decompress_ptr cinfo,
                 break;
         }
 
-        jpeg_start_decompress( cinfo );
+        jpeg_calc_output_dimensions( cinfo );
         bytes_per_scanline = cinfo->output_width * bytes_per_pixel;
 
         /* Double-check tile dimensions.
@@ -1958,6 +1958,8 @@ rtiff_decompress_jpeg_run( Rtiff *rtiff, j_decompress_ptr cinfo,
                 cinfo->output_height > rtiff->header.tile_height ||
                 bytes_per_scanline > rtiff->header.tile_row_size )
                 return( -1 );
+
+        jpeg_start_decompress( cinfo );
 
         q = (VipsPel *) out;
         for( y = 0; y < cinfo->output_height; y++ ) {


### PR DESCRIPTION
This PR ensures we call `jpeg_calc_output_dimensions()` to populate the `cinfo` struct with dimensions before calling `jpeg_start_decompress()`, like jpegload already does, to prevent libjpeg from allocating memory based on untrusted input.

Fixes https://bugs.chromium.org/p/oss-fuzz/issues/detail?id=55111

I haven't added an entry to the changelog yet as we might want to backport this to 8.14.