### PR TITLE
Move rounding from reduce(h/v)_notab to cast

### DIFF
--- a/libvips/conversion/cast.c
+++ b/libvips/conversion/cast.c
@@ -227,7 +227,7 @@ G_DEFINE_TYPE( VipsCast, vips_cast, VIPS_TYPE_CONVERSION );
 	OTYPE * restrict q = (OTYPE *) out; \
 	\
 	for( x = 0; x < sz; x++ ) \
-		q[x] = CAST( (double) p[x] ); \
+		q[x] = CAST( VIPS_ROUND_INT( (double) p[x] ) ); \
 }
 
 /* Cast complex types to an int type. Just take the real part.
@@ -240,7 +240,7 @@ G_DEFINE_TYPE( VipsCast, vips_cast, VIPS_TYPE_CONVERSION );
 	OTYPE * restrict q = (OTYPE *) out; \
 	\
 	for( x = 0; x < sz; x++ ) { \
-		q[x] = CAST( (double) p[0] ); \
+		q[x] = CAST( VIPS_ROUND_INT( (double) p[0] ) ); \
 		p += 2; \
 	} \
 }

--- a/libvips/resample/reduceh.cpp
+++ b/libvips/resample/reduceh.cpp
@@ -284,12 +284,8 @@ reduceh_notab( VipsReduceh *reduceh,
 
 	vips_reduce_make_mask( cx, reduceh->kernel, reduceh->hshrink, x ); 
 
-	for( int z = 0; z < bands; z++ ) {
-		double sum;
-		sum = reduce_sum<T, double>( in + z, bands, cx, n );
-
-		out[z] = VIPS_ROUND_UINT( sum );
-	}
+	for( int z = 0; z < bands; z++ )
+		out[z] = reduce_sum<T, double>( in + z, bands, cx, n );
 }
 
 /* Tried a vector path (see reducev) but it was slower. The vectors for

--- a/libvips/resample/reducev.cpp
+++ b/libvips/resample/reducev.cpp
@@ -501,12 +501,8 @@ reducev_notab( VipsReducev *reducev,
 
 	vips_reduce_make_mask( cy, reducev->kernel, reducev->vshrink, y ); 
 
-	for( int z = 0; z < ne; z++ ) {
-		double sum;
-		sum = reduce_sum<T, double>( in + z, l1, cy, n );
-
-		out[z] = VIPS_ROUND_UINT( sum );
-	}
+	for( int z = 0; z < ne; z++ )
+		out[z] = reduce_sum<T, double>( in + z, l1, cy, n );
 }
 
 static int


### PR DESCRIPTION
This PR fixes the unexpected behavior brought by https://github.com/libvips/libvips/pull/1872 while keeping the rounding issue fixed.

https://github.com/libvips/libvips/pull/1872 added rounding to `reduce(h/v)_notab` functions. This behavior is unexpected. For example, I created an image with the `double` format and a pixel range of 0.0-1.0. If I apply `vips_reduce` to this image, all its pixels will become 0.0 or 1.0.

The rounding issue fixed with https://github.com/libvips/libvips/pull/1872 was caused by a lack of rounding when casting an image from a floating-point format to an integer format. So this PR removes rounding from `reduce(h/v)_notab` functions and adds it to the `cast` operation instead.

/cc @kleisauke 