### PR TITLE
colour: D65 uses a temperature of 6504K

### DIFF
--- a/libvips/colour/icc_transform.c
+++ b/libvips/colour/icc_transform.c
@@ -773,7 +773,7 @@ vips_icc_import_build( VipsObject *object )
 
 	if( icc->pcs == VIPS_PCS_LAB ) { 
 		cmsCIExyY white;
-		cmsWhitePointFromTemp( &white, 6500 );
+		cmsWhitePointFromTemp( &white, 6504 );
 
 		icc->out_profile = cmsCreateLab4Profile( &white );
 	}
@@ -936,7 +936,7 @@ vips_icc_export_build( VipsObject *object )
 
 	if( icc->pcs == VIPS_PCS_LAB ) { 
 		cmsCIExyY white;
-		cmsWhitePointFromTemp( &white, 6500 );
+		cmsWhitePointFromTemp( &white, 6504 );
 
 		icc->in_profile = cmsCreateLab4Profile( &white );
 	}


### PR DESCRIPTION
See: https://en.wikipedia.org/wiki/Illuminant_D65#Color_Temperature

> **Note**: this PR targets the [`8.14`](https://github.com/libvips/libvips/tree/8.14) branch.