### PR TITLE
Backport #3384 to 8.14

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -12,6 +12,7 @@ TBD 8.14.2
 - fix thumbnail of CMYK images with an embedded ICC profile [kleisauke]
 - fix ICC handling of RGB images with a monochrome profile [kleisauke]
 - ensure ICC transforms keep all precision [kleisauke]
+- fix openslideload associated=XXX load [jcupitt]
 
 9/1/23 8.14.1
 

--- a/libvips/foreign/openslideload.c
+++ b/libvips/foreign/openslideload.c
@@ -454,12 +454,11 @@ readslide_parse( ReadSlide *rslide, VipsImage *image )
 	double yres;
 
 	rslide->osr = openslide_open( rslide->filename );
-	if( rslide->osr == NULL ) {
+	if( !rslide->osr ) {
 		vips_error( "openslide2vips", 
 			"%s", _( "unsupported slide format" ) );
 		return( -1 );
 	}
-
 	error = openslide_get_error( rslide->osr );
 	if( error ) {
 		vips_error( "openslide2vips",
@@ -788,7 +787,7 @@ vips__openslide_read_associated( const char *filename, VipsImage *out,
 	if( !(rslide = readslide_new( filename, 
                 out, 0, FALSE, associated_name, FALSE, rgb )) )
 		return( -1 );
-
+	rslide->osr = openslide_open( rslide->filename );
         if( !(associated = vips__openslide_get_associated( rslide, 
                 associated_name )) )
                 return( -1 );


### PR DESCRIPTION
Trivial backport of #3384 to [`8.14`](https://github.com/libvips/libvips/tree/8.14).