### PR TITLE
Backport #3311 to 8.14

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -4,6 +4,7 @@ TBD 8.14.2
 - increase sanity checks on TIFF tile dimensions [lovell]
 - ensure compatibility with libheif > 1.14.2 [kleisauke]
 - minor doc fixes [jcupitt]
+- sanitise dimensions in JPEG-compressed TIFF images [lovell]
 
 9/1/23 8.14.1
 

--- a/libvips/foreign/tiff2vips.c
+++ b/libvips/foreign/tiff2vips.c
@@ -1949,7 +1949,7 @@ rtiff_decompress_jpeg_run( Rtiff *rtiff, j_decompress_ptr cinfo,
                 break;
         }
 
-        jpeg_start_decompress( cinfo );
+        jpeg_calc_output_dimensions( cinfo );
         bytes_per_scanline = cinfo->output_width * bytes_per_pixel;
 
         /* Double-check tile dimensions.
@@ -1958,6 +1958,8 @@ rtiff_decompress_jpeg_run( Rtiff *rtiff, j_decompress_ptr cinfo,
                 cinfo->output_height > rtiff->header.tile_height ||
                 bytes_per_scanline > rtiff->header.tile_row_size )
                 return( -1 );
+
+        jpeg_start_decompress( cinfo );
 
         q = (VipsPel *) out;
         for( y = 0; y < cinfo->output_height; y++ ) {


### PR DESCRIPTION
Trivial backport of #3311 to [`8.14`](https://github.com/libvips/libvips/tree/8.14).