### PR TITLE
Fix jxlsave.c description

### DIFF
--- a/libvips/foreign/jp2ksave.c
+++ b/libvips/foreign/jp2ksave.c
@@ -1058,7 +1058,7 @@ vips_foreign_save_jp2k_file_class_init(VipsForeignSaveJp2kFileClass *class)
 
 	VIPS_ARG_STRING(class, "filename", 1,
 		_("Filename"),
-		_("Filename to load from"),
+		_("Filename to save to"),
 		VIPS_ARGUMENT_REQUIRED_INPUT,
 		G_STRUCT_OFFSET(VipsForeignSaveJp2kFile, filename),
 		NULL);

--- a/libvips/foreign/jxlsave.c
+++ b/libvips/foreign/jxlsave.c
@@ -881,7 +881,7 @@ vips_foreign_save_jxl_file_class_init(VipsForeignSaveJxlFileClass *class)
 
 	VIPS_ARG_STRING(class, "filename", 1,
 		_("Filename"),
-		_("Filename to load from"),
+		_("Filename to save to"),
 		VIPS_ARGUMENT_REQUIRED_INPUT,
 		G_STRUCT_OFFSET(VipsForeignSaveJxlFile, filename),
 		NULL);


### PR DESCRIPTION
There's currently an error in the documentation for `vips jxlsave`:
```
save image in JPEG-XL format
usage:
   jxlsave in filename [--option-name option-value ...]
where:
   in           - Image to save, input VipsImage
   filename     - Filename to load from, input gchararray
```

"Filename to load from" should be "Filename to save to", just like with `pngsave`.