### PR TITLE
tiffsave: fix use-after-free during pyramid save

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,6 +1,7 @@
 TBD 8.14.3
 
 - fix ICC handling of greyscale images with a incompatible profile [kleisauke]
+- fix use-after-free during tiff pyramid save [kleisauke]
 
 21/3/23 8.14.2
 


### PR DESCRIPTION
`TIFFClose()` could still use the target after it had been unreffed.

Resolves: #3411.

Targets the 8.14 branch.