### PR TITLE
radiance: clean-up and update

### DIFF
--- a/libvips/foreign/radiance.c
+++ b/libvips/foreign/radiance.c
@@ -31,6 +31,7 @@
  * 	- revise for VipsConnection
  * 28/1/23 kleisauke
  * 	- clean-up unused macros/externs
+ * 	- sync with radiance 5.3
  */
 
 /*
@@ -165,17 +166,17 @@
  *
  * 1. Download and unpack latest stable radiance
  * 2. ray/src/common has the files we need ... copy in this order:
- * 	colour.h
+ * 	color.h
  * 	resolu.h
  * 	rtio.h
  * 	fputword.c
- * 	colour.c
+ * 	color.c
  * 	resolu.c
  * 	header.c
  * 3. trim each one down, removing extern decls
  * 4. make all functions static
  * 5. reorder to remove forward refs
- * 6. remove unused funcs, mostly related to HDR write
+ * 6. remove unused funcs/macros, mostly related to HDR write
  */
 
 #define  RED		0
@@ -260,13 +261,12 @@ typedef struct {
 
 			/* resolution string buffer and its size */
 #define  RESOLU_BUFLEN		32
+static char  resolu_buf[RESOLU_BUFLEN];	/* resolution line buffer */
 
 			/* identify header lines */
 #define  isformat(s)	formatval(NULL,s)
 
 typedef int gethfunc(char *s, void *p); /* callback to process header lines */
-
-static char  resolu_buf[RESOLU_BUFLEN];	/* resolution line buffer */
 
 static char *
 resolu2str(			/* convert resolution struct to line */
@@ -315,10 +315,8 @@ str2resolu(			/* convert resolution line to struct */
 	return(1);
 }
 
-#define	 MAXFMTLEN	2048
-
+#define	 MAXFMTLEN	64
 static const char  FMTSTR[] = "FORMAT=";	/* format identifier */
-
 
 static int
 formatval(			/* get format value (return true if format) */
@@ -339,7 +337,6 @@ formatval(			/* get format value (return true if format) */
 	*r = '\0';
 	return(1);
 }
-
 
 static int
 getheader(		/* get header from file */

--- a/libvips/foreign/radiance.c
+++ b/libvips/foreign/radiance.c
@@ -338,12 +338,10 @@ formatval(			/* get format value (return true if format) */
 	return(1);
 }
 
+/* Get header from source.
+ */
 static int
-getheader(		/* get header from file */
-	VipsSbuf *sbuf,
-	gethfunc *f,
-	void  *p
-)
+getheader( VipsSbuf *sbuf, gethfunc *f, void  *p )
 {
 	for(;;) { 
 		const char *line;

--- a/libvips/foreign/radiance.c
+++ b/libvips/foreign/radiance.c
@@ -426,9 +426,10 @@ typedef int gethfunc(char *s, void *p); /* callback to process header lines */
 static char  resolu_buf[RESOLU_BUFLEN];	/* resolution line buffer */
 
 static char *
-resolu2str(buf, rp)		/* convert resolution struct to line */
-char  *buf;
-register RESOLU  *rp;
+resolu2str(			/* convert resolution struct to line */
+	char  *buf,
+	register RESOLU  *rp
+)
 {
 	if (rp->rt&YMAJOR)
 		sprintf(buf, "%cY %d %cX %d\n",
@@ -441,11 +442,11 @@ register RESOLU  *rp;
 	return(buf);
 }
 
-
 static int
-str2resolu(rp, buf)		/* convert resolution line to struct */
-register RESOLU  *rp;
-char  *buf;
+str2resolu(			/* convert resolution line to struct */
+	register RESOLU  *rp,
+	char  *buf
+)
 {
 	register char  *xndx, *yndx;
 	register char  *cp;

--- a/libvips/foreign/radiance.c
+++ b/libvips/foreign/radiance.c
@@ -29,6 +29,8 @@
  * 	  [HongxuChen]
  * 6/11/19
  * 	- revise for VipsConnection
+ * 28/1/23 kleisauke
+ * 	- clean-up unused macros/externs
  */
 
 /*
@@ -181,49 +183,19 @@
 #define  BLU		2
 #define  CIEX		0	/* or, if input is XYZ... */
 #define  CIEY		1
-#define  CIEZ		2
 #define  EXP		3	/* exponent same for either format */
 #define  COLXS		128	/* excess used for exponent */
 #define  WHT		3	/* used for RGBPRIMS type */
 
-#undef uby8
-#define uby8  unsigned char	/* 8-bit unsigned integer */
+typedef unsigned char  COLR[4];	/* red, green, blue (or X,Y,Z), exponent */
 
-typedef uby8  COLR[4];		/* red, green, blue (or X,Y,Z), exponent */
-
-typedef float COLORV;
-typedef COLORV  COLOR[3];	/* red, green, blue (or X,Y,Z) */
+typedef float  COLOR[3];		/* red, green, blue (or X,Y,Z) */
 
 typedef float  RGBPRIMS[4][2];	/* (x,y) chromaticities for RGBW */
-typedef float  (*RGBPRIMP)[2];	/* pointer to RGBPRIMS array */
-
-typedef float  COLORMAT[3][3];	/* color coordinate conversion matrix */
 
 #define  copycolr(c1,c2)	(c1[0]=c2[0],c1[1]=c2[1], \
 				c1[2]=c2[2],c1[3]=c2[3])
 
-#define  colval(col,pri)	((col)[pri])
-
-#define  setcolor(col,r,g,b)	((col)[RED]=(r),(col)[GRN]=(g),(col)[BLU]=(b))
-
-#define  copycolor(c1,c2)	((c1)[0]=(c2)[0],(c1)[1]=(c2)[1],(c1)[2]=(c2)[2])
-
-#define  scalecolor(col,sf)	((col)[0]*=(sf),(col)[1]*=(sf),(col)[2]*=(sf))
-
-#define  addcolor(c1,c2)	((c1)[0]+=(c2)[0],(c1)[1]+=(c2)[1],(c1)[2]+=(c2)[2])
-
-#define  multcolor(c1,c2)	((c1)[0]*=(c2)[0],(c1)[1]*=(c2)[1],(c1)[2]*=(c2)[2])
-
-#ifdef  NTSC
-#define  CIE_x_r		0.670		/* standard NTSC primaries */
-#define  CIE_y_r		0.330
-#define  CIE_x_g		0.210
-#define  CIE_y_g		0.710
-#define  CIE_x_b		0.140
-#define  CIE_y_b		0.080
-#define  CIE_x_w		(1./3.)		/* use true white */
-#define  CIE_y_w		(1./3.)
-#else
 #define  CIE_x_r		0.640		/* nominal CRT primaries */
 #define  CIE_y_r		0.330
 #define  CIE_x_g		0.290
@@ -232,85 +204,22 @@ typedef float  COLORMAT[3][3];	/* color coordinate conversion matrix */
 #define  CIE_y_b		0.060
 #define  CIE_x_w		(1./3.)		/* use true white */
 #define  CIE_y_w		(1./3.)
-#endif
-
-#define  STDPRIMS	{{CIE_x_r,CIE_y_r},{CIE_x_g,CIE_y_g}, \
-				{CIE_x_b,CIE_y_b},{CIE_x_w,CIE_y_w}}
-
-#define CIE_D		(	CIE_x_r*(CIE_y_g - CIE_y_b) + \
-				CIE_x_g*(CIE_y_b - CIE_y_r) + \
-				CIE_x_b*(CIE_y_r - CIE_y_g)	)
-#define CIE_C_rD	( (1./CIE_y_w) * \
-				( CIE_x_w*(CIE_y_g - CIE_y_b) - \
-				  CIE_y_w*(CIE_x_g - CIE_x_b) + \
-				  CIE_x_g*CIE_y_b - CIE_x_b*CIE_y_g	) )
-#define CIE_C_gD	( (1./CIE_y_w) * \
-				( CIE_x_w*(CIE_y_b - CIE_y_r) - \
-				  CIE_y_w*(CIE_x_b - CIE_x_r) - \
-				  CIE_x_r*CIE_y_b + CIE_x_b*CIE_y_r	) )
-#define CIE_C_bD	( (1./CIE_y_w) * \
-				( CIE_x_w*(CIE_y_r - CIE_y_g) - \
-				  CIE_y_w*(CIE_x_r - CIE_x_g) + \
-				  CIE_x_r*CIE_y_g - CIE_x_g*CIE_y_r	) )
-
-#define CIE_rf		(CIE_y_r*CIE_C_rD/CIE_D)
-#define CIE_gf		(CIE_y_g*CIE_C_gD/CIE_D)
-#define CIE_bf		(CIE_y_b*CIE_C_bD/CIE_D)
-
-/* As of 9-94, CIE_rf=.265074126, CIE_gf=.670114631 and CIE_bf=.064811243 */
-
-/***** The following definitions are valid for RGB colors only... *****/
-
-#define  bright(col)	(CIE_rf*(col)[RED]+CIE_gf*(col)[GRN]+CIE_bf*(col)[BLU])
-#define  normbright(c)	( ( (long)(CIE_rf*256.+.5)*(c)[RED] + \
-			    (long)(CIE_gf*256.+.5)*(c)[GRN] + \
-			    (long)(CIE_bf*256.+.5)*(c)[BLU] ) >> 8 )
-
-				/* luminous efficacies over visible spectrum */
-#define  MAXEFFICACY		683.		/* defined maximum at 550 nm */
-#define  WHTEFFICACY		179.		/* uniform white light */
-#define  D65EFFICACY		203.		/* standard illuminant D65 */
-#define  INCEFFICACY		160.		/* illuminant A (incand.) */
-#define  SUNEFFICACY		208.		/* illuminant B (solar dir.) */
-#define  SKYEFFICACY		D65EFFICACY	/* skylight (should be 110) */
-#define  DAYEFFICACY		D65EFFICACY	/* combined sky and solar */
-
-#define  luminance(col)		(WHTEFFICACY * bright(col))
-
-/***** ...end of stuff specific to RGB colors *****/
-
-#define  intens(col)		( (col)[0] > (col)[1] \
-				? (col)[0] > (col)[2] ? (col)[0] : (col)[2] \
-				: (col)[1] > (col)[2] ? (col)[1] : (col)[2] )
-
-#define  colrval(c,p)		( (c)[EXP] ? \
-				ldexp((c)[p]+.5,(int)(c)[EXP]-(COLXS+8)) : \
-				0. )
-
-#define  WHTCOLOR		{1.0,1.0,1.0}
-#define  BLKCOLOR		{0.0,0.0,0.0}
-#define  WHTCOLR		{128,128,128,COLXS+1}
-#define  BLKCOLR		{0,0,0,0}
 
 				/* picture format identifier */
 #define  COLRFMT		"32-bit_rle_rgbe"
 #define  CIEFMT			"32-bit_rle_xyze"
-#define  PICFMT			"32-bit_rle_???e"	/* matches either */
-#define  LPICFMT		15			/* max format id len */
 
 				/* macros for exposures */
 #define  EXPOSSTR		"EXPOSURE="
 #define  LEXPOSSTR		9
 #define  isexpos(hl)		(!strncmp(hl,EXPOSSTR,LEXPOSSTR))
 #define  exposval(hl)		atof((hl)+LEXPOSSTR)
-#define  fputexpos(ex,fp)	fprintf(fp,"%s%e\n",EXPOSSTR,ex)
 
 				/* macros for pixel aspect ratios */
 #define  ASPECTSTR		"PIXASPECT="
 #define  LASPECTSTR		10
 #define  isaspect(hl)		(!strncmp(hl,ASPECTSTR,LASPECTSTR))
 #define  aspectval(hl)		atof((hl)+LASPECTSTR)
-#define  fputaspect(pa,fp)	fprintf(fp,"%s%f\n",ASPECTSTR,pa)
 
 				/* macros for primary specifications */
 #define  PRIMARYSTR		"PRIMARIES="
@@ -322,13 +231,6 @@ typedef float  COLORMAT[3][3];	/* color coordinate conversion matrix */
 					&(p)[GRN][CIEX],&(p)[GRN][CIEY], \
 					&(p)[BLU][CIEX],&(p)[BLU][CIEY], \
 					&(p)[WHT][CIEX],&(p)[WHT][CIEY]) == 8)
-#define  fputprims(p,fp)	fprintf(fp, \
-				"%s %.4f %.4f %.4f %.4f %.4f %.4f %.4f %.4f\n",\
-					PRIMARYSTR, \
-					(p)[RED][CIEX],(p)[RED][CIEY], \
-					(p)[GRN][CIEX],(p)[GRN][CIEY], \
-					(p)[BLU][CIEX],(p)[BLU][CIEY], \
-					(p)[WHT][CIEX],(p)[WHT][CIEY])
 
 				/* macros for color correction */
 #define  COLCORSTR		"COLORCORR="
@@ -336,34 +238,6 @@ typedef float  COLORMAT[3][3];	/* color coordinate conversion matrix */
 #define  iscolcor(hl)		(!strncmp(hl,COLCORSTR,LCOLCORSTR))
 #define  colcorval(cc,hl)	sscanf((hl)+LCOLCORSTR,"%f %f %f", \
 					&(cc)[RED],&(cc)[GRN],&(cc)[BLU])
-#define  fputcolcor(cc,fp)	fprintf(fp,"%s %f %f %f\n",COLCORSTR, \
-					(cc)[RED],(cc)[GRN],(cc)[BLU])
-
-/*
- * Conversions to and from XYZ space generally don't apply WHTEFFICACY.
- * If you need Y to be luminance (cd/m^2), this must be applied when
- * converting from radiance (watts/sr/m^2).
- */
-
-extern RGBPRIMS  stdprims;	/* standard primary chromaticities */
-extern COLORMAT  rgb2xyzmat;	/* RGB to XYZ conversion matrix */
-extern COLORMAT  xyz2rgbmat;	/* XYZ to RGB conversion matrix */
-extern COLOR  cblack, cwhite;	/* black (0,0,0) and white (1,1,1) */
-
-#define  CGAMUT_LOWER		01
-#define  CGAMUT_UPPER		02
-#define  CGAMUT			(CGAMUT_LOWER|CGAMUT_UPPER)
-
-#define  rgb_cie(xyz,rgb)	colortrans(xyz,rgb2xyzmat,rgb)
-
-#define  cpcolormat(md,ms)	memcpy((void *)md,(void *)ms,sizeof(COLORMAT))
-
-#ifdef getc_unlocked		/* avoid horrendous overhead of flockfile */
-#undef getc
-#undef putc
-#define getc    getc_unlocked
-#define putc    putc_unlocked
-#endif
 
 #define  MINELEN	8	/* minimum scanline length for encoding */
 #define  MAXELEN	0x7fff	/* maximum scanline length for encoding */
@@ -373,10 +247,6 @@ extern COLOR  cblack, cwhite;	/* black (0,0,0) and white (1,1,1) */
 #define  XDECR			1
 #define  YDECR			2
 #define  YMAJOR			4
-
-			/* standard scanline ordering */
-#define  PIXSTANDARD		(YMAJOR|YDECR)
-#define  PIXSTDFMT		"-Y %d +X %d\n"
 
 			/* structure for image dimensions */
 typedef struct {
@@ -391,37 +261,10 @@ typedef struct {
 			/* resolution string buffer and its size */
 #define  RESOLU_BUFLEN		32
 
-			/* macros for reading/writing resolution struct */
-#define  fputsresolu(rs,fp)	fputs(resolu2str(resolu_buf,rs),fp)
-#define  fgetsresolu(rs,fp)	str2resolu(rs, \
-					fgets(resolu_buf,RESOLU_BUFLEN,fp))
-
-			/* reading/writing of standard ordering */
-#define  fprtresolu(sl,ns,fp)	fprintf(fp,PIXSTDFMT,ns,sl)
-#define  fscnresolu(sl,ns,fp)	(fscanf(fp,PIXSTDFMT,ns,sl)==2)
-
 			/* identify header lines */
-#define  isheadid(s)	headidval(NULL,s)
 #define  isformat(s)	formatval(NULL,s)
-#define  isdate(s)	dateval(NULL,s)
-#define  isgmt(s)	gmtval(NULL,s)
-
-#define  LATLONSTR	"LATLONG="
-#define  LLATLONSTR	8
-#define  islatlon(hl)		(!strncmp(hl,LATLONSTR,LLATLONSTR))
-#define  latlonval(ll,hl)	sscanf((hl)+LLATLONSTR, "%f %f", \
-						&(ll)[0],&(ll)[1])
-#define  fputlatlon(lat,lon,fp)	fprintf(fp,"%s %.6f %.6f\n",LATLONSTR,lat,lon)
 
 typedef int gethfunc(char *s, void *p); /* callback to process header lines */
-
-#ifdef getc_unlocked		/* avoid horrendous overhead of flockfile */
-#undef getc
-#undef putc
-#define getc    getc_unlocked
-#define putc    putc_unlocked
-#endif
-
 
 static char  resolu_buf[RESOLU_BUFLEN];	/* resolution line buffer */
 
@@ -472,7 +315,6 @@ str2resolu(			/* convert resolution line to struct */
 	return(1);
 }
 
-#define	 MAXLINE	2048
 #define	 MAXFMTLEN	2048
 
 static const char  FMTSTR[] = "FORMAT=";	/* format identifier */


### PR DESCRIPTION
This PR started with resolving these Clang warnings (commit 5d925edf9257ae298e2eea324769d21348924082):
```
../libvips/foreign/radiance.c:429:1: warning: a function definition without a prototype is deprecated in all versions of C and is not supported in C2x [-Wdeprecated-non-prototype]
resolu2str(buf, rp)             /* convert resolution struct to line */
^
../libvips/foreign/radiance.c:446:1: warning: a function definition without a prototype is deprecated in all versions of C and is not supported in C2x [-Wdeprecated-non-prototype]
str2resolu(rp, buf)             /* convert resolution line to struct */
^
2 warnings generated.
```

But then I realised that these sources were actually bundled. So, I also cleaned up the unused macros/externs (commit 7dbd710970162370994906937e57ffb094665bdb) and re-synced this with Radiance 5.3 (commit 0764c5840319d58a301efa8b222f747e9416a84c).