### PR TITLE
fix static linking when libwebp is used

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -347,9 +347,9 @@ endif
 # insist on having both of them
 libwebp_dep = dependency('libwebp', version: '>=0.6', required: get_option('webp'))
 if libwebp_dep.found()
-    libvips_deps += libwebp_dep
     libvips_deps += dependency('libwebpmux', version: '>=0.6')
     libvips_deps += dependency('libwebpdemux', version: '>=0.6')
+    libvips_deps += libwebp_dep
     cfg_var.set('HAVE_LIBWEBP', '1')
 endif
 


### PR DESCRIPTION
libwebp depends on symbols from its sublibs, so it must come after them on the linker command, not before, or else ld will complain about missing symbols.

static building libvips.a used to work for me with the autotools Makefile and the same libwebp, before it was replaced with meson ( https://github.com/libvips/libvips/pull/2637 & https://github.com/libvips/libvips/pull/2941 )

fwiw, pkg-config was used by autotools' `PKG_CHECK_MODULES(LIBWEBP, libwebp >= 0.6 libwebpmux >= 0.6 libwebpdemux >= 0.6)` so that got the order right then, but meson's dependency() is [supposed to use pkg-config as well](https://mesonbuild.com/Dependencies.html#dependency-detection-method). I'm not sure why that doesn't automagically get the order right for me with the current meson & pkg-config tools installed.

tested with meson setup build -Ddefault_library=static ; cd build; meson compile;