### PR TITLE
Remove a couple of redundant GLib version guards

### DIFF
--- a/libvips/foreign/pforeign.h
+++ b/libvips/foreign/pforeign.h
@@ -35,15 +35,6 @@
 extern "C" {
 #endif /*__cplusplus*/
 
-/* Slow and horrid version if there's no recent glib.
- */
-#if !GLIB_CHECK_VERSION(2, 48, 0)
-#define g_uint_checked_mul(dest, a, b) ( \
-	((guint64) a * b) > UINT_MAX \
-		? (*dest = UINT_MAX, FALSE) \
-		: (*dest = a * b, TRUE))
-#endif /*!GLIB_CHECK_VERSION(2, 48, 0)*/
-
 /* We've seen real images with 28 chunks, so set 50.
  */
 #define MAX_PNG_TEXT_CHUNKS 50

--- a/libvips/iofuncs/init.c
+++ b/libvips/iofuncs/init.c
@@ -489,14 +489,6 @@ vips_init(const char *argv0)
 	vips__buffer_init();
 	vips__meta_init();
 
-	/* This does an unsynchronised static hash table init on first call --
-	 * we have to make sure we do this single-threaded. See:
-	 * https://github.com/openslide/openslide/issues/161
-	 */
-#if !GLIB_CHECK_VERSION(2, 48, 1)
-	(void) g_get_language_names();
-#endif
-
 	if (!vips__global_lock)
 		vips__global_lock = vips_g_mutex_new();
 


### PR DESCRIPTION
The minimum required GLib version was raised to 2.52, making these guards unnecessary.