### PR TITLE
Sync vips__jpeg_region_write_target definitions

### DIFF
--- a/libvips/foreign/vips2jpeg.c
+++ b/libvips/foreign/vips2jpeg.c
@@ -1035,7 +1035,7 @@ vips__jpeg_region_write_target(VipsRegion *region, VipsRect *rect,
 	VipsTarget *target,
 	int Q, const char *profile,
 	gboolean optimize_coding, gboolean progressive,
-	gboolean strip, gboolean trellis_quant,
+	VipsForeignKeep keep, gboolean trellis_quant,
 	gboolean overshoot_deringing, gboolean optimize_scans,
 	int quant_table, VipsForeignSubsample subsample_mode,
 	int restart_interval)


### PR DESCRIPTION
Trivial fix, prevents a build failure in the off-chance jpeg was disabled.

aka with `-Djpeg=disabled`:
```
../vips-8.15.0/libvips/foreign/vips2jpeg.c:1034:1: error: conflicting types for ‘vips__jpeg_region_write_target’; have ‘int(VipsRegion *, VipsRect *, VipsTarget *, int,  const char *, gboolean,  gboolean,  gboolean,  gboolean,  gboolean,  gboolean,  int,  VipsForeignSubsample,  int)’ {aka ‘int(struct _VipsRegion *, struct _VipsRect *, struct _VipsTarget *, int,  const char *, int,  int,  int,  int,  int,  int,  int,  VipsForeignSubsample,  int)’}
 1034 | vips__jpeg_region_write_target(VipsRegion *region, VipsRect *rect,
      | ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
In file included from ../vips-8.15.0/libvips/foreign/vips2jpeg.c:151:
../vips-8.15.0/libvips/foreign/pforeign.h:148:5: note: previous declaration of ‘vips__jpeg_region_write_target’ with type ‘int(VipsRegion *, VipsRect *, VipsTarget *, int,  const char *, gboolean,  gboolean,  VipsForeignKeep,  gboolean,  gboolean,  gboolean,  int,  VipsForeignSubsample,  int)’ {aka ‘int(struct _VipsRegion *, struct _VipsRect *, struct _VipsTarget *, int,  const char *, int,  int,  VipsForeignKeep,  int,  int,  int,  int,  VipsForeignSubsample,  int)’}
  148 | int vips__jpeg_region_write_target(VipsRegion *region, VipsRect *rect,
      |     ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
```
Downstream bug: https://bugs.gentoo.org/918954