### PR TITLE
tiffload: slightly relax tile size sanity check

### DIFF
--- a/libvips/foreign/tiff2vips.c
+++ b/libvips/foreign/tiff2vips.c
@@ -2929,8 +2929,8 @@ rtiff_header_read( Rtiff *rtiff, RtiffHeader *header )
 
 		/* Arbitrary sanity-checking limits.
 		 */
-		max_tile_dimension = VIPS_MIN( 10000, VIPS_ROUND_UP(
-			VIPS_MAX ( header->width, header->height ), 256 ) );
+		max_tile_dimension = VIPS_MIN( 8192, VIPS_ROUND_UP(
+			2 * VIPS_MAX ( header->width, header->height ), 256 ) );
 		if( header->tile_width <= 0 ||
 			header->tile_width > max_tile_dimension ||
 			header->tile_width % 16 != 0 ||


### PR DESCRIPTION
Fixes #3403 by doubling the longest overall image edge before rounding up max tile edge to nearest multiple of 256. Also slightly lowers the (still arbitrary) upper limit to 8192 as that is a commonly-used multiple of 16.

Targets the 8.14 branch.

EDIT: Should we should commit this to the `master` branch first and let fuzz testing do its thing before backporting?