### PR TITLE
fix vips7 PNG support with libspng

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -2,6 +2,7 @@ TBD 8.14.3
 
 - fix ICC handling of greyscale images with a incompatible profile [kleisauke]
 - fix use-after-free during tiff pyramid save [kleisauke]
+- fix vips7 PNG load and save when using libspng [jcupitt]
 
 21/3/23 8.14.2
 

--- a/libvips/deprecated/format.c
+++ b/libvips/deprecated/format.c
@@ -273,7 +273,7 @@ im__format_init( void )
 	extern GType vips_format_jpeg_get_type( void );
 	vips_format_jpeg_get_type();
 #endif /*HAVE_JPEG*/
-#ifdef HAVE_PNG
+#if defined(HAVE_PNG) || defined(HAVE_SPNG)
 	extern GType vips_format_png_get_type( void );
 	vips_format_png_get_type();
 #endif /*HAVE_PNG*/


### PR DESCRIPTION
We were not registering the vips7 PNG loader when built against libspng.

See https://github.com/libvips/libvips/issues/3466