### PR TITLE
thumbnail: skip colourspace conversion when needed

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -9,6 +9,7 @@ TBD 8.14.2
 - dedupe FITS header write [ewelot]
 - fix `strip` parameter in webpsave [jcupitt]
 - earlier abort of webpsave on kill [dloebl]
+- fix thumbnail of CMYK images with an embedded ICC profile [kleisauke]
 
 9/1/23 8.14.1
 

--- a/libvips/resample/thumbnail.c
+++ b/libvips/resample/thumbnail.c
@@ -707,6 +707,18 @@ vips_thumbnail_build( VipsObject *object )
 		(thumbnail->import_profile ||
 		 vips_image_get_typeof( in, VIPS_META_ICC_NAME ) );
 
+	/* RAD needs special unpacking.
+	 */
+	if( in->Coding == VIPS_CODING_RAD ) {
+		g_info( "unpacking Rad to float" );
+
+		/* rad is scrgb.
+		 */
+		if( vips_rad2float( in, &t[12], NULL ) )
+			return( -1 );
+		in = t[12];
+	}
+
 	/* In linear mode, we need to transform to a linear space before 
 	 * vips_resize(). 
 	 */

--- a/libvips/resample/thumbnail.c
+++ b/libvips/resample/thumbnail.c
@@ -703,18 +703,6 @@ vips_thumbnail_build( VipsObject *object )
 	 */
 	preshrunk_page_height = vips_image_get_page_height( in );
 
-	/* RAD needs special unpacking.
-	 */
-	if( in->Coding == VIPS_CODING_RAD ) {
-		g_info( "unpacking Rad to float" );
-
-		/* rad is scrgb.
-		 */
-		if( vips_rad2float( in, &t[12], NULL ) )
-			return( -1 );
-		in = t[12];
-	}
-
 	needs_icc_transform = thumbnail->export_profile &&
 		(thumbnail->import_profile ||
 		 vips_image_get_typeof( in, VIPS_META_ICC_NAME ) );
@@ -896,9 +884,9 @@ vips_thumbnail_build( VipsObject *object )
 			return( -1 ); 
 		in = t[10];
 	}
-	else {
-		/* We are in one of the resize spaces and there's no export
-		 * profile. Output to sRGB or B_W
+	else if( thumbnail->linear ) {
+		/* We are in one of the scRGB or GREY16 spaces and there's
+		 * no export profile. Output to sRGB or B_W.
 		 */
 		VipsInterpretation interpretation;
 


### PR DESCRIPTION
i.e. if the image needs to transformed with a pair of ICC profiles.

Resolves: #3159.

> **Note**: this PR targets the [`8.14`](https://github.com/libvips/libvips/tree/8.14) branch.