### PR TITLE
colour: fix ICC handling of RGB images w/ a monochrome profile

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -10,6 +10,7 @@ TBD 8.14.2
 - fix `strip` parameter in webpsave [jcupitt]
 - earlier abort of webpsave on kill [dloebl]
 - fix thumbnail of CMYK images with an embedded ICC profile [kleisauke]
+- fix ICC handling of RGB images with a monochrome profile [kleisauke]
 
 9/1/23 8.14.1
 


### PR DESCRIPTION
This restores the `vips_image_expected_bands` function and matching logic (which had been removed in commit 1297f2c) to almost its original state.

See: #3361.

> **Note**: this PR targets the [`8.14`](https://github.com/libvips/libvips/tree/8.14) branch.