### PR TITLE
Prevent use of void pointer arithmetic

### DIFF
--- a/libvips/foreign/exif.c
+++ b/libvips/foreign/exif.c
@@ -188,7 +188,7 @@ vips_exif_load_data_without_fix( const void *data, size_t length )
 		void* data_with_prefix;
 		data_with_prefix = g_malloc0( length + 6 );
 		memcpy( data_with_prefix, "Exif\0\0", 6 );
-		memcpy( data_with_prefix + 6, data, length );
+		memcpy( (char *) data_with_prefix + 6, data, length );
 		exif_data_load_data( ed, data_with_prefix, length + 6 );
 		g_free( data_with_prefix );
 	} else

--- a/libvips/foreign/heifload.c
+++ b/libvips/foreign/heifload.c
@@ -1121,7 +1121,7 @@ vips_foreign_load_heif_read( void *data, size_t size, void *userdata )
 			return( -1 );
 
 		size -= bytes_read;
-		data += bytes_read;
+		data = (char *) data + bytes_read;
 	}
 
 	return( 0 );

--- a/libvips/foreign/matlab.c
+++ b/libvips/foreign/matlab.c
@@ -274,7 +274,7 @@ mat2vips_get_data( mat_t *mat, matvar_t *var, VipsImage *im )
 		return( -1 );
 
 	for( y = 0; y < im->Ysize; y++ ) {
-		const VipsPel *p = var->data + y * es;
+		const VipsPel *p = (VipsPel *) var->data + y * es;
 		int x;
 		VipsPel *q;
 

--- a/libvips/foreign/nsgifload.c
+++ b/libvips/foreign/nsgifload.c
@@ -488,7 +488,7 @@ vips_foreign_load_nsgif_generate( VipsRegion *or,
 			gif->frame_number = page;
 		}
 
-		p = gif->bitmap + line * gif->info->width * sizeof( int );
+		p = (VipsPel *) gif->bitmap + line * gif->info->width * sizeof( int );
 		q = VIPS_REGION_ADDR( or, 0, r->top + y );
 		if( gif->has_transparency )
 			memcpy( q, p, VIPS_REGION_SIZEOF_LINE( or ) );

--- a/libvips/foreign/ppmload.c
+++ b/libvips/foreign/ppmload.c
@@ -484,8 +484,8 @@ vips_foreign_load_ppm_map( VipsForeignLoadPpm *ppm )
 	if( header_offset < 0 || 
 		!data )
 		return( NULL );
-	data += header_offset;
-       	length -= header_offset;
+	data = (char *) data + header_offset;
+	length -= header_offset;
 
 	if( !(out = vips_image_new_from_memory( data, length,
 		ppm->width, ppm->height, ppm->bands, ppm->format )) )

--- a/libvips/foreign/spngload.c
+++ b/libvips/foreign/spngload.c
@@ -110,7 +110,7 @@ vips_foreign_load_png_stream( spng_ctx *ctx, void *user,
 		if( bytes_read == 0 )
 			return( SPNG_IO_EOF );
 
-		dest += bytes_read;
+		dest = (char *) dest + bytes_read;
 		length -= bytes_read;
 	}
 

--- a/libvips/foreign/vipspng.c
+++ b/libvips/foreign/vipspng.c
@@ -1200,7 +1200,7 @@ write_vips( Write *write,
 			 */
 			if( length >= 6 &&
 				vips_isprefix( "Exif", (char *) data ) ) {
-				data += 6;
+				data = (char *) data + 6;
 				length -= 6;
 			}
 

--- a/libvips/iofuncs/source.c
+++ b/libvips/iofuncs/source.c
@@ -775,7 +775,7 @@ vips_source_read( VipsSource *source, void *buffer, size_t length )
 
 		VIPS_DEBUG_MSG( "    %zd bytes from memory\n", available );
 		memcpy( buffer, 
-			source->data + source->read_position, available );
+			(char *) source->data + source->read_position, available );
 		source->read_position += available;
 		total_read += available;
 	}
@@ -798,7 +798,7 @@ vips_source_read( VipsSource *source, void *buffer, size_t length )
 					source->read_position, 
 				available );
 			source->read_position += available;
-			buffer += available;
+			buffer = (char *) buffer + available;
 			length -= available;
 			total_read += available;
 		}

--- a/libvips/iofuncs/target.c
+++ b/libvips/iofuncs/target.c
@@ -470,7 +470,7 @@ vips_target_write_unbuffered( VipsTarget *target,
 		}
 
 		length -= bytes_written;
-		data += bytes_written;
+		data = (char *) data + bytes_written;
 	}
 
 	return( 0 );

--- a/meson.build
+++ b/meson.build
@@ -50,9 +50,7 @@ cc = meson.get_compiler('c')
 cpp = meson.get_compiler('cpp')
 
 # Prevent use of void* pointer arithmetic to support MSVC
-if cc.has_argument('-Werror=pointer-arith')
-    add_project_arguments('-Werror=pointer-arith', language : ['cpp', 'c'])
-endif
+add_project_arguments(cc.get_supported_arguments('-Werror=pointer-arith'), language : ['cpp', 'c'])
 
 glib_dep = dependency('glib-2.0', version: '>=2.40')
 gio_dep = dependency('gio-2.0')

--- a/meson.build
+++ b/meson.build
@@ -49,6 +49,11 @@ host_os = host_machine.system()
 cc = meson.get_compiler('c')
 cpp = meson.get_compiler('cpp')
 
+# Prevent use of void* pointer arithmetic to support MSVC
+if cc.has_argument('-Werror=pointer-arith')
+    add_project_arguments('-Werror=pointer-arith', language : ['cpp', 'c'])
+endif
+
 glib_dep = dependency('glib-2.0', version: '>=2.40')
 gio_dep = dependency('gio-2.0')
 gobject_dep = dependency('gobject-2.0')


### PR DESCRIPTION
Fixes the specific problems mentioned in #3378 plus a few others I found, and adds a compiler flag (for clang/gcc) to help catch this in the future. Targets the 8.14 branch.