### PR TITLE
OSS-Fuzz: mark `heif_deinit()` as dtor

### DIFF
--- a/fuzz/oss_fuzz_build.sh
+++ b/fuzz/oss_fuzz_build.sh
@@ -67,6 +67,8 @@ popd
 pushd $SRC/libheif
 # Ensure libvips finds heif_image_handle_get_raw_color_profile
 sed -i '/^Libs.private:/s/-lstdc++/-lc++/' libheif.pc.in
+# Ensure heif_deinit is called at program exit
+sed -i '/void heif_deinit()/i __attribute__((destructor))' libheif/init.cc
 cmake \
   -DCMAKE_BUILD_TYPE=RelWithDebInfo \
   -DCMAKE_INSTALL_PREFIX=$WORK \


### PR DESCRIPTION
Ensures the 'static' conversion tables are properly cleaned up.

Might resolve https://bugs.chromium.org/p/oss-fuzz/issues/detail?id=58618

---

I'm not sure if this will work, as I could not reproduce that issue. I tried:
```console
$ python infra/helper.py build_fuzzers libvips > build_log.txt
$ mkdir -p tmp
$ python infra/helper.py run_fuzzer --corpus-dir=$PWD/tmp/ libvips pngsave_buffer_fuzzer -- -max_total_time=1800
```
(i.e. run the fuzzer for 30 minutes without pressing CTRL+C)