### PR TITLE
colour: mark `->process_line` functions as static

### DIFF
--- a/libvips/colour/CMYK2XYZ.c
+++ b/libvips/colour/CMYK2XYZ.c
@@ -136,7 +136,7 @@ typedef VipsColourCodeClass VipsCMYK2XYZClass;
 
 G_DEFINE_TYPE(VipsCMYK2XYZ, vips_CMYK2XYZ, VIPS_TYPE_COLOUR_CODE);
 
-void
+static void
 vips_CMYK2XYZ_line( VipsColour *colour, VipsPel *out, VipsPel **in, int width )
 {
 	unsigned char *p = (unsigned char *) in[0];

--- a/libvips/colour/UCS2LCh.c
+++ b/libvips/colour/UCS2LCh.c
@@ -233,7 +233,7 @@ vips_col_make_tables_CMC( void )
 
 /* Process a buffer of data.
  */
-void
+static void
 vips_CMC2LCh_line( VipsColour *colour, VipsPel *out, VipsPel **in, int width )
 {
 	float *p = (float *) in[0];

--- a/libvips/colour/XYZ2CMYK.c
+++ b/libvips/colour/XYZ2CMYK.c
@@ -137,7 +137,7 @@ typedef VipsColourCodeClass VipsXYZ2CMYKClass;
 
 G_DEFINE_TYPE(VipsXYZ2CMYK, vips_XYZ2CMYK, VIPS_TYPE_COLOUR_CODE);
 
-void
+static void
 vips_XYZ2CMYK_line( VipsColour *colour, VipsPel *out, VipsPel **in, int width )
 {
 	float *p = (float *) in[0];

--- a/libvips/colour/XYZ2scRGB.c
+++ b/libvips/colour/XYZ2scRGB.c
@@ -68,7 +68,7 @@ G_DEFINE_TYPE( VipsXYZ2scRGB, vips_XYZ2scRGB, VIPS_TYPE_COLOUR_TRANSFORM );
 
  */
 
-void
+static void
 vips_XYZ2scRGB_line( VipsColour *colour, VipsPel *out, VipsPel **in, int width )
 {
 	float * restrict p = (float *) in[0];

--- a/libvips/colour/Yxy2XYZ.c
+++ b/libvips/colour/Yxy2XYZ.c
@@ -56,7 +56,7 @@ typedef VipsColourTransformClass VipsYxy2XYZClass;
 
 G_DEFINE_TYPE( VipsYxy2XYZ, vips_Yxy2XYZ, VIPS_TYPE_COLOUR_TRANSFORM );
 
-void
+static void
 vips_Yxy2XYZ_line( VipsColour *colour, VipsPel *out, VipsPel **in, int width )
 {
 	float * restrict p = (float *) in[0];

--- a/libvips/colour/scRGB2XYZ.c
+++ b/libvips/colour/scRGB2XYZ.c
@@ -54,7 +54,7 @@ typedef VipsColourTransformClass VipsscRGB2XYZClass;
 
 G_DEFINE_TYPE( VipsscRGB2XYZ, vips_scRGB2XYZ, VIPS_TYPE_COLOUR_TRANSFORM );
 
-void
+static void
 vips_scRGB2XYZ_line( VipsColour *colour, VipsPel *out, VipsPel **in, int width )
 {
 	float * restrict p = (float *) in[0];


### PR DESCRIPTION
These are only used in the same file, and not exported.

Noticed while reviewing PR #3310.