### PR TITLE
v8.15.0 release proposal 

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,4 +1,4 @@
-3/11/23 8.15.0-rc2
+11/11/23 8.15.0
 
 - add support for target_clones attribute [lovell]
 	* use with (un)premultiply for ~10% perf gain on AVX CPUs


### PR DESCRIPTION
Release notes:

https://www.libvips.org/2023/10/10/What's-new-in-8.15.html

Changes for this release:

- add support for target_clones attribute [lovell]
	* use with (un)premultiply for ~10% perf gain on AVX CPUs
	* use with XYZ to LAB colourspace conversion for ~10% perf gain on AVX CPUs
- add fast path to extract_band and bandjoin for uchar images [lovell]
- reduce `vips_sharpen` max `sigma` to 10 [lovell]
- inline scRGB to XYZ colourspace conversion, ~2x faster [lovell]
- set "interlaced=1" for interlaced GIF images [kleisauke]
- add @line_art to find_trim [miltoncandelero]
- improve C++ binding [MathemanFlo]
	* add `inplace()` / `VImage::new_from_memory_copy()`
	* add overloads for `draw_*()` / `VImage::thumbnail_buffer()`
- allow negative line spacing in text [donghuikugou]
- add VIPS_META_BITS_PER_SAMPLE metadata, deprecate the
  "palette-bit-depth" and "heif-bitdepth" meta fields [MathemanFlo]
- add "revalidate" to foreign loaders [jcupitt]
- add `premultiplied` option to smartcrop [lovell]
- add "prewitt" and "scharr" edge detectors, "sobel" is more accurate for
  non-uchar formats [jcupitt]
- add support for forms in pdfium loader [kleisauke]
- swap built-in profiles with ICC v4 variants [kleisauke]
- remove libgsf dependency in favor of libarchive [kleisauke]
- better chunking for small shrinks [jcupitt]
- use alpha range of 0.0 - 1.0 for scRGB images [DarthSim]
- add support for 16-bit float TIFFs [DarthSim]
- add direct mode to dzsave [jcupitt]
- require C++11 as a minimum standard [kleisauke]
- add support for SIMD via Highway [kleisauke]
- threaded write in tiffsave for tiled JPEG and JPEG2000 [jcupitt]
- add vips_thread_execute() to the public API [jcupitt]
- add "keep" flag to foreign savers, deprecate "strip" [a3mar]
- improve scRGB handling [jcupitt]