### PR TITLE
colour: use `cmsFLAGS_NOOPTIMIZE` to keep all precision

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -10,6 +10,7 @@ TBD 8.14.2
 - fix `strip` parameter in webpsave [jcupitt]
 - earlier abort of webpsave on kill [dloebl]
 - fix thumbnail of CMYK images with an embedded ICC profile [kleisauke]
+- ensure ICC transforms keep all precision [kleisauke]
 
 9/1/23 8.14.1
 

--- a/libvips/colour/icc_transform.c
+++ b/libvips/colour/icc_transform.c
@@ -438,8 +438,9 @@ vips_icc_build( VipsObject *object )
 
 	/* Use cmsFLAGS_NOCACHE to disable the 1-pixel cache and make
 	 * calling cmsDoTransform() from multiple threads safe.
+	 * Use cmsFLAGS_NOOPTIMIZE to ensure we keep all precision.
 	 */
-	flags = cmsFLAGS_NOCACHE;
+	flags = cmsFLAGS_NOCACHE | cmsFLAGS_NOOPTIMIZE;
 
 	if( icc->black_point_compensation ) 
 		flags |= cmsFLAGS_BLACKPOINTCOMPENSATION;
@@ -1228,7 +1229,7 @@ vips_icc_transform_init( VipsIccTransform *transform )
  * @out: (out): output image
  * @profile_filename: use this profile
  *
- * Transform an image from absolute to relative colorimetry using the
+ * Transform an image from absolute to relative colorimetric using the
  * MediaWhitePoint stored in the ICC profile.
  *
  * See also: vips_icc_transform(), vips_icc_import().

--- a/test/test-suite/test_resample.py
+++ b/test/test-suite/test_resample.py
@@ -237,12 +237,11 @@ class TestResample:
         assert im.width == 290
         assert im.height == 442
         assert im.bands == 3
-        assert im.bands == 3
 
         # the colour distance should not deviate too much
         # (i.e. the embedded profile should not be ignored)
         im_orig = pyvips.Image.new_from_file(JPEG_FILE)
-        assert im_orig.de00(im).max() < 10
+        assert im_orig.de00(im).max() < 11
 
     def test_similarity(self):
         im = pyvips.Image.new_from_file(JPEG_FILE)


### PR DESCRIPTION
Resolves: #3150.

> **Note**: this PR targets the [`8.14`](https://github.com/libvips/libvips/tree/8.14) branch.