### PR TITLE
add threadset to the public API

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -28,6 +28,7 @@
 - require C++11 as a minimum standard [kleisauke]
 - add support for SIMD via Highway [kleisauke]
 - threaded write in tiffsave for tiled JPEG and JPEG2000 [jcupitt]
+- add vips_threadset public API [jcupitt]
 
 18/9/23 8.14.5
 

--- a/ChangeLog
+++ b/ChangeLog
@@ -28,7 +28,7 @@
 - require C++11 as a minimum standard [kleisauke]
 - add support for SIMD via Highway [kleisauke]
 - threaded write in tiffsave for tiled JPEG and JPEG2000 [jcupitt]
-- add vips_threadset public API [jcupitt]
+- add vips_thread_execute() public API [jcupitt]
 
 18/9/23 8.14.5
 

--- a/ChangeLog
+++ b/ChangeLog
@@ -28,7 +28,7 @@
 - require C++11 as a minimum standard [kleisauke]
 - add support for SIMD via Highway [kleisauke]
 - threaded write in tiffsave for tiled JPEG and JPEG2000 [jcupitt]
-- add vips_thread_execute() public API [jcupitt]
+- add vips_thread_execute() to the public API [jcupitt]
 
 18/9/23 8.14.5
 

--- a/libvips/include/vips/thread.h
+++ b/libvips/include/vips/thread.h
@@ -59,13 +59,13 @@ GThread *vips_g_thread_new(const char *, GThreadFunc, gpointer);
 VIPS_API
 gboolean vips_thread_isvips(void);
 
+VIPS_API
+int vips_thread_execute(const char *domain, GFunc func, gpointer data);
+
 typedef struct _VipsThreadset VipsThreadset;
-VIPS_API
 VipsThreadset *vips_threadset_new(int max_threads);
-VIPS_API
 int vips_threadset_run(VipsThreadset *set,
 	const char *domain, GFunc func, gpointer data);
-VIPS_API
 void vips_threadset_free(VipsThreadset *set);
 
 #ifdef __cplusplus

--- a/libvips/include/vips/thread.h
+++ b/libvips/include/vips/thread.h
@@ -60,9 +60,12 @@ VIPS_API
 gboolean vips_thread_isvips(void);
 
 typedef struct _VipsThreadset VipsThreadset;
+VIPS_API
 VipsThreadset *vips_threadset_new(int max_threads);
+VIPS_API
 int vips_threadset_run(VipsThreadset *set,
 	const char *domain, GFunc func, gpointer data);
+VIPS_API
 void vips_threadset_free(VipsThreadset *set);
 
 #ifdef __cplusplus

--- a/libvips/iofuncs/sinkdisc.c
+++ b/libvips/iofuncs/sinkdisc.c
@@ -236,8 +236,7 @@ wbuffer_new(Write *write)
 
 	/* Make this last (picks up parts of wbuffer on startup).
 	 */
-	if (vips__thread_execute("wbuffer", wbuffer_write_thread,
-			wbuffer)) {
+	if (vips_thread_execute("wbuffer", wbuffer_write_thread, wbuffer)) {
 		wbuffer_free(wbuffer);
 		return NULL;
 	}

--- a/libvips/iofuncs/sinkscreen.c
+++ b/libvips/iofuncs/sinkscreen.c
@@ -1052,7 +1052,7 @@ vips__sink_screen_once(void *data)
 	render_dirty_lock = vips_g_mutex_new();
 	vips_semaphore_init(&n_render_dirty_sem, 0, "n_render_dirty");
 
-	/* Don't use vips__thread_execute() since this thread will only be
+	/* Don't use vips_thread_execute(), since this thread will only be
 	 * ended by vips_shutdown, and that isn't always called.
 	 */
 	render_thread = vips_g_thread_new("sink_screen",

--- a/libvips/iofuncs/threadpool.c
+++ b/libvips/iofuncs/threadpool.c
@@ -142,9 +142,9 @@ vips__threadpool_shutdown(void)
 }
 
 /**
- * vips__thread_execute:
+ * vips_thread_execute:
  * @name: a name for the thread
- * @func: a function to execute in the global threadset
+ * @func: a function to execute in the libvips threadset
  * @data: an argument to supply to @func
  *
  * A newly created or reused thread will execute @func with the
@@ -153,7 +153,7 @@ vips__threadpool_shutdown(void)
  * Returns: 0 on success, -1 on error.
  */
 int
-vips__thread_execute(const char *domain, GFunc func, gpointer data)
+vips_thread_execute(const char *domain, GFunc func, gpointer data)
 {
 	return vips_threadset_run(vips__threadset, domain, func, data);
 }
@@ -445,8 +445,7 @@ vips_worker_new(VipsThreadpool *pool)
 	 * owned by the correct thread.
 	 */
 
-	if (vips__thread_execute("worker",
-			vips_thread_main_loop, worker)) {
+	if (vips_thread_execute("worker", vips_thread_main_loop, worker)) {
 		g_free(worker);
 		return -1;
 	}


### PR DESCRIPTION
It's in the headers already, just not in the library binary. I'd like to use it in vipsdisp for background workers.

Does this have any consequences? I think it's pretty safe, and these functions are already documented.