### PR TITLE
vips2tiff: fix function pointer cast issue

### DIFF
--- a/libvips/foreign/vips2tiff.c
+++ b/libvips/foreign/vips2tiff.c
@@ -1771,7 +1771,7 @@ wtiff_row_free(WtiffRow *row)
 }
 
 static int
-wtiff_tile_compare(WtiffTile *a, WtiffTile *b)
+wtiff_tile_compare(WtiffTile *a, WtiffTile *b, void *user_data)
 {
 	return b->x - a->x;
 }

--- a/libvips/iofuncs/object.c
+++ b/libvips/iofuncs/object.c
@@ -1712,12 +1712,10 @@ traverse_find_required_priority(void *data, void *a, void *b)
 	return NULL;
 }
 
-static gint
-traverse_sort(gconstpointer a, gconstpointer b, void *user_data)
+static int
+traverse_sort(VipsArgumentClass *class1, VipsArgumentClass *class2,
+	void *user_data)
 {
-	VipsArgumentClass *class1 = (VipsArgumentClass *) a;
-	VipsArgumentClass *class2 = (VipsArgumentClass *) b;
-
 	return class1->priority - class2->priority;
 }
 


### PR DESCRIPTION
`g_slist_sort()` uses the same implementation as `g_slist_sort_with_data()` within GLib; hence, the function's signature must align with that of `GCompareDataFunc`.

Helps wasm-vips, where function pointer cast issues fails at runtime.

---
SO answer https://stackoverflow.com/a/14044244 might be relevant here.