### PR TITLE
OSS-Fuzz: suppress leak warnings from libheif

### DIFF
--- a/fuzz/oss_fuzz_build.sh
+++ b/fuzz/oss_fuzz_build.sh
@@ -67,8 +67,8 @@ popd
 pushd $SRC/libheif
 # Ensure libvips finds heif_image_handle_get_raw_color_profile
 sed -i '/^Libs.private:/s/-lstdc++/-lc++/' libheif.pc.in
-# Ensure heif_deinit is called at program exit
-sed -i '/void heif_deinit()/i __attribute__((destructor))' libheif/init.cc
+# Suppress leak warnings from ColorConversionPipeline::init_ops()
+sed -i '/void ColorConversionPipeline::init_ops()/i __attribute__((no_sanitize_address))' libheif/color-conversion/colorconversion.cc
 cmake \
   -DCMAKE_BUILD_TYPE=RelWithDebInfo \
   -DCMAKE_INSTALL_PREFIX=$WORK \


### PR DESCRIPTION
Alternative to PR #3489, which didn't work since LSan performs the leak check within an `atexit()` handler, which is called prior to any destructors referenced in the `.dtors` ELF section.

<details>
  <summary>Details</summary>

```cpp
#include <stdio.h>      /* puts */
#include <stdlib.h>     /* atexit */

void DoLeakCheck() {
    puts("DoLeakCheck()");
}

/* Reference:
 * https://github.com/llvm/llvm-project/blob/llvmorg-16.0.4/compiler-rt/lib/lsan/lsan.cpp#L103
 * https://github.com/llvm/llvm-project/blob/llvmorg-16.0.4/compiler-rt/lib/lsan/lsan_posix.cpp#L96-L99
 */
void __lsan_init() {
    atexit(DoLeakCheck);
}

__attribute__((destructor))
void heif_deinit()
{
    puts("heif_deinit()");
}

int main()
{
    __lsan_init();

    return 0;
}
```
```console
$ clang++ test.cpp
$ ./a.out
DoLeakCheck()
heif_deinit()
```
</details>

Might resolve https://bugs.chromium.org/p/oss-fuzz/issues/detail?id=58618

---

Disabling the leak check in OSS-Fuzz could be an alternative if this happens again.

<details>
  <summary>Details</summary>

```diff
--- a/fuzz/oss_fuzz_build.sh
+++ b/fuzz/oss_fuzz_build.sh
@@ -205,10 +205,16 @@ find \
   -exec bash -c 'hash=($(sha1sum {})); mv {} fuzz/corpus/$hash' \;
 zip -jrq $OUT/seed_corpus.zip fuzz/corpus
 
-# Link corpus
 for fuzzer in fuzz/*_fuzzer.cc; do
   target=$(basename "$fuzzer" .cc)
+  # Link corpus
   ln -sf "seed_corpus.zip" "$OUT/${target}_seed_corpus.zip"
+
+  # Instruct ASan to not check for leaks at exit
+  cat > $OUT/$target.options << EOF
+[asan]
+leak_check_at_exit = 0
+EOF
 done
 
 # Copy options and dictionary files to $OUT
```
(see e.g. commit https://github.com/google/oss-fuzz/commit/9381b4796d36093065bf0ae4fdc123345674ff74)
</details>