### PR TITLE
v8.15.0-rc2 release proposal

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,4 +1,4 @@
-18/10/23 8.15.0-rc1
+3/11/23 8.15.0-rc2
 
 - add support for target_clones attribute [lovell]
 	* use with (un)premultiply for ~10% perf gain on AVX CPUs


### PR DESCRIPTION
A test release for 8.15. This release candidate will likely be last or next-to-last before the formal 8.15.0 release.

Changes since -rc1:
https://github.com/libvips/libvips/compare/v8.15.0-rc1...66ee9f1
