### PR TITLE
Don't use 0 as a default for pngsave bitdepth

### DIFF
--- a/libvips/foreign/pngsave.c
+++ b/libvips/foreign/pngsave.c
@@ -263,7 +263,7 @@ vips_foreign_save_png_class_init( VipsForeignSavePngClass *class )
 		_( "Write as a 1, 2, 4, 8 or 16 bit image" ),
 		VIPS_ARGUMENT_OPTIONAL_INPUT,
 		G_STRUCT_OFFSET( VipsForeignSavePng, bitdepth ),
-		0, 16, 0 );
+		1, 16, 8 );
 
 	VIPS_ARG_INT( class, "effort", 18,
 		_( "Effort" ),

--- a/libvips/foreign/spngsave.c
+++ b/libvips/foreign/spngsave.c
@@ -737,7 +737,7 @@ vips_foreign_save_spng_class_init( VipsForeignSaveSpngClass *class )
 		_( "Write as a 1, 2, 4, 8 or 16 bit image" ),
 		VIPS_ARGUMENT_OPTIONAL_INPUT,
 		G_STRUCT_OFFSET( VipsForeignSaveSpng, bitdepth ),
-		0, 16, 0 );
+		1, 16, 8 );
 
 	VIPS_ARG_INT( class, "effort", 18,
 		_( "Effort" ),


### PR DESCRIPTION
pngsave introspection lists 0 as the default value for bitdepth, but this value does not work:

```
$ vips pngsave
save image to png file
...
   bitdepth     - Write as a 1, 2, 4, 8 or 16 bit image, input gint
			default: 0
			min: 0, max: 16
...

$ vips pngsave k2.jpg x.png --bitdepth 0

(vips:1393285): VIPS-WARNING **: 13:15:09.883: Invalid bit depth in IHDR

(vips:1393285): VIPS-WARNING **: 13:15:09.883: Invalid IHDR data
vips2png: unable to write to target x.png
```

Instead, set the default value to 8. This will be overridden in _build() if bitdepth has not been set.