### PR TITLE
Guard against `NULL`-blobs during `*_add_custom_icc`

### DIFF
--- a/libvips/foreign/heifsave.c
+++ b/libvips/foreign/heifsave.c
@@ -232,8 +232,11 @@ vips_foreign_save_heif_add_custom_icc(VipsForeignSaveHeif *heif, const char *pro
 		size_t length;
 		const void *data = vips_blob_get(blob, &length);
 
-		if (vips_foreign_save_heif_add_icc(heif, data, length))
+		if (vips_foreign_save_heif_add_icc(heif, data, length)) {
+			vips_area_unref((VipsArea *) blob);
 			return -1;
+		}
+		vips_area_unref((VipsArea *) blob);
 	}
 
 	return 0;

--- a/libvips/foreign/heifsave.c
+++ b/libvips/foreign/heifsave.c
@@ -224,15 +224,17 @@ static int
 vips_foreign_save_heif_add_custom_icc(VipsForeignSaveHeif *heif, const char *profile)
 {
 	VipsBlob *blob;
-	size_t length;
 
 	if (vips_profile_load(profile, &blob, NULL))
 		return -1;
 
-	const void *data = vips_blob_get(blob, &length);
+	if (blob) {
+		size_t length;
+		const void *data = vips_blob_get(blob, &length);
 
-	if (vips_foreign_save_heif_add_icc(heif, data, length))
-		return -1;
+		if (vips_foreign_save_heif_add_icc(heif, data, length))
+			return -1;
+	}
 
 	return 0;
 }

--- a/libvips/foreign/heifsave.c
+++ b/libvips/foreign/heifsave.c
@@ -202,7 +202,8 @@ vips_foreign_save_heif_write_metadata(VipsForeignSaveHeif *heif)
 
 #ifdef HAVE_HEIF_COLOR_PROFILE
 static int
-vips_foreign_save_heif_add_icc(VipsForeignSaveHeif *heif, const void *profile, size_t length)
+vips_foreign_save_heif_add_icc(VipsForeignSaveHeif *heif,
+	const void *profile, size_t length)
 {
 #ifdef DEBUG
 	printf("attaching profile ..\n");

--- a/libvips/foreign/heifsave.c
+++ b/libvips/foreign/heifsave.c
@@ -221,7 +221,8 @@ vips_foreign_save_heif_add_icc(VipsForeignSaveHeif *heif, const void *profile, s
 }
 
 static int
-vips_foreign_save_heif_add_custom_icc(VipsForeignSaveHeif *heif, const char *profile)
+vips_foreign_save_heif_add_custom_icc(VipsForeignSaveHeif *heif,
+	const char *profile)
 {
 	VipsBlob *blob;
 
@@ -236,6 +237,7 @@ vips_foreign_save_heif_add_custom_icc(VipsForeignSaveHeif *heif, const char *pro
 			vips_area_unref((VipsArea *) blob);
 			return -1;
 		}
+
 		vips_area_unref((VipsArea *) blob);
 	}
 

--- a/libvips/foreign/spngsave.c
+++ b/libvips/foreign/spngsave.c
@@ -186,6 +186,7 @@ vips_foreign_save_spng_profile(VipsForeignSaveSpng *spng, VipsImage *in)
 
 		if (vips_profile_load(save->profile, &blob, NULL))
 			return -1;
+
 		if (blob) {
 			size_t length;
 			const void *data = vips_blob_get(blob, &length);

--- a/libvips/foreign/vipspng.c
+++ b/libvips/foreign/vipspng.c
@@ -1036,15 +1036,17 @@ static int
 vips_png_add_custom_icc(Write *write, const char *profile)
 {
 	VipsBlob *blob;
-	size_t length;
 
 	if (vips_profile_load(profile, &blob, NULL))
 		return -1;
 
-	const void *data = vips_blob_get(blob, &length);
+	if (blob) {
+		size_t length;
+		const void *data = vips_blob_get(blob, &length);
 
-	vips_png_add_icc(write, data, length);
-	vips_area_unref((VipsArea *) blob);
+		vips_png_add_icc(write, data, length);
+		vips_area_unref((VipsArea *) blob);
+	}
 
 	return 0;
 }

--- a/libvips/foreign/vipspng.c
+++ b/libvips/foreign/vipspng.c
@@ -1045,6 +1045,7 @@ vips_png_add_custom_icc(Write *write, const char *profile)
 		const void *data = vips_blob_get(blob, &length);
 
 		vips_png_add_icc(write, data, length);
+
 		vips_area_unref((VipsArea *) blob);
 	}
 

--- a/libvips/foreign/webpsave.c
+++ b/libvips/foreign/webpsave.c
@@ -459,7 +459,8 @@ vips_webp_get_webp_name(const char *vips_name)
 }
 
 static int
-vips_webp_add_icc(VipsForeignSaveWebp *webp, const void *profile, size_t length)
+vips_webp_add_icc(VipsForeignSaveWebp *webp,
+	const void *profile, size_t length)
 {
 	const char *webp_name = vips_webp_get_webp_name(VIPS_META_ICC_NAME);
 
@@ -476,7 +477,7 @@ vips_webp_add_custom_icc(VipsForeignSaveWebp *webp, const char *profile)
 
 	if (vips_profile_load(profile, &blob, NULL))
 		return -1;
-	
+
 	if (blob) {
 		size_t length;
 		const void *data = vips_blob_get(blob, &length);

--- a/libvips/foreign/webpsave.c
+++ b/libvips/foreign/webpsave.c
@@ -473,18 +473,20 @@ static int
 vips_webp_add_custom_icc(VipsForeignSaveWebp *webp, const char *profile)
 {
 	VipsBlob *blob;
-	size_t length;
 
 	if (vips_profile_load(profile, &blob, NULL))
 		return -1;
+	
+	if (blob) {
+		size_t length;
+		const void *data = vips_blob_get(blob, &length);
 
-	const void *data = vips_blob_get(blob, &length);
-
-	if (vips_webp_add_icc(webp, data, length)) {
+		if (vips_webp_add_icc(webp, data, length)) {
+			vips_area_unref((VipsArea *) blob);
+			return -1;
+		}
 		vips_area_unref((VipsArea *) blob);
-		return -1;
 	}
-	vips_area_unref((VipsArea *) blob);
 
 	return 0;
 }

--- a/libvips/foreign/webpsave.c
+++ b/libvips/foreign/webpsave.c
@@ -485,6 +485,7 @@ vips_webp_add_custom_icc(VipsForeignSaveWebp *webp, const char *profile)
 			vips_area_unref((VipsArea *) blob);
 			return -1;
 		}
+
 		vips_area_unref((VipsArea *) blob);
 	}
 


### PR DESCRIPTION
Test cases:
```console
$ vips copy x.jpg x.webp[profile=none]
Segmentation fault (core dumped)
$ vips copy x.jpg x.png[profile=none]
Segmentation fault (core dumped)
$ VIPS_LEAK=1 vips copy x.jpg x.avif[profile=libvips/colour/profiles/sRGB.icm]
vips_threadset_free: peak of 15 threads
1 VipsArea alive
	0x7f6648001260 count = 1, bytes = 480
memory: high-water mark 25.69 MB
```

Regressed since commit 32ddfe702de0617eaaf390ac240e1caf40ba7217. This bug did not affect any released versions.