### PR TITLE
Use alpha range of 0.0-1.0 for scRGB

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -22,6 +22,7 @@
 - swap built-in profiles with ICC v4 variants [kleisauke]
 - remove libgsf dependency in favor of libarchive [kleisauke]
 - better chunking for small shrinks [jcupitt]
+- use alpha range of 0.0 - 1.0 for scRGB images [DarthSim]
 
 18/9/23 8.14.5
 

--- a/libvips/colour/XYZ2scRGB.c
+++ b/libvips/colour/XYZ2scRGB.c
@@ -47,10 +47,20 @@
 
 #include "pcolour.h"
 
-typedef VipsColourTransform VipsXYZ2scRGB;
-typedef VipsColourTransformClass VipsXYZ2scRGBClass;
+/* We can't use VipsColourCode as our parent class. We want to handle
+ * alpha ourselves.
+ */
 
-G_DEFINE_TYPE(VipsXYZ2scRGB, vips_XYZ2scRGB, VIPS_TYPE_COLOUR_TRANSFORM);
+typedef struct _VipsXYZ2scRGB {
+	VipsOperation parent_instance;
+
+	VipsImage *in;
+	VipsImage *out;
+} VipsXYZ2scRGB;
+
+typedef VipsOperationClass VipsXYZ2scRGBClass;
+
+G_DEFINE_TYPE(VipsXYZ2scRGB, vips_XYZ2scRGB, VIPS_TYPE_OPERATION);
 
 /* We used to have the comment:
 
@@ -69,17 +79,15 @@ G_DEFINE_TYPE(VipsXYZ2scRGB, vips_XYZ2scRGB, VIPS_TYPE_COLOUR_TRANSFORM);
  */
 
 static void
-vips_XYZ2scRGB_line(VipsColour *colour, VipsPel *out, VipsPel **in, int width)
+vips_XYZ2scRGB_line(float *restrict q, float *restrict p,
+	int extra_bands, int width)
 {
-	float *restrict p = (float *) in[0];
-	float *restrict q = (float *) out;
-
-	int i;
+	int i, j;
 
 	for (i = 0; i < width; i++) {
-		float X = p[0];
-		float Y = p[1];
-		float Z = p[2];
+		const float X = p[0];
+		const float Y = p[1];
+		const float Z = p[2];
 
 		float R, G, B;
 
@@ -92,27 +100,118 @@ vips_XYZ2scRGB_line(VipsColour *colour, VipsPel *out, VipsPel **in, int width)
 		q[2] = B;
 
 		q += 3;
+
+		for (j = 0; j < extra_bands; j++)
+			q[j] = VIPS_CLIP(0, p[j] / 255.0, 1.0);
+		p += extra_bands;
+		q += extra_bands;
 	}
+}
+
+static int
+vips_XYZ2scRGB_gen(VipsRegion *out_region,
+	void *seq, void *a, void *b, gboolean *stop)
+{
+	VipsRegion *ir = (VipsRegion *) seq;
+	VipsRect *r = &out_region->valid;
+	VipsImage *in = ir->im;
+
+	int y;
+
+	if (vips_region_prepare(ir, r))
+		return -1;
+
+	VIPS_GATE_START("vips_XYZ2scRGB: work");
+
+	for (y = 0; y < r->height; y++) {
+		float *p = (float *)
+			VIPS_REGION_ADDR(ir, r->left, r->top + y);
+		float *q = (float *)
+			VIPS_REGION_ADDR(out_region, r->left, r->top + y);
+
+		vips_XYZ2scRGB_line(q, p, in->Bands - 3, r->width);
+	}
+
+	VIPS_GATE_STOP("vips_XYZ2scRGB: work");
+
+	return 0;
+}
+
+static int
+vips_XYZ2scRGB_build(VipsObject *object)
+{
+	VipsObjectClass *class = VIPS_OBJECT_GET_CLASS(object);
+	VipsXYZ2scRGB *XYZ2scRGB = (VipsXYZ2scRGB *) object;
+
+	VipsImage **t = (VipsImage **) vips_object_local_array(object, 2);
+
+	VipsImage *in;
+	VipsImage *out;
+
+	if (VIPS_OBJECT_CLASS(vips_XYZ2scRGB_parent_class)->build(object))
+		return -1;
+
+	in = XYZ2scRGB->in;
+	if (vips_check_bands_atleast(class->nickname, in, 3))
+		return -1;
+
+	if (vips_cast_float(in, &t[0], NULL))
+		return -1;
+	in = t[0];
+
+	out = vips_image_new();
+	if (vips_image_pipelinev(out,
+			VIPS_DEMAND_STYLE_THINSTRIP, in, NULL)) {
+		g_object_unref(out);
+		return -1;
+	}
+	out->Type = VIPS_INTERPRETATION_scRGB;
+	out->BandFmt = VIPS_FORMAT_FLOAT;
+
+	if (vips_image_generate(out,
+			vips_start_one, vips_XYZ2scRGB_gen, vips_stop_one,
+			in, XYZ2scRGB)) {
+		g_object_unref(out);
+		return -1;
+	}
+
+	g_object_set(object, "out", out, NULL);
+
+	return 0;
 }
 
 static void
 vips_XYZ2scRGB_class_init(VipsXYZ2scRGBClass *class)
 {
+	GObjectClass *gobject_class = G_OBJECT_CLASS(class);
 	VipsObjectClass *object_class = (VipsObjectClass *) class;
-	VipsColourClass *colour_class = VIPS_COLOUR_CLASS(class);
+	VipsOperationClass *operation_class = VIPS_OPERATION_CLASS(class);
+
+	gobject_class->set_property = vips_object_set_property;
+	gobject_class->get_property = vips_object_get_property;
 
 	object_class->nickname = "XYZ2scRGB";
 	object_class->description = _("transform XYZ to scRGB");
+	object_class->build = vips_XYZ2scRGB_build;
 
-	colour_class->process_line = vips_XYZ2scRGB_line;
+	operation_class->flags = VIPS_OPERATION_SEQUENTIAL;
+
+	VIPS_ARG_IMAGE(class, "in", 1,
+		_("Input"),
+		_("Input image"),
+		VIPS_ARGUMENT_REQUIRED_INPUT,
+		G_STRUCT_OFFSET(VipsXYZ2scRGB, in));
+
+	VIPS_ARG_IMAGE(class, "out", 100,
+		_("Output"),
+		_("Output image"),
+		VIPS_ARGUMENT_REQUIRED_OUTPUT,
+		G_STRUCT_OFFSET(VipsXYZ2scRGB, out));
 }
 
 static void
 vips_XYZ2scRGB_init(VipsXYZ2scRGB *XYZ2scRGB)
 {
-	VipsColour *colour = VIPS_COLOUR(XYZ2scRGB);
-
-	colour->interpretation = VIPS_INTERPRETATION_scRGB;
 }
 
 /**

--- a/libvips/colour/sRGB2scRGB.c
+++ b/libvips/colour/sRGB2scRGB.c
@@ -98,7 +98,7 @@ vips_sRGB2scRGB_line_8(float *restrict q, VipsPel *restrict p,
 			q[0] = vips_v2Y_8[p[0]];
 			q[1] = vips_v2Y_8[p[1]];
 			q[2] = vips_v2Y_8[p[2]];
-			q[3] = p[3];
+			q[3] = p[3] / 255.0;
 
 			p += 4;
 			q += 4;
@@ -114,7 +114,7 @@ vips_sRGB2scRGB_line_8(float *restrict q, VipsPel *restrict p,
 			q += 3;
 
 			for (j = 0; j < extra_bands; j++)
-				q[j] = p[j];
+				q[j] = p[j] / 255.0;
 			p += extra_bands;
 			q += extra_bands;
 		}
@@ -144,7 +144,7 @@ vips_sRGB2scRGB_line_16(float *restrict q, unsigned short *restrict p,
 			q[0] = vips_v2Y_16[p[0]];
 			q[1] = vips_v2Y_16[p[1]];
 			q[2] = vips_v2Y_16[p[2]];
-			q[3] = p[3] / 256.0;
+			q[3] = p[3] / 65535.0;
 
 			p += 4;
 			q += 4;
@@ -160,7 +160,7 @@ vips_sRGB2scRGB_line_16(float *restrict q, unsigned short *restrict p,
 			q += 3;
 
 			for (j = 0; j < extra_bands; j++)
-				q[j] = p[j] / 256.0;
+				q[j] = p[j] / 65535.0;
 			p += extra_bands;
 			q += extra_bands;
 		}

--- a/libvips/colour/scRGB2BW.c
+++ b/libvips/colour/scRGB2BW.c
@@ -84,7 +84,7 @@ vips_scRGB2BW_line_8(VipsPel *restrict q, float *restrict p,
 		q += 1;
 
 		for (j = 0; j < extra_bands; j++)
-			q[j] = VIPS_CLIP(0, p[j], UCHAR_MAX);
+			q[j] = VIPS_CLIP(0, (int) (p[j] * 255.0), UCHAR_MAX);
 		p += extra_bands;
 		q += extra_bands;
 	}
@@ -113,7 +113,7 @@ vips_scRGB2BW_line_16(unsigned short *restrict q, float *restrict p,
 		q += 1;
 
 		for (j = 0; j < extra_bands; j++)
-			q[j] = VIPS_CLIP(0, (int) (p[j] * 256.0), USHRT_MAX);
+			q[j] = VIPS_CLIP(0, (int) (p[j] * 65535.0), USHRT_MAX);
 		p += extra_bands;
 		q += extra_bands;
 	}

--- a/libvips/colour/scRGB2XYZ.c
+++ b/libvips/colour/scRGB2XYZ.c
@@ -49,23 +49,31 @@
 
 #include "pcolour.h"
 
-typedef VipsColourTransform VipsscRGB2XYZ;
-typedef VipsColourTransformClass VipsscRGB2XYZClass;
+/* We can't use VipsColourCode as our parent class. We want to handle
+ * alpha ourselves.
+ */
 
-G_DEFINE_TYPE(VipsscRGB2XYZ, vips_scRGB2XYZ, VIPS_TYPE_COLOUR_TRANSFORM);
+typedef struct _VipsscRGB2XYZ {
+	VipsOperation parent_instance;
+
+	VipsImage *in;
+	VipsImage *out;
+} VipsscRGB2XYZ;
+
+typedef VipsOperationClass VipsscRGB2XYZClass;
+
+G_DEFINE_TYPE(VipsscRGB2XYZ, vips_scRGB2XYZ, VIPS_TYPE_OPERATION);
 
 static void
-vips_scRGB2XYZ_line(VipsColour *colour, VipsPel *out, VipsPel **in, int width)
+vips_scRGB2XYZ_line(float *restrict q, float *restrict p,
+	int extra_bands, int width)
 {
-	float *restrict p = (float *) in[0];
-	float *restrict q = (float *) out;
-
-	int i;
+	int i, j;
 
 	for (i = 0; i < width; i++) {
-		float R = p[0] * VIPS_D65_Y0;
-		float G = p[1] * VIPS_D65_Y0;
-		float B = p[2] * VIPS_D65_Y0;
+		const float R = p[0] * VIPS_D65_Y0;
+		const float G = p[1] * VIPS_D65_Y0;
+		const float B = p[2] * VIPS_D65_Y0;
 
 		/* Manually inlined logic from the vips_col_scRGB2XYZ function
 		 * as the original is defined in a separate file and is part of
@@ -83,27 +91,118 @@ vips_scRGB2XYZ_line(VipsColour *colour, VipsPel *out, VipsPel **in, int width)
 
 		p += 3;
 		q += 3;
+
+		for (j = 0; j < extra_bands; j++)
+			q[j] = VIPS_CLIP(0, p[j] * 255.0, 255.0);
+		p += extra_bands;
+		q += extra_bands;
 	}
+}
+
+static int
+vips_scRGB2XYZ_gen(VipsRegion *out_region,
+	void *seq, void *a, void *b, gboolean *stop)
+{
+	VipsRegion *ir = (VipsRegion *) seq;
+	VipsRect *r = &out_region->valid;
+	VipsImage *in = ir->im;
+
+	int y;
+
+	if (vips_region_prepare(ir, r))
+		return -1;
+
+	VIPS_GATE_START("vips_scRGB2XYZ_gen: work");
+
+	for (y = 0; y < r->height; y++) {
+		float *p = (float *)
+			VIPS_REGION_ADDR(ir, r->left, r->top + y);
+		float *q = (float *)
+			VIPS_REGION_ADDR(out_region, r->left, r->top + y);
+
+		vips_scRGB2XYZ_line(q, p, in->Bands - 3, r->width);
+	}
+
+	VIPS_GATE_STOP("vips_scRGB2XYZ_gen: work");
+
+	return 0;
+}
+
+static int
+vips_scRGB2XYZ_build(VipsObject *object)
+{
+	VipsObjectClass *class = VIPS_OBJECT_GET_CLASS(object);
+	VipsscRGB2XYZ *scRGB2XYZ = (VipsscRGB2XYZ *) object;
+
+	VipsImage **t = (VipsImage **) vips_object_local_array(object, 2);
+
+	VipsImage *in;
+	VipsImage *out;
+
+	if (VIPS_OBJECT_CLASS(vips_scRGB2XYZ_parent_class)->build(object))
+		return -1;
+
+	in = scRGB2XYZ->in;
+	if (vips_check_bands_atleast(class->nickname, in, 3))
+		return -1;
+
+	if (vips_cast_float(in, &t[0], NULL))
+		return -1;
+	in = t[0];
+
+	out = vips_image_new();
+	if (vips_image_pipelinev(out,
+			VIPS_DEMAND_STYLE_THINSTRIP, in, NULL)) {
+		g_object_unref(out);
+		return -1;
+	}
+	out->Type = VIPS_INTERPRETATION_XYZ;
+	out->BandFmt = VIPS_FORMAT_FLOAT;
+
+	if (vips_image_generate(out,
+			vips_start_one, vips_scRGB2XYZ_gen, vips_stop_one,
+			in, scRGB2XYZ)) {
+		g_object_unref(out);
+		return -1;
+	}
+
+	g_object_set(object, "out", out, NULL);
+
+	return 0;
 }
 
 static void
 vips_scRGB2XYZ_class_init(VipsscRGB2XYZClass *class)
 {
+	GObjectClass *gobject_class = G_OBJECT_CLASS(class);
 	VipsObjectClass *object_class = (VipsObjectClass *) class;
-	VipsColourClass *colour_class = VIPS_COLOUR_CLASS(class);
+	VipsOperationClass *operation_class = VIPS_OPERATION_CLASS(class);
+
+	gobject_class->set_property = vips_object_set_property;
+	gobject_class->get_property = vips_object_get_property;
 
 	object_class->nickname = "scRGB2XYZ";
 	object_class->description = _("transform scRGB to XYZ");
+	object_class->build = vips_scRGB2XYZ_build;
 
-	colour_class->process_line = vips_scRGB2XYZ_line;
+	operation_class->flags = VIPS_OPERATION_SEQUENTIAL;
+
+	VIPS_ARG_IMAGE(class, "in", 1,
+		_("Input"),
+		_("Input image"),
+		VIPS_ARGUMENT_REQUIRED_INPUT,
+		G_STRUCT_OFFSET(VipsscRGB2XYZ, in));
+
+	VIPS_ARG_IMAGE(class, "out", 100,
+		_("Output"),
+		_("Output image"),
+		VIPS_ARGUMENT_REQUIRED_OUTPUT,
+		G_STRUCT_OFFSET(VipsscRGB2XYZ, out));
 }
 
 static void
 vips_scRGB2XYZ_init(VipsscRGB2XYZ *scRGB2XYZ)
 {
-	VipsColour *colour = VIPS_COLOUR(scRGB2XYZ);
-
-	colour->interpretation = VIPS_INTERPRETATION_XYZ;
 }
 
 /**

--- a/libvips/colour/scRGB2sRGB.c
+++ b/libvips/colour/scRGB2sRGB.c
@@ -110,7 +110,7 @@ vips_scRGB2sRGB_line_8(VipsPel *restrict q, float *restrict p,
 		q += 3;
 
 		for (j = 0; j < extra_bands; j++)
-			q[j] = VIPS_CLIP(0, p[j], UCHAR_MAX);
+			q[j] = VIPS_CLIP(0, (int) (p[j] * 255.0), UCHAR_MAX);
 		p += extra_bands;
 		q += extra_bands;
 	}
@@ -140,7 +140,7 @@ vips_scRGB2sRGB_line_16(unsigned short *restrict q, float *restrict p,
 		q += 3;
 
 		for (j = 0; j < extra_bands; j++)
-			q[j] = VIPS_CLIP(0, (int) (p[j] * 256.0), USHRT_MAX);
+			q[j] = VIPS_CLIP(0, (int) (p[j] * 65535.0), USHRT_MAX);
 		p += extra_bands;
 		q += extra_bands;
 	}

--- a/libvips/conversion/bandjoin.c
+++ b/libvips/conversion/bandjoin.c
@@ -533,14 +533,8 @@ vips_bandjoin_const1(VipsImage *in, VipsImage **out, double c, ...)
 int
 vips_addalpha(VipsImage *in, VipsImage **out, ...)
 {
-	double max_alpha;
-
-	max_alpha = 255.0;
-	if (in->Type == VIPS_INTERPRETATION_GREY16 ||
-		in->Type == VIPS_INTERPRETATION_RGB16)
-		max_alpha = 65535;
-
-	if (vips_bandjoin_const1(in, out, max_alpha, NULL))
+	if (vips_bandjoin_const1(in, out,
+		vips_interpretation_max_alpha(in->Type), NULL))
 		return -1;
 
 	return 0;

--- a/libvips/conversion/composite.cpp
+++ b/libvips/conversion/composite.cpp
@@ -356,10 +356,7 @@ vips_composite_base_max_band(VipsCompositeBase *composite, double *max_band)
 	double max_alpha;
 	int b;
 
-	max_alpha = 255.0;
-	if (composite->compositing_space == VIPS_INTERPRETATION_GREY16 ||
-		composite->compositing_space == VIPS_INTERPRETATION_RGB16)
-		max_alpha = 65535.0;
+	max_alpha = vips_interpretation_max_alpha(composite->compositing_space);
 
 	for (b = 0; b <= composite->bands; b++)
 		max_band[b] = max_alpha;

--- a/libvips/conversion/flatten.c
+++ b/libvips/conversion/flatten.c
@@ -326,9 +326,7 @@ vips_flatten_build(VipsObject *object)
 	 * interpretation.
 	 */
 	if (!vips_object_argument_isset(object, "max_alpha"))
-		if (in->Type == VIPS_INTERPRETATION_GREY16 ||
-			in->Type == VIPS_INTERPRETATION_RGB16)
-			flatten->max_alpha = 65535;
+		flatten->max_alpha = vips_interpretation_max_alpha(in->Type);
 
 	/* Is max_alpha less than the numeric range of this image? If it is,
 	 * we can get int overflow.

--- a/libvips/conversion/premultiply.c
+++ b/libvips/conversion/premultiply.c
@@ -224,9 +224,7 @@ vips_premultiply_build(VipsObject *object)
 	 * interpretation.
 	 */
 	if (!vips_object_argument_isset(object, "max_alpha"))
-		if (in->Type == VIPS_INTERPRETATION_GREY16 ||
-			in->Type == VIPS_INTERPRETATION_RGB16)
-			premultiply->max_alpha = 65535;
+		premultiply->max_alpha = vips_interpretation_max_alpha(in->Type);
 
 	if (in->BandFmt == VIPS_FORMAT_DOUBLE)
 		conversion->out->BandFmt = VIPS_FORMAT_DOUBLE;

--- a/libvips/conversion/unpremultiply.c
+++ b/libvips/conversion/unpremultiply.c
@@ -281,9 +281,7 @@ vips_unpremultiply_build(VipsObject *object)
 	 * interpretation.
 	 */
 	if (!vips_object_argument_isset(object, "max_alpha"))
-		if (in->Type == VIPS_INTERPRETATION_GREY16 ||
-			in->Type == VIPS_INTERPRETATION_RGB16)
-			unpremultiply->max_alpha = 65535;
+		unpremultiply->max_alpha = vips_interpretation_max_alpha(in->Type);
 
 	/* Is alpha-band unset? Default to the final band for this image.
 	 */

--- a/libvips/include/vips/header.h
+++ b/libvips/include/vips/header.h
@@ -177,6 +177,9 @@ VIPS_API
 guint64 vips_format_sizeof_unsafe(VipsBandFormat format);
 
 VIPS_API
+double vips_interpretation_max_alpha(VipsInterpretation interpretation);
+
+VIPS_API
 int vips_image_get_width(const VipsImage *image);
 VIPS_API
 int vips_image_get_height(const VipsImage *image);

--- a/libvips/iofuncs/header.c
+++ b/libvips/iofuncs/header.c
@@ -238,6 +238,26 @@ vips_format_sizeof_unsafe(VipsBandFormat format)
 	return vips__image_sizeof_bandformat[format];
 }
 
+/**
+ * vips_interpretation_max_alpha:
+ * @interpretation: image interpretation
+ *
+ * Returns: the maximum alpha value for an interpretation.
+ */
+double
+vips_interpretation_max_alpha(VipsInterpretation interpretation)
+{
+	switch (interpretation) {
+	case VIPS_INTERPRETATION_GREY16:
+	case VIPS_INTERPRETATION_RGB16:
+		return 65535.0;
+	case VIPS_INTERPRETATION_scRGB:
+		return 1.0;
+	default:
+		return 255.0;
+	}
+}
+
 #ifdef DEBUG
 /* Check that this meta is on the hash table.
  */

--- a/test/test-suite/test_colour.py
+++ b/test/test-suite/test_colour.py
@@ -25,7 +25,10 @@ class TestColour:
                 assert pytest.approx(min_l) == max_h
 
             pixel = im(10, 10)
-            assert pytest.approx(pixel[3], 0.01) == 42
+            if col == pyvips.Interpretation.SCRGB:
+                assert pytest.approx(pixel[3], 0.0001) == 42.0 / 255.0
+            else:
+                assert pytest.approx(pixel[3], 0.01) == 42
 
         # alpha won't be equal for RGB16, but it should be preserved if we go
         # there and back


### PR DESCRIPTION
Hey there 👋

This PR changes the alpha range of scRGB to `0.0 - 1.0` as discussed here https://github.com/libvips/libvips/issues/3621#issuecomment-1691925346