### PR TITLE
Ensure libheif symbols are found when built statically

### DIFF
--- a/fuzz/oss_fuzz_build.sh
+++ b/fuzz/oss_fuzz_build.sh
@@ -65,8 +65,6 @@ popd
 
 # libheif
 pushd $SRC/libheif
-# Ensure libvips finds heif_image_handle_get_raw_color_profile
-sed -i '/^Libs.private:/s/$/ -lc++/' libheif.pc.in
 cmake \
   -DCMAKE_BUILD_TYPE=RelWithDebInfo \
   -DCMAKE_INSTALL_PREFIX=$WORK \

--- a/meson.build
+++ b/meson.build
@@ -485,14 +485,14 @@ if libheif_dep.found()
     endif
     cfg_var.set('HAVE_HEIF', '1')
     # added in 1.6.0
-    if cc.has_function('heif_image_handle_get_raw_color_profile', prefix: '#include <libheif/heif.h>', dependencies: libheif_dep)
+    if cpp.has_function('heif_image_handle_get_raw_color_profile', prefix: '#include <libheif/heif.h>', dependencies: libheif_dep)
         cfg_var.set('HAVE_HEIF_COLOR_PROFILE', '1')
     endif
-    if cc.has_function('heif_context_set_maximum_image_size_limit', prefix: '#include <libheif/heif.h>', dependencies: libheif_dep)
+    if cpp.has_function('heif_context_set_maximum_image_size_limit', prefix: '#include <libheif/heif.h>', dependencies: libheif_dep)
         cfg_var.set('HAVE_HEIF_SET_MAX_IMAGE_SIZE_LIMIT', '1')
     endif
     # added in 1.7.0
-    if cc.has_member('struct heif_decoding_options', 'convert_hdr_to_8bit', prefix: '#include <libheif/heif.h>', dependencies: libheif_dep)
+    if cpp.has_member('struct heif_decoding_options', 'convert_hdr_to_8bit', prefix: '#include <libheif/heif.h>', dependencies: libheif_dep)
         cfg_var.set('HAVE_HEIF_DECODING_OPTIONS_CONVERT_HDR_TO_8BIT', '1')
     endif
     # heif_main_brand added in 1.4.0, but heif_avif appeared in 1.7 ... just check


### PR DESCRIPTION
libheif is a C++ library that exposes a C API. When it's built statically, the linker must also link with the C++ stdlib, which is done automatically when using a C++ compiler.

Prior to commit strukturag/libheif@27097a6, libheif included libstdc++ in the `Libs.private` field of their .pc file. This meant it was exposed in the case of static linking, enabling a build system for a C application to link against libstdc++ as needed. However, this was not portable as libstdc++ is specific to the GNU toolchain, when using Clang, you can optionally use libc++.

This PR aims to find symbols in libheif using a C++ compiler, ensuring that Meson can confirm their availability at link-time, even when libheif is statically built.