### PR TITLE
fix: check libwebp availability

### DIFF
--- a/test/meson.build
+++ b/test/meson.build
@@ -64,13 +64,15 @@ if host_os == 'linux'
     )
 endif
 
-test_timeout_webpsave = executable('test_timeout_webpsave',
-    'test_timeout_webpsave.c',
-    dependencies: libvips_dep,
-)
+if libwebp_dep.found()
+    test_timeout_webpsave = executable('test_timeout_webpsave',
+        'test_timeout_webpsave.c',
+        dependencies: libvips_dep,
+    )
 
-test('webpsave_timeout',
-    test_timeout_webpsave,
-    depends: test_timeout_webpsave,
-    workdir: meson.current_build_dir(),
-)
+    test('webpsave_timeout',
+        test_timeout_webpsave,
+        depends: test_timeout_webpsave,
+        workdir: meson.current_build_dir(),
+ )
+endif


### PR DESCRIPTION
`webpsave_timeout` test runs even when libwebp is not available

Resolves: https://github.com/libvips/libvips/issues/3446.

Targets the 8.14 branch.