### PR TITLE
CI: fix test failure on macOS

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -67,6 +67,8 @@ jobs:
       - name: Install macOS dependencies
         if: runner.os == 'macOS'
         run: |
+          # FIXME: remove when the GitHub Actions runner image ships with Homebrew/homebrew-core#122689
+          brew update
           brew install meson ninja fftw fontconfig glib libexif libgsf little-cms2 orc pango
           brew install cfitsio cgif jpeg-xl libheif libimagequant libjpeg-turbo libmatio librsvg libspng libtiff openexr openjpeg openslide poppler webp
 

--- a/test/test-suite/test_foreign.py
+++ b/test/test-suite/test_foreign.py
@@ -1488,9 +1488,11 @@ class TestForeign:
                               scrgb_no_profile, 120)
 
         # 16-bit mode
-        rgb16 = self.colour.colourspace("rgb16")
+        rgb16 = self.colour.colourspace("rgb16").copy()
+        # remove the ICC profile: the RGB one will no longer be appropriate
+        rgb16.remove("icc-profile-data")
         self.save_load_buffer("jxlsave_buffer", "jxlload_buffer",
-                              rgb16, 30300)
+                              rgb16, 10700)
 
         # repeat for lossless mode
         self.save_load_buffer("jxlsave_buffer", "jxlload_buffer",


### PR DESCRIPTION
Remove the ICC profile after the image is converted to 16-bit.

Ensures that pixels are correctly interpreted and that the maximum absolute difference remains consistent across different colour management software (i.e. lcms and skcms).

> **Note**: this PR targets the [`8.14`](https://github.com/libvips/libvips/tree/8.14) branch.