### PR TITLE
Prefer use of `G_VALUE_INIT` / `G_PRIVATE_INIT`

### DIFF
--- a/cplusplus/VImage.cpp
+++ b/cplusplus/VImage.cpp
@@ -402,7 +402,7 @@ set_property(VipsObject *object, const char *name, const GValue *value)
 		GType pspec_type = G_PARAM_SPEC_VALUE_TYPE(pspec);
 
 		int enum_value;
-		GValue value2 = { 0 };
+		GValue value2 = G_VALUE_INIT;
 
 		if ((enum_value = vips_enum_from_nick(object_class->nickname,
 				 pspec_type, g_value_get_string(value))) < 0) {

--- a/doc/binding.md
+++ b/doc/binding.md
@@ -57,7 +57,7 @@ main(int argc, char **argv)
 	VipsImage *out;
 	VipsOperation *op;
 	VipsOperation *new_op;
-	GValue gvalue = { 0 };
+	GValue gvalue = G_VALUE_INIT;
 
 	if (VIPS_INIT(argv[0]))
 		/* This shows the vips error buffer and quits with a fail exit

--- a/doc/binding.xml
+++ b/doc/binding.xml
@@ -65,7 +65,7 @@ main(int argc, char **argv)
     VipsImage *out;
     VipsOperation *op;
     VipsOperation *new_op;
-    GValue gvalue = { 0 };
+    GValue gvalue = G_VALUE_INIT;
 
     if (VIPS_INIT(argv[0]))
         /* This shows the vips error buffer and quits with a fail exit

--- a/libvips/colour/profile_load.c
+++ b/libvips/colour/profile_load.c
@@ -214,7 +214,7 @@ vips__profile_set(VipsImage *image, const char *name)
 		return -1;
 
 	if (profile) {
-		GValue value = { 0 };
+		GValue value = G_VALUE_INIT;
 
 		g_value_init(&value, VIPS_TYPE_BLOB);
 		g_value_set_boxed(&value, profile);

--- a/libvips/conversion/copy.c
+++ b/libvips/conversion/copy.c
@@ -205,7 +205,7 @@ vips_copy_build(VipsObject *object)
 
 		if (argument_instance->assigned) {
 			GType type = G_PARAM_SPEC_VALUE_TYPE(pspec);
-			GValue value = { 0 };
+			GValue value = G_VALUE_INIT;
 
 			g_value_init(&value, type);
 			g_object_get_property(G_OBJECT(object),

--- a/libvips/foreign/dzsave.c
+++ b/libvips/foreign/dzsave.c
@@ -1032,8 +1032,8 @@ build_scan_property(VipsDbuf *dbuf, VipsImage *image,
 	const char *vips_name, const char *szi_name)
 {
 	const char *str;
-	GValue value = { 0 };
-	GValue save_value = { 0 };
+	GValue value = G_VALUE_INIT;
+	GValue save_value = G_VALUE_INIT;
 	GType type;
 
 	if (!vips_image_get_typeof(image, vips_name))

--- a/libvips/foreign/niftiload.c
+++ b/libvips/foreign/niftiload.c
@@ -324,7 +324,7 @@ vips__foreign_nifti_map(VipsNiftiMapFn fn, void *a, void *b)
 	void *result;
 
 	for (i = 0; i < VIPS_NUMBER(vips_foreign_nifti_fields); i++) {
-		GValue value = { 0 };
+		GValue value = G_VALUE_INIT;
 
 		g_value_init(&value, vips_foreign_nifti_fields[i].type);
 		result = fn(vips_foreign_nifti_fields[i].name, &value,

--- a/libvips/foreign/niftisave.c
+++ b/libvips/foreign/niftisave.c
@@ -215,7 +215,7 @@ vips_foreign_save_nifti_set_fields(const char *name,
 	 */
 	if (info->n >= 8) {
 		char vips_name[256];
-		GValue value_copy = { 0 };
+		GValue value_copy = G_VALUE_INIT;
 
 		vips_snprintf(vips_name, 256, "nifti-%s", name);
 		if (vips_image_get(info->image, vips_name, &value_copy))

--- a/libvips/include/vips/object.h
+++ b/libvips/include/vips/object.h
@@ -397,7 +397,7 @@ int vips_object_get_argument_priority(VipsObject *object, const char *name);
  */
 #define VIPS_ARGUMENT_COLLECT_SET(PSPEC, ARG_CLASS, AP) \
 	if ((ARG_CLASS->flags & VIPS_ARGUMENT_INPUT)) { \
-		GValue value = { 0 }; \
+		GValue value = G_VALUE_INIT; \
 		gchar *error = NULL; \
 \
 		/* Input args are given inline, eg. ("factor", 12.0) \

--- a/libvips/iofuncs/cache.c
+++ b/libvips/iofuncs/cache.c
@@ -324,7 +324,7 @@ vips_object_hash_arg(VipsObject *object,
 		argument_instance->assigned) {
 		const char *name = g_param_spec_get_name(pspec);
 		GType type = G_PARAM_SPEC_VALUE_TYPE(pspec);
-		GValue value = { 0 };
+		GValue value = G_VALUE_INIT;
 
 		g_value_init(&value, type);
 		g_object_get_property(G_OBJECT(object), name, &value);
@@ -371,8 +371,8 @@ vips_object_equal_arg(VipsObject *object,
 
 	const char *name = g_param_spec_get_name(pspec);
 	GType type = G_PARAM_SPEC_VALUE_TYPE(pspec);
-	GValue v1 = { 0 };
-	GValue v2 = { 0 };
+	GValue v1 = G_VALUE_INIT;
+	GValue v2 = G_VALUE_INIT;
 
 	gboolean equal;
 

--- a/libvips/iofuncs/header.c
+++ b/libvips/iofuncs/header.c
@@ -1212,7 +1212,7 @@ vips__image_copy_fields_array(VipsImage *out, VipsImage *in[])
  * convenience function vips_image_set_int() in practice), you would do:
  *
  * |[
- * GValue value = { 0 };
+ * GValue value = G_VALUE_INIT;
  *
  * g_value_init(&value, G_TYPE_INT);
  * g_value_set_int(&value, 42);
@@ -1299,7 +1299,7 @@ vips_set_value_from_pointer(GValue *value, void *data)
  * vips_image_get_double() in practice):
  *
  * |[
- * GValue value = { 0 };
+ * GValue value = G_VALUE_INIT;
  * double d;
  *
  * if (vips_image_get(image, name, &value))
@@ -1493,7 +1493,7 @@ void *
 vips_image_map(VipsImage *image, VipsImageMapFn fn, void *a)
 {
 	int i;
-	GValue value = { 0 };
+	GValue value = G_VALUE_INIT;
 	void *result;
 
 	for (i = 0; i < VIPS_NUMBER(vips_header_fields); i++) {
@@ -1581,7 +1581,7 @@ void
 vips_image_set_area(VipsImage *image, const char *name,
 	VipsCallbackFn free_fn, void *data)
 {
-	GValue value = { 0 };
+	GValue value = G_VALUE_INIT;
 
 	vips_value_set_area(&value, free_fn, data);
 	vips_image_set(image, name, &value);
@@ -1592,7 +1592,7 @@ static int
 meta_get_value(const VipsImage *image,
 	const char *name, GType type, GValue *value_copy)
 {
-	GValue value = { 0 };
+	GValue value = G_VALUE_INIT;
 
 	if (vips_image_get(image, name, &value))
 		return -1;
@@ -1631,7 +1631,7 @@ int
 vips_image_get_area(const VipsImage *image,
 	const char *name, const void **data)
 {
-	GValue value_copy = { 0 };
+	GValue value_copy = G_VALUE_INIT;
 
 	if (!meta_get_value(image, name, VIPS_TYPE_AREA, &value_copy)) {
 		*data = vips_value_get_area(&value_copy, NULL);
@@ -1661,7 +1661,7 @@ void
 vips_image_set_blob(VipsImage *image, const char *name,
 	VipsCallbackFn free_fn, const void *data, size_t size)
 {
-	GValue value = { 0 };
+	GValue value = G_VALUE_INIT;
 
 	g_value_init(&value, VIPS_TYPE_BLOB);
 	vips_value_set_blob(&value, free_fn, data, size);
@@ -1729,7 +1729,7 @@ int
 vips_image_get_blob(const VipsImage *image, const char *name,
 	const void **data, size_t *length)
 {
-	GValue value_copy = { 0 };
+	GValue value_copy = G_VALUE_INIT;
 
 	if (!meta_get_value(image, name, VIPS_TYPE_BLOB, &value_copy)) {
 		*data = vips_value_get_blob(&value_copy, length);
@@ -1757,7 +1757,7 @@ vips_image_get_blob(const VipsImage *image, const char *name,
 int
 vips_image_get_int(const VipsImage *image, const char *name, int *out)
 {
-	GValue value = { 0 };
+	GValue value = G_VALUE_INIT;
 
 	if (meta_get_value(image, name, G_TYPE_INT, &value))
 		return -1;
@@ -1782,7 +1782,7 @@ vips_image_get_int(const VipsImage *image, const char *name, int *out)
 void
 vips_image_set_int(VipsImage *image, const char *name, int i)
 {
-	GValue value = { 0 };
+	GValue value = G_VALUE_INIT;
 
 	g_value_init(&value, G_TYPE_INT);
 	g_value_set_int(&value, i);
@@ -1807,7 +1807,7 @@ vips_image_set_int(VipsImage *image, const char *name, int i)
 int
 vips_image_get_double(const VipsImage *image, const char *name, double *out)
 {
-	GValue value = { 0 };
+	GValue value = G_VALUE_INIT;
 
 	if (meta_get_value(image, name, G_TYPE_DOUBLE, &value))
 		return -1;
@@ -1832,7 +1832,7 @@ vips_image_get_double(const VipsImage *image, const char *name, double *out)
 void
 vips_image_set_double(VipsImage *image, const char *name, double d)
 {
-	GValue value = { 0 };
+	GValue value = G_VALUE_INIT;
 
 	g_value_init(&value, G_TYPE_DOUBLE);
 	g_value_set_double(&value, d);
@@ -1862,7 +1862,7 @@ int
 vips_image_get_string(const VipsImage *image, const char *name,
 	const char **out)
 {
-	GValue value = { 0 };
+	GValue value = G_VALUE_INIT;
 
 	if (vips_image_get(image, name, &value))
 		return -1;
@@ -1906,7 +1906,7 @@ vips_image_get_string(const VipsImage *image, const char *name,
 void
 vips_image_set_string(VipsImage *image, const char *name, const char *str)
 {
-	GValue value = { 0 };
+	GValue value = G_VALUE_INIT;
 
 	g_value_init(&value, VIPS_TYPE_REF_STRING);
 	vips_value_set_ref_string(&value, str);
@@ -1935,7 +1935,7 @@ int
 vips_image_get_as_string(const VipsImage *image,
 	const char *name, char **out)
 {
-	GValue value = { 0 };
+	GValue value = G_VALUE_INIT;
 	GType type;
 
 	if (vips_image_get(image, name, &value))
@@ -1946,7 +1946,7 @@ vips_image_get_as_string(const VipsImage *image,
 	 */
 	type = G_VALUE_TYPE(&value);
 	if (g_value_type_transformable(type, VIPS_TYPE_SAVE_STRING)) {
-		GValue save_value = { 0 };
+		GValue save_value = G_VALUE_INIT;
 
 		g_value_init(&save_value, VIPS_TYPE_SAVE_STRING);
 		if (!g_value_transform(&value, &save_value))
@@ -2005,7 +2005,7 @@ int
 vips_image_get_image(const VipsImage *image,
 	const char *name, VipsImage **out)
 {
-	GValue value = { 0 };
+	GValue value = G_VALUE_INIT;
 
 	if (meta_get_value(image, name, VIPS_TYPE_IMAGE, &value))
 		return -1;
@@ -2029,7 +2029,7 @@ vips_image_get_image(const VipsImage *image,
 void
 vips_image_set_image(VipsImage *image, const char *name, VipsImage *im)
 {
-	GValue value = { 0 };
+	GValue value = G_VALUE_INIT;
 
 	g_value_init(&value, VIPS_TYPE_IMAGE);
 	g_value_set_object(&value, im);
@@ -2061,7 +2061,7 @@ int
 vips_image_get_array_int(VipsImage *image, const char *name,
 	int **out, int *n)
 {
-	GValue value = { 0 };
+	GValue value = G_VALUE_INIT;
 
 	if (meta_get_value(image, name, VIPS_TYPE_ARRAY_INT, &value))
 		return -1;
@@ -2087,7 +2087,7 @@ void
 vips_image_set_array_int(VipsImage *image, const char *name,
 	const int *array, int n)
 {
-	GValue value = { 0 };
+	GValue value = G_VALUE_INIT;
 
 	g_value_init(&value, VIPS_TYPE_ARRAY_INT);
 	vips_value_set_array_int(&value, array, n);
@@ -2119,7 +2119,7 @@ int
 vips_image_get_array_double(VipsImage *image, const char *name,
 	double **out, int *n)
 {
-	GValue value = { 0 };
+	GValue value = G_VALUE_INIT;
 
 	if (meta_get_value(image, name, VIPS_TYPE_ARRAY_DOUBLE, &value))
 		return -1;
@@ -2145,7 +2145,7 @@ void
 vips_image_set_array_double(VipsImage *image, const char *name,
 	const double *array, int n)
 {
-	GValue value = { 0 };
+	GValue value = G_VALUE_INIT;
 
 	g_value_init(&value, VIPS_TYPE_ARRAY_DOUBLE);
 	vips_value_set_array_double(&value, array, n);

--- a/libvips/iofuncs/object.c
+++ b/libvips/iofuncs/object.c
@@ -1880,7 +1880,7 @@ vips_object_set_argument_from_string(VipsObject *object,
 	VipsObjectClass *oclass;
 	GType otype;
 
-	GValue gvalue = { 0 };
+	GValue gvalue = G_VALUE_INIT;
 
 	VIPS_DEBUG_MSG("vips_object_set_argument_from_string: %s = %s\n",
 		name, value);
@@ -2174,7 +2174,7 @@ vips_object_print_arg(VipsObject *object, GParamSpec *pspec, VipsBuf *buf)
 {
 	GType type = G_PARAM_SPEC_VALUE_TYPE(pspec);
 	const char *name = g_param_spec_get_name(pspec);
-	GValue value = { 0 };
+	GValue value = G_VALUE_INIT;
 	char *str_value;
 
 	g_value_init(&value, type);

--- a/libvips/iofuncs/operation.c
+++ b/libvips/iofuncs/operation.c
@@ -532,7 +532,7 @@ vips_operation_vips_operation_print_summary_arg(VipsObject *object,
 		const char *name = g_param_spec_get_name(pspec);
 		GType type = G_PARAM_SPEC_VALUE_TYPE(pspec);
 
-		GValue gvalue = { 0 };
+		GValue gvalue = G_VALUE_INIT;
 		char *str;
 
 		g_value_init(&gvalue, type);
@@ -1184,7 +1184,7 @@ vips_call_options_set(const gchar *option_name, const gchar *value,
 #ifdef VIPS_DEBUG
 		{
 			GType type = G_PARAM_SPEC_VALUE_TYPE(pspec);
-			GValue gvalue = { 0 };
+			GValue gvalue = G_VALUE_INIT;
 			char *str;
 
 			g_value_init(&gvalue, type);

--- a/libvips/iofuncs/sourcecustom.c
+++ b/libvips/iofuncs/sourcecustom.c
@@ -94,8 +94,8 @@ static gint64
 vips_source_custom_seek_real(VipsSource *source,
 	gint64 offset, int whence)
 {
-	GValue args[3] = { { 0 } };
-	GValue result = { 0 };
+	GValue args[3] = { G_VALUE_INIT, G_VALUE_INIT, G_VALUE_INIT };
+	GValue result = G_VALUE_INIT;
 	gint64 new_position;
 
 	VIPS_DEBUG_MSG("vips_source_custom_seek_real:\n");

--- a/libvips/iofuncs/targetcustom.c
+++ b/libvips/iofuncs/targetcustom.c
@@ -115,8 +115,8 @@ vips_target_custom_read_real(VipsTarget *target, void *buffer, size_t length)
 static gint64
 vips_target_custom_seek_real(VipsTarget *target, gint64 offset, int whence)
 {
-	GValue args[3] = { { 0 } };
-	GValue result = { 0 };
+	GValue args[3] = { G_VALUE_INIT, G_VALUE_INIT, G_VALUE_INIT };
+	GValue result = G_VALUE_INIT;
 	gint64 new_position;
 
 	VIPS_DEBUG_MSG("vips_target_custom_seek_real:\n");

--- a/libvips/iofuncs/thread.c
+++ b/libvips/iofuncs/thread.c
@@ -440,7 +440,7 @@ vips_get_tile_size(VipsImage *im,
 void
 vips__thread_init(void)
 {
-	static GPrivate private = { 0 };
+	static GPrivate private = G_PRIVATE_INIT(NULL);
 
 	is_vips_thread_key = &private;
 

--- a/libvips/iofuncs/threadpool.c
+++ b/libvips/iofuncs/threadpool.c
@@ -114,7 +114,7 @@ static GPrivate *worker_key = NULL;
 void
 vips__threadpool_init(void)
 {
-	static GPrivate private = { 0 };
+	static GPrivate private = G_PRIVATE_INIT(NULL);
 
 	/* 3 is the useful minimum, and huge values can crash the machine.
 	 */

--- a/libvips/iofuncs/type.c
+++ b/libvips/iofuncs/type.c
@@ -895,7 +895,7 @@ transform_array_int_g_string(const GValue *src_value, GValue *dest_value)
 static void
 transform_array_int_save_string(const GValue *src_value, GValue *dest_value)
 {
-	GValue intermediate = { 0 };
+	GValue intermediate = G_VALUE_INIT;
 
 	g_value_init(&intermediate, G_TYPE_STRING);
 
@@ -958,7 +958,7 @@ transform_g_string_array_int(const GValue *src_value, GValue *dest_value)
 static void
 transform_save_string_array_int(const GValue *src_value, GValue *dest_value)
 {
-	GValue intermediate = { 0 };
+	GValue intermediate = G_VALUE_INIT;
 
 	g_value_init(&intermediate, G_TYPE_STRING);
 

--- a/libvips/iofuncs/vips.c
+++ b/libvips/iofuncs/vips.c
@@ -671,8 +671,8 @@ set_history(VipsImage *im, char *history)
 static int
 set_meta(VipsImage *image, GType gtype, const char *name, const char *data)
 {
-	GValue save_value = { 0 };
-	GValue value = { 0 };
+	GValue save_value = G_VALUE_INIT;
+	GValue value = G_VALUE_INIT;
 
 	g_value_init(&save_value, VIPS_TYPE_SAVE_STRING);
 	vips_value_set_save_string(&save_value, data);
@@ -830,7 +830,7 @@ build_xml_meta(VipsMeta *meta, VipsTarget *target, void *b)
 	 */
 	if (g_value_type_transformable(type, VIPS_TYPE_SAVE_STRING) &&
 		g_value_type_transformable(VIPS_TYPE_SAVE_STRING, type)) {
-		GValue save_value = { 0 };
+		GValue save_value = G_VALUE_INIT;
 
 		g_value_init(&save_value, VIPS_TYPE_SAVE_STRING);
 		if (!g_value_transform(&meta->value, &save_value)) {
@@ -918,7 +918,7 @@ vips__xml_properties_meta(VipsImage *image,
 	 */
 	if (g_value_type_transformable(type, VIPS_TYPE_SAVE_STRING) &&
 		g_value_type_transformable(VIPS_TYPE_SAVE_STRING, type)) {
-		GValue save_value = { 0 };
+		GValue save_value = G_VALUE_INIT;
 
 		g_value_init(&save_value, VIPS_TYPE_SAVE_STRING);
 		if (!g_value_transform(value, &save_value)) {


### PR DESCRIPTION
These macros are available since GLib v2.30 and v2.32, respectively.