### PR TITLE
v8.14.5 release proposal

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,4 +1,4 @@
-TBD 8.14.5
+18/9/23 8.14.5
 
 - fix a crash with alpha plus icc_import and icc_export [jcupitt]
 - fix a crash in jxlsave [jcupitt]


### PR DESCRIPTION
A few bugfixes since 8.14.4:

- fix a crash with alpha plus icc_import and icc_export [jcupitt]
- fix a crash in jxlsave [jcupitt]