### PR TITLE
Better shrinkv chunking

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -21,6 +21,7 @@
 - add support for forms in pdfium loader [kleisauke]
 - swap built-in profiles with ICC v4 variants [kleisauke]
 - remove libgsf dependency in favor of libarchive [kleisauke]
+- better chunking for small vshrink [jcupitt]
 
 20/7/23 8.14.3
 
@@ -65,7 +66,7 @@
 - remove various obsolete scripts
 - remove benchmark
 - `jp2ksave` defaults to chroma subsample off, and jp2 write
-- don't minimise `vips_sink_screen()` input after expose ... improves 
+- don't minimise `vips_sink_screen()` input after expose ... improves
   caching during interactive use
 - require libjxl 0.6+
 - add `interlace` option to GIF save [dloebl]
@@ -168,13 +169,13 @@
 - make exif resuint optional and default to inch
 - win: don't set create time on inappropriate file descriptors [lovell]
 - fall back to magicksave for gif if cgif is not present [erik-frontify]
-- fix a crash with 0 length vectors 
+- fix a crash with 0 length vectors
 - change default frame delay for GIFs from 1s to 0.1s
 - remove stray trailing comma from iiif3 dirnames [whalehub]
 - fix TTF load [chregu]
 - revise GIF save alpha threshold [jfcalvo]
 - raise libpng pixel size limit from 1m to 10m pixels [jskrzypek]
-- fix gif save change detector [TheEssem] 
+- fix gif save change detector [TheEssem]
 - fix load from pipe with variable size reads
 
 21/11/21 started 8.12.1
@@ -186,7 +187,7 @@
 - fix thumbnail with small image plus crop plus no upsize [Andrewsville]
 - rename speed / reduction-effort / etc. params as "effort"
 - add gifsave [lovell]
-- arrayjoin minimises inputs during sequential processing, saving a lot of 
+- arrayjoin minimises inputs during sequential processing, saving a lot of
   memory and file descriptors
 - add vips_image_get_format_max()
 - flatten handles out of range alpha and max_alpha correctly
@@ -222,7 +223,7 @@
 
 18/6/21 started 8.11.1
 - add more example code to C docs
-- update libtool support in configure.ac 
+- update libtool support in configure.ac
 - more startup info if VIPS_INFO is set
 - command-line programs set glib prgname (no longer set for you by VIPS_INIT)
 - enable strip chopping for TIFF read [DavidStorm]
@@ -233,7 +234,7 @@
 - add vips_jpegload_source() and vips_svgload_source() to public C API
 - integrate doxygen in build system to generate C++ API docs
 - improve C++ API doc comments
-- add VipsInterpolate and guint64 support to C++ API 
+- add VipsInterpolate and guint64 support to C++ API
 - add VImage::new_from_memory_steal [Zeranoe]
 - vipsthumbnail supports stdin / stdout thumbnailing
 - have a lock just for pdfium [DarthSim]
@@ -247,7 +248,7 @@
 - avoid NaN in mapim [afontenot]
 - hist_find outputs a double histogram for large images [erdmann]
 - fix ref leaks in mosaicing package
-- run libvips leak test in CI 
+- run libvips leak test in CI
 - add vips_fitsload_source(), vips_niftiload_source()
 - png and gif load note background colour as metadata [781545872]
 - add vips_image_[set|get]_array_double()
@@ -260,7 +261,7 @@
 - move openslide, libheif, poppler and magick to loadable modules [kleisauke]
 - better detection of invalid ICC profiles, better fallback paths
 - add "premultiply" flag to tiffsave
-- new threading model has a single threadpool shared by all 
+- new threading model has a single threadpool shared by all
   pipelines [kleisauke]
 
 30/4/21 start 8.10.7
@@ -346,7 +347,7 @@
 - add max and min to region shrink [rgluskin]
 - allow \ as an escape character in vips_break_token() [akemrir]
 - tiffsave has a "depth" param to set max pyr depth
-- libtiff LOGLUV images load and save as libvips XYZ 
+- libtiff LOGLUV images load and save as libvips XYZ
 - add gifload_source, csvload_source, csvsave_target, matrixload_source,
   matrixsave_source, pdfload_source, heifload_source, heifsave_target,
   ppmload_source, ppmsave_target
@@ -358,16 +359,16 @@
 - add subsample_mode, deprecate no_subsample in jpegsave [Elad-Laufer]
 - add vips_isdirf()
 - add PAGENUMBER support to tiff write [jclavoie-jive]
-- add "all" mode to smartcrop 
+- add "all" mode to smartcrop
 - flood fill could stop half-way for some very complex shapes
 - better handling of unaligned reads in multipage tiffs [petoor]
 - mark old --delete option to vipsthumbnail as deprecated [UweOhse]
 - png save with a bad ICC profile just gives a warning
-- add "premultipled" option to vips_affine(), clarified vips_resize() 
+- add "premultipled" option to vips_affine(), clarified vips_resize()
   behaviour with alpha channels
 - improve bioformats support with read and write of tiff subifd pyramids
 - thumbnail exploits subifd pyramids
-- handle all EXIF orientation cases, deprecate 
+- handle all EXIF orientation cases, deprecate
   vips_autorot_get_angle() [Elad-Laufer]
 - load PNGs with libspng, if possible
 - deprecate heifload autorotate -- it's now always on
@@ -391,7 +392,7 @@
 31/1/19 started 8.9.2
 - fix a deadlock with --vips-leak [DarthSim]
 - better gifload behaviour for DISPOSAL_UNSPECIFIED [DarthSim]
-- ban ppm max_value < 0 
+- ban ppm max_value < 0
 - add fuzz corpus to dist
 - detect read errors correctly in source_sniff
 - fix regression in autorot [malomalo]
@@ -426,14 +427,14 @@
 - nifti load/save uses double for all floating point metadata
 - add vips_error_buffer_copy()
 - add VipsSource and VipsTarget: a universal IO class for loaders and savers
-- jpeg, png, tiff (though not tiffsave), rad, svg, ppm and webp use the 
+- jpeg, png, tiff (though not tiffsave), rad, svg, ppm and webp use the
   new IO class
 - rewritten ppm load/save is faster and uses less memory
 - add @no_strip option to dzsave [kalozka1]
 - add iiif layout to dzsave
 - fix use of resolution-unit metadata on tiff save [kayarre]
 - support TIFF CIELAB images with alpha [angelmixu]
-- support TIFF with premultiplied alpha in any band 
+- support TIFF with premultiplied alpha in any band
 - block metadata changes on shared images [pvdz]
 - RGB and sRGB are synonmous
 
@@ -453,7 +454,7 @@
 - better support for PNGs with long comment names
 - fix build with GM
 - add locks for pdfium load
-- fix build with MSVC 
+- fix build with MSVC
 - fix a problem with shinkv tail processing [angelmixu]
 - fix a read one byte beyond buffer bug in jpegload
 - make GIF parsing less strict
@@ -481,7 +482,7 @@
 - fix vipsthumbnail with pyr tiff [kleisauke]
 - text autofit could occasionally terminate early [levmorozov]
 - fewer warnings on tiffload [chregu]
-- vips_resize() breaks aspect ratio and limits shrink to prevent <1px 
+- vips_resize() breaks aspect ratio and limits shrink to prevent <1px
   dimensions [lovell]
 
 21/9/18 started 8.8.0
@@ -500,7 +501,7 @@
 - composite is much faster at positioning subimages
 - stop tiff pyr layers if width or height drop to 1 [gvincke]
 - dzsave has a new skip_blanks option
-- add vips_CMYK2XYZ() and vips_XYZ2CMYK(), plus associated routes 
+- add vips_CMYK2XYZ() and vips_XYZ2CMYK(), plus associated routes
 - include cmyk and srgb fallback profiles
 - add vips_profile_load() and use it everywhere
 - fix race in temp filename creation [lhecker]
@@ -511,7 +512,7 @@
 - tilecache speedups
 - add vips_heifload(), vips_heifsave()
 - add heif thumbnail support to vips_thumbnail()
-- free threadpool earlier, reducing mem growth for some long-running 
+- free threadpool earlier, reducing mem growth for some long-running
   processes [jtorresfabra]
 - add vips_region_fetch() / _width() / _height() for language bindings
 - vips_text() supports justification
@@ -531,11 +532,11 @@
 4/1/19 started 8.7.4
 - magickload with magick6 API did not chain exceptions correctly causing a
   memory leak under some conditions [kleisauke]
-- zero memory on allocate to prevent write of uninitialized memory under some 
+- zero memory on allocate to prevent write of uninitialized memory under some
   error conditions [Balint Varga-Perke]
 
 21/11/18 started 8.7.3
-- fix infinite loop for autofit with non-scaleable font 
+- fix infinite loop for autofit with non-scaleable font
 - mapim was not offsetting by window offset [erdmann]
 - better rounding for scale [kleisauke]
 - fix a memleak in magick6load [kleisauke]
@@ -546,7 +547,7 @@
 - vips_text() leaked in autofit mode
 
 23/9/18 started 8.7.1
-- update function list in docs [janko-m] 
+- update function list in docs [janko-m]
 - test for g_str_to_ascii() [jcupitt]
 - fix temp file open on Windows and fallback on linux [lovell]
 
@@ -568,14 +569,14 @@
 - set "interlaced=1" for interlaced JPG and PNG images
 - add PDFium PDF loader
 - jpegload adds a jpeg-chroma-subsample field with eg. 4:4:4 for no
-  chrominance subsampling. 
+  chrominance subsampling.
 - tiffload, pdfload, magickload set VIPS_META_N_PAGES "n-pages" metadata item
 - add fontfile option to vips_text() [fangqiao]
 - add vips_transpose3d() -- swap major dimensions in a volumetric image
 - remove vips7 stuff from default API ... you must now #include it explicitly
 - added vips_argument_get_id() to fix derived classes on win32 [angelmixu]
 - fix compile with MSVC 2017 [angelmixu]
-- pdfload has a option for background 
+- pdfload has a option for background
 - vips7 C++ interface defaults off
 - make members, getters and operators "const" in cpp API
 - composite has params for x/y position of sub-images [medakk]
@@ -606,7 +607,7 @@
 
 12/2/18 started 8.6.3
 - use pkg-config to find libjpeg, if we can
-- better clean of output image in vips_image_write() fixes a crash 
+- better clean of output image in vips_image_write() fixes a crash
   writing twice to memory
 - better rounding behaviour in convolution means we hit the vector path more
   often
@@ -620,10 +621,10 @@
 - fix a C++ warning in composite.cpp [lovell]
 - remove number of images limit in composite
 - composite allows 1 mode ... reused for all joins
-- fix race in vips_sink() for seq read 
+- fix race in vips_sink() for seq read
 
 10/12/17 started 8.6.1
-- fix mmap window new/free cycling 
+- fix mmap window new/free cycling
 - fix some compiler warnings
 - remove the 64-image limit on bandary operations
 - better version date [bmwiedemann]
@@ -646,12 +647,12 @@
 - better prefix guessing on Windows, thanks tumagonx
 - savers support a "page_height" option for multipage save
 - rename 'disc' as 'memory' and default off
-- add vips_find_trim(), search for non-background areas 
+- add vips_find_trim(), search for non-background areas
 - remove lcms1 support, it had bitrotted
 - `join` tagged as seq
 - support tiffsave_buffer for pyramids, thanks bubba
-- thumbnail and vipsthumbnail have an option for rendering intent, thanks 
-  kleisauke 
+- thumbnail and vipsthumbnail have an option for rendering intent, thanks
+  kleisauke
 - set file create time on Windows, thanks dlong500
 - remove python tests ... moved to pyvips test suite
 - vips7 and vips8 python bindings default to off ... use the new pyvips
@@ -659,15 +660,15 @@
 - better svgload: larger output, handle missing width/height, thanks lovell
 - add vips_gravity() ... embed, but with direction rather than position
 - vips_text() can autofit text to a box, thanks gargsms
-- add vips_composite() / vips_composite2(): merge a set of images with 
+- add vips_composite() / vips_composite2(): merge a set of images with
   a set of blend modes
-- better gobject-introspection annotations, thanks astavale 
+- better gobject-introspection annotations, thanks astavale
 - vips_image_write() severs all links between images, when it can ... thanks
   Warren and Nakilon
 - vector path for convolution is more accurate and can handle larger masks
 - linear and cubic kernels for reduce are higher quality
 - added vips_value_set_blob_free()
-- "--size Nx" to vipsthumbnail was broken, thanks jrochkind 
+- "--size Nx" to vipsthumbnail was broken, thanks jrochkind
 - fix build with gcc 7
 - add vips_fill_nearest() ... fill pixels with nearest colour
 - add VIPS_COMBINE_MIN, a new combining mode for vips_compass()
@@ -685,8 +686,8 @@
 29/8/17 started 8.5.9
 - make --fail stop jpeg read on any libjpeg warning, thanks @mceachen
 - don't build enumtypes so often, removing perl as a compile dependency
-- fix a crash with heavy use of draw operations from language bindings, 
-  thanks @Nakilon 
+- fix a crash with heavy use of draw operations from language bindings,
+  thanks @Nakilon
 
 2/8/17 started 8.5.8
 - fix transparency detection in merge, thanks Haida
@@ -710,7 +711,7 @@
 
 23/4/17 started 8.5.5
 - doc polishing
-- more improvements for truncated PNG files, thanks juyunsang 
+- more improvements for truncated PNG files, thanks juyunsang
 - improve corrupted jpg handling, thanks juyunsang
 - fix small test suite issues on os x
 
@@ -718,7 +719,7 @@
 - don't depend on image width when setting n_lines, thanks kleisauke
 
 7/4/17 started 8.5.3
-- more link fixing in docs 
+- more link fixing in docs
 - revise cache sizing again to help out of order errors under heavy load, thanks
   kleisauke
 
@@ -754,12 +755,12 @@
 - deprecate vips_warn() / vips_info(); use g_warning() / g_info() instead
 - vipsthumbnail supports much fancier geometry strings, thanks tomasc
 - vips_thumbnail() has new @size option
-- fix --vips-cache-max etc. 
+- fix --vips-cache-max etc.
 - add compute reordering, plus some new API to support it:
   vips_reorder_margin_hint() and vips_reorder_prepare_many(), thanks
   aferrero2707
-- kick load operations from cache on read error, thanks gaillard 
-- fix return from C++ assignment operator overloads (+=, -= etc) 
+- kick load operations from cache on read error, thanks gaillard
+- fix return from C++ assignment operator overloads (+=, -= etc)
 - add @max_slope to vips_hist_local() to implement CLAHE, thanks hunter-87
 - vips_gaussnoise() pixels are reproducible on recalc, thanks MvGulik
 - max/min sort values by y and x coordinate
@@ -805,22 +806,22 @@
 - tiffsave converts for jpg if jpg compression is turned on
 - tiffsave supports --strip
 - conversions to GREY16 could lock
-- free pixel buffers on image close as well as thread exit ... stops main 
+- free pixel buffers on image close as well as thread exit ... stops main
   thread buffers clogging up the system
 - dzsave can write compressed zips [Felix Bünemann]
 - vips_image_write() only refs the input when it has to ... makes it easier to
   combine many images in bounded memory
 - VImage::write() implementation was missing
 - VImage::write() return value changed from void to VImage to help chaining
-- added C++ arithmetic assignment overloads, += etc. 
+- added C++ arithmetic assignment overloads, += etc.
 - VImage::ifthenelse() with double args was missing =0 on options
 - better accuracy for reducev with smarter multiplication
-- better quality for vips_resize() with linear/cubic kernels 
+- better quality for vips_resize() with linear/cubic kernels
 - pyvips8 can create new metadata
 - better upsizing with vips_resize()
-- add imagemagick v7 support, thanks sachinwalia2k8 
+- add imagemagick v7 support, thanks sachinwalia2k8
 - added vips_worley(), vips_perlin() noise generators
-- added vips_convf(), vips_convi(), vips_convasep(), vips_conva() ... 
+- added vips_convf(), vips_convi(), vips_convasep(), vips_conva() ...
   im_conv*() functions rewritten as classes
 - vips_convsep() calls vips_convasep() for the approximate case
 - new fixed-point vector path for convi is up to about 2x faster
@@ -828,15 +829,15 @@
 - support --strip for pngsave
 - add svgz support [Felix Bünemann]
 - rename bootstrap.sh -> autogen.sh to help snapcraft
-- support unicode filenames on Windows 
+- support unicode filenames on Windows
 - added VIPS_ROUND as well as VIPS_RINT
-- resize/reduce*/shrink*/affine now round output size to nearest rather than 
+- resize/reduce*/shrink*/affine now round output size to nearest rather than
   rounding down, thanks ioquatix
 - better support for tile overlaps in google maps mode in dzsave
 - dzsave puts vips-properties.xml in the main dir for gm and zoomify layouts
 - resize and reduce have @centre option for centre convention downsampling
 - vipsthumbnail uses centre convention to better match imagemagick
-_ add vips_foreign_get_suffixes() 
+_ add vips_foreign_get_suffixes()
 
 19/8/16 started 8.3.4
 - better transparency handling in gifload, thanks diegocsandrim
@@ -860,11 +861,11 @@ _ add vips_foreign_get_suffixes()
 
 29/1/16 started 8.3
 - add vips_reduce*() ... a fast path for affine downsize
-- vips_resize() uses vips_reduce() with lanczos3 
+- vips_resize() uses vips_reduce() with lanczos3
 - bicubic is better on 32-bit int images
-- add pdfload, svgload, gifload for PDF, SVG and GIF rendering 
+- add pdfload, svgload, gifload for PDF, SVG and GIF rendering
 - vipsthumbnail knows about pdfload and svgload
-- added @page param to magickload 
+- added @page param to magickload
 - matload is more specific (thanks bithive)
 - lower mem use for progressive jpg decode
 - sharpen has a new @sigma param, @radius is deprecated
@@ -900,12 +901,12 @@ _ add vips_foreign_get_suffixes()
 - ifthenelse needs less C stack during eval
 - better rounding in bilinear interpolator
 - fix to "make check" in non-C locales [felixbuenemann]
-- use compiler builtins isnan, isinf, fabs, fmin, fmax, ceil, floor when 
+- use compiler builtins isnan, isinf, fabs, fmin, fmax, ceil, floor when
   possible [Lovell Fuller]
 - tune vips_shrinkh(), 30% faster [Lovell Fuller]
 - remove SEQ hint from vips_subsample(), fixes cli performance [erdmann]
 - fix double free on attach ICC profile from file in tiff write [erdmann]
-- use g_assert_not_reached() 
+- use g_assert_not_reached()
 - better vips-from-C docs
 - remove Duff from im_conv() / im_conv_f() for a 25% speedup [Lovell Fuller]
 
@@ -982,14 +983,14 @@ _ add vips_foreign_get_suffixes()
 - remove a couple of stray header decls, thanks benjamin
 
 25/4/15 started 8.0.1
-- fix some compiler warnings 
+- fix some compiler warnings
 - work around a glib bug that can cause segv under load
 - add some notes on threading to the docs
 - better leak reporting
 
 11/2/15 started 8.0
 - remove old doc stuff, lots of doc improvements
-- add fliphor(), flipver(), rot90(), rot180(), rot270(), median(), dilate(), 
+- add fliphor(), flipver(), rot90(), rot180(), rot270(), median(), dilate(),
   erode() convenience methods to Python and C++
 - python: use [] to index and slice image bands, use () to get a point
 - c++: use [] to band index, () returns a vector<double>
@@ -1002,7 +1003,7 @@ _ add vips_foreign_get_suffixes()
 - rewritten tiff writer is about 3 - 4x faster at making pyramids
 - jpg, magick, png, tiff readers now use only 1 fd per input image
 - added vips_info_set(), vips_progress_set(), vips_profile_set() ... bindings
-  can now support all the vips command-line options if they wish 
+  can now support all the vips command-line options if they wish
 - better conversion to greyscale, thanks bkw
 - add vips_image_copy_memory(), improves stability with heavy threading
 - jpegsave supports new mozjpeg features [lovell]
@@ -1020,7 +1021,7 @@ _ add vips_foreign_get_suffixes()
 - improvements to configure for python
 - remove --disable-cxx configure flag
 - python imageize preserves interpretation
-- fix dzsave as a target format 
+- fix dzsave as a target format
 
 30/12/14 started 7.42.2
 - C++ required output params were broken, thanks Lovell
@@ -1097,7 +1098,7 @@ _ add vips_foreign_get_suffixes()
 - set interpretation of matlut output more carefully
 
 8/9/14 started 7.40.10
-- icc_import and icc_transform checks the input profile for compatibility 
+- icc_import and icc_transform checks the input profile for compatibility
   with the image, thanks James
 - try to make vips_thread_shutdown() optional
 
@@ -1140,22 +1141,22 @@ _ add vips_foreign_get_suffixes()
 - add "autocrop" option to openslide load
 - argh fix affine, again, there were sometimes black bars with nohalo and the
   vips8 interface
-- pngsave in interlaced mode makes a copy of the image, so it's always seq 
+- pngsave in interlaced mode makes a copy of the image, so it's always seq
 - vipsthumbnail shrinks to 1/2 window_size
 - vipsthumbnail has an anti-alias filter between shrink and affine
-- vipsthumbnail defaults to bicubic 
+- vipsthumbnail defaults to bicubic
 - better rounding behaviour for fixed-point bicubic reduces noise
 - fix pngload with libpng >=1.6.11
 - fix colour for openslide read associated
 
 4/7/14 started 7.40.4
-- fix vips_rawsave_fd(), thanks aferrero2707 
+- fix vips_rawsave_fd(), thanks aferrero2707
 - fix im_point()
 - vips_scale() now does round to nearest to avoid rounding errors
 - improve im_openout() compat macro
 - more vips7 compatibility fixes, thanks steve
 - more robust vips_system()
-- add webp support to vips7 
+- add webp support to vips7
 
 30/6/14 started 7.40.3
 - fix interlaced thumbnails in vipsthumbnail, thanks lovell
@@ -1191,7 +1192,7 @@ _ add vips_foreign_get_suffixes()
 - vipsthumbnail has --rotate auto-rotate option
 - removed embedded thumbnail reader from vipsthumbnail: embedded thumbnails
   are too unlike the main image
-- fix to vipsthumbnail --crop, thanks Alessandro 
+- fix to vipsthumbnail --crop, thanks Alessandro
 - add vips_sum()
 - add vips_hough base class and vips_hough_line()
 - add "mode" param to vips_draw_image()
@@ -1201,13 +1202,13 @@ _ add vips_foreign_get_suffixes()
 - vips_system() now supports many input images and you can change image
   argument order
 - support 16-bit palette TIFFs, plus palette TIFFs can have an alpha
-- libgsf-1 is now an optional dependency 
-- dzsave can directly write a ZIP file 
+- libgsf-1 is now an optional dependency
+- dzsave can directly write a ZIP file
 - add ".vips" as an alternative suffix for vips files
 - added vips_tiffload_buffer()
 - added vips_image_new_from_buffer(), vips_image_write_to_buffer()
 - added vips_object_set_from_string()
-- added @container option to dzsave 
+- added @container option to dzsave
 - support 1/2/4 bit palette tiff images with alpha
 - vips_system() now uses g_spawn_command_line_sync()
 - added im_tile_cache_random() to help nip2
@@ -1238,7 +1239,7 @@ _ add vips_foreign_get_suffixes()
 13/2/14 started 7.38.4
 - --sharpen=none option to vipsthumbnail was broken, thanks ferryfax
 - more locking on property create and lookup to help very-threaded systems,
-  thanks Nick 
+  thanks Nick
 
 22/1/14 started 7.38.3
 - undeprecate VIPS_MASK_IDEAL_HIGHPASS and friends, ruby-vips was using them,
@@ -1254,7 +1255,7 @@ _ add vips_foreign_get_suffixes()
 
 19/1/14 started 7.38.1
 - bump soname, thanks benjamin
-- better conversion to and from scrgb/xyz for rad (hdr) 
+- better conversion to and from scrgb/xyz for rad (hdr)
 - fix --interpolate flag to vipsthumbnail, thanks Lovell
 
 18/1/14 started 7.38.0
@@ -1269,7 +1270,7 @@ _ add vips_foreign_get_suffixes()
 - vips_init() now does some ABI compat checking, though this change requires
   an ABI break
 - add "interlace" option to vips_jpegsave()
-- remove vips_image_copy_fields() and vips_demand_hint() and add 
+- remove vips_image_copy_fields() and vips_demand_hint() and add
   vips_image_pipeline() to do both jobs
 - vipsthumbnail allows non-square bounding boxes, thanks seth
 - add vips_matrixprint()
@@ -1285,7 +1286,7 @@ _ add vips_foreign_get_suffixes()
 - support XYZ as a PCS for vips_icc_import() and vips_icc_export()
 - add --strip option to jpegsave
 - added vips_gaussblur() convenience function
-- added --vips-profile, records and dumps thread timing and memory use info 
+- added --vips-profile, records and dumps thread timing and memory use info
 - added vipsprofile, visualises --vips-profile output
 - auto-vectorization-friendly inner loops
 - added vips::init() and vips::shutdown() to C++ API
@@ -1316,7 +1317,7 @@ _ add vips_foreign_get_suffixes()
 
 18/10/13 started 7.36.3
 - fix compiler warnings in ubuntu 13.10
-- reverse similarity rotation direction to match the convention used 
+- reverse similarity rotation direction to match the convention used
   elsewhere in vips
 - fix blocked caching of sequential load operations
 - fix cache flags
@@ -1335,7 +1336,7 @@ _ add vips_foreign_get_suffixes()
 1/7/13 started 7.35.0
 - added vips_matrixload() and vips_matrixsave(), load and save vips mat format
 - rename image arrays as image matrices ... INTERPRETATION_ARRAY ->
-  INTERPRETATION_MATRIX etc. 
+  INTERPRETATION_MATRIX etc.
 - rewrite im_buildlut(), im_identity*(), im_maplut(), im_falsecolour(),
   im_gammacorrect(), im_histgr(), im_histcum(), im_histnorm(), im_heq(),
   im_histnD(), im_histindexed(), im_histspec(), im_invertlut(), im_lhisteq(),
@@ -1345,13 +1346,13 @@ _ add vips_foreign_get_suffixes()
 - thin vips8 wrapper for im_histplot()
 - added vips_error_freeze() / vips_error_thaw()
 - used freeze() / thaw() to stop file format sniffers logging spurious errors
-- vipsthumbnail uses embedded jpg thumbnails if it can 
+- vipsthumbnail uses embedded jpg thumbnails if it can
 - rename vips_diag() as vips_info(), add --vips-info flag
 - deprecate im_hsp()
 - added vips_webpload(), vips_webpload_buffer(), vips_webpsave(),
   vips_webpsave_buffer(), vips_webpsave_mime()
 - tiff reader allows separate planes for strip read
-- tiff reader and writer allow many more formats, eg. 32-bit int, complex, etc. 
+- tiff reader and writer allow many more formats, eg. 32-bit int, complex, etc.
 - tiff reader and writer allow any number of bands
 - added vips_image_new_matrixv()
 - dzsave basename param now called filename, so you can use .dz as a
@@ -1359,7 +1360,7 @@ _ add vips_foreign_get_suffixes()
 - new _UNBUFFERED sequential mode saves memory in some important cases
 - vips_conv() is a simple wrapper over the old convolution functions
 - new optimize_coding param for jpeg write produces optimal Huffman tables,
-  thanks Lovell 
+  thanks Lovell
 - im_tone_map() and im_tone_analyse() deprecated
 - new --band arg to vips_maplut() replaces im_tone_map() functionality
 - added vips_similarity(), simple wrapper for vips_affine() that lets you
@@ -1428,13 +1429,13 @@ _ add vips_foreign_get_suffixes()
 - vipsthumbnail is better at cache sizing
 
 31/8/12 started 7.31.0
-- redone im_Lab2XYZ(), im_XYZ2Lab(), im_Lab2LCh(), im_LCh2Lab(), im_UCS2LCh, 
+- redone im_Lab2XYZ(), im_XYZ2Lab(), im_Lab2LCh(), im_LCh2Lab(), im_UCS2LCh,
   im_LCh2UCS(), im_XYZ2Yxy(), im_Yxy2XYZ(), im_float2rad(), im_rad2float(),
   im_Lab2LabQ(), im_LabQ2Lab(), im_Lab2LabS(), im_LabS2Lab(), im_LabQ2LabS(),
   im_LabS2LabQ(), im_LabQ2disp(), im_XYZ2disp(), im_disp2XYZ(),
   im_icc_import*(), im_icc_export*(), im_icc_transform*(), im_dE_fromLab(),
   im_dECMC_fromLab(), im_dE00_from_Lab(), im_icc_ac2rc() as classes
-- added vips_colourspace(), vips_colourspace_issupported(), replaces all 
+- added vips_colourspace(), vips_colourspace_issupported(), replaces all
   derived conversions
 - faster and more accurate sRGB <-> XYZ conversion
 - support 16-bit sRGB import and export
@@ -1472,7 +1473,7 @@ _ add vips_foreign_get_suffixes()
 31/12/12 started 7.30.7
 - better option parsing for "vips", thanks Haida
 - small fixes to help OS X
-- backported threaded tile cache from next version, im_tile_cache() now 
+- backported threaded tile cache from next version, im_tile_cache() now
   uses it to prevent a deadlock, see comment there
 
 14/11/12 started 7.30.6
@@ -1490,7 +1491,7 @@ _ add vips_foreign_get_suffixes()
 13/9/12 started 7.30.3
 - linecache sized itself too large
 - fix a compile failure if libtiff was not found (thanks Martin)
-- dzsave did not work for images with an odd number of scanlines 
+- dzsave did not work for images with an odd number of scanlines
   (thanks Martin)
 
 4/9/12 started 7.30.2
@@ -1498,8 +1499,8 @@ _ add vips_foreign_get_suffixes()
 - sequential delays ahead threads rather than blocking them completely
 
 6/8/12 started 7.30.1
-- fixes to dzsave: shrink down to a 1x1 pixel tile, round image size up on 
-  shrink, write a .dzi file with the pyramid params, default tile size and 
+- fixes to dzsave: shrink down to a 1x1 pixel tile, round image size up on
+  shrink, write a .dzi file with the pyramid params, default tile size and
   overlap now matches the openslide writer
 - wrap VipsInterpolate for C++
 - so affinei and affinei_all appear in Python
@@ -1521,7 +1522,7 @@ _ add vips_foreign_get_suffixes()
 
 19/3/12 started 7.29.0
 - sanity-check PNG read geometry
-- nearest-neighbor interpolation rounds coordinates to nearest instead of 
+- nearest-neighbor interpolation rounds coordinates to nearest instead of
   rounding down (thanks Nicolas)
 - add dzsave, save in deep zoom format
 - rework im_shrink() as a class
@@ -1546,13 +1547,13 @@ _ add vips_foreign_get_suffixes()
 - vips_sign() was broken
 - png save compression range was wrong
 - more/moreeq was wrong
-- vips7 ppm save with options was broken 
+- vips7 ppm save with options was broken
 - don't cache write operations
 
 18/6/12 started 7.28.9
 - slightly more memory debugging output
 - remove references to the static bicubic interpolator from the docs
-- fix temp file handling on Windows --- was breaking for non-vips files 
+- fix temp file handling on Windows --- was breaking for non-vips files
   over 100mb
 - better support for using images from multiple threads
 
@@ -1607,7 +1608,7 @@ _ add vips_foreign_get_suffixes()
 - added vips_foreign_find_save_options()/vips_foreign_find_load_options()
 - delayed write to foreign via a "w" image was not working
 - support operations with many returns in Python
-- sequential read mode 
+- sequential read mode
 - better im_shrink()
 - added vips_sequential()
 - new vips_sink_memory() keeps read ordering
@@ -1626,14 +1627,14 @@ _ add vips_foreign_get_suffixes()
   im_tbjoin(), im_extract_area(), im_extract_bands(), im_extract_areabands(),
   im_replicate(), im_clip2fmt(), im_gbandjoin(), im_bandjoin(), im_invert(),
   im_lintra(), im_lintra_vec(), im_black(), im_rot90, im_rot180(), im_rot270()
-  im_sintra(), im_costra(), im_tantra(), im_asintra(), im_acostra(), 
+  im_sintra(), im_costra(), im_tantra(), im_asintra(), im_acostra(),
   im_atantra(), im_exptra(), im_exp10tra(), im_logtra(), im_log10tra(),
   im_abs(), im_sign(), im_max(), im_maxpos(), im_deviate(), im_divide(),
   im_multiply(), im_stats(), im_measure(), im_recomb(), im_floor(), im_ceil(),
   im_rint(), im_equal*(), im_notequal*(), im_less*(), im_lesseq*(), im_more*(),
   im_moreeq*(), im_remainder*(), im_and*(), im_or*(), im_eor*(), im_shift*(),
   im_pow*(), im_exp*(), im_ifthenelse(), im_blend(), im_c2amph(), im_c2rect(),
-  im_bandmean(), im_c2real(), im_c2imag(), im_ri2c(), im_jpeg*2vips(), 
+  im_bandmean(), im_c2real(), im_c2imag(), im_ri2c(), im_jpeg*2vips(),
   im_vips2jpeg*(), im_tiff2vips(), im_vips2tiff(), im_exr2vips(),
   im_fits2vips(), im_vips2fits(), im_analyze2vips(), im_raw2vips(),
   im_vips2raw(), im_magick2vips(), im_png2vips(), im_png2*(), im_ppm2vips(),
@@ -1664,7 +1665,7 @@ _ add vips_foreign_get_suffixes()
 - remove VipsPool, vips_object_local_array() is much better
 - cache.c now drops if you have too many open files
 - CLI args to change max files
-- new format for handling exif tags 
+- new format for handling exif tags
 - switch SMALLTILE to 128, 512 was just too big
 - oop mode "rd" was not always being used for images
 - added ARRAY interpretation for images
@@ -1682,11 +1683,11 @@ _ add vips_foreign_get_suffixes()
 - "header" is terse by default
 - "header" outputs filenames if working on many files
 - added openslide support (Benjamin Gilbert)
-- allow new-style load/save options in filenames to 
+- allow new-style load/save options in filenames to
   vips_image_new_from_file() etc.
 - VipsFormat is deprecated
 - remove outchecks from documented API
-- support gobject-introspection 
+- support gobject-introspection
 - new Python binding based on gobject-introspection
 - only spot options at the end of arg strings
 - add vips_cache() as a vips8 operator
@@ -1705,7 +1706,7 @@ _ add vips_foreign_get_suffixes()
   (broken since March 2011, oops)
 
 12/10/11 started 7.26.6
-- NOCACHE was not being set correctly on OS X causing performance 
+- NOCACHE was not being set correctly on OS X causing performance
   problems with large files
 - update Orientation exif tag on jpeg write
 
@@ -1717,7 +1718,7 @@ _ add vips_foreign_get_suffixes()
 - VipsExtend, VipsDirection enums added
 
 12/9/11 started 7.26.4
-- fallback vips_init() 
+- fallback vips_init()
 - im_openout() compat stub was wrong, breaking ruby-vips
 - vips_class_map_concrete_all() needed a compat macro too
 - vips_class_map_all() was broken
@@ -1748,7 +1749,7 @@ _ add vips_foreign_get_suffixes()
 - attach the jpeg thumbnail and multiscan fields (thanks Mike)
 - faster tiff read for some common cases
 - faster im_tile_cache()
-- if we use C++ in libvips, add -lstdc++ to vips-7.xx.pc 
+- if we use C++ in libvips, add -lstdc++ to vips-7.xx.pc
 - im_vips2png() / im_png2vips() set / get png resolution (thanks Zhiyu Wu)
 - updated README
 - don't use tables for bilinear on float data for a small speedup (thanks
@@ -1761,7 +1762,7 @@ _ add vips_foreign_get_suffixes()
 - gtk-doc for mosaicing
 - add im_fits2vips() to the operation database
 - im_fits2vips() is lazy and much faster
-- im__file_open_write() / _read() has a flag for text_mode, get rid of all the 
+- im__file_open_write() / _read() has a flag for text_mode, get rid of all the
   remaining fopen()s
 - move cooc_* and glds_* to deprecated
 - move im_dif_std() to almostdeprecated
@@ -1774,7 +1775,7 @@ _ add vips_foreign_get_suffixes()
 - move im_stretch3() to deprecated
 - move im_clamp() to deprecated
 - gtk-doc for video ... all operators done! amazing argh
-- set MAP_NOCACHE on OS X, otherwise performance dives off a cliff with 
+- set MAP_NOCACHE on OS X, otherwise performance dives off a cliff with
   files larger than memory
 - removed man pages, we are all gtk-doc now
 - im_jpeg2vips() ignores weird APP1 chunks

--- a/ChangeLog
+++ b/ChangeLog
@@ -21,7 +21,7 @@
 - add support for forms in pdfium loader [kleisauke]
 - swap built-in profiles with ICC v4 variants [kleisauke]
 - remove libgsf dependency in favor of libarchive [kleisauke]
-- better chunking for small vshrink [jcupitt]
+- better chunking for small shrinks [jcupitt]
 
 20/7/23 8.14.3
 

--- a/libvips/resample/shrinkh.c
+++ b/libvips/resample/shrinkh.c
@@ -10,6 +10,8 @@
  * 	- use a double sum buffer for int32 types
  * 22/4/22 kleisauke
  * 	- add @ceil option
+ * 12/8/23 jcupitt
+ *	- improve chunking for small shrinks
  */
 
 /*
@@ -194,47 +196,47 @@ static int
 vips_shrinkh_gen(VipsRegion *out_region,
 	void *seq, void *a, void *b, gboolean *stop)
 {
+	/* How do we chunk up the image? We don't want to prepare the whole of
+	 * the input region corresponding to *r since it could be huge.
+	 *
+	 * Reading a line at a time could cause a lot of overcomputation, depending
+	 * on what's upstream from us. In SMALLTILE, output scanlines could be
+	 * quite small.
+	 */
+	const int dy = 32;
+
 	VipsShrinkh *shrink = (VipsShrinkh *) b;
 	VipsRegion *ir = (VipsRegion *) seq;
 	VipsRect *r = &out_region->valid;
 
-	int y;
-
-	/* How do we chunk up the image? We don't want to prepare the whole of
-	 * the input region corresponding to *r since it could be huge.
-	 *
-	 * Request input a line at a time.
-	 *
-	 * We don't chunk horizontally. We want "vips shrink x.jpg b.jpg 100
-	 * 100" to run sequentially. If we chunk horizontally, we will fetch
-	 * 100x100 lines from the top of the image, then 100x100 100 lines
-	 * down, etc. for each thread, then when they've finished, fetch
-	 * 100x100, 100 pixels across from the top of the image. This will
-	 * break sequentiality.
-	 */
+	int y, y1;
 
 #ifdef DEBUG
 	printf("vips_shrinkh_gen: generating %d x %d at %d x %d\n",
 		r->width, r->height, r->left, r->top);
 #endif /*DEBUG*/
 
-	for (y = 0; y < r->height; y++) {
+	for (y = 0; y < r->height; y += dy) {
+		int chunk_height = VIPS_MIN(dy, r->height - y);
+
 		VipsRect s;
 
 		s.left = r->left * shrink->hshrink;
 		s.top = r->top + y;
 		s.width = r->width * shrink->hshrink;
-		s.height = 1;
+		s.height = chunk_height;
 #ifdef DEBUG
-		printf("shrinkh_gen: requesting line %d\n", s.top);
+		printf("vips_shrinkh_gen: requesting %d lines from %d\n",
+			s.height, s.top);
 #endif /*DEBUG*/
 		if (vips_region_prepare(ir, &s))
 			return -1;
 
 		VIPS_GATE_START("vips_shrinkh_gen: work");
 
-		vips_shrinkh_gen2(shrink, out_region, ir,
-			r->left, r->top + y, r->width);
+		for (y1 = 0; y1 < chunk_height; y1++)
+			vips_shrinkh_gen2(shrink, out_region, ir,
+				r->left, r->top + y + y1, r->width);
 
 		VIPS_GATE_STOP("vips_shrinkh_gen: work");
 	}

--- a/libvips/resample/shrinkh.c
+++ b/libvips/resample/shrinkh.c
@@ -202,8 +202,10 @@ vips_shrinkh_gen(VipsRegion *out_region,
 	 * Reading a line at a time could cause a lot of overcomputation, depending
 	 * on what's upstream from us. In SMALLTILE, output scanlines could be
 	 * quite small.
+	 *
+	 * Use fatstrip height as a compromise.
 	 */
-	const int dy = 32;
+	const int dy = vips__fatstrip_height;
 
 	VipsShrinkh *shrink = (VipsShrinkh *) b;
 	VipsRegion *ir = (VipsRegion *) seq;

--- a/libvips/resample/shrinkv.c
+++ b/libvips/resample/shrinkv.c
@@ -326,7 +326,8 @@ vips_shrinkv_gen(VipsRegion *out_region,
 		s.width = r->width;
 		s.height = chunk_height * shrink->vshrink;
 #ifdef DEBUG
-		printf("shrink_gen: requesting %d lines from %d\n", s.height, s.top);
+		printf("vips_shrinkv_gen: requesting %d lines from %d\n",
+			s.height, s.top);
 #endif /*DEBUG*/
 		if (vips_region_prepare(ir, &s))
 			return -1;

--- a/libvips/resample/shrinkv.c
+++ b/libvips/resample/shrinkv.c
@@ -49,6 +49,8 @@
  * 	- use a double sum buffer for int32 types
  * 22/4/22 kleisauke
  * 	- add @ceil option
+ * 12/8/23 jcupitt
+ *	- improve chunking for small shrinks
  */
 
 /*
@@ -296,47 +298,56 @@ vips_shrinkv_gen(VipsRegion *out_region,
 	VipsRegion *ir = seq->ir;
 	VipsRect *r = &out_region->valid;
 
-	int y, y1;
-
-	/* How do we chunk up the image? We don't want to prepare the whole of
-	 * the input region corresponding to *r since it could be huge.
+	/* How do we chunk up the output image? We don't want to prepare the
+	 * whole of the input region corresponding to *r since it could be huge.
 	 *
-	 * Request input a line at a time, average to a line buffer.
+	 * We also don't want to fetch a line at a time, since that can make
+	 * upstream coodinate changes very expensive.
+	 *
+	 * Instead, aim for a minimum of tile_height on the input image.
 	 */
+	int input_target = VIPS_MAX(shrink->vshrink, r->height);
+	int dy = input_target / shrink->vshrink;
+
+	int y, y1, y2;
 
 #ifdef DEBUG
 	printf("vips_shrinkv_gen: generating %d x %d at %d x %d\n",
 		r->width, r->height, r->left, r->top);
 #endif /*DEBUG*/
 
-	for (y = 0; y < r->height; y++) {
-		memset(seq->sum, 0, shrink->sizeof_line_buffer);
+	for (y = 0; y < r->height; y += dy) {
+		int chunk_height = VIPS_MIN(dy, r->height - y);
 
-		for (y1 = 0; y1 < shrink->vshrink; y1++) {
-			VipsRect s;
+		VipsRect s;
 
-			s.left = r->left;
-			s.top = y1 + (y + r->top) * shrink->vshrink;
-			s.width = r->width;
-			s.height = 1;
+		s.left = r->left;
+		s.top = (r->top + y) * shrink->vshrink;
+		s.width = r->width;
+		s.height = chunk_height * shrink->vshrink;
 #ifdef DEBUG
-			printf("shrink_gen: requesting line %d\n", s.top);
+		printf("shrink_gen: requesting %d lines from %d\n", s.height, s.top);
 #endif /*DEBUG*/
-			if (vips_region_prepare(ir, &s))
-				return -1;
-
-			VIPS_GATE_START("vips_shrinkv_gen: work");
-
-			vips_shrinkv_add_line(shrink, seq, ir,
-				s.left, s.top, s.width);
-
-			VIPS_GATE_STOP("vips_shrinkv_gen: work");
-		}
+		if (vips_region_prepare(ir, &s))
+			return -1;
 
 		VIPS_GATE_START("vips_shrinkv_gen: work");
 
-		vips_shrinkv_write_line(shrink, seq, out_region,
-			r->left, r->top + y, r->width);
+		// each output line
+		for (y1 = 0; y1 < chunk_height; y1++) {
+			// top of this line in the input
+			int top = s.top + y1 * shrink->vshrink;
+
+			memset(seq->sum, 0, shrink->sizeof_line_buffer);
+
+			// each line in the corresponding area of input
+			for (y2 = 0; y2 < shrink->vshrink; y2++)
+				vips_shrinkv_add_line(shrink, seq, ir,
+					s.left, top + y2, s.width);
+
+			vips_shrinkv_write_line(shrink, seq, out_region,
+				r->left, r->top + y + y1, r->width);
+		}
 
 		VIPS_GATE_STOP("vips_shrinkv_gen: work");
 	}
@@ -412,6 +423,7 @@ vips_shrinkv_build(VipsObject *object)
 	}
 
 #ifdef DEBUG
+	printf("vips_shrinkv_build: vshrink = %d\n", shrink->vshrink);
 	printf("vips_shrinkv_build: shrinking %d x %d image to %d x %d\n",
 		in->Xsize, in->Ysize,
 		t[2]->Xsize, t[2]->Ysize);

--- a/libvips/resample/shrinkv.c
+++ b/libvips/resample/shrinkv.c
@@ -302,7 +302,7 @@ vips_shrinkv_gen(VipsRegion *out_region,
 	 * whole of the input region corresponding to *r since it could be huge.
 	 *
 	 * We also don't want to fetch a line at a time, since that can make
-	 * upstream coodinate changes very expensive.
+	 * upstream coordinate changes very expensive.
 	 *
 	 * Instead, aim for a minimum of tile_height on the input image.
 	 */

--- a/test/test-suite/test_create.py
+++ b/test/test-suite/test_create.py
@@ -403,7 +403,7 @@ class TestCreate:
     @pytest.mark.skipif(pyvips.type_find("VipsOperation", "text") == 0,
                         reason="no text, skipping test")
     def test_text(self):
-        im = pyvips.Image.text("Hello, world!")
+        im = pyvips.Image.text("Hello, world!", dpi=300)
         assert im.width > 10
         assert im.height > 10
         assert im.bands == 1
@@ -413,7 +413,7 @@ class TestCreate:
 
         # test autofit
         im = pyvips.Image.text("Hello, world!", width=500, height=500)
-        # quite a large threshold, since we need to work with a huge range of 
+        # quite a large threshold, since we need to work with a huge range of
         # text rendering systems
         assert abs(im.width - 500) < 50
 


### PR DESCRIPTION
shrinkv used to always fetch single lines from the input image. This kept memuse low, but could cause severe overcomputation if earlier pipeline stages performed coordinate transforms.
    
This PR makes it fetch in larger chunks, up to the tile height, or more for very large shrinks. Larger tiles means less upstream overcomputation.

See https://github.com/libvips/libvips/issues/3600
