### PR TITLE
cplusplus: ensure `operator-` is not no-op

### DIFF
--- a/cplusplus/VImage.cpp
+++ b/cplusplus/VImage.cpp
@@ -999,8 +999,7 @@ operator-=(VImage &a, const std::vector<double> b)
 VImage
 operator-(const VImage a)
 {
-	a * -1;
-	return a;
+	return a * -1;
 }
 
 VImage


### PR DESCRIPTION
Regressed since commit 873ae7305f07a3a1493249148c1d0f0a0407f797.