### PR TITLE
add an experimental "nocache" option

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -14,6 +14,7 @@
 - allow negative line spacing in text [donghuikugou]
 - add VIPS_META_BITS_PER_SAMPLE metadata, deprecate the
   "palette-bit-depth" and "heif-bitdepth" meta fields [MathemanFlo]
+- add "nocache" to operation class [jcupitt]
 
 TBD 8.14.2
 

--- a/libvips/include/vips/operation.h
+++ b/libvips/include/vips/operation.h
@@ -80,6 +80,10 @@ typedef struct _VipsOperation {
 	 */
 	int pixels;
 
+	/* Set to force execution of this operation.
+	 */
+	gboolean nocache;
+
 } VipsOperation;
 
 typedef struct _VipsOperationClass {

--- a/libvips/iofuncs/operation.c
+++ b/libvips/iofuncs/operation.c
@@ -596,6 +596,8 @@ vips_operation_class_init( VipsOperationClass *class )
 
 	gobject_class->finalize = vips_operation_finalize;
 	gobject_class->dispose = vips_operation_dispose;
+	gobject_class->set_property = vips_object_set_property;
+	gobject_class->get_property = vips_object_get_property;
 
 	vobject_class->build = vips_operation_build;
 	vobject_class->summary = vips_operation_summary;
@@ -605,6 +607,13 @@ vips_operation_class_init( VipsOperationClass *class )
 
 	class->usage = vips_operation_usage;
 	class->get_flags = vips_operation_real_get_flags;
+
+	VIPS_ARG_BOOL( class, "nocache", 200, 
+		_( "No cache" ), 
+		_( "Force execution of this operation" ),
+		VIPS_ARGUMENT_OPTIONAL_INPUT,
+		G_STRUCT_OFFSET( VipsOperation, nocache ),
+		FALSE );
 
 	vips_operation_signals[SIG_INVALIDATE] = g_signal_new( "invalidate",
 		G_TYPE_FROM_CLASS( class ),


### PR DESCRIPTION
This experimental PR adds a "nocache" option to all operations. 

The idea is that if this flag is set, the operation is always executed and never fetched from the operation cache. If the operation succeeds, any old cache entry is replaced.

This is supposed to be useful for things like opening file where you know that the file might have changed since you last opened it. Setting `nocache` ensures that you always get a fresh file open.

See https://github.com/libvips/ruby-vips/issues/360 for the reporting issue.

Questions:

- I think it's threadsafe, but I'm often wrong heh
- This is a bit obtrusive, since it appears *everywhere*. We could tag this as DEPRECATED, or perhaps internal API, and only expose it in `new_from_file` and friends.
- I've not done tests or docs
- Any thoughts?