### PR TITLE
svgload: fix null-pointer dereference

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,7 @@
+TBD 8.14.4
+
+- fix null-pointer dereference during svgload [kleisauke]
+
 20/7/23 8.14.3
 
 - fix ICC handling of greyscale images with a incompatible profile [kleisauke]

--- a/libvips/foreign/svgload.c
+++ b/libvips/foreign/svgload.c
@@ -145,7 +145,7 @@ vips_foreign_load_svg_zfree( void *opaque, void *ptr )
 /* Find a utf-8 substring within the first len_bytes (not characters). 
  *
  *   - case-insensitive
- *   - needle must be zero-terminated, but hackstack need not be
+ *   - needle must be zero-terminated, but haystack need not be
  *   - haystack can be null-terminated
  *   - if haystack is shorter than len bytes, that'll end the search 
  *   - if we hit invalid utf-8, we return NULL
@@ -191,12 +191,6 @@ vips_utf8_strcasestr( const char *haystack_start, const char *needle_start,
 				b == (gunichar) -2 )
                                 return( NULL );
 
-                        /* End of haystack. There can't be a complete needle
-                         * anywhere.
-                         */
-                        if( a == (gunichar) 0 )
-                                return( NULL );
-
                         /* Mismatch.
                          */
                         if( g_unichar_tolower( a ) != g_unichar_tolower( b ) )
@@ -205,6 +199,15 @@ vips_utf8_strcasestr( const char *haystack_start, const char *needle_start,
                         haystack_char = 
 				g_utf8_find_next_char( haystack_char, 
 					haystack_start + len_bytes );
+
+                        /* End of haystack. There can't be a complete needle
+                         * anywhere.
+                         */
+                        if( haystack_char == NULL )
+                                return( NULL );
+
+                        /* needle_char will never be NULL.
+                         */
                         needle_char = 
 				g_utf8_find_next_char( needle_char, NULL );
                 }

--- a/libvips/foreign/svgload.c
+++ b/libvips/foreign/svgload.c
@@ -191,6 +191,15 @@ vips_utf8_strcasestr( const char *haystack_start, const char *needle_start,
 				b == (gunichar) -2 )
                                 return( NULL );
 
+                        /* Disallow codepoint U+0000 as it's a nul byte.
+                         * This is redundant with GLib >= 2.63.0, see:
+                         * https://gitlab.gnome.org/GNOME/glib/-/merge_requests/967
+                         */
+#if !GLIB_CHECK_VERSION( 2, 63, 0 )
+                        if( a == (gunichar) 0 )
+                                return( NULL );
+#endif
+
                         /* Mismatch.
                          */
                         if( g_unichar_tolower( a ) != g_unichar_tolower( b ) )


### PR DESCRIPTION
`g_utf8_find_next_char()` might return NULL when called with a non-NULL second argument, indicating that the end of the string has been reached.

Targets the 8.14 branch.