### PR TITLE
Backport commit 6715108 to 8.14

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -7,6 +7,7 @@ TBD 8.14.2
 - sanitise dimensions in JPEG-compressed TIFF images [lovell]
 - fix target pnm write [ewelot]
 - dedupe FITS header write [ewelot]
+- fix `strip` parameter in webpsave [jcupitt]
 
 9/1/23 8.14.1
 


### PR DESCRIPTION
Trivial backport of 6715108a2dc45c04634ab0ed545ccac6a63e7592 to [`8.14`](https://github.com/libvips/libvips/tree/8.14).