### PR TITLE
colour: ensure CMYK conversion uses the embedded ICC profile

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -5,6 +5,7 @@ TBD 8.14.3
 - fix vips7 PNG load and save when using libspng [jcupitt]
 - tiffload: slightly relax tile size sanity check [lovell]
 - heifsave: limit dimensions to a maximum edge of 16384 [lovell]
+- colourspace: ensure CMYK conversion uses the embedded ICC profile [kleisauke]
 
 21/3/23 8.14.2
 

--- a/libvips/colour/CMYK2XYZ.c
+++ b/libvips/colour/CMYK2XYZ.c
@@ -3,6 +3,8 @@
  *
  * 21/12/18
  *      - from scRGB2XYZ.c
+ * 7/5/23 kleisauke
+ *      - use embedded ICC profile, if available
  */
 
 /*

--- a/libvips/colour/CMYK2XYZ.c
+++ b/libvips/colour/CMYK2XYZ.c
@@ -66,6 +66,7 @@ static int
 vips_CMYK2XYZ_process( VipsImage *in, VipsImage **out, ... )
 {
 	return( vips_icc_import( in, out,
+		"input_profile", "cmyk",
 		"embedded", TRUE,
 		"pcs", VIPS_PCS_XYZ,
 		NULL ) );
@@ -75,9 +76,9 @@ static int
 vips_CMYK2XYZ_build( VipsObject *object )
 {
 	VipsCMYK2XYZ *CMYK2XYZ = (VipsCMYK2XYZ *) object;
-	VipsImage **t = (VipsImage **) vips_object_local_array( object, 2 );
 
 	VipsImage *out; 
+	VipsImage *t;
 
 	if( VIPS_OBJECT_CLASS( vips_CMYK2XYZ_parent_class )->build( object ) )
 		return( -1 );
@@ -85,12 +86,14 @@ vips_CMYK2XYZ_build( VipsObject *object )
 	out = vips_image_new();
 	g_object_set( object, "out", out, NULL ); 
 
-	if( vips_copy( CMYK2XYZ->in, &t[0], NULL ) ||
-		vips__profile_set( t[0], "cmyk" ) ||
-		vips__colourspace_process_n( "CMYK2XYZ", 
-			t[0], &t[1], 4, vips_CMYK2XYZ_process ) ||
-		vips_image_write( t[1], out ) )
+	if( vips__colourspace_process_n( "CMYK2XYZ", 
+			CMYK2XYZ->in, &t, 4, vips_CMYK2XYZ_process ) )
 		return( -1 );
+	if( vips_image_write( t, out ) ) {
+		g_object_unref( t );
+		return( -1 );
+	}
+	g_object_unref( t );
 
 	return( 0 );
 }

--- a/libvips/colour/XYZ2CMYK.c
+++ b/libvips/colour/XYZ2CMYK.c
@@ -219,9 +219,7 @@ vips_XYZ2CMYK_init( VipsXYZ2CMYK *XYZ2CMYK )
  * @out: (out): output image
  * @...: %NULL-terminated list of optional named arguments
  *
- * Turn XYZ to CMYK. If the image has an embedded ICC profile this will be
- * used for the conversion. If there is no embedded profile, a generic
- * fallback profile will be used. 
+ * Turn XYZ to CMYK.
  *
  * Conversion is from D65 XYZ with relative intent. If you need more control 
  * over the process, use vips_icc_export() instead.

--- a/libvips/colour/icc_transform.c
+++ b/libvips/colour/icc_transform.c
@@ -1391,7 +1391,7 @@ vips_icc_is_compatible_profile( VipsImage *image,
  *
  * If @embedded is set, the input profile is taken from the input image
  * metadata. If there is no embedded profile,
- * @input_profile_filename is used as a fall-back. 
+ * @input_profile is used as a fall-back. 
  * You can test for the
  * presence of an embedded profile with
  * vips_image_get_typeof() with #VIPS_META_ICC_NAME as an argument. This will


### PR DESCRIPTION
i.e. when using `vips_colourspace()`. This corresponds to what is stated in the docs:
https://github.com/libvips/libvips/blob/1d29a12d7cb25cfe97676ddd73ce0a079c9e0146/libvips/colour/CMYK2XYZ.c#L206-L208

Targets the 8.14 branch.

---
Using the provided image from #3159, this ensures these commands will produce the same image:
```console
$ vips colourspace cmyk.jpeg cmyk-colourspace.jpeg srgb
$ vips icc_import cmyk.jpeg cmyk-icc.jpeg --pcs xyz
$ sha256sum cmyk-{colourspace,icc}.jpeg
06d8fedf015be0dfb55e7476691ea79bb67eba1dce40419db9e81bcdf8bc3fcb  cmyk-colourspace.jpeg
06d8fedf015be0dfb55e7476691ea79bb67eba1dce40419db9e81bcdf8bc3fcb  cmyk-icc.jpeg
```