### PR TITLE
reduce{h,v}: simplify coefficients handling

### DIFF
--- a/libvips/resample/presample.h
+++ b/libvips/resample/presample.h
@@ -70,8 +70,6 @@ GType vips_resample_get_type(void);
 #define MAX_POINT (2000)
 
 int vips_reduce_get_points(VipsKernel kernel, double shrink);
-void vips_reduce_make_mask(double *c,
-	VipsKernel kernel, int n_points, double shrink, double x);
 
 void vips_reduceh_uchar_hwy(VipsPel *pout, VipsPel *pin,
 	int n, int width, int bands,

--- a/libvips/resample/presample.h
+++ b/libvips/resample/presample.h
@@ -71,7 +71,7 @@ GType vips_resample_get_type(void);
 
 int vips_reduce_get_points(VipsKernel kernel, double shrink);
 void vips_reduce_make_mask(double *c,
-	VipsKernel kernel, double shrink, double x);
+	VipsKernel kernel, int n_points, double shrink, double x);
 
 void vips_reduceh_uchar_hwy(VipsPel *pout, VipsPel *pin,
 	int n, int width, int bands,

--- a/libvips/resample/reduceh.cpp
+++ b/libvips/resample/reduceh.cpp
@@ -120,8 +120,6 @@ vips_reduce_get_points(VipsKernel kernel, double shrink)
 		return 2 * rint(2 * shrink) + 1;
 
 	case VIPS_KERNEL_LANCZOS2:
-		/* Needs to be in sync with calculate_coefficients_lanczos().
-		 */
 		return 2 * rint(2 * shrink) + 1;
 
 	case VIPS_KERNEL_LANCZOS3:
@@ -136,7 +134,8 @@ vips_reduce_get_points(VipsKernel kernel, double shrink)
 /* Calculate a mask element.
  */
 void
-vips_reduce_make_mask(double *c, VipsKernel kernel, double shrink, double x)
+vips_reduce_make_mask(double *c, VipsKernel kernel, int n_points,
+	double shrink, double x)
 {
 	switch (kernel) {
 	case VIPS_KERNEL_NEAREST:
@@ -144,26 +143,26 @@ vips_reduce_make_mask(double *c, VipsKernel kernel, double shrink, double x)
 		break;
 
 	case VIPS_KERNEL_LINEAR:
-		calculate_coefficients_triangle(c, shrink, x);
+		calculate_coefficients_triangle(c, n_points, shrink, x);
 		break;
 
 	case VIPS_KERNEL_CUBIC:
 		/* Catmull-Rom.
 		 */
-		calculate_coefficients_cubic(c, shrink, x, 0.0, 0.5);
+		calculate_coefficients_cubic(c, n_points, shrink, x, 0.0, 0.5);
 		break;
 
 	case VIPS_KERNEL_MITCHELL:
-		calculate_coefficients_cubic(c, shrink, x,
+		calculate_coefficients_cubic(c, n_points, shrink, x,
 			1.0 / 3.0, 1.0 / 3.0);
 		break;
 
 	case VIPS_KERNEL_LANCZOS2:
-		calculate_coefficients_lanczos(c, 2, shrink, x);
+		calculate_coefficients_lanczos(c, n_points, 2, shrink, x);
 		break;
 
 	case VIPS_KERNEL_LANCZOS3:
-		calculate_coefficients_lanczos(c, 3, shrink, x);
+		calculate_coefficients_lanczos(c, n_points, 3, shrink, x);
 		break;
 
 	default:
@@ -275,7 +274,8 @@ static void inline reduceh_notab(VipsReduceh *reduceh,
 
 	double cx[MAX_POINT];
 
-	vips_reduce_make_mask(cx, reduceh->kernel, reduceh->hshrink, x);
+	vips_reduce_make_mask(cx, reduceh->kernel, reduceh->n_point,
+		reduceh->hshrink, x);
 
 	for (int z = 0; z < bands; z++) {
 		double sum;
@@ -555,8 +555,8 @@ vips_reduceh_build(VipsObject *object)
 			!reduceh->matrixs[x])
 			return -1;
 
-		vips_reduce_make_mask(reduceh->matrixf[x],
-			reduceh->kernel, reduceh->hshrink,
+		vips_reduce_make_mask(reduceh->matrixf[x], reduceh->kernel,
+			reduceh->n_point, reduceh->hshrink,
 			(float) x / VIPS_TRANSFORM_SCALE);
 
 		for (int i = 0; i < reduceh->n_point; i++)

--- a/libvips/resample/reduceh.cpp
+++ b/libvips/resample/reduceh.cpp
@@ -131,46 +131,6 @@ vips_reduce_get_points(VipsKernel kernel, double shrink)
 	}
 }
 
-/* Calculate a mask element.
- */
-void
-vips_reduce_make_mask(double *c, VipsKernel kernel, int n_points,
-	double shrink, double x)
-{
-	switch (kernel) {
-	case VIPS_KERNEL_NEAREST:
-		c[0] = 1.0;
-		break;
-
-	case VIPS_KERNEL_LINEAR:
-		calculate_coefficients_triangle(c, n_points, shrink, x);
-		break;
-
-	case VIPS_KERNEL_CUBIC:
-		/* Catmull-Rom.
-		 */
-		calculate_coefficients_cubic(c, n_points, shrink, x, 0.0, 0.5);
-		break;
-
-	case VIPS_KERNEL_MITCHELL:
-		calculate_coefficients_cubic(c, n_points, shrink, x,
-			1.0 / 3.0, 1.0 / 3.0);
-		break;
-
-	case VIPS_KERNEL_LANCZOS2:
-		calculate_coefficients_lanczos(c, n_points, 2, shrink, x);
-		break;
-
-	case VIPS_KERNEL_LANCZOS3:
-		calculate_coefficients_lanczos(c, n_points, 3, shrink, x);
-		break;
-
-	default:
-		g_assert_not_reached();
-		break;
-	}
-}
-
 template <typename T, int max_value>
 static void inline reduceh_unsigned_int_tab(VipsReduceh *reduceh,
 	VipsPel *pout, const VipsPel *pin,

--- a/libvips/resample/reducev.cpp
+++ b/libvips/resample/reducev.cpp
@@ -511,7 +511,8 @@ static void inline reducev_notab(VipsReducev *reducev,
 
 	double cy[MAX_POINT];
 
-	vips_reduce_make_mask(cy, reducev->kernel, reducev->vshrink, y);
+	vips_reduce_make_mask(cy, reducev->kernel, reducev->n_point,
+		reducev->vshrink, y);
 
 	for (int z = 0; z < ne; z++) {
 		double sum;
@@ -956,8 +957,8 @@ vips_reducev_build(VipsObject *object)
 			!reducev->matrixs[y])
 			return -1;
 
-		vips_reduce_make_mask(reducev->matrixf[y],
-			reducev->kernel, reducev->vshrink,
+		vips_reduce_make_mask(reducev->matrixf[y], reducev->kernel,
+			reducev->n_point, reducev->vshrink,
 			(float) y / VIPS_TRANSFORM_SCALE);
 
 		for (int i = 0; i < reducev->n_point; i++)

--- a/libvips/resample/templates.h
+++ b/libvips/resample/templates.h
@@ -317,11 +317,8 @@ static void inline calculate_coefficients_catmull(double c[4], const double x)
  * from the interpolator as well as from the table builder.
  */
 static void inline calculate_coefficients_triangle(double *c,
-	const double shrink, const double x)
+	const int n_points, const double shrink, const double x)
 {
-	/* Needs to be in sync with vips_reduce_get_points().
-	 */
-	const int n_points = 2 * rint(shrink) + 1;
 	const double half = x + n_points / 2.0 - 1;
 
 	int i;
@@ -354,11 +351,9 @@ static void inline calculate_coefficients_triangle(double *c,
  * B = 0,   C = 1/2 - Catmull-Rom spline
  */
 static void inline calculate_coefficients_cubic(double *c,
-	const double shrink, const double x, double B, double C)
+	const int n_points, const double shrink, const double x,
+	double B, double C)
 {
-	/* Needs to be in sync with vips_reduce_get_points().
-	 */
-	const int n_points = 2 * rint(2 * shrink) + 1;
 	const double half = x + n_points / 2.0 - 1;
 
 	int i;
@@ -404,11 +399,8 @@ static void inline calculate_coefficients_cubic(double *c,
  * points for large decimations to avoid aliasing.
  */
 static void inline calculate_coefficients_lanczos(double *c,
-	const int a, const double shrink, const double x)
+	const int n_points, const int a, const double shrink, const double x)
 {
-	/* Needs to be in sync with vips_reduce_get_points().
-	 */
-	const int n_points = 2 * rint(a * shrink) + 1;
 	const double half = x + n_points / 2.0 - 1;
 
 	int i;


### PR DESCRIPTION
- De-duplicate `n_points` calculations.
- Extract the various filters in inline functions.
- Merge the `calculate_coefficients*` functions into a single one.
- Simplify `reduce_sum()`.

Split from: #3532.