### PR TITLE
Add premultiplied option to smartcrop

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -15,6 +15,7 @@
 - add VIPS_META_BITS_PER_SAMPLE metadata, deprecate the
   "palette-bit-depth" and "heif-bitdepth" meta fields [MathemanFlo]
 - add "revalidate" to foreign loaders [jcupitt]
+- add `premultiplied` option to smartcrop [lovell]
 
 TBD 8.14.3
 

--- a/libvips/conversion/smartcrop.c
+++ b/libvips/conversion/smartcrop.c
@@ -72,6 +72,7 @@ typedef struct _VipsSmartcrop {
 	int width;
 	int height;
 	VipsInteresting interesting;
+	gboolean premultiplied;
 
 	int attention_x;
 	int attention_y;
@@ -346,7 +347,7 @@ vips_smartcrop_build( VipsObject *object )
 	 * content. There could be stuff in transparent areas which we don't
 	 * want to consider. 
 	 */
-	if( vips_image_hasalpha( in ) ) { 
+	if( vips_image_hasalpha( in ) && !smartcrop->premultiplied ) {
 		if( vips_premultiply( in, &t[0], NULL ) ) 
 			return( -1 );
 		in = t[0];
@@ -466,6 +467,12 @@ vips_smartcrop_class_init( VipsSmartcropClass *class )
 		G_STRUCT_OFFSET( VipsSmartcrop, attention_y ),
 		0, VIPS_MAX_COORD, 0 );
 
+	VIPS_ARG_BOOL( class, "premultiplied", 7,
+		_( "Premultiplied" ),
+		_( "Input image already has premultiplied alpha" ),
+		VIPS_ARGUMENT_OPTIONAL_INPUT,
+		G_STRUCT_OFFSET( VipsSmartcrop, premultiplied ),
+		FALSE );
 
 }
 
@@ -473,6 +480,7 @@ static void
 vips_smartcrop_init( VipsSmartcrop *smartcrop )
 {
 	smartcrop->interesting = VIPS_INTERESTING_ATTENTION;
+	smartcrop->premultiplied = FALSE;
 }
 
 /**
@@ -486,6 +494,7 @@ vips_smartcrop_init( VipsSmartcrop *smartcrop )
  * Optional arguments:
  * 
  * * @interesting: #VipsInteresting to use to find interesting areas (default: #VIPS_INTERESTING_ATTENTION)
+ * * @premultiplied: %gboolean, input image already has premultiplied alpha
  * * @attention_x: %gint, horizontal position of attention centre when using attention based cropping
  * * @attention_y: %gint, vertical position of attention centre when using attention based cropping
  * 

--- a/test/test-suite/test_conversion.py
+++ b/test/test-suite/test_conversion.py
@@ -347,6 +347,27 @@ class TestConversion:
         assert opts["attention_x"] == 199
         assert opts["attention_y"] == 234
 
+    def test_smartcrop_rgba(self):
+        rgba = pyvips.Image.new_from_file(RGBA_FILE)
+        test, opts = rgba.smartcrop(
+            80, 60,
+            attention_x=True, attention_y=True)
+        assert test.width == 80
+        assert test.height == 60
+        assert opts["attention_x"] == 20
+        assert opts["attention_y"] == 124
+
+    def test_smartcrop_rgba_premultiplied(self):
+        rgba = pyvips.Image.new_from_file(RGBA_FILE)
+        test, opts = rgba.premultiply().smartcrop(
+            80, 60,
+            premultiplied=True,
+            attention_x=True, attention_y=True)
+        assert test.width == 80
+        assert test.height == 60
+        assert opts["attention_x"] == 20
+        assert opts["attention_y"] == 124
+
     def test_falsecolour(self):
         for fmt in all_formats:
             test = self.colour.cast(fmt)


### PR DESCRIPTION
This will be useful for sharp, hopefully others, where the input image to crop is already premultiplied.

I've added a couple of new tests for the smartcrop operation when using images with an alpha channel as this wasn't previously covered.

(The context is that I discovered sharp is currently premultiplying twice when using smartcrop, which is making it slower and less accurate.)