### PR TITLE
pdfiumload: add support for forms

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -18,6 +18,7 @@
 - add `premultiplied` option to smartcrop [lovell]
 - add "prewitt" and "scharr" edge detectors, "sobel" is more accurate for
   non-uchar formats [jcupitt]
+- add support for forms in pdfium loader [kleisauke]
 
 TBD 8.14.3
 

--- a/libvips/foreign/pdfiumload.c
+++ b/libvips/foreign/pdfiumload.c
@@ -16,6 +16,8 @@
  * 	- add password
  * 21/5/22
  * 	- improve transparency handling [DarthSim]
+ * 21/4/23
+ * 	- add support for forms [kleisauke]
  */
 
 /*


### PR DESCRIPTION
Resolves: #3455.

Used https://pdfium.googlesource.com/pdfium/+/main/samples/simple_no_v8.c as reference, without implementing the additional-action calls:
```
FORM_OnAfterLoadPage
FORM_DoPageAAction
FORM_OnBeforeClosePage
FORM_DoDocumentAAction
```
(which is apparently optional?)