### PR TITLE
reduce{h,v}: remove rounding from the double paths

### DIFF
--- a/libvips/resample/reduceh.cpp
+++ b/libvips/resample/reduceh.cpp
@@ -141,7 +141,7 @@ static void inline reduceh_unsigned_int_tab(VipsReduceh *reduceh,
 	const int n = reduceh->n_point;
 
 	for (int z = 0; z < bands; z++) {
-		typename intermediate<T>::type sum;
+		typename LongT<T>::type sum;
 
 		sum = reduce_sum<T>(in + z, bands, cx, n);
 		sum = unsigned_fixed_round(sum);
@@ -159,7 +159,7 @@ static void inline reduceh_signed_int_tab(VipsReduceh *reduceh,
 	const int n = reduceh->n_point;
 
 	for (int z = 0; z < bands; z++) {
-		typename intermediate<T>::type sum;
+		typename LongT<T>::type sum;
 
 		sum = reduce_sum<T>(in + z, bands, cx, n);
 		sum = signed_fixed_round(sum);
@@ -193,7 +193,7 @@ static void inline reduceh_notab(VipsReduceh *reduceh,
 	const T *restrict in = (T *) pin;
 	const int n = reduceh->n_point;
 
-	typename intermediate<T>::type cx[MAX_POINT];
+	typename LongT<T>::type cx[MAX_POINT];
 
 	vips_reduce_make_mask(cx, reduceh->kernel, reduceh->n_point,
 		reduceh->hshrink, x);

--- a/libvips/resample/reducev.cpp
+++ b/libvips/resample/reducev.cpp
@@ -402,7 +402,7 @@ vips_reducev_compile(VipsReducev *reducev)
 /* You'd think this would vectorise, but gcc hates mixed types in nested loops
  * :-(
  */
-template <typename T, int max_value>
+template <typename T, T max_value>
 static void inline reducev_unsigned_int_tab(VipsReducev *reducev,
 	VipsPel *pout, const VipsPel *pin,
 	const int ne, const int lskip, const short *restrict cy)
@@ -413,9 +413,9 @@ static void inline reducev_unsigned_int_tab(VipsReducev *reducev,
 	const int l1 = lskip / sizeof(T);
 
 	for (int z = 0; z < ne; z++) {
-		int sum;
+		typename intermediate<T>::type sum;
 
-		sum = reduce_sum<T, int>(in + z, l1, cy, n);
+		sum = reduce_sum<T>(in + z, l1, cy, n);
 		sum = unsigned_fixed_round(sum);
 		out[z] = VIPS_CLIP(0, sum, max_value);
 	}
@@ -432,9 +432,9 @@ static void inline reducev_signed_int_tab(VipsReducev *reducev,
 	const int l1 = lskip / sizeof(T);
 
 	for (int z = 0; z < ne; z++) {
-		int sum;
+		typename intermediate<T>::type sum;
 
-		sum = reduce_sum<T, int>(in + z, l1, cy, n);
+		sum = reduce_sum<T>(in + z, l1, cy, n);
 		sum = signed_fixed_round(sum);
 		out[z] = VIPS_CLIP(min_value, sum, max_value);
 	}
@@ -453,48 +453,7 @@ static void inline reducev_float_tab(VipsReducev *reducev,
 	const int l1 = lskip / sizeof(T);
 
 	for (int z = 0; z < ne; z++)
-		out[z] = reduce_sum<T, double>(in + z, l1, cy, n);
-}
-
-/* 32-bit int output needs a 64-bits intermediate.
- */
-
-template <typename T, unsigned int max_value>
-static void inline reducev_unsigned_int32_tab(VipsReducev *reducev,
-	VipsPel *pout, const VipsPel *pin,
-	const int ne, const int lskip, const short *restrict cy)
-{
-	T *restrict out = (T *) pout;
-	const T *restrict in = (T *) pin;
-	const int n = reducev->n_point;
-	const int l1 = lskip / sizeof(T);
-
-	for (int z = 0; z < ne; z++) {
-		uint64_t sum;
-
-		sum = reduce_sum<T, uint64_t>(in + z, l1, cy, n);
-		sum = unsigned_fixed_round(sum);
-		out[z] = VIPS_CLIP(0, sum, max_value);
-	}
-}
-
-template <typename T, int min_value, int max_value>
-static void inline reducev_signed_int32_tab(VipsReducev *reducev,
-	VipsPel *pout, const VipsPel *pin,
-	const int ne, const int lskip, const short *restrict cy)
-{
-	T *restrict out = (T *) pout;
-	const T *restrict in = (T *) pin;
-	const int n = reducev->n_point;
-	const int l1 = lskip / sizeof(T);
-
-	for (int z = 0; z < ne; z++) {
-		int64_t sum;
-
-		sum = reduce_sum<T, int64_t>(in + z, l1, cy, n);
-		sum = signed_fixed_round(sum);
-		out[z] = VIPS_CLIP(min_value, sum, max_value);
-	}
+		out[z] = reduce_sum<T>(in + z, l1, cy, n);
 }
 
 /* Ultra-high-quality version for double images.
@@ -509,17 +468,13 @@ static void inline reducev_notab(VipsReducev *reducev,
 	const int n = reducev->n_point;
 	const int l1 = lskip / sizeof(T);
 
-	double cy[MAX_POINT];
+	typename intermediate<T>::type cy[MAX_POINT];
 
 	vips_reduce_make_mask(cy, reducev->kernel, reducev->n_point,
 		reducev->vshrink, y);
 
-	for (int z = 0; z < ne; z++) {
-		double sum;
-		sum = reduce_sum<T, double>(in + z, l1, cy, n);
-
-		out[z] = VIPS_ROUND_UINT(sum);
-	}
+	for (int z = 0; z < ne; z++)
+		out[z] = reduce_sum<T>(in + z, l1, cy, n);
 }
 
 static int
@@ -591,12 +546,12 @@ vips_reducev_gen(VipsRegion *out_region, void *vseq,
 			break;
 
 		case VIPS_FORMAT_UINT:
-			reducev_unsigned_int32_tab<unsigned int,
+			reducev_unsigned_int_tab<unsigned int,
 				UINT_MAX>(reducev, q, p, ne, lskip, cys);
 			break;
 
 		case VIPS_FORMAT_INT:
-			reducev_signed_int32_tab<signed int,
+			reducev_signed_int_tab<signed int,
 				INT_MIN, INT_MAX>(reducev, q, p, ne, lskip, cys);
 			break;
 

--- a/libvips/resample/reducev.cpp
+++ b/libvips/resample/reducev.cpp
@@ -413,7 +413,7 @@ static void inline reducev_unsigned_int_tab(VipsReducev *reducev,
 	const int l1 = lskip / sizeof(T);
 
 	for (int z = 0; z < ne; z++) {
-		typename intermediate<T>::type sum;
+		typename LongT<T>::type sum;
 
 		sum = reduce_sum<T>(in + z, l1, cy, n);
 		sum = unsigned_fixed_round(sum);
@@ -432,7 +432,7 @@ static void inline reducev_signed_int_tab(VipsReducev *reducev,
 	const int l1 = lskip / sizeof(T);
 
 	for (int z = 0; z < ne; z++) {
-		typename intermediate<T>::type sum;
+		typename LongT<T>::type sum;
 
 		sum = reduce_sum<T>(in + z, l1, cy, n);
 		sum = signed_fixed_round(sum);
@@ -468,7 +468,7 @@ static void inline reducev_notab(VipsReducev *reducev,
 	const int n = reducev->n_point;
 	const int l1 = lskip / sizeof(T);
 
-	typename intermediate<T>::type cy[MAX_POINT];
+	typename LongT<T>::type cy[MAX_POINT];
 
 	vips_reduce_make_mask(cy, reducev->kernel, reducev->n_point,
 		reducev->vshrink, y);


### PR DESCRIPTION
This PR ensures that `reduce{h,v}_notab` is in-line with `reduce{h,v}_float_tab`, i.e. no rounding. 

`vips_reduce_make_mask()` needed a slight refactor, since the `*_notab` functions requires a `long double` intermediate instead of a `double`. Additionally, as part of the process, I consolidated the `calculate_coefficients_*` functions into a single function.

See commit https://github.com/kleisauke/pyvips-issue-148/commit/c6d0049686b97f97feb5a8a5ade14aa2ad905e73 for the ResampleScope difference.

Supersedes: #3501.