### PR TITLE
lsan: suppress leak warnings from libheif

### DIFF
--- a/suppressions/lsan.supp
+++ b/suppressions/lsan.supp
@@ -5,3 +5,4 @@ leak:libIlmImf-2_5.so
 leak:libIlmThread-2_5.so
 leak:libMagickCore-6.Q16.so
 leak:libx265.so
+leak:libheif.so


### PR DESCRIPTION
Since https://github.com/strukturag/libheif/commit/8f9ac3d6db58d91ebb36f68244cdc534253b889b libheif creates static conversion tables on initialisation. We rely on libheif implicitly calling `heif_init` for us, so `heif_uninit` is never called and these tables will appear to leak.

Should silence https://bugs.chromium.org/p/oss-fuzz/issues/detail?id=58618