### PR TITLE
check return of profile_load more carefully

### DIFF
--- a/libvips/foreign/heifsave.c
+++ b/libvips/foreign/heifsave.c
@@ -221,18 +221,25 @@ vips_foreign_save_heif_add_icc(VipsForeignSaveHeif *heif, const void *profile, s
 }
 
 static int
-vips_foreign_save_heif_add_custom_icc(VipsForeignSaveHeif *heif, const char *profile)
+vips_foreign_save_heif_add_custom_icc(VipsForeignSaveHeif *heif,
+									  const char *profile)
 {
 	VipsBlob *blob;
-	size_t length;
 
 	if (vips_profile_load(profile, &blob, NULL))
 		return -1;
 
-	const void *data = vips_blob_get(blob, &length);
+	if (blob) {
+		size_t length;
+		const void *data = vips_blob_get(blob, &length);
 
-	if (vips_foreign_save_heif_add_icc(heif, data, length))
-		return -1;
+		if (vips_foreign_save_heif_add_icc(heif, data, length)) {
+			vips_area_unref((VipsArea *) blob);
+			return -1;
+		}
+
+		vips_area_unref((VipsArea *) blob);
+	}
 
 	return 0;
 }

--- a/libvips/foreign/spngsave.c
+++ b/libvips/foreign/spngsave.c
@@ -186,6 +186,7 @@ vips_foreign_save_spng_profile(VipsForeignSaveSpng *spng, VipsImage *in)
 
 		if (vips_profile_load(save->profile, &blob, NULL))
 			return -1;
+
 		if (blob) {
 			size_t length;
 			const void *data = vips_blob_get(blob, &length);

--- a/libvips/foreign/vipspng.c
+++ b/libvips/foreign/vipspng.c
@@ -1036,15 +1036,18 @@ static int
 vips_png_add_custom_icc(Write *write, const char *profile)
 {
 	VipsBlob *blob;
-	size_t length;
 
 	if (vips_profile_load(profile, &blob, NULL))
 		return -1;
 
-	const void *data = vips_blob_get(blob, &length);
+	if (blob) {
+		size_t length;
+		const void *data = vips_blob_get(blob, &length);
 
-	vips_png_add_icc(write, data, length);
-	vips_area_unref((VipsArea *) blob);
+		vips_png_add_icc(write, data, length);
+
+		vips_area_unref((VipsArea *) blob);
+	}
 
 	return 0;
 }

--- a/libvips/foreign/webpsave.c
+++ b/libvips/foreign/webpsave.c
@@ -473,18 +473,21 @@ static int
 vips_webp_add_custom_icc(VipsForeignSaveWebp *webp, const char *profile)
 {
 	VipsBlob *blob;
-	size_t length;
 
 	if (vips_profile_load(profile, &blob, NULL))
 		return -1;
 
-	const void *data = vips_blob_get(blob, &length);
+	if (blob) {
+		size_t length;
+		const void *data = vips_blob_get(blob, &length);
 
-	if (vips_webp_add_icc(webp, data, length)) {
+		if (vips_webp_add_icc(webp, data, length)) {
+			vips_area_unref((VipsArea *) blob);
+			return -1;
+		}
+
 		vips_area_unref((VipsArea *) blob);
-		return -1;
 	}
-	vips_area_unref((VipsArea *) blob);
 
 	return 0;
 }


### PR DESCRIPTION
profile_load could succeed but also set the blob to NULL if the profile name was "none". Not all savers handled this correctly.

eg. before this PR:

```
$ vips thumbnail k2.jpg x.webp[profile=none] 1024
Segmentation fault (core dumped)
```

This only affects 8.15 (8.14 was OK here).