### PR TITLE
colour: use floating-point APIs of lcms

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -10,6 +10,7 @@ TBD 8.14.2
 - fix `strip` parameter in webpsave [jcupitt]
 - earlier abort of webpsave on kill [dloebl]
 - fix thumbnail of CMYK images with an embedded ICC profile [kleisauke]
+- ensure ICC transforms keep all precision [kleisauke]
 
 9/1/23 8.14.1
 

--- a/libvips/colour/icc_transform.c
+++ b/libvips/colour/icc_transform.c
@@ -845,12 +845,11 @@ decode_lab( guint16 *fixed, float *lab, int n )
 	int i;
 
 	for( i = 0; i < n; i++ ) {
-		cmsCIELab Lab;
-		cmsLabEncoded2Float( &Lab, fixed );
-
-		lab[0] = (float) Lab.L;
-		lab[1] = (float) Lab.a;
-		lab[2] = (float) Lab.b;
+		/* cmsLabEncoded2Float inlined.
+		 */
+		lab[0] = (double) fixed[0] / 655.35;
+		lab[1] = ((double) fixed[1] / 257.0) - 128.0;
+		lab[2] = ((double) fixed[2] / 257.0) - 128.0;
 
 		lab += 3;
 		fixed += 3;
@@ -867,12 +866,11 @@ decode_xyz( guint16 *fixed, float *xyz, int n )
 	int i;
 
 	for( i = 0; i < n; i++ ) {
-		cmsCIEXYZ XYZ;
-		cmsXYZEncoded2Float( &XYZ, fixed );
-
-		xyz[0] = (float) XYZ.X / X_FAC;
-		xyz[1] = (float) XYZ.Y / Y_FAC;
-		xyz[2] = (float) XYZ.Z / Z_FAC;
+		/* cmsXYZEncoded2Float inlined.
+ 		 */
+		xyz[0] = (double) fixed[0] / (X_FAC * 32768.0);
+		xyz[1] = (double) fixed[1] / (Y_FAC * 32768.0);
+		xyz[2] = (double) fixed[2] / (Z_FAC * 32768.0);
 
 		xyz += 3;
 		fixed += 3;

--- a/libvips/colour/icc_transform.c
+++ b/libvips/colour/icc_transform.c
@@ -801,15 +801,19 @@ vips_icc_import_build( VipsObject *object )
 	return( 0 );
 }
 
+#define X_FAC (cmsD50X / VIPS_D65_X0)
+#define Y_FAC (cmsD50Y / VIPS_D65_Y0)
+#define Z_FAC (cmsD50Z / VIPS_D65_Z0)
+
 static void 
 decode_xyz( float *in, float *out, int n )
 {
 	int i;
 
 	for( i = 0; i < n; i++ ) {
-		out[0] = in[0] * VIPS_D65_X0;
-		out[1] = in[1] * VIPS_D65_Y0;
-		out[2] = in[2] * VIPS_D65_Z0;
+		out[0] = in[0] / X_FAC;
+		out[1] = in[1] / Y_FAC;
+		out[2] = in[2] / Z_FAC;
 
 		out += 3;
 		in += 3;
@@ -962,9 +966,9 @@ encode_xyz( float *in, float *out, int n )
 	int i;
 
 	for( i = 0; i < n; i++ ) {
-		out[0] = in[0] / VIPS_D65_X0;
-		out[1] = in[1] / VIPS_D65_Y0;
-		out[2] = in[2] / VIPS_D65_Z0;
+		out[0] = in[0] * X_FAC;
+		out[1] = in[1] * Y_FAC;
+		out[2] = in[2] * Z_FAC;
 
 		in += 3;
 		out += 3;

--- a/test/test-suite/test_colour.py
+++ b/test/test-suite/test_colour.py
@@ -81,7 +81,7 @@ class TestColour:
             before = cmyk(10, 10)
             after = im2(10, 10)
 
-            assert_almost_equal_objects(before, after, threshold=11)
+            assert_almost_equal_objects(before, after, threshold=10)
 
     # test results from Bruce Lindbloom's calculator:
     # http://www.brucelindbloom.com

--- a/test/test-suite/test_colour.py
+++ b/test/test-suite/test_colour.py
@@ -81,7 +81,7 @@ class TestColour:
             before = cmyk(10, 10)
             after = im2(10, 10)
 
-            assert_almost_equal_objects(before, after, threshold=10)
+            assert_almost_equal_objects(before, after, threshold=11)
 
     # test results from Bruce Lindbloom's calculator:
     # http://www.brucelindbloom.com


### PR DESCRIPTION
Avoids the need to pack the buffer of floats into lcms's fixed-point formats and ensures full precision internally in lcms.

Resolves: #3150.
Supersedes: #3368.

> **Note**: this PR targets the [`8.14`](https://github.com/libvips/libvips/tree/8.14) branch.