### PR TITLE
composite: ensure compilation on i386

### DIFF
--- a/libvips/conversion/composite.cpp
+++ b/libvips/conversion/composite.cpp
@@ -864,7 +864,7 @@ vips_composite_base_blend3(VipsCompositeSequence *seq,
 			break;
 
 		case VIPS_BLEND_MODE_OVERLAY:
-			f = B <= 0.5
+			f = B <= 0.5f
 				? 2 * A * B
 				: 1 - 2 * (1 - A) * (1 - B);
 			break;
@@ -890,7 +890,7 @@ vips_composite_base_blend3(VipsCompositeSequence *seq,
 			break;
 
 		case VIPS_BLEND_MODE_HARD_LIGHT:
-			f = A <= 0.5
+			f = A <= 0.5f
 				? 2 * A * B
 				: 1 - 2 * (1 - A) * (1 - B);
 			break;


### PR DESCRIPTION
Curiously, this only seems to happen with `-std=c++11` (commit 5482ead701b29cbfd3eeab6e91603d972b3b8850 / c264c54b351c8faac8e6f2db42413226a8428e16), it compiles fine when that's omitted.

Resolves: #3749.

Targets the 8.15 branch.