### PR TITLE
Change introspection option to feature type

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -112,7 +112,6 @@ jobs:
           meson setup build
             -Ddebug=true
             -Ddeprecated=false
-            -Dintrospection=false
           || (cat build/meson-logs/meson-log.txt && exit 1)
 
       - name: Build libvips

--- a/README.md
+++ b/README.md
@@ -83,10 +83,6 @@ libvips must have `build-essential`, `pkg-config`, `libglib2.0-dev`,
 `libexpat1-dev`.  See the **Dependencies** section below for a full list
 of the libvips optional dependencies.
 
-libvips uses the GObject introspection mechanism by default, so you'll need
-packages like `libgirepository1.0-dev`. Use `-Dintrospection=false` to
-disable introspection support.
-
 There are basic bash completions in `completions/`, see the README in there.
 
 ## Cheatsheet 

--- a/fuzz/oss_fuzz_build.sh
+++ b/fuzz/oss_fuzz_build.sh
@@ -182,8 +182,8 @@ EOF
 # Disable building man pages, gettext po files, tools, and tests
 sed -i "/subdir('man')/{N;N;N;d;}" meson.build
 meson setup build --prefix=$WORK --libdir=lib --prefer-static --default-library=static \
-  -Ddeprecated=false -Dexamples=false -Dcplusplus=false -Dintrospection=false \
-  -Dmodules=disabled -Dcpp_link_args="$LDFLAGS -Wl,-rpath=\$ORIGIN/lib"
+  -Ddeprecated=false -Dexamples=false -Dcplusplus=false -Dmodules=disabled \
+  -Dcpp_link_args="$LDFLAGS -Wl,-rpath=\$ORIGIN/lib"
 ninja -C build
 ninja -C build install
 

--- a/libvips/meson.build
+++ b/libvips/meson.build
@@ -41,7 +41,7 @@ pkg.generate(
     description: 'Image processing library',
 )
 
-if get_option('introspection')
+if enable_introspection
     vips_gir = gnome.generate_gir(
         libvips_lib,
         namespace: 'Vips',

--- a/meson.build
+++ b/meson.build
@@ -640,6 +640,9 @@ config_dep = declare_dependency(
 
 libvips_deps += config_dep
 
+gir = find_program('g-ir-scanner', required: get_option('introspection'))
+enable_introspection = gir.found() and (not meson.is_cross_build() or get_option('introspection').enabled())
+
 build_summary = {
   'Build options':
     {'enable debug': [get_option('debug')],
@@ -647,7 +650,7 @@ build_summary = {
      'enable modules': [modules_enabled],
      'enable gtk-doc': [get_option('gtk_doc')],
      'enable doxygen': [get_option('doxygen')],
-     'enable introspection': [get_option('introspection')],
+     'enable introspection': [enable_introspection],
      'enable examples': [get_option('examples')],
      'enable cplusplus': [get_option('cplusplus')],
      'enable RAD load/save': [get_option('radiance')],

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -31,9 +31,9 @@ option('modules',
   description: 'Build dynamic modules')
 
 option('introspection', 
-  type: 'boolean', 
-  value: true, 
-  description: 'Build GObject introspection')
+  type: 'feature', 
+  value: 'auto', 
+  description: 'Build GObject introspection data')
 
 option('vapi', 
   type: 'boolean', 


### PR DESCRIPTION
Avoids having to explicitly disable introspection support if GOI is not installed.

Also, disable it by default for cross builds unless the option was explicitly enabled by the user.