### PR TITLE
archive: ensure files are written in binary mode

### DIFF
--- a/libvips/foreign/archive.c
+++ b/libvips/foreign/archive.c
@@ -301,7 +301,7 @@ vips__archive_mkfile_file(VipsArchive *archive,
 
 	path = g_build_filename(archive->base_dirname, filename, NULL);
 
-	if (!(f = vips__file_open_write(path, TRUE))) {
+	if (!(f = vips__file_open_write(path, FALSE))) {
 		g_free(path);
 		return -1;
 	}


### PR DESCRIPTION
On POSIX-compliant operating systems (e.g. Linux, macOS), there is no difference between binary mode and text mode, but Windows transforms line feeds ("\n") to "\r\n" sequences during write operations, resulting in corrupted images.
```console
$ pngcheck -v x_files/10/0_0.png
File: 0_0.png (41180 bytes)
  File is CORRUPTED.  It seems to have suffered Unix->DOS conversion.
ERRORS DETECTED in 0_0.png
```

---

Regressed since commit 00e4047ff9a223132adfdf874f723139e399c6f2 for non-images (e.g. XML/JSON files), corrupted images were written since commit 7ac29928123a276e126c803147db75966afb49c4 (prior to that, `VIPS_FOREIGN_DZ_CONTAINER_FS` images were written using `vips_image_write_to_file()`).