### PR TITLE
Fix clang warnings

### DIFF
--- a/libvips/deprecated/im_convsub.c
+++ b/libvips/deprecated/im_convsub.c
@@ -160,13 +160,8 @@ im__create_int_luts( int *buffer, int buffersize,
 }
 
 
-int im_convsub( in, out, m, xskip, yskip )
-IMAGE *in, *out;
-INTMASK *m;
-int xskip, yskip;
+int im_convsub( IMAGE *in, IMAGE *out, INTMASK *m, int xskip, int yskip )
 {
-
-
 	int x;		/* horizontal direction */
 	int y;		/* vertical direction */
 	int n_clipped = 0;

--- a/libvips/deprecated/im_line.c
+++ b/libvips/deprecated/im_line.c
@@ -54,14 +54,11 @@
 #include <vips/vips.h>
 #include <vips/vips7compat.h>
 
-int im_line(image, x1, y1, x2, y2, pelval)
-IMAGE *image;
-int   x1, x2, y1, y2, pelval;
+int im_line(IMAGE *image, int x1, int y1, int x2, int y2, int pelval)
 {
-
-double x, y, dx, dy, m;
-long offset;
-double signx, signy;
+	double x, y, dx, dy, m;
+	long offset;
+	double signx, signy;
 
 	if( im_rwcheck( image ) )
 		return( -1 );

--- a/libvips/deprecated/im_slice.c
+++ b/libvips/deprecated/im_slice.c
@@ -74,9 +74,7 @@
 
 /* Replacement for im_slice */
 int
-im_slice( in, out, t1, t2 )
-IMAGE *in, *out;
-double t1, t2;
+im_slice( IMAGE *in, IMAGE *out, double t1, double t2 )
 {	
 	int x, y, z;
 	PEL *bu;		/* Buffer we write to */

--- a/libvips/deprecated/im_thresh.c
+++ b/libvips/deprecated/im_thresh.c
@@ -68,9 +68,7 @@
 
 /* Replacement for im_thresh */
 int
-im_thresh( in, out, threshold )
-IMAGE *in, *out;
-double threshold;
+im_thresh( IMAGE *in, IMAGE *out, double threshold )
 {	
 	int x, y;
 	PEL *bu;		/* Buffer we write to */

--- a/libvips/foreign/magick7load.c
+++ b/libvips/foreign/magick7load.c
@@ -573,8 +573,7 @@ vips_foreign_load_magick7_parse( VipsForeignLoadMagick7 *magick7,
 
         /* Something like "BMP".
          */
-        if( magick7->image->magick &&
-                strlen( magick7->image->magick ) > 0 )
+        if( strlen( magick7->image->magick ) > 0 )
                 vips_image_set_string( out, "magick-format", 
                         magick7->image->magick );
 

--- a/libvips/iofuncs/buf.c
+++ b/libvips/iofuncs/buf.c
@@ -284,10 +284,7 @@ vips_buf_appendns( VipsBuf *buf, const char *str, int sz )
 	 *
 	 * gcc10.3 (I think?) issues a false-positive warning about this.
 	 */
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wstringop-overflow"
 	strncpy( buf->base + buf->i, str, cpy );
-#pragma GCC diagnostic pop
 	buf->i += cpy;
 
 	if( buf->i >= buf->mx - 4 ) {

--- a/libvips/iofuncs/init.c
+++ b/libvips/iofuncs/init.c
@@ -270,31 +270,26 @@ vips_load_plugins( const char *fmt, ... )
 	if( !(dir = g_dir_open( dir_name, 0, NULL )) )
 		return;
 
-        while( (name = g_dir_read_name( dir )) )
-                if( vips_ispostfix( name, "." G_MODULE_SUFFIX )
-#if ENABLE_DEPRECATED
-				|| vips_ispostfix( name, ".plg" ) 
-#endif
-			) { 
-			char path[VIPS_PATH_MAX];
-			GModule *module;
+        while( (name = g_dir_read_name( dir )) ) {
+		char path[VIPS_PATH_MAX];
+		GModule *module;
 
-			vips_snprintf( path, VIPS_PATH_MAX - 1, 
-				"%s" G_DIR_SEPARATOR_S "%s", dir_name, name );
+		vips_snprintf( path, VIPS_PATH_MAX - 1, 
+			"%s" G_DIR_SEPARATOR_S "%s", dir_name, name );
 
-			g_info( "loading \"%s\"", path );
+		g_info( "loading \"%s\"", path );
 
-			module = g_module_open( path, G_MODULE_BIND_LAZY );
-			if( module )
-				/* Modules will almost certainly create new 
-				 * types, so they can't be unloaded.
-				 */
-				g_module_make_resident( module );
-			else
-				g_warning( _( "unable to load \"%s\" -- %s" ), 
-					path, g_module_error() ); 
+		module = g_module_open( path, G_MODULE_BIND_LAZY );
+		if( module )
+			/* Modules will almost certainly create new 
+			 * types, so they can't be unloaded.
+			 */
+			g_module_make_resident( module );
+		else
+			g_warning( _( "unable to load \"%s\" -- %s" ), 
+				path, g_module_error() ); 
+	}
 
-                }
         g_dir_close( dir );
 }
 #endif /*ENABLE_MODULES*/

--- a/meson.build
+++ b/meson.build
@@ -4,6 +4,8 @@ project('vips', 'c', 'cpp',
     default_options: [
         # this is what glib uses (one of our required deps), so we use it too
         'c_std=gnu99',
+	# we use some C++11 features 
+	'cpp_std=c++11',
         # turn off asserts etc. in release mode
         'b_ndebug=if-release'
     ]


### PR DESCRIPTION
Fix a few warnings from clang. With this PR, libvips builds cleanly on macOS and on Ubuntu in debug and release mode, and pytest passes.