### PR TITLE
dzsave: fix a couple of minor bugs

### DIFF
--- a/libvips/foreign/dzsave.c
+++ b/libvips/foreign/dzsave.c
@@ -1147,7 +1147,6 @@ tile_name(Level *level, int x, int y)
 {
 	VipsForeignSaveDz *dz = level->dz;
 	VipsForeignSave *save = (VipsForeignSave *) dz;
-	const char *suffix = iszip(dz->container) ? dz->file_suffix : dz->suffix;
 
 	char *out;
 	char *dirname;
@@ -1159,7 +1158,7 @@ tile_name(Level *level, int x, int y)
 	switch (dz->layout) {
 	case VIPS_FOREIGN_DZ_LAYOUT_DZ:
 		vips_snprintf(subdir, VIPS_PATH_MAX, "%d", level->n);
-		vips_snprintf(name, VIPS_PATH_MAX, "%d_%d%s", x, y, suffix);
+		vips_snprintf(name, VIPS_PATH_MAX, "%d_%d%s", x, y, dz->file_suffix);
 
 		break;
 
@@ -1182,7 +1181,7 @@ tile_name(Level *level, int x, int y)
 
 		vips_snprintf(subdir, VIPS_PATH_MAX, "TileGroup%d", n / 256);
 		vips_snprintf(name, VIPS_PATH_MAX,
-			"%d-%d-%d%s", level->n, x, y, suffix);
+			"%d-%d-%d%s", level->n, x, y, dz->file_suffix);
 
 		/* Used at the end in ImageProperties.xml
 		 */
@@ -1194,7 +1193,7 @@ tile_name(Level *level, int x, int y)
 		vips_snprintf(subdir, VIPS_PATH_MAX,
 			"%d" G_DIR_SEPARATOR_S "%d", level->n, y);
 		vips_snprintf(name, VIPS_PATH_MAX,
-			"%d%s", x, suffix);
+			"%d%s", x, dz->file_suffix);
 
 		break;
 
@@ -1245,7 +1244,7 @@ tile_name(Level *level, int x, int y)
 				rotation);
 		}
 
-		vips_snprintf(name, VIPS_PATH_MAX, "default%s", suffix);
+		vips_snprintf(name, VIPS_PATH_MAX, "default%s", dz->file_suffix);
 	}
 
 	break;

--- a/libvips/foreign/dzsave.c
+++ b/libvips/foreign/dzsave.c
@@ -1280,7 +1280,7 @@ static gboolean
 region_tile_equal(VipsRegion *region, VipsRect *rect,
 	int threshold, VipsPel *restrict ink)
 {
-	int bytes = VIPS_REGION_SIZEOF_LINE(region);
+	int bytes = VIPS_REGION_SIZEOF_PEL(region);
 
 	int x, y, b;
 

--- a/libvips/foreign/dzsave.c
+++ b/libvips/foreign/dzsave.c
@@ -2131,7 +2131,7 @@ vips_foreign_save_dz_build(VipsObject *object)
 			? dz->filename
 			: vips_connection_filename(VIPS_CONNECTION(dz->target));
 
-		if (!vips_object_argument_isset(object, "imagename") ||
+		if (!vips_object_argument_isset(object, "imagename") &&
 			!vips_object_argument_isset(object, "basename")) {
 			if (filename) {
 				dz->imagename = g_path_get_basename(filename);

--- a/libvips/foreign/dzsave.c
+++ b/libvips/foreign/dzsave.c
@@ -2202,22 +2202,15 @@ vips_foreign_save_dz_build(VipsObject *object)
 				return -1;
 		}
 
-		char *path;
-
 		// SZI needs an enclosing folder named after the image, according to
 		// the spec
-		if (dz->container == VIPS_FOREIGN_DZ_CONTAINER_SZI)
-			path = g_build_filename(dz->dirname, dz->imagename, NULL);
-		else
-			path = g_strdup(dz->dirname);
+		char *path = dz->container == VIPS_FOREIGN_DZ_CONTAINER_SZI
+			? dz->imagename
+			: "";
 
 		if (!(dz->archive = vips__archive_new_to_target(dz->target,
-				  path, dz->compression))) {
-			g_free(path);
+				  path, dz->compression)))
 			return -1;
-		}
-
-		g_free(path);
 	}
 	else {
 		if (!(dz->archive = vips__archive_new_to_dir(dz->dirname)))

--- a/test/test-suite/test_foreign.py
+++ b/test/test-suite/test_foreign.py
@@ -1310,8 +1310,7 @@ class TestForeign:
         with open(filename, 'rb') as f:
             buf1 = f.read()
         buf2 = self.colour.dzsave_buffer(basename=root)
-        # won't be identical since tiles can be in a different order
-        assert abs(len(buf1) - len(buf2)) < 5000
+        assert len(buf1) == len(buf2)
 
         # we can't test the bytes are exactly equal -- the timestamp in
         # vips-properties.xml will be different


### PR DESCRIPTION
See for context #3718, targets the 8.15 branch.

<details>
  <summary>Test cases</summary>

Commit a3d88a326d83192bcfbcecb7881e95e922944ce3:
```bash
$ vips black x.png 1000 1000
$ vips dzsave x.png x.dzi --suffix=".jpeg[Q=100]"

# Before
$ ls x.dzi_files/0/
'0_0.jpeg[Q=100]'

# After
$ ls x.dzi_files/0/
0_0.jpeg
```

Commit 94e80e1cd27ad71a4fc490eb896c5eaf30bead6f:
```bash
$ vips black x.png 1000 1000
$ vips dzsave x.png x.dzi --imagename hello

# Before
$ [ -e "hello_files/0/0_0.jpeg" ] && echo "OK" || echo "FAIL"
FAIL

# After
$ [ -e "hello_files/0/0_0.jpeg" ] && echo "OK" || echo "FAIL"
OK
```

Commit bdeda2bcbd01c9a88c3dae51bff6ab78b0974b5f:
```bash
$ vips black x.v 1000 1000
$ vips embed x.v x.png 1000 1000 2000 2000 --extend white
$ vips dzsave x.png x.dzi --skip-blanks 0

# Before
$ [ -e "x.dzi_files/11/0_0.jpeg" ] && echo "FAIL" || echo "OK"
FAIL

# After
$ [ -e "x.dzi_files/11/0_0.jpeg" ] && echo "FAIL" || echo "OK"
OK
```

Commit 9a02fb8a2a5939c0aff2e2f9501ba80d9772a73f:
```bash
$ vips black x.png 1000 1000
$ vips dzsave x.png $HOME/x.zip

# Before
$ zipinfo $HOME/x.zip | grep x.dzi
-rw-rw-r--  1.0 unx      206 bX stor 80-Jan-01 00:00 /home/kleisauke/x.dzi

# After
$ zipinfo $HOME/x.zip | grep x.dzi
-rw-rw-r--  1.0 unx      206 bX stor 80-Jan-01 00:00 x.dzi
```
</details>
