### PR TITLE
Add support for Canon CR3 magic bytes

### DIFF
--- a/libvips/foreign/magick.c
+++ b/libvips/foreign/magick.c
@@ -75,6 +75,17 @@
 static const char *
 magick_sniff( const unsigned char *bytes, size_t length )
 {
+	if( length >= 12 &&
+		bytes[4] == 'f' &&
+		bytes[5] == 't' &&
+		bytes[6] == 'y' &&
+		bytes[7] == 'p' &&
+		bytes[8] == 'c' &&
+		bytes[9] == 'r' &&
+		bytes[10] == 'x' &&
+		bytes[11] == ' ' )
+		return("CR3");
+
 	if( length >= 4 &&
 		bytes[0] == 0 &&
 		bytes[1] == 0 &&

--- a/libvips/foreign/magick.c
+++ b/libvips/foreign/magick.c
@@ -71,6 +71,7 @@
  * * https://www.dca.fee.unicamp.br/~martino/disciplinas/ea978/tgaffs.pdf
  * * http://www.paulbourke.net/dataformats/tga/
  * * https://en.wikipedia.org/wiki/Truevision_TGA#Technical_details
+ * * https://github.com/lclevy/canon_cr3
  */
 static const char *
 magick_sniff( const unsigned char *bytes, size_t length )
@@ -84,7 +85,7 @@ magick_sniff( const unsigned char *bytes, size_t length )
 		bytes[9] == 'r' &&
 		bytes[10] == 'x' &&
 		bytes[11] == ' ' )
-		return("CR3");
+		return( "CR3" );
 
 	if( length >= 4 &&
 		bytes[0] == 0 &&


### PR DESCRIPTION
Canon CR3 formats currently get incorrectly detected as TGA, so explicitly handling their edge case first.