### PR TITLE
fix crash with alpha handling for icc import and export

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,7 @@
+2/9/23 8.14.5
+
+- fix a crash with alpha plus icc_import and icc_export [jcupitt]
+
 15/8/23 8.14.4
 
 - fix null-pointer dereference during svgload [kleisauke]

--- a/libvips/colour/icc_transform.c
+++ b/libvips/colour/icc_transform.c
@@ -935,7 +935,11 @@ vips_icc_import_line( VipsColour *colour,
 		else
 			decode_xyz( encoded, q, chunk );
 
-		p += PIXEL_BUFFER_SIZE * VIPS_IMAGE_SIZEOF_PEL( colour->in[0] );
+		// use input_bands, since in[0] may have had alpha removed,
+		// and can have 1, 3 or 4 bands
+		p += PIXEL_BUFFER_SIZE * 
+			colour->input_bands * 
+			VIPS_IMAGE_SIZEOF_ELEMENT( colour->in[0] );
 		q += PIXEL_BUFFER_SIZE * 3;
 	}
 }
@@ -1078,7 +1082,7 @@ vips_icc_export_line_xyz( VipsColour *colour,
 	VipsPel *q;
 	int x;
 
-	/* Buffer of encoded float pixels we transform.
+	/* Buffer of encoded float pixels we transform to device space.
 	 */
 	float encoded[3 * PIXEL_BUFFER_SIZE];
 
@@ -1091,7 +1095,11 @@ vips_icc_export_line_xyz( VipsColour *colour,
 		cmsDoTransform( icc->trans, encoded, q, chunk );
 
 		p += PIXEL_BUFFER_SIZE * 3;
-		q += PIXEL_BUFFER_SIZE * VIPS_IMAGE_SIZEOF_PEL( colour->out );
+		// use colour->bands, since out may have had alpha reattached
+		// and can have extra bands
+		q += PIXEL_BUFFER_SIZE * 
+			colour->bands *
+			VIPS_IMAGE_SIZEOF_ELEMENT( colour->out );
 	}
 }
 

--- a/meson.build
+++ b/meson.build
@@ -1,5 +1,5 @@
 project('vips', 'c', 'cpp',
-    version: '8.14.4',
+    version: '8.14.5',
     meson_version: '>=0.55',
     default_options: [
         # this is what glib uses (one of our required deps), so we use it too
@@ -19,7 +19,7 @@ version_patch = version_parts[2]
 # binary interface changed: increment current, reset revision to 0
 #   binary interface changes backwards compatible?: increment age
 #   binary interface changes not backwards compatible?: reset age to 0
-library_revision = 4
+library_revision = 5
 library_current = 58
 library_age = 16
 library_version = '@0@.@1@.@2@'.format(library_current - library_age, library_age, library_revision)

--- a/test/test-suite/test_create.py
+++ b/test/test-suite/test_create.py
@@ -403,7 +403,8 @@ class TestCreate:
     @pytest.mark.skipif(pyvips.type_find("VipsOperation", "text") == 0,
                         reason="no text, skipping test")
     def test_text(self):
-        im = pyvips.Image.text("Hello, world!")
+        # high DPI to make sure we have some solid white pixels with all fonts
+        im = pyvips.Image.text("Hello, world!", dpi=300)
         assert im.width > 10
         assert im.height > 10
         assert im.bands == 1


### PR DESCRIPTION
The ICC import and export line process functions were using `SIZEOF_PEL` on the input and output images, but the image they actually handle may have had alpha removed. This could cause SEGVs with formats like CMYKA.

This PR makes them use the band count that LCMS will see.

Also bump version, and fix a test fail.

See https://github.com/libvips/libvips/discussions/3640