### PR TITLE
Fix openslide associated

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -14,6 +14,7 @@
 - allow negative line spacing in text [donghuikugou]
 - add VIPS_META_BITS_PER_SAMPLE metadata, deprecate the
   "palette-bit-depth" and "heif-bitdepth" meta fields [MathemanFlo]
+- fix openslideload associated=XXX load [jcupitt]
 
 TBD 8.14.2
 

--- a/libvips/foreign/openslideload.c
+++ b/libvips/foreign/openslideload.c
@@ -454,12 +454,11 @@ readslide_parse( ReadSlide *rslide, VipsImage *image )
 	double yres;
 
 	rslide->osr = openslide_open( rslide->filename );
-	if( rslide->osr == NULL ) {
+	if( !rslide->osr ) {
 		vips_error( "openslide2vips", 
 			"%s", _( "unsupported slide format" ) );
 		return( -1 );
 	}
-
 	error = openslide_get_error( rslide->osr );
 	if( error ) {
 		vips_error( "openslide2vips",
@@ -788,7 +787,7 @@ vips__openslide_read_associated( const char *filename, VipsImage *out,
 	if( !(rslide = readslide_new( filename, 
                 out, 0, FALSE, associated_name, FALSE, rgb )) )
 		return( -1 );
-
+	rslide->osr = openslide_open( rslide->filename );
         if( !(associated = vips__openslide_get_associated( rslide, 
                 associated_name )) )
                 return( -1 );


### PR DESCRIPTION
Before this PR I see:

```
$ vips copy CMU-1.svs[associated=label] x.png
Segmentation fault (core dumped)
```

I suppose the recent refactoring broke this case.

This should probably be cherry-picked for 8.14 as well.

openslideload could use a mild rewrite -- it's still split into two parts.