### PR TITLE
OSS-Fuzz: adapt sed replacement for libheif

### DIFF
--- a/fuzz/oss_fuzz_build.sh
+++ b/fuzz/oss_fuzz_build.sh
@@ -66,7 +66,7 @@ popd
 # libheif
 pushd $SRC/libheif
 # Ensure libvips finds heif_image_handle_get_raw_color_profile
-sed -i '/^Libs.private:/s/-lstdc++/-lc++/' libheif.pc.in
+sed -i '/^Libs.private:/s/$/ -lc++/' libheif.pc.in
 cmake \
   -DCMAKE_BUILD_TYPE=RelWithDebInfo \
   -DCMAKE_INSTALL_PREFIX=$WORK \


### PR DESCRIPTION
libheif removed `-lstdc++` from their pkg-config file with commit: https://github.com/strukturag/libheif/commit/27097a655d5e36bd57361207910cb6ba883256bc

---

See build logs at https://oss-fuzz-build-logs.storage.googleapis.com/index.html#libvips for why this is necessary.
```diff
--- a/oss-fuzz-log-10-10-2023.txt
+++ b/oss-fuzz-log-10-11-2023.txt
@@ -15649,8 +15643,8 @@ Step #21 - "compile-libfuzzer-address-x86_64": Run-time dependency libhwy
 Step #21 - "compile-libfuzzer-address-x86_64": WARNING: Static library 'pdfium' not found for dependency 'pdfium', may not be statically linked
 Step #21 - "compile-libfuzzer-address-x86_64": Run-time dependency pdfium found: YES 4901
 Step #21 - "compile-libfuzzer-address-x86_64": Run-time dependency libheif found: YES 1.16.2
-Step #21 - "compile-libfuzzer-address-x86_64": Checking for function "heif_image_handle_get_raw_color_profile" with dependency libheif: YES 
-Step #21 - "compile-libfuzzer-address-x86_64": Checking for function "heif_context_set_maximum_image_size_limit" with dependency libheif: YES 
+Step #21 - "compile-libfuzzer-address-x86_64": Checking for function "heif_image_handle_get_raw_color_profile" with dependency libheif: NO 
+Step #21 - "compile-libfuzzer-address-x86_64": Checking for function "heif_context_set_maximum_image_size_limit" with dependency libheif: NO 
 Step #21 - "compile-libfuzzer-address-x86_64": Checking whether type "struct heif_decoding_options" has member "convert_hdr_to_8bit" with dependency libheif: YES 
 Step #21 - "compile-libfuzzer-address-x86_64": Run-time dependency libjxl found: NO (tried pkgconfig and cmake)
 Step #21 - "compile-libfuzzer-address-x86_64": Run-time dependency libjxl_threads found: NO (tried pkgconfig and cmake)
```