### PR TITLE
Bits per sample

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -12,6 +12,8 @@
 - improve C++ binding [MathemanFlo]
 	* add `inplace()` / `VImage::new_from_memory_copy()`
 	* add overloads for `draw_*()` / `VImage::thumbnail_buffer()`
+- add VIPS_META_BITS_PER_SAMPLE metadata, deprecate the
+  "palette-bit-depth" and "heif-bitdepth" meta fields [MathemanFlo]
 
 TBD 8.14.2
 

--- a/libvips/foreign/heifload.c
+++ b/libvips/foreign/heifload.c
@@ -26,6 +26,8 @@
  * 	- add >8 bit support
  * 23/2/22 lovell
  * 	- add @unlimited
+ * 13/03/23 MathemanFlo
+ * 	- add bits per sample metadata
  */
 
 /*
@@ -658,7 +660,8 @@ vips_foreign_load_heif_set_header( VipsForeignLoadHeif *heif, VipsImage *out )
 			compression ) );
 
 	vips_image_set_int( out, "heif-bitdepth", heif->bits_per_pixel );
-	vips_image_set_int( out, VIPS_META_BITS_PER_SAMPLE, heif->bits_per_pixel );
+	vips_image_set_int( out, VIPS_META_BITS_PER_SAMPLE,
+		heif->bits_per_pixel );
 
 	if( heif->bits_per_pixel > 8 ) {
 		interpretation = VIPS_INTERPRETATION_RGB16;

--- a/libvips/foreign/heifload.c
+++ b/libvips/foreign/heifload.c
@@ -659,9 +659,12 @@ vips_foreign_load_heif_set_header( VipsForeignLoadHeif *heif, VipsImage *out )
 		vips_enum_nick( VIPS_TYPE_FOREIGN_HEIF_COMPRESSION,
 			compression ) );
 
-	vips_image_set_int( out, "heif-bitdepth", heif->bits_per_pixel );
 	vips_image_set_int( out, VIPS_META_BITS_PER_SAMPLE,
 		heif->bits_per_pixel );
+
+	/* Deprecated "heif-bitdepth" use "bits-per-sample" instead.
+	 */
+	vips_image_set_int( out, "heif-bitdepth", heif->bits_per_pixel );
 
 	if( heif->bits_per_pixel > 8 ) {
 		interpretation = VIPS_INTERPRETATION_RGB16;

--- a/libvips/foreign/heifload.c
+++ b/libvips/foreign/heifload.c
@@ -658,6 +658,7 @@ vips_foreign_load_heif_set_header( VipsForeignLoadHeif *heif, VipsImage *out )
 			compression ) );
 
 	vips_image_set_int( out, "heif-bitdepth", heif->bits_per_pixel );
+	vips_image_set_int( out, VIPS_META_BITS_PER_SAMPLE, heif->bits_per_pixel );
 
 	if( heif->bits_per_pixel > 8 ) {
 		interpretation = VIPS_INTERPRETATION_RGB16;

--- a/libvips/foreign/jp2kload.c
+++ b/libvips/foreign/jp2kload.c
@@ -6,6 +6,8 @@
  * 	- add untiled load
  * 17/1/22
  * 	- left-justify bits for eg. 12-bit read
+ * 13/3/23 MathemanFlo
+ * 	- add bits per sample metadata
  */
 
 /*
@@ -479,6 +481,7 @@ vips_foreign_load_jp2k_set_header( VipsForeignLoadJp2k *jp2k, VipsImage *out )
 				numresolutions );
 
 	vips_image_set_int( out, VIPS_META_BITS_PER_SAMPLE, first->prec );
+
 	return( 0 );
 }
 

--- a/libvips/foreign/jp2kload.c
+++ b/libvips/foreign/jp2kload.c
@@ -478,6 +478,7 @@ vips_foreign_load_jp2k_set_header( VipsForeignLoadJp2k *jp2k, VipsImage *out )
 			jp2k->info->m_default_tile_info.tccp_info->
 				numresolutions );
 
+	vips_image_set_int( out, VIPS_META_BITS_PER_SAMPLE, first->prec );
 	return( 0 );
 }
 

--- a/libvips/foreign/jxlload.c
+++ b/libvips/foreign/jxlload.c
@@ -487,6 +487,7 @@ vips_foreign_load_jxl_set_header( VipsForeignLoadJxl *jxl, VipsImage *out )
 	vips_image_set_int( out, 
 		VIPS_META_ORIENTATION, jxl->info.orientation );
 
+	vips_image_set_int( out, VIPS_META_BITS_PER_SAMPLE, jxl->info.bits_per_sample );
 	return( 0 );
 }
 

--- a/libvips/foreign/jxlload.c
+++ b/libvips/foreign/jxlload.c
@@ -4,6 +4,8 @@
  * 	- from heifload.c
  * 1/10/21
  * 	- reset read point for _load
+ * 13/3/23 MathemanFlo
+ * 	- add bits per sample metadata
  */
 
 /*
@@ -487,7 +489,9 @@ vips_foreign_load_jxl_set_header( VipsForeignLoadJxl *jxl, VipsImage *out )
 	vips_image_set_int( out, 
 		VIPS_META_ORIENTATION, jxl->info.orientation );
 
-	vips_image_set_int( out, VIPS_META_BITS_PER_SAMPLE, jxl->info.bits_per_sample );
+	vips_image_set_int( out, VIPS_META_BITS_PER_SAMPLE,
+		jxl->info.bits_per_sample );
+
 	return( 0 );
 }
 

--- a/libvips/foreign/magick2vips.c
+++ b/libvips/foreign/magick2vips.c
@@ -68,6 +68,8 @@
  * 	- set "orientation"
  * 26/8/22
  *      - set "magick-format"
+ * 13/3/23 MathemanFlo
+ * 	- add bits per sample metadata
  */
 
 /*
@@ -553,6 +555,8 @@ parse_header( Read *read )
 
 	vips_image_set_int( im, VIPS_META_ORIENTATION, 
 		VIPS_CLIP( 1, image->orientation, 8 ) );
+
+	vips_image_set_int( im, VIPS_META_BITS_PER_SAMPLE, depth );
 
 	return( 0 );
 }

--- a/libvips/foreign/magick7load.c
+++ b/libvips/foreign/magick7load.c
@@ -632,7 +632,7 @@ vips_foreign_load_magick7_parse( VipsForeignLoadMagick7 *magick7,
 	vips_image_set_int( out, VIPS_META_ORIENTATION, 
 		VIPS_CLIP( 1, image->orientation, 8 ) );
 
-	vips_image_set_int( im, VIPS_META_BITS_PER_SAMPLE, image->depth );
+	vips_image_set_int( out, VIPS_META_BITS_PER_SAMPLE, image->depth );
 
 	return( 0 );
 }

--- a/libvips/foreign/magick7load.c
+++ b/libvips/foreign/magick7load.c
@@ -10,6 +10,8 @@
  * 	- add profile (xmp, ipct, etc.) read
  * 12/11/21
  * 	- set "orientation"
+ * 22/3/23 MathemanFlo
+ * 	- add bits per sample metadata
  */
 
 /*
@@ -629,6 +631,8 @@ vips_foreign_load_magick7_parse( VipsForeignLoadMagick7 *magick7,
 
 	vips_image_set_int( out, VIPS_META_ORIENTATION, 
 		VIPS_CLIP( 1, image->orientation, 8 ) );
+
+	vips_image_set_int( im, VIPS_META_BITS_PER_SAMPLE, image->depth );
 
 	return( 0 );
 }

--- a/libvips/foreign/nsgifload.c
+++ b/libvips/foreign/nsgifload.c
@@ -10,6 +10,8 @@
  * 	- avoid minimise after mapping -- not reliable on Win32
  * 25/1/23 kleisauke
  * 	- set interlaced=1 for interlaced images
+ * 13/3/23 MathemanFlo
+ *  - add bits per sample metadata
  */
 
 /*

--- a/libvips/foreign/nsgifload.c
+++ b/libvips/foreign/nsgifload.c
@@ -334,6 +334,8 @@ vips_foreign_load_nsgif_set_header( VipsForeignLoadNsgif *gif,
 
 	vips_image_set_int( image, "palette-bit-depth", 
 		ceil( log2( colours ) ) ); 
+	vips_image_set_int( image, VIPS_META_BITS_PER_SAMPLE, 
+		ceil( log2( colours ) ) ); 
 
 	/* Let our caller know if the GIF is interlaced.
 	 */

--- a/libvips/foreign/nsgifload.c
+++ b/libvips/foreign/nsgifload.c
@@ -11,7 +11,7 @@
  * 25/1/23 kleisauke
  * 	- set interlaced=1 for interlaced images
  * 13/3/23 MathemanFlo
- *  - add bits per sample metadata
+ * 	- add bits per sample metadata
  */
 
 /*

--- a/libvips/foreign/nsgifload.c
+++ b/libvips/foreign/nsgifload.c
@@ -334,10 +334,13 @@ vips_foreign_load_nsgif_set_header( VipsForeignLoadNsgif *gif,
 		}
 	}
 
-	vips_image_set_int( image, "palette-bit-depth", 
-		ceil( log2( colours ) ) ); 
-	vips_image_set_int( image, VIPS_META_BITS_PER_SAMPLE, 
-		ceil( log2( colours ) ) ); 
+	vips_image_set_int( image, VIPS_META_BITS_PER_SAMPLE,
+		ceil( log2( colours ) ) );
+
+	/* Deprecated "palette-bit-depth" use "bits-per-sample" instead.
+	 */
+	vips_image_set_int( image, "palette-bit-depth",
+		ceil( log2( colours ) ) );
 
 	/* Let our caller know if the GIF is interlaced.
 	 */

--- a/libvips/foreign/spngload.c
+++ b/libvips/foreign/spngload.c
@@ -6,6 +6,8 @@
  * 	- read out background, if we can
  * 29/8/21 joshuamsager
  *	-  add "unlimited" flag to png load
+ * 03/02/23 MathemanFlo
+ *  - add bits per sample metadata
  */
 
 /*
@@ -269,6 +271,8 @@ vips_foreign_load_png_set_header( VipsForeignLoadPng *png, VipsImage *image )
 		vips_image_set_blob_copy( image, VIPS_META_EXIF_NAME, 
 			exif.data, exif.length );
 
+	vips_image_set_int( image, VIPS_META_BITS_PER_SAMPLE, png->ihdr.bit_depth );
+	
 	/* Attach original palette bit depth, if any, as metadata.
 	 */
 	if( png->ihdr.color_type == SPNG_COLOR_TYPE_INDEXED )

--- a/libvips/foreign/spngload.c
+++ b/libvips/foreign/spngload.c
@@ -274,7 +274,7 @@ vips_foreign_load_png_set_header( VipsForeignLoadPng *png, VipsImage *image )
 	vips_image_set_int( image, VIPS_META_BITS_PER_SAMPLE,
 		png->ihdr.bit_depth );
 
-	/* Attach original palette bit depth, if any, as metadata.
+	/* Deprecated "palette-bit-depth" use "bits-per-sample" instead.
 	 */
 	if( png->ihdr.color_type == SPNG_COLOR_TYPE_INDEXED )
 		vips_image_set_int( image, 

--- a/libvips/foreign/spngload.c
+++ b/libvips/foreign/spngload.c
@@ -6,7 +6,7 @@
  * 	- read out background, if we can
  * 29/8/21 joshuamsager
  *	-  add "unlimited" flag to png load
- * 03/02/23 MathemanFlo
+ * 3/2/23 MathemanFlo
  *  - add bits per sample metadata
  */
 
@@ -271,8 +271,9 @@ vips_foreign_load_png_set_header( VipsForeignLoadPng *png, VipsImage *image )
 		vips_image_set_blob_copy( image, VIPS_META_EXIF_NAME, 
 			exif.data, exif.length );
 
-	vips_image_set_int( image, VIPS_META_BITS_PER_SAMPLE, png->ihdr.bit_depth );
-	
+	vips_image_set_int( image, VIPS_META_BITS_PER_SAMPLE,
+		png->ihdr.bit_depth );
+
 	/* Attach original palette bit depth, if any, as metadata.
 	 */
 	if( png->ihdr.color_type == SPNG_COLOR_TYPE_INDEXED )

--- a/libvips/foreign/spngload.c
+++ b/libvips/foreign/spngload.c
@@ -7,7 +7,7 @@
  * 29/8/21 joshuamsager
  *	-  add "unlimited" flag to png load
  * 3/2/23 MathemanFlo
- *  - add bits per sample metadata
+ * 	- add bits per sample metadata
  */
 
 /*

--- a/libvips/foreign/tiff2vips.c
+++ b/libvips/foreign/tiff2vips.c
@@ -211,7 +211,7 @@
  *      - move jp2k decompress outside the lock
  *      - move jpeg decode outside the lock
  *      - fix demand hinting
- * 03/02/23 MathemanFlo
+ * 3/2/23 MathemanFlo
  *  - add bits per sample metadata
  */
 
@@ -1735,7 +1735,8 @@ rtiff_set_header( Rtiff *rtiff, VipsImage *out )
 	if( get_resolution( rtiff->tiff, out ) )
 		return( -1 );
 
-	vips_image_set_int( out, VIPS_META_BITS_PER_SAMPLE, rtiff->header.bits_per_sample );
+	vips_image_set_int( out, VIPS_META_BITS_PER_SAMPLE,
+		rtiff->header.bits_per_sample );
 
 	/* Set the "orientation" tag. This is picked up later by autorot, if
 	 * requested.

--- a/libvips/foreign/tiff2vips.c
+++ b/libvips/foreign/tiff2vips.c
@@ -211,6 +211,8 @@
  *      - move jp2k decompress outside the lock
  *      - move jpeg decode outside the lock
  *      - fix demand hinting
+ * 03/02/23 MathemanFlo
+ *  - add bits per sample metadata
  */
 
 /*
@@ -1732,6 +1734,8 @@ rtiff_set_header( Rtiff *rtiff, VipsImage *out )
 
 	if( get_resolution( rtiff->tiff, out ) )
 		return( -1 );
+
+	vips_image_set_int( out, VIPS_META_BITS_PER_SAMPLE, rtiff->header.bits_per_sample );
 
 	/* Set the "orientation" tag. This is picked up later by autorot, if
 	 * requested.

--- a/libvips/foreign/tiff2vips.c
+++ b/libvips/foreign/tiff2vips.c
@@ -212,7 +212,7 @@
  *      - move jpeg decode outside the lock
  *      - fix demand hinting
  * 3/2/23 MathemanFlo
- *  - add bits per sample metadata
+ * 	- add bits per sample metadata
  */
 
 /*

--- a/libvips/foreign/vipspng.c
+++ b/libvips/foreign/vipspng.c
@@ -530,8 +530,6 @@ png2vips_header( Read *read, VipsImage *out )
 	if( vips_image_pipelinev( out, VIPS_DEMAND_STYLE_THINSTRIP, NULL ) )
 		return( -1 );
 
-	vips_image_set_int( out, VIPS_META_BITS_PER_SAMPLE, bitdepth );
-
 	/* Fetch the ICC profile. @name is useless, something like "icc" or
 	 * "ICC Profile" etc. Ignore it.
 	 *
@@ -595,6 +593,8 @@ png2vips_header( Read *read, VipsImage *out )
 				text_ptr[i].key, text_ptr[i].text ) ) 
 				return( -1 ); 
 	}
+
+	vips_image_set_int( out, VIPS_META_BITS_PER_SAMPLE, bitdepth );
 
 	/* Deprecated "palette-bit-depth" use "bits-per-sample" instead.
 	 */

--- a/libvips/foreign/vipspng.c
+++ b/libvips/foreign/vipspng.c
@@ -87,7 +87,7 @@
  * 	- raise libpng pixel size limit to VIPS_MAX_COORD 
  * 17/11/22
  * 	- add exif read/write
-* 03/02/23 MathemanFlo
+ * 3/2/23 MathemanFlo
  *  - add bits per sample metadata
  */
 

--- a/libvips/foreign/vipspng.c
+++ b/libvips/foreign/vipspng.c
@@ -87,6 +87,8 @@
  * 	- raise libpng pixel size limit to VIPS_MAX_COORD 
  * 17/11/22
  * 	- add exif read/write
+* 03/02/23 MathemanFlo
+ *  - add bits per sample metadata
  */
 
 /*
@@ -527,6 +529,8 @@ png2vips_header( Read *read, VipsImage *out )
 
 	if( vips_image_pipelinev( out, VIPS_DEMAND_STYLE_THINSTRIP, NULL ) )
 		return( -1 );
+
+	vips_image_set_int( out, VIPS_META_BITS_PER_SAMPLE, bitdepth );
 
 	/* Fetch the ICC profile. @name is useless, something like "icc" or
 	 * "ICC Profile" etc. Ignore it.

--- a/libvips/foreign/vipspng.c
+++ b/libvips/foreign/vipspng.c
@@ -596,7 +596,7 @@ png2vips_header( Read *read, VipsImage *out )
 				return( -1 ); 
 	}
 
-	/* Attach original palette bit depth, if any, as metadata.
+	/* Deprecated "palette-bit-depth" use "bits-per-sample" instead.
 	 */
 	if( color_type == PNG_COLOR_TYPE_PALETTE )
 		vips_image_set_int( out, "palette-bit-depth", bitdepth );

--- a/libvips/foreign/vipspng.c
+++ b/libvips/foreign/vipspng.c
@@ -88,7 +88,7 @@
  * 17/11/22
  * 	- add exif read/write
  * 3/2/23 MathemanFlo
- *  - add bits per sample metadata
+ * 	- add bits per sample metadata
  */
 
 /*

--- a/libvips/include/vips/header.h
+++ b/libvips/include/vips/header.h
@@ -93,6 +93,13 @@ extern "C" {
 #define VIPS_META_RESOLUTION_UNIT "resolution-unit"
 
 /**
+ * VIPS_META_BITS_PER_SAMPLE:
+ *
+ * The bits per sample for each channel.
+ */
+#define VIPS_META_BITS_PER_SAMPLE "bits-per-sample"
+
+/**
  * VIPS_META_LOADER:
  *
  * Record the name of the original loader here. Handy for hinting file formats

--- a/libvips/iofuncs/header.c
+++ b/libvips/iofuncs/header.c
@@ -1456,7 +1456,8 @@ vips_image_remove( VipsImage *image, const char *name )
 static const char *vips_image_header_deprecated[] = {
 	"ipct-data",
 	"gif-delay",
-	"gif-loop"
+	"gif-loop",
+	"palette-bit-depth"
 };
 
 static void *

--- a/libvips/iofuncs/header.c
+++ b/libvips/iofuncs/header.c
@@ -1457,7 +1457,8 @@ static const char *vips_image_header_deprecated[] = {
 	"ipct-data",
 	"gif-delay",
 	"gif-loop",
-	"palette-bit-depth"
+	"palette-bit-depth",
+	"heif-bitdepth"
 };
 
 static void *

--- a/test/test-suite/test_foreign.py
+++ b/test/test-suite/test_foreign.py
@@ -426,6 +426,7 @@ class TestForeign:
             assert im.width == 290
             assert im.height == 442
             assert im.bands == 3
+            assert im.get("bits-per-sample") == 16
 
         self.file_loader("pngload", PNG_FILE, png_valid)
         self.buffer_loader("pngload_buffer", PNG_FILE, png_valid)
@@ -453,6 +454,7 @@ class TestForeign:
         data = onebit.write_to_buffer(".png", bitdepth=1)
         after = pyvips.Image.new_from_buffer(data, "")
         assert( (onebit - after).abs().max() == 0 )
+        assert after.get("bits-per-sample") == 1
 
         # we can't test palette save since we can't be sure libimagequant is
         # available and there's no easy test for its presence
@@ -484,6 +486,7 @@ class TestForeign:
             assert im.width == 290
             assert im.height == 442
             assert im.bands == 3
+            assert im.get("bits-per-sample") == 16
 
         self.file_loader("tiffload", TIF_FILE, tiff_valid)
         self.buffer_loader("tiffload_buffer", TIF_FILE, tiff_valid)
@@ -496,6 +499,7 @@ class TestForeign:
             assert im.width == 256
             assert im.height == 4
             assert im.bands == 1
+            assert im.get("bits-per-sample") == 1
 
         self.file_loader("tiffload", TIF1_FILE, tiff1_valid)
 
@@ -507,6 +511,7 @@ class TestForeign:
             assert im.width == 256
             assert im.height == 4
             assert im.bands == 1
+            assert im.get("bits-per-sample") == 2
 
         self.file_loader("tiffload", TIF2_FILE, tiff2_valid)
 
@@ -518,6 +523,7 @@ class TestForeign:
             assert im.width == 256
             assert im.height == 4
             assert im.bands == 1
+            assert im.get("bits-per-sample") == 4
 
         self.file_loader("tiffload", TIF4_FILE, tiff4_valid)
 
@@ -698,6 +704,7 @@ class TestForeign:
             assert_almost_equal_objects(a, [227, 216, 201])
             assert im.width == 1419
             assert im.height == 1001
+            assert im.get("bits-per-sample") == 8
 
         self.file_loader("magickload", BMP_FILE, bmp_valid)
         self.buffer_loader("magickload_buffer", BMP_FILE, bmp_valid)
@@ -996,6 +1003,7 @@ class TestForeign:
         assert x2.get("n-pages") == 1
         assert x2.get("background") == [81, 81, 81]
         assert x2.get("interlaced") == 1
+        assert x2.get("bits-per-sample") == 4
 
         x2 = pyvips.Image.new_from_file(GIF_ANIM_FILE, n=-1)
         # our test gif has delay 0 for the first frame set in error
@@ -1391,7 +1399,7 @@ class TestForeign:
         assert(im.width == rgb16.width)
         assert(im.format == rgb16.format)
         assert(im.interpretation == rgb16.interpretation)
-        assert(im.get("heif-bitdepth") == 12)
+        assert(im.get("bits-per-sample") == 12)
         # good grief, some kind of lossless
         assert((im - rgb16).abs().max() < 4500)
 
@@ -1405,7 +1413,7 @@ class TestForeign:
         assert(im.width == rgb16.width)
         assert(im.format == "uchar")
         assert(im.interpretation == "srgb")
-        assert(im.get("heif-bitdepth") == 8)
+        assert(im.get("bits-per-sample") == 8)
         # good grief, some kind of lossless
         assert((im - rgb16 / 256).abs().max() < 80)
 
@@ -1418,7 +1426,7 @@ class TestForeign:
         assert(im.width == self.colour.width)
         assert(im.format == "ushort")
         assert(im.interpretation == "rgb16")
-        assert(im.get("heif-bitdepth") == 12)
+        assert(im.get("bits-per-sample") == 12)
         # good grief, some kind of lossless
         assert((im - self.colour * 256).abs().max() < 4500)
 
@@ -1430,6 +1438,7 @@ class TestForeign:
             assert im.width == 800
             assert im.height == 400
             assert im.bands == 3
+            assert im.get("bits-per-sample") == 8
 
         self.file_loader("jp2kload", JP2K_FILE, jp2k_valid)
         self.buffer_loader("jp2kload_buffer", JP2K_FILE, jp2k_valid)
@@ -1463,6 +1472,7 @@ class TestForeign:
         buf = im.jp2ksave_buffer(lossless=True)
         im2 = pyvips.Image.new_from_buffer(buf, "")
         assert (im == im2).min() == 255
+        assert im2.get("bits-per-sample") == 16
 
         # openjpeg 32-bit load and save doesn't seem to work, comment out
         # im = self.colour.colourspace("rgb16").cast("uint") << 14


### PR DESCRIPTION
Implements https://github.com/libvips/libvips/discussions/3321

- I added a `VIPS_META_BITS_PER_SAMPLE` flag which contains the bits per pixel of each channel. Hope you are okay with the name. Alternative would be `VIPS_META_BITS_PER_CHANNEL` or `VIPS_META_BITS_PER_BITDEPTH`. Avoided the latter because it is unclear whether it is per channel or the total color depth.
- Support for tiffs via `TIFFTAG_BITSPERSAMPLE`. According to [libtiff reference](https://www.awaresystems.be/imaging/tiff/tifftags/bitspersample.html) a tiff file could contain different bits per sample for each channel but libtiff does not support that, so it is okay to only read the tag once. 
- Support for libpng and libspng. [libpng reference](https://refspecs.linuxfoundation.org/LSB_5.0.0/LSB-TrialUse/LSB-TrialUse/libpng15-png-get-ihdr.html)

I noticed that the code for png and gif contains `"palette-bit-depth"` which is very similar to `VIPS_META_BITS_PER_SAMPLE`.
Haven't looked at gif and webp yet, but will asap.