### PR TITLE
Optimize vips_foreign_save_cgif_set_transparent

### DIFF
--- a/libvips/foreign/cgifsave.c
+++ b/libvips/foreign/cgifsave.c
@@ -202,7 +202,7 @@ vips_foreign_save_cgif_set_transparent( VipsForeignSaveCgif *cgif,
 	int sq_maxerror = cgif->interframe_maxerror * cgif->interframe_maxerror;
 
 	int i;
-	int this_trans = FALSE;
+	gboolean this_trans = FALSE;
 	int trans_state = TRANS_STATE_NONE;
 	int trans_count = 0;
 	int same_count = 0;
@@ -220,7 +220,8 @@ vips_foreign_save_cgif_set_transparent( VipsForeignSaveCgif *cgif,
 			if( !old[3] && !new[3] ) {
 				*index = trans;
 				this_trans = TRUE;
-			} else {
+			}
+			else {
 				/* Compare RGB.
 				 */
 				const int dR = old[0] - new[0];
@@ -243,10 +244,9 @@ vips_foreign_save_cgif_set_transparent( VipsForeignSaveCgif *cgif,
 			 * we haven't been copying new to old since then.
 			 * Time to do it now
 			 */
-			if ( trans_state == TRANS_STATE_SINGLE ) {
+			if( trans_state == TRANS_STATE_SINGLE )
 				memcpy( trans_start_old, trans_start_new,
 					old - trans_start_old );
-			}
 
 			/* And reset the transparent pixels state
 			 */
@@ -261,14 +261,14 @@ vips_foreign_save_cgif_set_transparent( VipsForeignSaveCgif *cgif,
 				/* Found the first pixel that should be
 				 * transparent
 				 */
-				if( x == 0 ) {
+				if( x == 0 )
 					/* If we are at the start of the row,
 					 * start making pixels transparent
 					 * right away to help CGIF to trim the
 					 * frame
 					 */
 					trans_state = TRANS_STATE_ROW;
-				} else {
+				else {
 					/* Otherwise, just mark the
 					 * point where we found it and update 
 					 * the transparent pixels state
@@ -286,15 +286,14 @@ vips_foreign_save_cgif_set_transparent( VipsForeignSaveCgif *cgif,
 			 * row. In this case, transparent pixels will help CGIF
 			 * to trim the frame
 			 */
-			} else if (
-				trans_state == TRANS_STATE_SINGLE &&
-				( trans_count * 2 >= same_count + 32  || 
-					x == width - 1 || *index != index[-1] )
-			) {
+			}
+			else if( trans_state == TRANS_STATE_SINGLE &&
+				(trans_count * 2 >= same_count + 32 ||
+					x == width - 1 || *index != index[-1]) ) {
 				/* We found a transparent pixel before
 				 * and the previous index doesn't match the
 				 * current index. Make all pixels from the
-				 * marked point to the currect point
+				 * marked point to the current point
 				 * transparent and update the transparent
 				 * pixels state
 				 */
@@ -304,13 +303,13 @@ vips_foreign_save_cgif_set_transparent( VipsForeignSaveCgif *cgif,
 			}
 		}
 
-		if( trans_state == TRANS_STATE_ROW ) {
+		if( trans_state == TRANS_STATE_ROW )
 			/* Since we have more than one transparent pixel in
 			 * a row, it's safe to make the current pixel
 			 * transparent
 			 */
 			*index = trans;
-		} else if ( trans_state == TRANS_STATE_NONE ) {
+		else if( trans_state == TRANS_STATE_NONE ) {
 			/* We did not find a pixel that should be transparent
 			 * before. Just copy new to old
 			 */
@@ -329,7 +328,7 @@ vips_foreign_save_cgif_set_transparent( VipsForeignSaveCgif *cgif,
 	/* If we are still in the single transparent pixel state, make the rest
 	 * of pixels transparent
 	 */
-	if ( trans_state == TRANS_STATE_SINGLE )
+	if( trans_state == TRANS_STATE_SINGLE )
 		memset( trans_start_index, trans, index - trans_start_index );
 }
 


### PR DESCRIPTION
Hey there 👋

The current implementation of `vips_foreign_save_cgif_set_transparent` makes every pixel that is the same in the previous frame transparent. This approach is not very optimal.

The main purpose of making pixels transparent is to create sequences of identical indexes that are well compressed with LZW. But when we put a transparent index in the middle of a sequence of identical opaque pixels, we regrade compression instead of improving it.

The approach in this PR improves two things:
– Ensures that all sequences of transparent indexes are at least 2 indexes long. Single transparent pixels do not improve the compression.
– Ensures that sequences of identical indexes aren't broken with transparent indexes. The longer the sequence of identical pixels, the better the compression.

I tried to make the comments in the code as detailed as possible.

During my work, I made a collection of 27 animated GIFs. I won't upload them all here as they'll blow up the page 😅 But here's the table that compares the resulting file sizes gotten with the old and the new approaches:

|    | Old      | New      |
|----|----------|----------|
|  1 |    62054 |    59065 |
|  2 | 10072565 |  9934901 |
|  3 |  1949862 |  1873109 |
|  4 |  1532111 |  1555288 |
|  5 |   588365 |   588365 |
|  6 |  1560594 |  1535870 |
|  7 |   940467 |   849573 |
|  8 |  1834721 |  1688166 |
|  9 |  1839172 |  1880116 |
| 10 |   353883 |   338544 |
| 11 |  1087711 |  1027800 |
| 12 |   569076 |   567802 |
| 13 |  6468343 |  6069303 |
| 14 |  3670662 |  3501091 |
| 15 |  6354098 |  5634058 |
| 16 |  8952147 |  8382168 |
| 17 |  2477702 |  2160698 |
| 18 | 21725015 | 21070510 |
| 19 |     4021 |     4021 |
| 20 | 25080961 | 24944675 |
| 21 |  2857020 |  2856962 |
| 22 |  5633272 |  5469025 |
| 23 |    15800 |    15800 |
| 24 |  1859363 |  1927136 |
| 25 |   486429 |   482680 |
| 26 |  2582378 |  2539698 |
| 27 |  2376621 |  2166445 |

