### PR TITLE
Skip descriptors test at runtime instead

### DIFF
--- a/test/meson.build
+++ b/test/meson.build
@@ -44,25 +44,22 @@ test('connections',
     workdir: meson.current_build_dir(),
 )
 
-# Uses /proc/self/fd, which is only available on *nix
-if host_os == 'linux'
-    test_descriptors = executable('test_descriptors',
-        'test_descriptors.c',
-        dependencies: libvips_dep,
-    )
+test_descriptors = executable('test_descriptors',
+    'test_descriptors.c',
+    dependencies: libvips_dep,
+)
 
-    test_descriptors_sh = configure_file(
-        input: 'test_descriptors.sh',
-        output: 'test_descriptors.sh',
-        copy: true,
-    )
+test_descriptors_sh = configure_file(
+    input: 'test_descriptors.sh',
+    output: 'test_descriptors.sh',
+    copy: true,
+)
 
-    test('descriptors',
-        test_descriptors_sh,
-        depends: test_descriptors,
-        workdir: meson.current_build_dir(),
-    )
-endif
+test('descriptors',
+    test_descriptors_sh,
+    depends: test_descriptors,
+    workdir: meson.current_build_dir(),
+)
 
 test_timeout_webpsave = executable('test_timeout_webpsave',
     'test_timeout_webpsave.c',

--- a/test/test_descriptors.c
+++ b/test/test_descriptors.c
@@ -101,9 +101,9 @@ main( int argc, char **argv )
 
 	list = get_open_files();
 	if( list == NULL )
-		/* Probably not linux, silent success.
+		/* Probably not *nix, skip test with return code 77.
 		 */
-		return( 0 );
+		return( 77 );
 
 	/* This is usually a list of 4 files. stdout / stdin / stderr plus one
 	 * more made for us by glib, I think, doing what I don't know.


### PR DESCRIPTION
`/proc/self/fd` might still be available when running on some BSD variants or under emulation. This also ensures that the user will be aware that the test is skipped when not supported.

Targets the 8.14 branch.