### PR TITLE
reduce{h,v}: ensure rounding for the uint/int paths

### DIFF
--- a/libvips/resample/reduceh.cpp
+++ b/libvips/resample/reduceh.cpp
@@ -182,12 +182,10 @@ reduceh_unsigned_int_tab( VipsReduceh *reduceh,
 
 	for( int z = 0; z < bands; z++ ) {
 		int sum;
-	       
-		sum = reduce_sum<T, int>( in + z, bands, cx, n );
-		sum = unsigned_fixed_round( sum ); 
-		sum = VIPS_CLIP( 0, sum, max_value ); 
 
-		out[z] = sum;
+		sum = reduce_sum<T, int>( in + z, bands, cx, n );
+		sum = unsigned_fixed_round( sum );
+		out[z] = VIPS_CLIP( 0, sum, max_value );
 	}
 }
 
@@ -206,9 +204,7 @@ reduceh_signed_int_tab( VipsReduceh *reduceh,
 
 		sum = reduce_sum<T, int>( in + z, bands, cx, n );
 		sum = signed_fixed_round( sum ); 
-		sum = VIPS_CLIP( min_value, sum, max_value ); 
-
-		out[z] = sum;
+		out[z] = VIPS_CLIP( min_value, sum, max_value );
 	}
 }
 
@@ -263,8 +259,7 @@ reduceh_signed_int32_tab( VipsReduceh *reduceh,
 		double sum;
 
 		sum = reduce_sum<T, double>( in + z, bands, cx, n );
-		sum = VIPS_CLIP( min_value, sum, max_value ); 
-		out[z] = sum;
+		out[z] = VIPS_CLIP( min_value, sum, max_value );
 	}
 }
 

--- a/libvips/resample/reduceh.cpp
+++ b/libvips/resample/reduceh.cpp
@@ -53,6 +53,7 @@
 
 #include <stdio.h>
 #include <stdlib.h>
+#include <stdint.h>
 #include <math.h>
 
 #include <vips/vips.h>
@@ -214,7 +215,7 @@ template <typename T>
 static void inline
 reduceh_float_tab( VipsReduceh *reduceh,
 	VipsPel *pout, const VipsPel *pin,
-	const int bands, const double *cx )
+	const int bands, const double * restrict cx )
 {
 	T* restrict out = (T *) pout;
 	const T* restrict in = (T *) pin;
@@ -224,23 +225,24 @@ reduceh_float_tab( VipsReduceh *reduceh,
 		out[z] = reduce_sum<T, double>( in + z, bands, cx, n );
 }
 
-/* 32-bit int output needs a double intermediate.
+/* 32-bit int output needs a 64-bits intermediate.
  */
 
-template <typename T, int max_value>
+template <typename T, unsigned int max_value>
 static void inline
 reduceh_unsigned_int32_tab( VipsReduceh *reduceh,
 	VipsPel *pout, const VipsPel *pin,
-	const int bands, const double * restrict cx )
+	const int bands, const int * restrict cx )
 {
 	T* restrict out = (T *) pout;
 	const T* restrict in = (T *) pin;
 	const int n = reduceh->n_point;
 
 	for( int z = 0; z < bands; z++ ) {
-		double sum;
+		uint64_t sum;
 
-		sum = reduce_sum<T, double>( in + z, bands, cx, n );
+		sum = reduce_sum<T, uint64_t>( in + z, bands, cx, n );
+		sum = unsigned_fixed_round( sum );
 		out[z] = VIPS_CLIP( 0, sum, max_value );
 	}
 }
@@ -249,16 +251,17 @@ template <typename T, int min_value, int max_value>
 static void inline
 reduceh_signed_int32_tab( VipsReduceh *reduceh,
 	VipsPel *pout, const VipsPel *pin,
-	const int bands, const double * restrict cx )
+	const int bands, const int * restrict cx )
 {
 	T* restrict out = (T *) pout;
 	const T* restrict in = (T *) pin;
 	const int n = reduceh->n_point;
 
 	for( int z = 0; z < bands; z++ ) {
-		double sum;
+		int64_t sum;
 
-		sum = reduce_sum<T, double>( in + z, bands, cx, n );
+		sum = reduce_sum<T, int64_t>( in + z, bands, cx, n );
+		sum = signed_fixed_round( sum );
 		out[z] = VIPS_CLIP( min_value, sum, max_value );
 	}
 }
@@ -385,16 +388,16 @@ vips_reduceh_gen( VipsRegion *out_region, void *seq,
 
 			case VIPS_FORMAT_UINT:
 				reduceh_unsigned_int32_tab
-					<unsigned int, INT_MAX>(
+					<unsigned int, UINT_MAX>(
 					reduceh,
-					q, p, bands, cxf );
+					q, p, bands, cxi );
 				break;
 
 			case VIPS_FORMAT_INT:
 				reduceh_signed_int32_tab
 					<signed int, INT_MIN, INT_MAX>(
 					reduceh,
-					q, p, bands, cxf );
+					q, p, bands, cxi );
 				break;
 
 			case VIPS_FORMAT_FLOAT:

--- a/libvips/resample/reducev.cpp
+++ b/libvips/resample/reducev.cpp
@@ -398,9 +398,7 @@ reducev_unsigned_int_tab( VipsReducev *reducev,
 
 		sum = reduce_sum<T, int>( in + z, l1, cy, n );
 		sum = unsigned_fixed_round( sum ); 
-		sum = VIPS_CLIP( 0, sum, max_value ); 
-
-		out[z] = sum;
+		out[z] = VIPS_CLIP( 0, sum, max_value );
 	}
 }
 
@@ -420,9 +418,7 @@ reducev_signed_int_tab( VipsReducev *reducev,
 
 		sum = reduce_sum<T, int>( in + z, l1, cy, n );
 		sum = signed_fixed_round( sum ); 
-		sum = VIPS_CLIP( min_value, sum, max_value ); 
-
-		out[z] = sum;
+		out[z] = VIPS_CLIP( min_value, sum, max_value );
 	}
 }
 

--- a/libvips/resample/reducev.cpp
+++ b/libvips/resample/reducev.cpp
@@ -65,6 +65,7 @@
 
 #include <stdio.h>
 #include <stdlib.h>
+#include <stdint.h>
 #include <math.h>
 
 #include <vips/vips.h>
@@ -439,14 +440,14 @@ reducev_float_tab( VipsReducev *reducev,
 		out[z] = reduce_sum<T, double>( in + z, l1, cy, n );
 }
 
-/* 32-bit int output needs a double intermediate.
+/* 32-bit int output needs a 64-bits intermediate.
  */
 
-template <typename T, int max_value>
+template <typename T, unsigned int max_value>
 static void inline
 reducev_unsigned_int32_tab( VipsReducev *reducev,
 	VipsPel *pout, const VipsPel *pin,
-	const int ne, const int lskip, const double * restrict cy )
+	const int ne, const int lskip, const int * restrict cy )
 {
 	T* restrict out = (T *) pout;
 	const T* restrict in = (T *) pin;
@@ -454,9 +455,10 @@ reducev_unsigned_int32_tab( VipsReducev *reducev,
 	const int l1 = lskip / sizeof( T );
 
 	for( int z = 0; z < ne; z++ ) {
-		double sum;
+		uint64_t sum;
 
-		sum = reduce_sum<T, double>( in + z, l1, cy, n );
+		sum = reduce_sum<T, uint64_t>( in + z, l1, cy, n );
+		sum = unsigned_fixed_round( sum );
 		out[z] = VIPS_CLIP( 0, sum, max_value ); 
 	}
 }
@@ -465,7 +467,7 @@ template <typename T, int min_value, int max_value>
 static void inline
 reducev_signed_int32_tab( VipsReducev *reducev,
 	VipsPel *pout, const VipsPel *pin,
-	const int ne, const int lskip, const double * restrict cy )
+	const int ne, const int lskip, const int * restrict cy )
 {
 	T* restrict out = (T *) pout;
 	const T* restrict in = (T *) pin;
@@ -473,9 +475,10 @@ reducev_signed_int32_tab( VipsReducev *reducev,
 	const int l1 = lskip / sizeof( T );
 
 	for( int z = 0; z < ne; z++ ) {
-		double sum;
+		int64_t sum;
 
-		sum = reduce_sum<T, double>( in + z, l1, cy, n );
+		sum = reduce_sum<T, int64_t>( in + z, l1, cy, n );
+		sum = signed_fixed_round( sum );
 		out[z] = VIPS_CLIP( min_value, sum, max_value ); 
 	}
 }
@@ -583,16 +586,16 @@ vips_reducev_gen( VipsRegion *out_region, void *vseq,
 
 		case VIPS_FORMAT_UINT:
 			reducev_unsigned_int32_tab
-				<unsigned int, INT_MAX>(
+				<unsigned int, UINT_MAX>(
 				reducev,
-				q, p, ne, lskip, cyf );
+				q, p, ne, lskip, cyi );
 			break;
 
 		case VIPS_FORMAT_INT:
 			reducev_signed_int32_tab
 				<signed int, INT_MIN, INT_MAX>(
 				reducev,
-				q, p, ne, lskip, cyf );
+				q, p, ne, lskip, cyi );
 			break;
 
 		case VIPS_FORMAT_FLOAT:

--- a/libvips/resample/templates.h
+++ b/libvips/resample/templates.h
@@ -146,10 +146,10 @@ bilinear_nosign(
  * Bicubic (Catmull-Rom) interpolation templates:
  */
 
-static int inline
-unsigned_fixed_round( int v )
+template <typename T> static T inline
+unsigned_fixed_round( T v )
 {
-	const int round_by = VIPS_INTERPOLATE_SCALE >> 1;
+	const T round_by = VIPS_INTERPOLATE_SCALE >> 1;
 
 	return( (v + round_by) >> VIPS_INTERPOLATE_SHIFT );
 }
@@ -197,11 +197,11 @@ bicubic_unsigned_int(
 		cy[3] * r3 ) ); 
 }
 
-static int inline
-signed_fixed_round( int v )
+template <typename T> static T inline
+signed_fixed_round( T v )
 {
-	const int sign_of_v = 2 * (v >= 0) - 1;
-	const int round_by = sign_of_v * (VIPS_INTERPOLATE_SCALE >> 1);
+	const T sign_of_v = 2 * (v >= 0) - 1;
+	const T round_by = sign_of_v * (VIPS_INTERPOLATE_SCALE >> 1);
 
 	return( (v + round_by) >> VIPS_INTERPOLATE_SHIFT );
 }
@@ -444,7 +444,24 @@ calculate_coefficients_lanczos( double *c,
  */
 template <typename T, typename IT>
 static IT
-reduce_sum( const T * restrict in, int stride, const IT * restrict c, int n )
+reduce_sum( const T * restrict in, int stride, const int * restrict c, int n,
+	typename std::enable_if<std::is_integral<T>::value>::type* = 0 )
+{
+	IT sum;
+
+	sum = 0; 
+	for( int i = 0; i < n; i++ ) {
+		sum += (IT) c[i] * in[0];
+		in += stride;
+	}
+
+	return( sum ); 
+}
+
+template <typename T, typename IT>
+static IT
+reduce_sum( const T * restrict in, int stride, const double * restrict c, int n,
+	typename std::enable_if<std::is_floating_point<T>::value>::type* = 0 )
 {
 	IT sum;
 


### PR DESCRIPTION
See: #3501.