### PR TITLE
Fix build with upcoming libjxl 0.9

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -3,6 +3,7 @@ TBD 8.15.1
 - reduceh: fix Highway path on SSE2 [DarthSim]
 - fix JPEG in TIFF colourspace for Q >= 90 [heman1-test]
 - fix build with upcoming libjxl 0.9 [kleisauke]
+- jxlsave: lower min effort value to 1 [DarthSim]
 
 11/11/23 8.15.0
 

--- a/ChangeLog
+++ b/ChangeLog
@@ -2,6 +2,7 @@ TBD 8.15.1
 
 - reduceh: fix Highway path on SSE2 [DarthSim]
 - fix JPEG in TIFF colourspace for Q >= 90 [heman1-test]
+- fix build with upcoming libjxl 0.9 [kleisauke]
 
 11/11/23 8.15.0
 

--- a/libvips/foreign/jxlload.c
+++ b/libvips/foreign/jxlload.c
@@ -564,7 +564,9 @@ vips_foreign_load_jxl_header(VipsForeignLoad *load)
 
 		case JXL_DEC_COLOR_ENCODING:
 			if (JxlDecoderGetICCProfileSize(jxl->decoder,
+#ifndef HAVE_LIBJXL_0_9
 					&jxl->format,
+#endif
 					JXL_COLOR_PROFILE_TARGET_DATA,
 					&jxl->icc_size)) {
 				vips_foreign_load_jxl_error(jxl,
@@ -583,7 +585,9 @@ vips_foreign_load_jxl_header(VipsForeignLoad *load)
 				return -1;
 
 			if (JxlDecoderGetColorAsICCProfile(jxl->decoder,
+#ifndef HAVE_LIBJXL_0_9
 					&jxl->format,
+#endif
 					JXL_COLOR_PROFILE_TARGET_DATA,
 					jxl->icc_data, jxl->icc_size)) {
 				vips_foreign_load_jxl_error(jxl,

--- a/libvips/foreign/jxlsave.c
+++ b/libvips/foreign/jxlsave.c
@@ -243,13 +243,16 @@ vips_foreign_save_jxl_build(VipsObject *object)
 		return -1;
 
 	/* If Q is set and distance is not, use Q to set a rough distance
-	 * value. Formula stolen from cjxl.c and very roughly approximates
-	 * libjpeg values.
+	 * value.
 	 */
 	if (!vips_object_argument_isset(object, "distance"))
+#ifdef HAVE_LIBJXL_0_9
+		jxl->distance = JxlEncoderDistanceFromQuality((float) jxl->Q);
+#else
 		jxl->distance = jxl->Q >= 30
 			? 0.1 + (100 - jxl->Q) * 0.09
 			: 53.0 / 3000.0 * jxl->Q * jxl->Q - 23.0 / 20.0 * jxl->Q + 25.0;
+#endif
 
 	/* Distance 0 is lossless. libjxl will fail for lossy distance 0.
 	 */

--- a/libvips/foreign/jxlsave.c
+++ b/libvips/foreign/jxlsave.c
@@ -561,7 +561,7 @@ vips_foreign_save_jxl_class_init(VipsForeignSaveJxlClass *class)
 		_("Encoding effort"),
 		VIPS_ARGUMENT_OPTIONAL_INPUT,
 		G_STRUCT_OFFSET(VipsForeignSaveJxl, effort),
-		3, 9, 7);
+		1, 9, 7);
 
 	VIPS_ARG_BOOL(class, "lossless", 13,
 		_("Lossless"),

--- a/meson.build
+++ b/meson.build
@@ -527,6 +527,9 @@ if libjxl_found
     if libjxl_dep.version().version_compare('>=0.7')
         cfg_var.set('HAVE_LIBJXL_0_7', '1')
     endif
+    if libjxl_dep.version().version_compare('>=0.9')
+        cfg_var.set('HAVE_LIBJXL_0_9', '1')
+    endif
 endif
 
 libpoppler_dep = dependency('poppler-glib', version: '>=0.16.0', required: get_option('poppler'))

--- a/test/test-suite/test_foreign.py
+++ b/test/test-suite/test_foreign.py
@@ -1533,7 +1533,7 @@ class TestForeign:
         # remove the ICC profile: the RGB one will no longer be appropriate
         rgb16.remove("icc-profile-data")
         self.save_load_buffer("jxlsave_buffer", "jxlload_buffer",
-                              rgb16, 10700)
+                              rgb16, 12000)
 
         # repeat for lossless mode
         self.save_load_buffer("jxlsave_buffer", "jxlload_buffer",


### PR DESCRIPTION
See https://github.com/libjxl/libjxl/blob/v0.9.x/CHANGELOG.md
> ```md
> ### Removed
>  - decoder API: the signature of `JxlDecoderGetColorAsEncodedProfile`,
>    `JxlDecoderGetICCProfileSize`, and `JxlDecoderGetColorAsICCProfile`
>    changed: a deprecated unused argument was removed.
> ```

While we're here, prefer use of `JxlEncoderDistanceFromQuality`.
> ```md
> ### Added
>  - encoder API: new function `JxlEncoderDistanceFromQuality` for convenience to
>    calculate a `distance` given a `quality`
> ```

And backport commit 4caf924b153b4cc329c931b8dd46f8faaa05216a.

Targets the 8.15 branch.