### PR TITLE
Improve JPEG XL support

### DIFF
--- a/libvips/foreign/jxlsave.c
+++ b/libvips/foreign/jxlsave.c
@@ -85,6 +85,17 @@ typedef struct _VipsForeignSaveJxl {
 	gboolean lossless;
 	int Q;
 
+	/* Animated jxl options.
+	 */
+	int gif_delay;
+	int *delay;
+	int delay_length;
+
+	/* The image we save. This is a copy of save->ready since we need to
+	 * be able to update the metadata.
+	 */
+	VipsImage *image;
+
 	/* Base image properties.
 	 */
 	JxlBasicInfo info;
@@ -95,6 +106,20 @@ typedef struct _VipsForeignSaveJxl {
 	 */
 	void *runner;
 	JxlEncoder *encoder;
+
+	/* The current y position in the frame, page height,
+	 * total number of pages, and the current page index.
+	 */
+	int write_y;
+	int page_height;
+	int page_count;
+	int page_number;
+
+	/* VipsRegion is not always contiguous, but we need contiguous RGB(A)
+	 * for libjxl. We need to copy each frame to a local buffer.
+	 */
+	VipsPel *frame_bytes;
+	size_t frame_size;
 
 	/* Write buffer.
 	 */
@@ -126,6 +151,8 @@ vips_foreign_save_jxl_dispose(GObject *gobject)
 
 	VIPS_FREEF(JxlThreadParallelRunnerDestroy, jxl->runner);
 	VIPS_FREEF(JxlEncoderDestroy, jxl->encoder);
+	VIPS_FREE(jxl->frame_bytes);
+
 	VIPS_UNREF(jxl->target);
 
 	G_OBJECT_CLASS(vips_foreign_save_jxl_parent_class)->dispose(gobject);
@@ -234,6 +261,128 @@ vips_foreign_save_jxl_print_status(JxlEncoderStatus status)
 #endif /*DEBUG*/
 
 static int
+vips_foreign_save_jxl_process_output(VipsForeignSaveJxl *jxl)
+{
+	JxlEncoderStatus status;
+	uint8_t *out;
+	size_t avail_out;
+
+	do {
+		out = jxl->output_buffer;
+		avail_out = OUTPUT_BUFFER_SIZE;
+		status = JxlEncoderProcessOutput(jxl->encoder,
+			&out, &avail_out);
+		switch (status) {
+		case JXL_ENC_SUCCESS:
+		case JXL_ENC_NEED_MORE_OUTPUT:
+			if (OUTPUT_BUFFER_SIZE > avail_out &&
+				vips_target_write(jxl->target,
+					jxl->output_buffer,
+					OUTPUT_BUFFER_SIZE - avail_out))
+				return -1;
+			break;
+
+		default:
+			vips_foreign_save_jxl_error(jxl,
+				"JxlEncoderProcessOutput");
+#ifdef DEBUG
+			vips_foreign_save_jxl_print_status(status);
+#endif /*DEBUG*/
+			return -1;
+		}
+	} while (status != JXL_ENC_SUCCESS);
+
+	return 0;
+}
+
+static int
+vips_foreign_save_jxl_add_frame(VipsForeignSaveJxl *jxl)
+{
+#ifdef HAVE_LIBJXL_0_7
+	JxlEncoderFrameSettings *frame_settings;
+#else
+	JxlEncoderOptions *frame_settings;
+#endif
+
+#ifdef HAVE_LIBJXL_0_7
+	frame_settings = JxlEncoderFrameSettingsCreate(jxl->encoder, NULL);
+	JxlEncoderFrameSettingsSetOption(frame_settings,
+		JXL_ENC_FRAME_SETTING_DECODING_SPEED, jxl->tier);
+	JxlEncoderSetFrameDistance(frame_settings, jxl->distance);
+	JxlEncoderFrameSettingsSetOption(frame_settings,
+		JXL_ENC_FRAME_SETTING_EFFORT, jxl->effort);
+	JxlEncoderSetFrameLossless(frame_settings, jxl->lossless);
+
+	if (jxl->info.have_animation) {
+		JxlFrameHeader header;
+		memset(&header, 0, sizeof(JxlFrameHeader));
+
+		if (jxl->delay && jxl->page_number < jxl->delay_length)
+			header.duration = jxl->delay[jxl->page_number];
+		else
+			header.duration = jxl->gif_delay * 10;
+
+		JxlEncoderSetFrameHeader(frame_settings, &header);
+	}
+#else
+	frame_settings = JxlEncoderOptionsCreate(jxl->encoder, NULL);
+	JxlEncoderOptionsSetDecodingSpeed(frame_settings, jxl->tier);
+	JxlEncoderOptionsSetDistance(frame_settings, jxl->distance);
+	JxlEncoderOptionsSetEffort(frame_settings, jxl->effort);
+	JxlEncoderOptionsSetLossless(frame_settings, jxl->lossless);
+#endif
+
+	if (JxlEncoderAddImageFrame(frame_settings, &jxl->format,
+			jxl->frame_bytes, jxl->frame_size)) {
+		vips_foreign_save_jxl_error(jxl, "JxlEncoderAddImageFrame");
+		return -1;
+	}
+
+	jxl->page_number += 1;
+
+	/* We should close frames before processing the output
+	 * if we have written the last frame
+	 */
+	if (jxl->page_number == jxl->page_count)
+		JxlEncoderCloseFrames(jxl->encoder);
+
+	return vips_foreign_save_jxl_process_output(jxl);
+}
+
+/* Another chunk of pixels have arrived from the pipeline. Add to frame, and
+ * if the frame completes, compress and write to the target.
+ */
+static int
+vips_foreign_save_jxl_sink_disc(VipsRegion *region, VipsRect *area, void *a)
+{
+	VipsForeignSaveJxl *jxl = (VipsForeignSaveJxl *) a;
+	size_t sz = VIPS_IMAGE_SIZEOF_PEL(region->im) * area->width;
+
+	int i;
+
+	/* Write the new pixels into the frame.
+	 */
+	for (i = 0; i < area->height; i++) {
+		memcpy(jxl->frame_bytes + sz * jxl->write_y,
+			VIPS_REGION_ADDR(region, 0, area->top + i),
+			sz);
+
+		jxl->write_y += 1;
+
+		/* If we've filled the frame, add it to the encoder.
+		 */
+		if (jxl->write_y == jxl->page_height) {
+			if (vips_foreign_save_jxl_add_frame(jxl))
+				return -1;
+
+			jxl->write_y = 0;
+		}
+	}
+
+	return 0;
+}
+
+static int
 vips_foreign_save_jxl_add_metadata(VipsForeignSaveJxl *jxl, VipsImage *in)
 {
 #ifdef HAVE_LIBJXL_0_7
@@ -312,17 +461,22 @@ vips_foreign_save_jxl_build(VipsObject *object)
 	VipsForeignSaveJxl *jxl = (VipsForeignSaveJxl *) object;
 	VipsImage **t = (VipsImage **) vips_object_local_array(object, 5);
 
-#ifdef HAVE_LIBJXL_0_7
-	JxlEncoderFrameSettings *frame_settings;
-#else
-	JxlEncoderOptions *frame_settings;
-#endif
-	JxlEncoderStatus status;
 	VipsImage *in;
 	VipsBandFormat format;
+	int i;
 
 	if (VIPS_OBJECT_CLASS(vips_foreign_save_jxl_parent_class)->build(object))
 		return -1;
+
+#ifdef HAVE_LIBJXL_0_7
+	jxl->page_height = vips_image_get_page_height(save->ready);
+#else
+	/* libjxl prior to 0.7 doesn't seem to have API for saving animations
+	 */
+	jxl->page_height = save->ready->Ysize;
+#endif /*HAVE_LIBJXL_0_7*/
+
+	jxl->page_count = save->ready->Ysize / jxl->page_height;
 
 	/* If Q is set and distance is not, use Q to set a rough distance
 	 * value. Formula stolen from cjxl.c and very roughly approximates
@@ -411,10 +565,25 @@ vips_foreign_save_jxl_build(VipsObject *object)
 		in->Bands - jxl->info.num_color_channels);
 
 	jxl->info.xsize = in->Xsize;
-	jxl->info.ysize = in->Ysize;
+	jxl->info.ysize = jxl->page_height;
 	jxl->format.num_channels = in->Bands;
 	jxl->format.endianness = JXL_NATIVE_ENDIAN;
 	jxl->format.align = 0;
+
+#ifdef HAVE_LIBJXL_0_7
+	if (jxl->page_count > 1) {
+		int num_loops = 0;
+
+		if (vips_image_get_typeof(in, "loop"))
+			vips_image_get_int(in, "loop", &num_loops);
+
+		jxl->info.have_animation = TRUE;
+		jxl->info.animation.tps_numerator = 1000;
+		jxl->info.animation.tps_denominator = 1;
+		jxl->info.animation.num_loops = num_loops;
+		jxl->info.animation.have_timecodes = FALSE;
+	}
+#endif /*HAVE_LIBJXL_0_7*/
 
 	if (vips_image_hasalpha(in)) {
 		jxl->info.alpha_bits = jxl->info.bits_per_sample;
@@ -496,27 +665,39 @@ vips_foreign_save_jxl_build(VipsObject *object)
 	if (vips_foreign_save_jxl_add_metadata(jxl, in))
 		return -1;
 
-	/* Render the entire image in memory. libjxl seems to be missing
-	 * tile-based write at the moment.
-	 */
-	if (vips_image_wio_input(in))
+	if (vips_foreign_save_jxl_process_output(jxl))
 		return -1;
 
-#ifdef HAVE_LIBJXL_0_7
-	frame_settings = JxlEncoderFrameSettingsCreate(jxl->encoder, NULL);
-	JxlEncoderFrameSettingsSetOption(frame_settings,
-		JXL_ENC_FRAME_SETTING_DECODING_SPEED, jxl->tier);
-	JxlEncoderSetFrameDistance(frame_settings, jxl->distance);
-	JxlEncoderFrameSettingsSetOption(frame_settings,
-		JXL_ENC_FRAME_SETTING_EFFORT, jxl->effort);
-	JxlEncoderSetFrameLossless(frame_settings, jxl->lossless);
-#else
-	frame_settings = JxlEncoderOptionsCreate(jxl->encoder, NULL);
-	JxlEncoderOptionsSetDecodingSpeed(frame_settings, jxl->tier);
-	JxlEncoderOptionsSetDistance(frame_settings, jxl->distance);
-	JxlEncoderOptionsSetEffort(frame_settings, jxl->effort);
-	JxlEncoderOptionsSetLossless(frame_settings, jxl->lossless);
-#endif
+	if (jxl->info.have_animation) {
+		/* Get delay array
+		 *
+		 * There might just be the old gif-delay field. This is centiseconds.
+		 */
+		jxl->gif_delay = 10;
+		if (vips_image_get_typeof(save->ready, "gif-delay") &&
+			vips_image_get_int(save->ready, "gif-delay",
+				&jxl->gif_delay))
+			return -1;
+
+		/* New images have an array of ints instead.
+		 */
+		jxl->delay = NULL;
+		if (vips_image_get_typeof(save->ready, "delay") &&
+			vips_image_get_array_int(save->ready, "delay",
+				&jxl->delay, &jxl->delay_length))
+			return -1;
+
+		/* Force frames with a small or no duration to 100ms
+		 * to be consistent with web browsers and other
+		 * transcoding tools.
+		 */
+		if (jxl->gif_delay <= 1)
+			jxl->gif_delay = 10;
+
+		for (i = 0; i < jxl->delay_length; i++)
+			if (jxl->delay[i] <= 10)
+				jxl->delay[i] = 100;
+	}
 
 #ifdef DEBUG
 	vips_foreign_save_jxl_print_info(&jxl->info);
@@ -528,44 +709,26 @@ vips_foreign_save_jxl_build(VipsObject *object)
 	printf("    lossless = %d\n", jxl->lossless);
 #endif /*DEBUG*/
 
-	if (JxlEncoderAddImageFrame(frame_settings, &jxl->format,
-			VIPS_IMAGE_ADDR(in, 0, 0),
-			VIPS_IMAGE_SIZEOF_IMAGE(in))) {
-		vips_foreign_save_jxl_error(jxl, "JxlEncoderAddImageFrame");
+	/* RGB(A) frame as a contiguous buffer.
+	 */
+	jxl->frame_size = VIPS_IMAGE_SIZEOF_LINE(in) * jxl->page_height;
+	jxl->frame_bytes = g_try_malloc(jxl->frame_size);
+	if (jxl->frame_bytes == NULL) {
+		vips_error("jxlsave",
+			_("failed to allocate %zu bytes"), jxl->frame_size);
 		return -1;
 	}
+
+	if (vips_sink_disc(in, vips_foreign_save_jxl_sink_disc, jxl))
+		return -1;
 
 	/* This function must be called after the final frame and/or box,
 	 * otherwise the codestream will not be encoded correctly.
 	 */
 	JxlEncoderCloseInput(jxl->encoder);
 
-	do {
-		uint8_t *out;
-		size_t avail_out;
-
-		out = jxl->output_buffer;
-		avail_out = OUTPUT_BUFFER_SIZE;
-		status = JxlEncoderProcessOutput(jxl->encoder,
-			&out, &avail_out);
-		switch (status) {
-		case JXL_ENC_SUCCESS:
-		case JXL_ENC_NEED_MORE_OUTPUT:
-			if (vips_target_write(jxl->target,
-					jxl->output_buffer,
-					OUTPUT_BUFFER_SIZE - avail_out))
-				return -1;
-			break;
-
-		default:
-			vips_foreign_save_jxl_error(jxl,
-				"JxlEncoderProcessOutput");
-#ifdef DEBUG
-			vips_foreign_save_jxl_print_status(status);
-#endif /*DEBUG*/
-			return -1;
-		}
-	} while (status != JXL_ENC_SUCCESS);
+	if (vips_foreign_save_jxl_process_output(jxl))
+		return -1;
 
 	if (vips_target_end(jxl->target))
 		return -1;

--- a/libvips/foreign/jxlsave.c
+++ b/libvips/foreign/jxlsave.c
@@ -797,7 +797,7 @@ vips_foreign_save_jxl_class_init(VipsForeignSaveJxlClass *class)
 		_("Encoding effort"),
 		VIPS_ARGUMENT_OPTIONAL_INPUT,
 		G_STRUCT_OFFSET(VipsForeignSaveJxl, effort),
-		3, 9, 7);
+		1, 9, 7);
 
 	VIPS_ARG_BOOL(class, "lossless", 13,
 		_("Lossless"),


### PR DESCRIPTION
Hey there 👋

Apple added JPEG XL support to macOS, iOS, and Safari, and lots of people want to try it. Unfortunately, JPEG XL support in libvips is pretty limited right now, and this PR fixes this.

## jxlload, jxlsave: support EXIF and XMP metadata

JPEG XL has two file formats:

1. A "naked" codestream that contains only image/animation data without any additional metadata.
2. An ISOBMFF-based container that may contain additional metadata like EXIF and XMP.

Currently, `jxlload` doesn't extract EXIF/XMP from the container format, and `jxlsave` doesn't save files JXL in the container format. This PR adds extracting EXIF/XMP from ISOBMFF boxes and saving it to ISOBMFF boxes.

## jxlload: close input on EOF instead of throwing an error

Currently, `jxlload` fails when meets the end of input. But in some cases, libjxl tries to read while the input is opened. So instead of returning an error on the end of input libvips should close the input.

## jxlload: add animation support

Unfortunately, JPEG XL header doesn't have contain frames count so we have to subscribe to `JXL_DEC_FRAME` and count frames ourselves. Luckily, libjxl doesn't decode frames unless we subscribe to `JXL_DEC_FULL_IMAGE`.

The sequential decoding of frames is done in `webpload` manner: we decode a frame to a separate image when we reach it and read it line-by-line in `vips_image_generate`.

## jxlsave: add animation support

This is done in a `webpsave` manner: we write image data in a memory buffer during `vips_sink_disc` and as soon as we've written a full frame, we add it to libjxl. Also, we process output after each frame to save memory.

## jxlsave: lower min effort value to 1

The valid range for `effort` in libjxl is 1-9 but libvips currently allows a range of 3-9, not sure why 