### PR TITLE
Release build by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,9 +107,6 @@ configuration.
   see `meson_options.txt` and the list below for a summary of all the libvips
   dependencies.
 
-- Meson will do a debug build by default. Add `--buildtype release` for a 
-  release (optimised) build.
-
 - You might need to add `--libdir lib` on Debian if you don't want the arch 
   name in the library path.
 

--- a/meson.build
+++ b/meson.build
@@ -6,6 +6,8 @@ project('vips', 'c', 'cpp',
         'c_std=gnu99',
 	# we use some C++11 features 
 	'cpp_std=c++11',
+        # do a release (optimised) build by default
+        'buildtype=release',
         # turn off asserts etc. in release mode
         'b_ndebug=if-release'
     ]


### PR DESCRIPTION
I've had a few users forget to enable release mode and then have performance issues. meson defaults to a debug build, so it's an easy mistake to make.

This PR makes meson default to a release build.