### PR TITLE
heif{load,save}: guard against `NULL` strings

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,7 +1,7 @@
 TBD 8.14.4
 
 - fix null-pointer dereference during svgload [kleisauke]
-- heifsave: avoid printing NULL strings with vsnprintf [kleisauke]
+- heif{load,save}: guard against NULL strings [kleisauke]
 
 20/7/23 8.14.3
 

--- a/ChangeLog
+++ b/ChangeLog
@@ -1,7 +1,7 @@
 TBD 8.14.4
 
 - fix null-pointer dereference during svgload [kleisauke]
-- heifsave: avoiding printing NULL strings with vsnprintf [kleisauke]
+- heifsave: avoid printing NULL strings with vsnprintf [kleisauke]
 
 20/7/23 8.14.3
 

--- a/ChangeLog
+++ b/ChangeLog
@@ -1,6 +1,7 @@
 TBD 8.14.4
 
 - fix null-pointer dereference during svgload [kleisauke]
+- heifsave: avoiding printing NULL strings with vsnprintf [kleisauke]
 
 20/7/23 8.14.3
 

--- a/libvips/foreign/heifload.c
+++ b/libvips/foreign/heifload.c
@@ -213,8 +213,9 @@ void
 vips__heif_error( struct heif_error *error )
 {
 	if( error->code ) 
-		vips_error( "heif", "%s (%d.%d)", error->message, error->code,
-			error->subcode );
+		vips_error( "heif", "%s (%d.%d)",
+			error->message ? error->message : "(null)",
+			error->code, error->subcode );
 }
 
 typedef struct _VipsForeignLoadHeifClass {

--- a/libvips/foreign/heifsave.c
+++ b/libvips/foreign/heifsave.c
@@ -424,16 +424,12 @@ vips_foreign_save_heif_write( struct heif_context *ctx,
 {
 	VipsForeignSaveHeif *heif = (VipsForeignSaveHeif *) userdata;
 
-	struct heif_error error = {
-		heif_error_Ok,
-		heif_suberror_Unspecified,
-		"Success"
-	};
+	struct heif_error error;
 
+	error.code = heif_error_Ok;
 	if( vips_target_write( heif->target, data, length ) ) {
 		error.code = heif_error_Encoding_error;
 		error.subcode = heif_suberror_Cannot_write_output_data;
-		error.message = "Write error";
 	}
 
 	return( error );

--- a/libvips/foreign/heifsave.c
+++ b/libvips/foreign/heifsave.c
@@ -424,11 +424,17 @@ vips_foreign_save_heif_write( struct heif_context *ctx,
 {
 	VipsForeignSaveHeif *heif = (VipsForeignSaveHeif *) userdata;
 
-	struct heif_error error;
+	struct heif_error error = {
+		heif_error_Ok,
+		heif_suberror_Unspecified,
+		"Success"
+	};
 
-	error.code = 0;
-	if( vips_target_write( heif->target, data, length ) )
-		error.code = -1;
+	if( vips_target_write( heif->target, data, length ) ) {
+		error.code = heif_error_Encoding_error;
+		error.subcode = heif_suberror_Cannot_write_output_data;
+		error.message = "Write error";
+	}
 
 	return( error );
 }


### PR DESCRIPTION
This would prevent a `NULL` string from being printed with `vsnprintf` in case of a write error.

See: #3588.

Targets the 8.14 branch.