### PR TITLE
reduceh: fix HWY path on SSE2

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,7 @@
+TBD 8.15.1
+
+- reduceh: fix Highway path on SSE2 [DarthSim]
+
 11/11/23 8.15.0
 
 - add support for target_clones attribute [lovell]

--- a/libvips/resample/reduceh_hwy.cpp
+++ b/libvips/resample/reduceh_hwy.cpp
@@ -135,12 +135,12 @@ vips_reduceh_uchar_hwy(VipsPel *pout, VipsPel *pin,
 			auto source = LoadU(du8, p);
 			p += bands * 4;
 
-			auto pix = TableLookupBytes(source, shuf_lo);
+			auto pix = TableLookupBytesOr0(source, shuf_lo);
 
 			sum0 = ReorderWidenMulAccumulate(di32, pix, mmk_lo, sum0,
 				/* byref */ sum1);
 
-			pix = TableLookupBytes(source, shuf_hi);
+			pix = TableLookupBytesOr0(source, shuf_hi);
 
 			sum0 = ReorderWidenMulAccumulate(di32, pix, mmk_hi, sum0,
 				/* byref */ sum1);
@@ -153,7 +153,7 @@ vips_reduceh_uchar_hwy(VipsPel *pout, VipsPel *pin,
 			auto source = LoadU(du8, p);
 			p += bands * 2;
 
-			auto pix = TableLookupBytes(source, shuf_lo);
+			auto pix = TableLookupBytesOr0(source, shuf_lo);
 
 			sum0 = ReorderWidenMulAccumulate(di32, pix, mmk_lo, sum0,
 				/* byref */ sum1);


### PR DESCRIPTION
Hey there 👋

`TableLookupBytes` doesn't work on SSE2 targets. `TableLookupBytesOr0` is a wrapper over `TableLookupBytes`. On targets higher than SSE2, it just calls `TableLookupBytes`, so there's no speed loss. On SSE2, it adds some code for zeroing. https://github.com/google/highway/blob/1.0.7/hwy/ops/x86_128-inl.h#L1590-L1602

Fixes https://github.com/imgproxy/imgproxy/issues/1223