### PR TITLE
Fix invalid UTF-8 strings instead of ignoring them

### DIFF
--- a/libvips/foreign/dzsave.c
+++ b/libvips/foreign/dzsave.c
@@ -1031,7 +1031,7 @@ static void
 build_scan_property(VipsDbuf *dbuf, VipsImage *image,
 	const char *vips_name, const char *szi_name)
 {
-	const char *str;
+	char *str;
 	GValue value = G_VALUE_INIT;
 	GValue save_value = G_VALUE_INIT;
 	GType type;
@@ -1055,12 +1055,8 @@ build_scan_property(VipsDbuf *dbuf, VipsImage *image,
 	}
 	g_value_unset(&value);
 
-	if (!(str = vips_value_get_save_string(&save_value))) {
-		g_value_unset(&save_value);
-		return;
-	}
-
-	if (!g_utf8_validate(str, -1, NULL)) {
+	if (!(str = g_utf8_make_valid(
+			  vips_value_get_save_string(&save_value), -1))) {
 		g_value_unset(&save_value);
 		return;
 	}
@@ -1074,6 +1070,8 @@ build_scan_property(VipsDbuf *dbuf, VipsImage *image,
 	vips_dbuf_write_amp(dbuf, str);
 	vips_dbuf_writef(dbuf, "</value>\n");
 	vips_dbuf_writef(dbuf, "    </property>\n");
+
+	g_free(str);
 
 	g_value_unset(&save_value);
 }

--- a/libvips/iofuncs/type.c
+++ b/libvips/iofuncs/type.c
@@ -563,14 +563,13 @@ vips_ref_string_new(const char *str)
 {
 	VipsArea *area;
 
-	if (!g_utf8_validate(str, -1, NULL))
-		str = "<invalid utf-8 string>";
+	char *utf8_str = g_utf8_make_valid(str, -1);
 
-	area = vips_area_new((VipsCallbackFn) vips_area_free_cb, g_strdup(str));
+	area = vips_area_new((VipsCallbackFn) vips_area_free_cb, utf8_str);
 
 	/* Handy place to cache this.
 	 */
-	area->length = strlen(str);
+	area->length = strlen(utf8_str);
 
 	return (VipsRefString *) area;
 }

--- a/libvips/iofuncs/vips.c
+++ b/libvips/iofuncs/vips.c
@@ -823,7 +823,7 @@ build_xml_meta(VipsMeta *meta, VipsTarget *target, void *b)
 {
 	GType type = G_VALUE_TYPE(&meta->value);
 
-	const char *str;
+	char *str;
 
 	/* If we can transform to VIPS_TYPE_SAVE_STRING and back, we can save
 	 * and restore.
@@ -842,8 +842,9 @@ build_xml_meta(VipsMeta *meta, VipsTarget *target, void *b)
 		/* We need to validate the str to make sure we'll be able to
 		 * read it back.
 		 */
-		str = vips_value_get_save_string(&save_value);
-		if (g_utf8_validate(str, -1, NULL)) {
+		str = g_utf8_make_valid(vips_value_get_save_string(&save_value), -1);
+
+		if (str) {
 			vips_target_writef(target,
 				"    <field type=\"%s\" name=\"",
 				g_type_name(type));
@@ -851,6 +852,8 @@ build_xml_meta(VipsMeta *meta, VipsTarget *target, void *b)
 			vips_target_writes(target, "\">");
 			vips_target_write_amp(target, str);
 			vips_target_writes(target, "</field>\n");
+
+			g_free(str);
 		}
 
 		g_value_unset(&save_value);

--- a/meson.build
+++ b/meson.build
@@ -54,7 +54,7 @@ cpp = meson.get_compiler('cpp')
 # Prevent use of void* pointer arithmetic to support MSVC
 add_project_arguments(cc.get_supported_arguments('-Werror=pointer-arith'), language : ['cpp', 'c'])
 
-glib_dep = dependency('glib-2.0', version: '>=2.40')
+glib_dep = dependency('glib-2.0', version: '>=2.52')
 gio_dep = dependency('gio-2.0')
 gobject_dep = dependency('gobject-2.0')
 gmodule_dep = dependency('gmodule-no-export-2.0', required: get_option('modules'))


### PR DESCRIPTION
Hey there 👋

libvips checks UTF-8 string validity using `g_utf8_validate` in several places and ignores invalid strings or replaces them with `<invlaid utf-8 string>`. This leads to cases where the whole string is ignored or replaced because of a single invalid character. Instead, we could use the `g_utf8_make_valid` function introduced in GLib 2.52 to replace invalid characters.

GLib 2.52 was released 6 years ago (even Debian Buster has GLib 2.58) so increasing the minimum required version to 2.52 shouldn't be a problem.