### PR TITLE
pngsave: ensure EXIF can be added to PNG output

### DIFF
--- a/libvips/foreign/spngsave.c
+++ b/libvips/foreign/spngsave.c
@@ -179,6 +179,7 @@ vips_foreign_save_spng_metadata( VipsForeignSaveSpng *spng, VipsImage *in )
 	struct spng_iccp iccp;
 	uint32_t n_text;
 	struct spng_text *text_chunk_array;
+	struct spng_exif exif;
 	int i;
 	GSList *p;
 
@@ -247,24 +248,19 @@ vips_foreign_save_spng_metadata( VipsForeignSaveSpng *spng, VipsImage *in )
 		g_free( str );
 	}
 
-	if( vips_image_get_typeof( in, VIPS_META_EXIF_NAME ) ) {
-		struct spng_exif exif;
+	if( vips__exif_update( in ) ||
+		vips_image_get_blob( in, VIPS_META_EXIF_NAME,
+			(const void **) &exif.data, &exif.length ) )
+		return( -1 );
 
-		if( vips__exif_update( in ) ||
-			vips_image_get_blob( in, VIPS_META_EXIF_NAME, 
-				(const void **) &exif.data, &exif.length ) )
-			return( -1 );
-
-		/* libspng does not want the JFIF "Exif\0\0" prefix.
-		 */
-		if( exif.length >= 6 &&
-			vips_isprefix( "Exif", exif.data ) ) {
-			exif.data += 6;
-			exif.length -= 6;
-		}
-
-		spng_set_exif( spng->ctx, &exif );
+	/* libspng does not want the JFIF "Exif\0\0" prefix.
+		*/
+	if( exif.length >= 6 &&
+		vips_isprefix( "Exif", exif.data ) ) {
+		exif.data += 6;
+		exif.length -= 6;
 	}
+	spng_set_exif( spng->ctx, &exif );
 
 	if( vips_image_map( in, vips_foreign_save_spng_comment, spng ) )
 		return( -1 );

--- a/libvips/foreign/vipspng.c
+++ b/libvips/foreign/vipspng.c
@@ -1191,26 +1191,26 @@ write_vips( Write *write,
 		}
 
 #ifdef PNG_eXIf_SUPPORTED
-		if( vips_image_get_typeof( in, VIPS_META_EXIF_NAME ) ) {
-			const void *data;
-			size_t length;
+{
+		const void *data;
+		size_t length;
 
-			if( vips__exif_update( in ) ||
-				vips_image_get_blob( in, VIPS_META_EXIF_NAME, 
-					&data, &length ) )
-				return( -1 );
+		if( vips__exif_update( in ) ||
+			vips_image_get_blob( in, VIPS_META_EXIF_NAME,
+				&data, &length ) )
+			return( -1 );
 
-			/* libpng does not want the JFIF "Exif\0\0" prefix.
-			 */
-			if( length >= 6 &&
-				vips_isprefix( "Exif", (char *) data ) ) {
-				data = (char *) data + 6;
-				length -= 6;
-			}
-
-			png_set_eXIf_1( write->pPng, write->pInfo,
-				length, (png_bytep) data );
+		/* libpng does not want the JFIF "Exif\0\0" prefix.
+		*/
+		if( length >= 6 &&
+			vips_isprefix( "Exif", (char *) data ) ) {
+			data = (char *) data + 6;
+			length -= 6;
 		}
+
+		png_set_eXIf_1( write->pPng, write->pInfo,
+			length, (png_bytep) data );
+}
 #endif /*PNG_eXIf_SUPPORTED*/
 
 		if( vips_image_map( in, write_png_comment, write ) )

--- a/test/test-suite/test_foreign.py
+++ b/test/test-suite/test_foreign.py
@@ -478,6 +478,14 @@ class TestForeign:
             y = x.get("orientation")
             assert y == 2
 
+        # Add EXIF to new PNG
+        im1 = pyvips.Image.black(8, 8)
+        im1.set_type(pyvips.GValue.gstr_type,
+            "exif-ifd0-ImageDescription", "test description")
+        im2 = pyvips.Image.new_from_buffer(
+            im1.write_to_buffer(".png"), "")
+        assert im2.get("exif-ifd0-ImageDescription").startswith("test description")
+
     @skip_if_no("tiffload")
     def test_tiff(self):
         def tiff_valid(im):


### PR DESCRIPTION
EXIF support for the PNG writers was added via https://github.com/libvips/libvips/pull/3168 but the `if( vips_image_get_typeof( in, VIPS_META_EXIF_NAME ) ) ...` guard means input must already contain `VIPS_META_EXIF_NAME` for PNG output to also contain EXIF.

This change removes the check, bringing the behaviour of the PNG saver in line with others e.g. JPEG, as well as adding a test cased that would previously have failed.

https://github.com/libvips/libvips/blob/16aeae9e76999d5bd8ac2fb2c4f356bd84b6f7cb/libvips/foreign/vips2jpeg.c#L718-L724

Originally reported at https://github.com/lovell/sharp/issues/3676