### PR TITLE
Ensure `load->nocache` is honored

### DIFF
--- a/libvips/iofuncs/cache.c
+++ b/libvips/iofuncs/cache.c
@@ -850,6 +850,11 @@ vips_cache_operation_buildp( VipsOperation **operation )
 		if( vips_object_build( VIPS_OBJECT( *operation ) ) ) 
 			return( -1 );
 
+		/* Retrieve the flags again, as vips_foreign_load_build() may
+		 * set load->nocache.
+		 */
+		flags = vips_operation_get_flags( *operation );
+
 		g_mutex_lock( vips_cache_lock );
 
 		/* If two threads build the same operation at the same time, 

--- a/libvips/iofuncs/cache.c
+++ b/libvips/iofuncs/cache.c
@@ -865,7 +865,7 @@ vips_cache_operation_buildp( VipsOperation **operation )
 				else
 					printf( "vips cache+: " );
 				vips_object_print_summary( 
-					VIPS_OBJECT( operation ) );
+					VIPS_OBJECT( *operation ) );
 			}
 
 			if( !(flags & VIPS_OPERATION_NOCACHE) ) 


### PR DESCRIPTION
This flag could be set during `_build()`.
https://github.com/libvips/libvips/blob/1e1c5ff108d285c5563e126985037f06705eb724/libvips/foreign/foreign.c#L1062-L1068

Before:
```console
$ VIPS_TRACE=1 vips copy x.jpg[access=sequential] x.png
vips cache+: jpegload filename="x.jpg" out=((VipsImage*) 0x1e79010) flags=((VipsForeignFlags) VIPS_FOREIGN_SEQUENTIAL) access=((VipsAccess) VIPS_ACCESS_SEQUENTIAL) -
...
```

After:
```console
$ VIPS_TRACE=1 vips copy x.jpg[access=sequential] x.png
vips cache : jpegload filename="x.jpg" out=((VipsImage*) 0x1b76010) flags=((VipsForeignFlags) VIPS_FOREIGN_SEQUENTIAL) access=((VipsAccess) VIPS_ACCESS_SEQUENTIAL) -
...
```