### PR TITLE
CI: ensure pkg-config is installed on macOS

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -67,7 +67,7 @@ jobs:
       - name: Install macOS dependencies
         if: runner.os == 'macOS'
         run: |
-          brew install meson ninja fftw fontconfig glib libexif libgsf little-cms2 orc pango
+          brew install meson ninja fftw fontconfig glib libexif libgsf little-cms2 orc pango pkg-config
           brew install cfitsio cgif jpeg-xl libheif libimagequant mozjpeg libmatio librsvg libspng libtiff openexr openjpeg openslide poppler webp
 
       - name: Install Clang 14


### PR DESCRIPTION
See: https://github.com/actions/runner-images/pull/7125

> **Note**: this PR targets the [`8.14`](https://github.com/libvips/libvips/tree/8.14) branch.