### PR TITLE
call heif_init on heif startup

### DIFF
--- a/libvips/foreign/heifsave.c
+++ b/libvips/foreign/heifsave.c
@@ -139,11 +139,6 @@ typedef struct _VipsForeignSaveHeif {
 
 typedef VipsForeignSaveClass VipsForeignSaveHeifClass;
 
-/* Defined in heifload.c
- */
-void vips__heif_image_print(struct heif_image *img);
-void vips__heif_error(struct heif_error *error);
-
 G_DEFINE_ABSTRACT_TYPE(VipsForeignSaveHeif, vips_foreign_save_heif,
 	VIPS_TYPE_FOREIGN_SAVE);
 
@@ -629,6 +624,8 @@ vips_foreign_save_heif_class_init(VipsForeignSaveHeifClass *class)
 	GObjectClass *gobject_class = G_OBJECT_CLASS(class);
 	VipsObjectClass *object_class = (VipsObjectClass *) class;
 	VipsForeignSaveClass *save_class = (VipsForeignSaveClass *) class;
+
+	vips__heif_init();
 
 	gobject_class->dispose = vips_foreign_save_heif_dispose;
 	gobject_class->set_property = vips_object_set_property;

--- a/libvips/foreign/pforeign.h
+++ b/libvips/foreign/pforeign.h
@@ -201,7 +201,12 @@ void *vips__foreign_nifti_map(VipsNiftiMapFn fn, void *a, void *b);
 extern const char *vips__heic_suffs[];
 extern const char *vips__avif_suffs[];
 extern const char *vips__heif_suffs[];
+struct heif_image;
+struct heif_error;
+void vips__heif_init(void);
 int vips__heif_chroma(int bits_per_pixel, gboolean has_alpha);
+void vips__heif_image_print(struct heif_image *img);
+void vips__heif_error(struct heif_error *error);
 
 extern const char *vips__jp2k_suffs[];
 int vips__foreign_load_jp2k_decompress(VipsImage *out,

--- a/meson.build
+++ b/meson.build
@@ -481,6 +481,11 @@ if libheif_dep.found()
     if libheif_dep.version().version_compare('>=1.7.0')
         cfg_var.set('HAVE_HEIF_AVIF', '1')
     endif
+
+    # heif_init in 1.13
+    if libheif_dep.version().version_compare('>=1.13.0')
+        cfg_var.set('HAVE_HEIF_INIT', '1')
+    endif
 endif
 
 libjxl_dep = dependency('libjxl', version: '>=0.6', required: get_option('jpeg-xl'))


### PR DESCRIPTION
a little safer, and helps libvips work with some versions of libheif