### PR TITLE
Backport #3620 to 8.14

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,6 +1,7 @@
 TBD 8.14.5
 
 - fix a crash with alpha plus icc_import and icc_export [jcupitt]
+- fix a crash in jxlsave [jcupitt]
 
 15/8/23 8.14.4
 

--- a/libvips/foreign/jxlsave.c
+++ b/libvips/foreign/jxlsave.c
@@ -313,13 +313,13 @@ vips_foreign_save_jxl_build( VipsObject *object )
 	switch( in->Type ) {
 	case VIPS_INTERPRETATION_B_W:
 	case VIPS_INTERPRETATION_GREY16:
-		jxl->info.num_color_channels = 1;
+		jxl->info.num_color_channels = VIPS_MIN( 1, in->Bands );
 		break;
 
 	case VIPS_INTERPRETATION_sRGB:
 	case VIPS_INTERPRETATION_scRGB:
 	case VIPS_INTERPRETATION_RGB16:
-		jxl->info.num_color_channels = 3;
+		jxl->info.num_color_channels = VIPS_MIN( 3, in->Bands );
 		break;
 
 	default:

--- a/libvips/foreign/magick2vips.c
+++ b/libvips/foreign/magick2vips.c
@@ -337,6 +337,7 @@ parse_header( Read *read )
 	printf( "image->rows = %zd\n", image->rows ); 
 #endif /*DEBUG*/
 
+	im->Coding = VIPS_CODING_NONE;
 	im->Xsize = image->columns;
 	im->Ysize = image->rows;
 	read->frame_height = image->rows;
@@ -383,6 +384,26 @@ parse_header( Read *read )
 		return( -1 );
 	}
 
+	switch( image->units ) {
+	case PixelsPerInchResolution:
+		im->Xres = image->x_resolution / 25.4;
+		im->Yres = image->y_resolution / 25.4;
+		break;
+
+	case PixelsPerCentimeterResolution:
+		im->Xres = image->x_resolution / 10.0;
+		im->Yres = image->y_resolution / 10.0;
+		break;
+
+	default:
+		im->Xres = 1.0;
+		im->Yres = 1.0;
+		break;
+	}
+
+	/* this can be wrong for some GM versions and must be sanity checked (see
+	 * below)
+	 */
 	switch( image->colorspace ) {
 	case GRAYColorspace:
 		if( im->BandFmt == VIPS_FORMAT_USHORT )
@@ -404,31 +425,13 @@ parse_header( Read *read )
 		break;
 
 	default:
-		vips_error( "magick2vips", _( "unsupported colorspace %d" ),
-			(int) image->colorspace );
-		return( -1 );
-	}
-
-	switch( image->units ) {
-	case PixelsPerInchResolution:
-		im->Xres = image->x_resolution / 25.4;
-		im->Yres = image->y_resolution / 25.4;
-		break;
-
-	case PixelsPerCentimeterResolution:
-		im->Xres = image->x_resolution / 10.0;
-		im->Yres = image->y_resolution / 10.0;
-		break;
-
-	default:
-		im->Xres = 1.0;
-		im->Yres = 1.0;
+		im->Type = VIPS_INTERPRETATION_ERROR;
 		break;
 	}
 
-	/* Other fields.
+	/* revise the interpretation if it seems crazy
 	 */
-	im->Coding = VIPS_CODING_NONE;
+	im->Type = vips_image_guess_interpretation( im );
 
 	if( vips_image_pipelinev( im, VIPS_DEMAND_STYLE_SMALLTILE, NULL ) )
 		return( -1 );

--- a/libvips/foreign/magick7load.c
+++ b/libvips/foreign/magick7load.c
@@ -457,6 +457,7 @@ vips_foreign_load_magick7_parse( VipsForeignLoadMagick7 *magick7,
 
 	/* Ysize updated below once we have worked out how many frames to load.
 	 */
+	out->Coding = VIPS_CODING_NONE;
 	out->Xsize = image->columns;
 	out->Ysize = image->rows;
 	magick7->frame_height = image->rows;
@@ -492,33 +493,6 @@ vips_foreign_load_magick7_parse( VipsForeignLoadMagick7 *magick7,
 		return( -1 );
 	}
 
-	switch( image->colorspace ) {
-	case GRAYColorspace:
-		if( out->BandFmt == VIPS_FORMAT_USHORT )
-			out->Type = VIPS_INTERPRETATION_GREY16;
-		else
-			out->Type = VIPS_INTERPRETATION_B_W;
-		break;
-
-	case sRGBColorspace:
-	case RGBColorspace:
-		if( out->BandFmt == VIPS_FORMAT_USHORT )
-			out->Type = VIPS_INTERPRETATION_RGB16;
-		else
-			out->Type = VIPS_INTERPRETATION_sRGB;
-		break;
-
-	case CMYKColorspace:
-		out->Type = VIPS_INTERPRETATION_CMYK;
-		break;
-
-	default:
-		vips_error( class->nickname, 
-			_( "unsupported colorspace %s" ), 
-			magick_ColorspaceType2str( image->colorspace ) );
-		return( -1 );
-	}
-
 	switch( image->units ) {
 	case PixelsPerInchResolution:
 		out->Xres = image->resolution.x / 25.4;
@@ -540,9 +514,34 @@ vips_foreign_load_magick7_parse( VipsForeignLoadMagick7 *magick7,
 		break;
 	}
 
-	/* Other fields.
+	switch( image->colorspace ) {
+	case GRAYColorspace:
+		if( out->BandFmt == VIPS_FORMAT_USHORT )
+			out->Type = VIPS_INTERPRETATION_GREY16;
+		else
+			out->Type = VIPS_INTERPRETATION_B_W;
+		break;
+
+	case sRGBColorspace:
+	case RGBColorspace:
+		if( out->BandFmt == VIPS_FORMAT_USHORT )
+			out->Type = VIPS_INTERPRETATION_RGB16;
+		else
+			out->Type = VIPS_INTERPRETATION_sRGB;
+		break;
+
+	case CMYKColorspace:
+		out->Type = VIPS_INTERPRETATION_CMYK;
+		break;
+
+	default:
+		out->Type = VIPS_INTERPRETATION_ERROR;
+		break;
+	}
+
+	/* revise the interpretation if it seems crazy
 	 */
-	out->Coding = VIPS_CODING_NONE;
+	out->Type = vips_image_guess_interpretation( out );
 
 	if( vips_image_pipelinev( out, VIPS_DEMAND_STYLE_SMALLTILE, NULL ) )
 		return( -1 );


### PR DESCRIPTION
Trivial backport of #3620 to [`8.14`](https://github.com/libvips/libvips/tree/8.14).