### PR TITLE
Avoid retrieving PDFium via pkg-config

### DIFF
--- a/README.md
+++ b/README.md
@@ -159,21 +159,11 @@ Untar to the libvips install prefix, for example:
     cd ~/vips
     tar xf ~/pdfium-linux.tgz
 
-Create a `pdfium.pc` like this (update the version number):
+For compilers to find PDFium you may need to set:
 
     VIPSHOME=/home/john/vips
-    cat > $VIPSHOME/lib/pkgconfig/pdfium.pc << EOF
-         prefix=$VIPSHOME
-         exec_prefix=\${prefix}
-         libdir=\${exec_prefix}/lib
-         includedir=\${prefix}/include
-         Name: pdfium
-         Description: pdfium
-         Version: 4290
-         Requires:
-         Libs: -L\${libdir} -lpdfium
-         Cflags: -I\${includedir}
-    EOF
+    export LDFLAGS="-L$VIPSHOME/lib"
+    export CPPFLAGS="-I$VIPSHOME/include"
 
 If PDFium is not detected, libvips will look for `poppler-glib` instead.
 

--- a/fuzz/oss_fuzz_build.sh
+++ b/fuzz/oss_fuzz_build.sh
@@ -2,8 +2,9 @@
 
 export PKG_CONFIG="pkg-config --static"
 export PKG_CONFIG_PATH="$WORK/lib/pkgconfig"
-export CPPFLAGS="-I$WORK/include"
 export LDFLAGS="-L$WORK/lib"
+export CPPFLAGS="-I$WORK/include"
+export LIBRARY_PATH="$WORK/lib" # https://github.com/mesonbuild/meson/issues/10172
 
 # libz
 pushd $SRC/zlib

--- a/fuzz/oss_fuzz_build.sh
+++ b/fuzz/oss_fuzz_build.sh
@@ -163,21 +163,6 @@ cp lib/* $WORK/lib
 cp -r include/* $WORK/include
 popd
 
-# make a pdfium.pc that libvips can use ... the version number just needs to
-# be higher than 4200 to satisfy libvips
-cat > $WORK/lib/pkgconfig/pdfium.pc << EOF
-  prefix=$WORK
-  exec_prefix=\${prefix}
-  libdir=\${exec_prefix}/lib
-  includedir=\${prefix}/include
-  Name: pdfium
-  Description: pdfium
-  Version: 4901
-  Requires:
-  Libs: -L\${libdir} -lpdfium
-  Cflags: -I\${includedir}
-EOF
-
 # libvips
 # Disable building man pages, gettext po files, tools, and tests
 sed -i "/subdir('man')/{N;N;N;d;}" meson.build

--- a/libvips/foreign/pdfiumload.c
+++ b/libvips/foreign/pdfiumload.c
@@ -62,24 +62,12 @@
  * 	cd ~/vips
  * 	tar xf ~/pdfium-linux.tgz
  *
- * Create a pdfium.pc like this (update the version number):
+ * For compilers to find PDFium you may need to set:
  *
-
-VIPSHOME=/home/john/vips
-cat > $VIPSHOME/lib/pkgconfig/pdfium.pc << EOF
-     prefix=$VIPSHOME
-     exec_prefix=\${prefix}
-     libdir=\${exec_prefix}/lib
-     includedir=\${prefix}/include
-     Name: pdfium
-     Description: pdfium
-     Version: 4290
-     Requires:
-     Libs: -L\${libdir} -lpdfium
-     Cflags: -I\${includedir}
-EOF
-
- * 
+ * 	VIPSHOME=/home/john/vips
+ * 	export LDFLAGS="-L$VIPSHOME/lib"
+ * 	export CPPFLAGS="-I$VIPSHOME/include"
+ *
  */
 
 /*

--- a/meson.build
+++ b/meson.build
@@ -446,9 +446,7 @@ if orc_dep.found()
     endif
 endif
 
-# pick 4200 as the starting version number ... no reason, really, it'd
-# probably work with much older versions
-pdfium_dep = dependency('pdfium', version: '>=4200', required: get_option('pdfium'))
+pdfium_dep = cc.find_library('pdfium', has_headers: ['fpdfview.h', 'fpdf_doc.h', 'fpdf_edit.h'], required: get_option('pdfium'))
 if pdfium_dep.found()
     libvips_deps += pdfium_dep
     cfg_var.set('HAVE_PDFIUM', '1')


### PR DESCRIPTION
PDFium doesn't ship with a pkg-config file, so it's recommend to use Meson's `find_library()` function to look for it. This would avoid the need to create `pdfium.pc`.