### PR TITLE
colour: ensure chromatic adaptation from/to D50

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -3,7 +3,7 @@ TBD 8.14.3
 - fix ICC handling of greyscale images with a incompatible profile [kleisauke]
 - fix use-after-free during tiff pyramid save [kleisauke]
 - fix vips7 PNG load and save when using libspng [jcupitt]
-- ensure chromatic adaptation during icc_export() [kleisauke]
+- ensure chromatic adaptation during icc_{im,ex}port() [kleisauke]
 
 21/3/23 8.14.2
 

--- a/ChangeLog
+++ b/ChangeLog
@@ -3,6 +3,7 @@ TBD 8.14.3
 - fix ICC handling of greyscale images with a incompatible profile [kleisauke]
 - fix use-after-free during tiff pyramid save [kleisauke]
 - fix vips7 PNG load and save when using libspng [jcupitt]
+- ensure chromatic adaptation during icc_export() [kleisauke]
 
 21/3/23 8.14.2
 

--- a/libvips/colour/LabQ2sRGB.c
+++ b/libvips/colour/LabQ2sRGB.c
@@ -227,9 +227,19 @@ vips_col_sRGB2scRGB_16( int r, int g, int b, float *R, float *G, float *B )
 int
 vips_col_scRGB2XYZ( float R, float G, float B, float *X, float *Y, float *Z )
 {
-	*X = SCALE * 0.4124 * R + SCALE * 0.3576 * G + SCALE * 0.18056 * B;
-	*Y = SCALE * 0.2126 * R + SCALE * 0.7152 * G + SCALE * 0.07220 * B;
-	*Z = SCALE * 0.0193 * R + SCALE * 0.1192 * G + SCALE * 0.9505 * B;
+	R *= SCALE;
+	G *= SCALE;
+	B *= SCALE;
+
+	*X = 0.4124 * R +
+		0.3576 * G +
+		0.1805 * B;
+	*Y = 0.2126 * R +
+		0.7152 * G +
+		0.0722 * B;
+	*Z = 0.0193 * R +
+		0.1192 * G +
+		0.9505 * B;
 
 	return( 0 );
 }
@@ -250,9 +260,21 @@ vips_col_scRGB2XYZ( float R, float G, float B, float *X, float *Y, float *Z )
 int
 vips_col_XYZ2scRGB( float X, float Y, float Z, float *R, float *G, float *B ) 
 {
-	*R =  3.2406 / SCALE * X + -1.5372 / SCALE * Y + -0.4986 / SCALE * Z;
-	*G = -0.9689 / SCALE * X +  1.8758 / SCALE * Y +  0.0415 / SCALE * Z;
-	*B =  0.0557 / SCALE * X + -0.2040 / SCALE * Y +  1.0570 / SCALE * Z;
+	X /= SCALE;
+	Y /= SCALE;
+	Z /= SCALE;
+
+	/* Use 6 decimal places of precision for the inverse matrix.
+	 */
+	*R = 3.240625 * X +
+		-1.537208 * Y +
+		-0.498629 * Z;
+	*G = -0.968931 * X +
+		1.875756 * Y +
+		0.041518 * Z;
+	*B = 0.055710 * X +
+		-0.204021 * Y + 
+		1.056996 * Z;
 
 	return( 0 ); 
 } 

--- a/libvips/colour/icc_transform.c
+++ b/libvips/colour/icc_transform.c
@@ -870,9 +870,10 @@ decode_lab( guint16 *fixed, float *lab, int n )
 	}
 }
 
-#define X_FAC (cmsD50X / VIPS_D65_X0)
-#define Y_FAC (cmsD50Y / VIPS_D65_Y0)
-#define Z_FAC (cmsD50Z / VIPS_D65_Z0)
+/* The matrix already includes the D65 channel weighting, so we just scale by
+ * Y.
+ */
+#define SCALE (VIPS_D65_Y0)
 
 static void
 decode_xyz( guint16 *fixed, float *xyz, int n )
@@ -882,9 +883,27 @@ decode_xyz( guint16 *fixed, float *xyz, int n )
 	for( i = 0; i < n; i++ ) {
 		/* cmsXYZEncoded2Float inlined.
  		 */
-		xyz[0] = (double) fixed[0] / (X_FAC * 32768.0);
-		xyz[1] = (double) fixed[1] / (Y_FAC * 32768.0);
-		xyz[2] = (double) fixed[2] / (Z_FAC * 32768.0);
+		float X = fixed[0] / 32768.0;
+		float Y = fixed[1] / 32768.0;
+		float Z = fixed[2] / 32768.0;
+
+		X *= SCALE;
+		Y *= SCALE;
+		Z *= SCALE;
+
+		/* Transform XYZ D50 to D65, chromatic adaption is done with the
+		 * Bradford transformation.
+		 * See: https://fujiwaratko.sakura.ne.jp/infosci/colorspace/bradford_e.html
+		 */
+		xyz[0] = 0.955513 * X +
+			-0.023073 * Y +
+			0.063309 * Z;
+		xyz[1] = -0.028325 * X +
+			1.009942 * Y +
+			0.021055 * Z;
+		xyz[2] = 0.012329 * X +
+			-0.020536 * Y +
+			1.330714 * Z;
 
 		xyz += 3;
 		fixed += 3;
@@ -1029,12 +1048,9 @@ encode_xyz( float *in, float *out, int n )
 	int i;
 
 	for( i = 0; i < n; i++ ) {
-		/* The matrix already includes the D65 channel weighting, so we
-		 * just divide by Y.
-		 */
-		float X = in[0] / VIPS_D65_Y0;
-		float Y = in[1] / VIPS_D65_Y0;
-		float Z = in[2] / VIPS_D65_Y0;
+		float X = in[0] / SCALE;
+		float Y = in[1] / SCALE;
+		float Z = in[2] / SCALE;
 
 		/* Transform XYZ D65 to D50, chromatic adaption is done with the
 		 * Bradford transformation.

--- a/libvips/colour/icc_transform.c
+++ b/libvips/colour/icc_transform.c
@@ -1029,9 +1029,26 @@ encode_xyz( float *in, float *out, int n )
 	int i;
 
 	for( i = 0; i < n; i++ ) {
-		out[0] = in[0] * X_FAC;
-		out[1] = in[1] * Y_FAC;
-		out[2] = in[2] * Z_FAC;
+		/* The matrix already includes the D65 channel weighting, so we
+		 * just divide by Y.
+		 */
+		float X = in[0] / VIPS_D65_Y0;
+		float Y = in[1] / VIPS_D65_Y0;
+		float Z = in[2] / VIPS_D65_Y0;
+
+		/* Transform XYZ D65 to D50, chromatic adaption is done with the
+		 * Bradford transformation.
+		 * See: https://fujiwaratko.sakura.ne.jp/infosci/colorspace/bradford_e.html
+		 */
+		out[0] = 1.047886 * X +
+			0.022919 * Y +
+			-0.050216 * Z;
+		out[1] = 0.029582 * X +
+			0.990484 * Y +
+			-0.017079 * Z;
+		out[2] = -0.009252 * X +
+			0.015073 * Y +
+			0.751678 * Z;
 
 		in += 3;
 		out += 3;


### PR DESCRIPTION
When converting between white points, a chromatic adaptation is required to compensate for a shift in warmness/coolness that would otherwise occur. Use the Bradford transformation method for this purpose.

Resolves: #3479

Targets the 8.14 branch.

---
Test case:
```console
$ vipsheader x.v
x.v: 1x1 float, 3 bands, xyz
$ vips getpoint x.v 0 0
77.8137 92.0897 21.2633
$ vips icc_export x.v x2.v --output-profile srgb --pcs xyz
$ vips getpoint x2.v 0 0
255 253 80
$ transicc -d0 -t3 -i '*XYZ' -o libvips/colour/profiles/sRGB.icm
LittleCMS ColorSpace conversion calculator - 5.1 [LittleCMS 2.15]
Copyright (c) 1998-2023 Marti Maria Saguer. See COPYING file for details.

Enter values, 'q' to quit

X? 77.8137
Y? 92.0897
Z? 21.2633 

R=254.9992 G=253.0000 B=80.0025
```