### PR TITLE
heifsave: set `threads` to vips_concurrency_get()

### DIFF
--- a/libvips/foreign/heifsave.c
+++ b/libvips/foreign/heifsave.c
@@ -490,6 +490,7 @@ vips_foreign_save_heif_build(VipsObject *object)
 	struct heif_writer writer;
 	char *chroma;
 	const struct heif_encoder_descriptor *out_encoder;
+	const struct heif_encoder_parameter *const *param;
 
 	if (VIPS_OBJECT_CLASS(vips_foreign_save_heif_parent_class)->build(object))
 		return -1;
@@ -578,6 +579,31 @@ vips_foreign_save_heif_build(VipsObject *object)
 		error.subcode != heif_suberror_Unsupported_parameter) {
 		vips__heif_error(&error);
 		return -1;
+	}
+
+	for (param = heif_encoder_list_parameters(heif->encoder); *param; param++) {
+		int have_minimum;
+		int have_maximum;
+		int minimum;
+		int maximum;
+
+		if (strcmp(heif_encoder_parameter_get_name(*param), "threads") != 0)
+			continue;
+
+		error = heif_encoder_parameter_get_valid_integer_values(*param,
+			&have_minimum, &have_maximum, &minimum, &maximum, NULL, NULL);
+		if (error.code) {
+			vips__heif_error(&error);
+			return -1;
+		}
+
+		error = heif_encoder_set_parameter_integer(heif->encoder,
+			"threads", VIPS_CLIP(minimum, vips_concurrency_get(), maximum));
+		if (error.code &&
+			error.subcode != heif_suberror_Unsupported_parameter) {
+			vips__heif_error(&error);
+			return -1;
+		}
 	}
 
 	/* TODO .. support extra per-encoder params with


### PR DESCRIPTION
Hey there 👋

Some AVIF encoders in libheif support the `threads` parameter. Its default value is `4` by default but it's almost never optimal. This PR sets it to the `vips_concurrency_get()` since it is the level of parallelism a Vips user wants.

On my machine (Apple M1, 10 cores), this speeds up the conversion of a 7360x4912 JPEG to AVIF from 11s to 6s.