### PR TITLE
Fix a crash in jxlsave

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -22,6 +22,7 @@
 - swap built-in profiles with ICC v4 variants [kleisauke]
 - remove libgsf dependency in favor of libarchive [kleisauke]
 - better chunking for small shrinks [jcupitt]
+- fix a crash in jxlsave [jcupitt]
 
 15/8/23 8.14.4
 

--- a/libvips/foreign/jxlsave.c
+++ b/libvips/foreign/jxlsave.c
@@ -311,13 +311,13 @@ vips_foreign_save_jxl_build(VipsObject *object)
 	switch (in->Type) {
 	case VIPS_INTERPRETATION_B_W:
 	case VIPS_INTERPRETATION_GREY16:
-		jxl->info.num_color_channels = 1;
+		jxl->info.num_color_channels = VIPS_MIN(1, in->Bands);
 		break;
 
 	case VIPS_INTERPRETATION_sRGB:
 	case VIPS_INTERPRETATION_scRGB:
 	case VIPS_INTERPRETATION_RGB16:
-		jxl->info.num_color_channels = 3;
+		jxl->info.num_color_channels = VIPS_MIN(3, in->Bands);
 		break;
 
 	default:

--- a/libvips/foreign/magick7load.c
+++ b/libvips/foreign/magick7load.c
@@ -539,7 +539,7 @@ vips_foreign_load_magick7_parse(VipsForeignLoadMagick7 *magick7,
 	}
 
 	// revise the interpretation if it seems crazy
-	im->Type = vips_image_guess_interpretation(im);
+	out->Type = vips_image_guess_interpretation(out);
 
 	if (vips_image_pipelinev(out, VIPS_DEMAND_STYLE_SMALLTILE, NULL))
 		return -1;

--- a/libvips/foreign/magick7load.c
+++ b/libvips/foreign/magick7load.c
@@ -534,7 +534,7 @@ vips_foreign_load_magick7_parse(VipsForeignLoadMagick7 *magick7,
 		break;
 
 	default:
-		im->Type = VIPS_INTERPRETATION_ERROR;
+		out->Type = VIPS_INTERPRETATION_ERROR;
 		break;
 	}
 

--- a/libvips/foreign/magick7load.c
+++ b/libvips/foreign/magick7load.c
@@ -456,6 +456,7 @@ vips_foreign_load_magick7_parse(VipsForeignLoadMagick7 *magick7,
 
 	/* Ysize updated below once we have worked out how many frames to load.
 	 */
+	out->Coding = VIPS_CODING_NONE;
 	out->Xsize = image->columns;
 	out->Ysize = image->rows;
 	magick7->frame_height = image->rows;
@@ -491,33 +492,6 @@ vips_foreign_load_magick7_parse(VipsForeignLoadMagick7 *magick7,
 		return -1;
 	}
 
-	switch (image->colorspace) {
-	case GRAYColorspace:
-		if (out->BandFmt == VIPS_FORMAT_USHORT)
-			out->Type = VIPS_INTERPRETATION_GREY16;
-		else
-			out->Type = VIPS_INTERPRETATION_B_W;
-		break;
-
-	case sRGBColorspace:
-	case RGBColorspace:
-		if (out->BandFmt == VIPS_FORMAT_USHORT)
-			out->Type = VIPS_INTERPRETATION_RGB16;
-		else
-			out->Type = VIPS_INTERPRETATION_sRGB;
-		break;
-
-	case CMYKColorspace:
-		out->Type = VIPS_INTERPRETATION_CMYK;
-		break;
-
-	default:
-		vips_error(class->nickname,
-			_("unsupported colorspace %s"),
-			magick_ColorspaceType2str(image->colorspace));
-		return -1;
-	}
-
 	switch (image->units) {
 	case PixelsPerInchResolution:
 		out->Xres = image->resolution.x / 25.4;
@@ -539,9 +513,33 @@ vips_foreign_load_magick7_parse(VipsForeignLoadMagick7 *magick7,
 		break;
 	}
 
-	/* Other fields.
-	 */
-	out->Coding = VIPS_CODING_NONE;
+	switch (image->colorspace) {
+	case GRAYColorspace:
+		if (out->BandFmt == VIPS_FORMAT_USHORT)
+			out->Type = VIPS_INTERPRETATION_GREY16;
+		else
+			out->Type = VIPS_INTERPRETATION_B_W;
+		break;
+
+	case sRGBColorspace:
+	case RGBColorspace:
+		if (out->BandFmt == VIPS_FORMAT_USHORT)
+			out->Type = VIPS_INTERPRETATION_RGB16;
+		else
+			out->Type = VIPS_INTERPRETATION_sRGB;
+		break;
+
+	case CMYKColorspace:
+		out->Type = VIPS_INTERPRETATION_CMYK;
+		break;
+
+	default:
+		im->Type = VIPS_INTERPRETATION_ERROR;
+		break;
+	}
+
+	// revise the interpretation if it seems crazy
+	im->Type = vips_image_guess_interpretation(im);
 
 	if (vips_image_pipelinev(out, VIPS_DEMAND_STYLE_SMALLTILE, NULL))
 		return -1;


### PR DESCRIPTION
Some versions of GraphicsMagick can report rgb colourspace for some mono BMPs. In turn, this can trigger a crash in jxlsave.

See https://github.com/libvips/libvips/issues/3619

@kleisauke this is against master, though since it's a crash (under some circumstances) maybe it should be cherrypicked for 8.14?