### PR TITLE
v8.14.2 release proposal

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,4 +1,4 @@
-TBD 8.14.2
+21/3/23 8.14.2
 
 - use a private fontmap in vips_text() [jcupitt]
 - increase sanity checks on TIFF tile dimensions [lovell]


### PR DESCRIPTION
A few bugfixes since 8.14.1:

- use a private fontmap in vips_text() [jcupitt]
- increase sanity checks on TIFF tile dimensions [lovell]
- ensure compatibility with libheif > 1.14.2 [kleisauke]
- minor doc fixes [jcupitt]
- sanitise dimensions in JPEG-compressed TIFF images [lovell]
- fix target pnm write [ewelot]
- dedupe FITS header write [ewelot]
- fix `strip` parameter in webpsave [jcupitt]
- earlier abort of webpsave on kill [dloebl]
- fix thumbnail of CMYK images with an embedded ICC profile [kleisauke]
- fix ICC handling of RGB images with a monochrome profile [kleisauke]
- ensure ICC transforms keep all precision [kleisauke]
- fix openslideload associated=XXX load [jcupitt]
- fix compatibility with MSVC [SpaceIm]

---

Note to myself: after this PR lands, a release tarball will be created with:
```console
$ meson setup release_build -Ddoxygen=true -Dgtk_doc=true -Dvapi=true
$ meson compile -Crelease_build
$ meson dist -Crelease_build
$ ls release_build/meson-dist
vips-8.14.2.tar.xz  vips-8.14.2.tar.xz.sha256sum
```

@jcupitt What's the preferred way of tagging a release? I usually do this through GitHub's web interface, but sometimes people prefer to do it via Git CLI.