### PR TITLE
heifsave: errors must have a message in libheif 1.17.0+

### DIFF
--- a/libvips/foreign/heifsave.c
+++ b/libvips/foreign/heifsave.c
@@ -465,10 +465,16 @@ vips_foreign_save_heif_write(struct heif_context *ctx,
 
 	struct heif_error error;
 
+#ifdef HAVE_HEIF_ERROR_SUCCESS
+	error = heif_error_success;
+#else
 	error.code = heif_error_Ok;
+#endif /*HAVE_HEIF_ERROR_SUCCESS*/
+
 	if (vips_target_write(heif->target, data, length)) {
 		error.code = heif_error_Encoding_error;
 		error.subcode = heif_suberror_Cannot_write_output_data;
+		error.message = "Cannot write output data";
 	}
 
 	return error;

--- a/meson.build
+++ b/meson.build
@@ -505,6 +505,10 @@ if libheif_dep.found()
     if libheif_dep.version().version_compare('>=1.13.0')
         cfg_var.set('HAVE_HEIF_INIT', '1')
     endif
+    # heif_error_success added in 1.17.0
+    if libheif_dep.version().version_compare('>=1.17.0')
+        cfg_var.set('HAVE_HEIF_ERROR_SUCCESS', '1')
+    endif
 endif
 
 libjxl_dep = dependency('libjxl', version: '>=0.6', required: get_option('jpeg-xl'))


### PR DESCRIPTION
Discovered whilst testing https://github.com/libvips/libvips/issues/3718, targets the 8.15 branch.

As of commit https://github.com/strukturag/libheif/commit/c95ed71a67003a49ddfe2e1bf810bfc96e61d333 libheif requires errors, including _"Ceci n'est pas une erreur"_, to have a message.

As of commit https://github.com/strukturag/libheif/commit/bea5f4b47def81a669f1bc0c1415f02a8b9f595b libheif provides a new `heif_error_success` API as the canonical way to represent _"Ceci n'est pas une erreur"_.