### PR TITLE
Backport #3282 to 8.14

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -6,6 +6,7 @@ TBD 8.14.2
 - minor doc fixes [jcupitt]
 - sanitise dimensions in JPEG-compressed TIFF images [lovell]
 - fix target pnm write [ewelot]
+- dedupe FITS header write [ewelot]
 
 9/1/23 8.14.1
 


### PR DESCRIPTION
Trivial backport of #3282 to [`8.14`](https://github.com/libvips/libvips/tree/8.14). Corresponds to the backport in Debian:
https://tracker.debian.org/media/packages/v/vips/changelog-8.14.1-3

/cc @ewelot