### PR TITLE
try putting version numbers into the meson summary

### DIFF
--- a/libvips/include/vips/meson.build
+++ b/libvips/include/vips/meson.build
@@ -93,10 +93,15 @@ foreach _, section : build_summary
            continue
         endif
 
-        vips_verbose_config += '@0@: @1@@2@@3@@4@'.format(key, arr[0],
-            arr.length() > 1 ? arr[1] : '',
-            arr.length() > 2 ? arr[2] : '',
-            arr.length() > 3 ? arr[3] : '')
+        vips_verbose_config += '@0@: @1@'.format(key, arr[0])
+    endforeach
+endforeach
+foreach _, section : build_features
+    foreach key, arr : section
+        found = arr[1].found()
+        dep_name = found ? arr[1].name() : arr[0]
+        dynamic_module = arr.length() > 2 ? ' (dynamic module: @0@)'.format(arr[2]) : ''
+        vips_verbose_config += '@0@ with @1@: @2@@3@'.format(key, dep_name, found, dynamic_module)
     endforeach
 endforeach
 

--- a/meson.build
+++ b/meson.build
@@ -722,7 +722,7 @@ build_features = {
      'HEIC/AVIF load/save': ['libheif', libheif_dep, libheif_module],
      'WebP load/save': ['libwebp', libwebp_dep],
      'PDF load': ['PDFium or Poppler', pdf_loader, libpoppler_module],
-     'SVG load': ['librsvg', librsvg_dep],
+     'SVG load': ['librsvg', librsvg_found ? librsvg_dep : disabler()],
      'EXR load': ['OpenEXR', openexr_dep],
      'WSI load': ['OpenSlide', openslide_dep],
      'Matlab load': ['Matio', matio_dep],

--- a/meson.build
+++ b/meson.build
@@ -314,6 +314,9 @@ if libjpeg_dep.found()
     endif
 endif
 
+# png package we use
+png_package = disabler()
+
 # Look for libspng first
 # - it's sometimes called "spng.pc", sometimes "libspng.pc", we must search for
 #   both
@@ -323,15 +326,14 @@ spng_dep = dependency('spng', version: '>=0.7', required: false)
 if not spng_dep.found()
     spng_dep = dependency('libspng', version: '>=0.7', required: get_option('spng'))
 endif
-spng_found = not get_option('spng').disabled() and spng_dep.found()
-if spng_found
+if not get_option('spng').disabled() and spng_dep.found()
     libvips_deps += spng_dep
     cfg_var.set('HAVE_SPNG', '1')
+    png_package = spng_dep
 endif
 
 # only if libspng not found
-png_dep = disabler()
-if not spng_found
+if not png_package.found()
     png_dep = dependency('libpng', version: '>=1.2.9', required: get_option('png'))
     if png_dep.found()
         libvips_deps += png_dep
@@ -339,6 +341,7 @@ if not spng_found
         if cc.has_function('png_set_chunk_malloc_max', prefix: '#include <png.h>', dependencies: png_dep)
             cfg_var.set('HAVE_PNG_SET_CHUNK_MALLOC_MAX', '1')
         endif
+        png_package = png_dep
     endif
 endif
 
@@ -435,6 +438,9 @@ if libopenjp2_dep.found()
     cfg_var.set('HAVE_LIBOPENJP2', '1')
 endif
 
+# simd package we use
+simd_package = disabler()
+
 # Require 1.0.5 to support the `ReorderDemote2To(u8, i16, i16)` operation
 # See: https://github.com/google/highway/pull/1247
 libhwy_dep = dependency('libhwy', version: '>=1.0.5', required: get_option('highway'))
@@ -448,11 +454,11 @@ if libhwy_dep.found()
     #disabled_targets += ['HWY_AVX3_ZEN4']
     #disabled_targets += ['HWY_AVX3_SPR']
     add_project_arguments('-DHWY_DISABLED_TARGETS=@0@'.format('|'.join(disabled_targets)), language: ['cpp'])
+    simd_package = libhwy_dep
 endif
 
 # only if highway not found
-orc_dep = disabler()
-if not libhwy_dep.found()
+if not simd_package.found()
     # we use loadpw etc.
     orc_dep = dependency('orc-0.4', version: '>=0.4.11', required: get_option('orc'))
     if orc_dep.found()
@@ -463,8 +469,12 @@ if not libhwy_dep.found()
         if orc_dep.version().version_compare('>=0.4.31')
             cfg_var.set('HAVE_ORC_CF_PROTECTION', '1')
         endif
+        simd_package = orc_dep
     endif
 endif
+
+# pdf loader we use
+pdf_loader = disabler()
 
 # pick 4200 as the starting version number ... no reason, really, it'd
 # probably work with much older versions
@@ -472,6 +482,7 @@ pdfium_dep = dependency('pdfium', version: '>=4200', required: get_option('pdfiu
 if pdfium_dep.found()
     libvips_deps += pdfium_dep
     cfg_var.set('HAVE_PDFIUM', '1')
+    pdf_loader = pdfium_dep
 endif
 
 libheif_dep = dependency('libheif', version: '>=1.4.0', required: get_option('heif'))
@@ -532,24 +543,24 @@ if libjxl_found
     endif
 endif
 
-libpoppler_dep = dependency('poppler-glib', version: '>=0.16.0', required: get_option('poppler'))
-libpoppler_found = false
+# only if pdfium not found
 libpoppler_module = false
-if not cairo_dep.found()
-    cairo_dep = dependency('cairo', version: '>=1.2', required: get_option('poppler'))
-endif
-if libpoppler_dep.found() and cairo_dep.found() and pdfium_dep.found()
-    message('PDFium has been found, ignoring Poppler support')
-elif libpoppler_dep.found() and cairo_dep.found()
-    libpoppler_found = true
-    libpoppler_module = modules_enabled and not get_option('poppler-module').disabled()
-    if libpoppler_module
-        cfg_var.set('POPPLER_MODULE', '1')
-    else
-        libvips_deps += libpoppler_dep
-        libvips_deps += cairo_dep
+if not pdf_loader.found()
+    libpoppler_dep = dependency('poppler-glib', version: '>=0.16.0', required: get_option('poppler'))
+    if not cairo_dep.found()
+        cairo_dep = dependency('cairo', version: '>=1.2', required: get_option('poppler'))
     endif
-    cfg_var.set('HAVE_POPPLER', '1')
+    if libpoppler_dep.found() and cairo_dep.found()
+        libpoppler_module = modules_enabled and not get_option('poppler-module').disabled()
+        if libpoppler_module
+            cfg_var.set('POPPLER_MODULE', '1')
+        else
+            libvips_deps += libpoppler_dep
+            libvips_deps += cairo_dep
+        endif
+        cfg_var.set('HAVE_POPPLER', '1')
+        pdf_loader = libpoppler_dep
+    endif
 endif
 
 # niftiio.pc is not present, and only provides the CMake package definition
@@ -689,92 +700,49 @@ build_summary = {
      'enable PPM load/save': [get_option('ppm')],
      'enable GIF load': [get_option('nsgif')],
     },
+}
+build_features = {
   'Optional external packages':
-    {'FFTs with fftw':
-        [fftw_dep.found(), fftw_dep.found() ?
-          fftw_dep.name() + ' ' + fftw_dep.version() : ''],
-     'SIMD support with Highway':
-        [libhwy_dep.found(), libhwy_dep.found() ?
-          libhwy_dep.name() + ' ' + libhwy_dep.version() : ''],
-     'accelerate loops with ORC':
-        [orc_dep.found(), orc_dep.found() ?
-          orc_dep.name() + orc_dep.version() : ''],
-     'ICC profile support with lcms':
-        [lcms_dep.found(), lcms_dep.found() ?
-          lcms_dep.name() + ' ' + lcms_dep.version() : ''],
-     'deflate compression with zlib':
-        [zlib_dep.found(), zlib_dep.found() ?
-          zlib_dep.name() + ' ' + zlib_dep.version() : ''],
-     'text rendering with pangocairo':
-        [pangocairo_dep.found(), pangocairo_dep.found() ?
-          pangocairo_dep.name() + ' ' + pangocairo_dep.version() : ''],
-     'font file support with fontconfig':
-        [fontconfig_found, fontconfig_found ?
-          fontconfig_dep.name() + ' ' + fontconfig_dep.version() : ''],
-     'EXIF metadata support with libexif':
-        [libexif_dep.found(), libexif_dep.found() ?
-          libexif_dep.name() + ' ' + libexif_dep.version() : ''],
+    {'FFTs': ['fftw', fftw_dep],
+     'SIMD support': ['libhwy or liborc', simd_package],
+     'ICC profile support': ['lcms2', lcms_dep],
+     'deflate compression': ['zlib', zlib_dep],
+     'text rendering': ['pangocairo', pangocairo_dep],
+     'font file support': ['fontconfig', fontconfig_found ? fontconfig_dep : disabler()],
+     'EXIF metadata support': ['libexif', libexif_dep],
     },
   'External image format libraries':
-    {'JPEG load/save with libjpeg':
-        [libjpeg_dep.found(), libjpeg_dep.version()],
-     'JXL load/save with libjxl':
-        [libjxl_found, libjxl_dep.version(),
-          'dynamic module:', libjxl_module],
-     'JPEG2000 load/save with OpenJPEG':
-        [libopenjp2_dep.found(), libopenjp2_dep.version()],
-     'PNG load/save with libspng':
-        [spng_found, spng_dep.version()],
-     'PNG load/save with libpng':
-        [png_dep.found(), png_dep.version()],
-     'selected quantisation package':
-        [quantisation_package.found() ?
-          quantisation_package.name() : 'none',
-         quantisation_package.version()],
-     'TIFF load/save with libtiff':
-        [libtiff_dep.found(), libtiff_dep.version()],
-     'image pyramid save with libarchive':
-        [libarchive_dep.found(), libarchive_dep.version()],
-     'HEIC/AVIF load/save with libheif':
-        [libheif_dep.found(), libheif_dep.version(),
-          'dynamic module:', libheif_module],
-     'WebP load/save with libwebp':
-        [libwebp_dep.found(), libwebp_dep.version()],
-     'PDF load with PDFium':
-        [pdfium_dep.found(), pdfium_dep.version()],
-     'PDF load with poppler-glib':
-        [libpoppler_found, libpoppler_dep.version(),
-          'dynamic module:', libpoppler_module],
-     'SVG load with librsvg':
-        [librsvg_found, librsvg_dep.version()],
-     'EXR load with OpenEXR':
-        [openexr_dep.found(), openexr_dep.version()],
-     'OpenSlide load':
-        [openslide_dep.found(), openslide_dep.version(),
-          'dynamic module:', openslide_module],
-     'Matlab load with libmatio':
-        [matio_dep.found(), matio_dep.version()],
-     'NIfTI load/save with niftiio':
-        [libnifti_found, libnifti_dep.version()],
-     'FITS load/save with cfitsio':
-        [cfitsio_dep.found(), cfitsio_dep.version()],
-     'GIF save with cgif':
-        [cgif_dep.found(), cgif_dep.version()],
-     'selected Magick package':
-        [magick_found ? magick_dep.name() : 'none', magick_dep.version(),
-          'dynamic module:', magick_module],
-     'Magick API version':
-        [magick_found ?
-          'magick' + magick_dep.version().split('.')[0] : 'none'],
-     'Magick load':
-        [magick_found and 'load' in get_option('magick-features')],
-     'Magick save':
-        [magick_found and 'save' in get_option('magick-features')],
+    {'JPEG load/save': ['libjpeg', libjpeg_dep],
+     'JXL load/save': ['libjxl', libjxl_found ? libjxl_dep : disabler(), libjxl_module],
+     'JPEG2000 load/save': ['OpenJPEG', libopenjp2_dep],
+     'PNG load/save': ['libspng or libpng', png_package],
+     'image quantisation': ['imagequant or quantizr', quantisation_package],
+     'TIFF load/save': ['libtiff', libtiff_dep],
+     'image pyramid save': ['libarchive', libarchive_dep],
+     'HEIC/AVIF load/save': ['libheif', libheif_dep, libheif_module],
+     'WebP load/save': ['libwebp', libwebp_dep],
+     'PDF load': ['PDFium or Poppler', pdf_loader, libpoppler_module],
+     'SVG load': ['librsvg', librsvg_dep],
+     'EXR load': ['OpenEXR', openexr_dep],
+     'WSI load': ['OpenSlide', openslide_dep],
+     'Matlab load': ['Matio', matio_dep],
+     'NIfTI load/save': ['libnifti', libnifti_found ? libnifti_dep : disabler()],
+     'FITS load/save': ['cfitsio', cfitsio_dep],
+     'GIF save': ['cgif', cgif_dep],
+     'Magick @0@'.format('/'.join(get_option('magick-features'))): [get_option('magick-package'), magick_found ? magick_dep : disabler(), magick_module],
     },
 }
 
 foreach section_title, section : build_summary
-    summary(section, bool_yn: true, list_sep: '\t', section: section_title)
+    summary(section, bool_yn: true, section: section_title)
+endforeach
+foreach section_title, section: build_features
+    foreach key, arr : section
+        found = arr[1].found()
+        dep_name = found ? arr[1].name() : arr[0]
+        dynamic_module = arr.length() > 2 ? [' (dynamic module: ', arr[2], ')'] : []
+        summary('@0@ with @1@'.format(key, dep_name), [found] + dynamic_module, bool_yn: true, list_sep: '', section: section_title)
+    endforeach
 endforeach
 
 subdir('libvips')

--- a/meson.build
+++ b/meson.build
@@ -690,44 +690,83 @@ build_summary = {
      'enable GIF load': [get_option('nsgif')],
     },
   'Optional external packages':
-    {'use fftw for FFTs': [fftw_dep.found()],
-     'SIMD support with highway': [libhwy_dep.found()],
-     'accelerate loops with ORC': [orc_dep.found()],
-     'ICC profile support with lcms': [lcms_dep.found()],
-     'zlib': [zlib_dep.found()],
-     'text rendering with pangocairo': [pangocairo_dep.found()],
-     'font file support with fontconfig': [fontconfig_found],
-     'EXIF metadata support with libexif': [libexif_dep.found()],
+    {'use fftw for FFTs':
+        [fftw_dep.found(), fftw_dep.version()],
+     'SIMD support with highway':
+        [libhwy_dep.found(), libhwy_dep.version()],
+     'accelerate loops with ORC':
+        [orc_dep.found(), orc_dep.version()],
+     'ICC profile support with lcms':
+        [lcms_dep.found(), lcms_dep.version()],
+     'zlib':
+        [zlib_dep.found(), zlib_dep.version()],
+     'text rendering with pangocairo':
+        [pangocairo_dep.found(), pangocairo_dep.version()],
+     'font file support with fontconfig':
+        [fontconfig_found, fontconfig_dep.version()],
+     'EXIF metadata support with libexif':
+        [libexif_dep.found(), libexif_dep.version()],
     },
   'External image format libraries':
-    {'JPEG load/save with libjpeg': [libjpeg_dep.found()],
-     'JXL load/save with libjxl': [libjxl_found, ' (dynamic module: ', libjxl_module, ')'],
-     'JPEG2000 load/save with OpenJPEG': [libopenjp2_dep.found()],
-     'PNG load/save with libspng': [spng_found],
-     'PNG load/save with libpng': [png_dep.found()],
-     'selected quantisation package': [quantisation_package.found() ? quantisation_package.name() : 'none'],
-     'TIFF load/save with libtiff': [libtiff_dep.found()],
-     'image pyramid save with libarchive': [libarchive_dep.found()],
-     'HEIC/AVIF load/save with libheif': [libheif_dep.found(), ' (dynamic module: ', libheif_module, ')'],
-     'WebP load/save with libwebp': [libwebp_dep.found()],
-     'PDF load with PDFium': [pdfium_dep.found()],
-     'PDF load with poppler-glib': [libpoppler_found, ' (dynamic module: ', libpoppler_module, ')'],
-     'SVG load with librsvg': [librsvg_found],
-     'EXR load with OpenEXR': [openexr_dep.found()],
-     'OpenSlide load': [openslide_dep.found(), ' (dynamic module: ', openslide_module, ')'],
-     'Matlab load with libmatio': [matio_dep.found()],
-     'NIfTI load/save with niftiio': [libnifti_found],
-     'FITS load/save with cfitsio': [cfitsio_dep.found()],
-     'GIF save with cgif': [cgif_dep.found()],
-     'selected Magick package': [magick_found ? magick_dep.name() : 'none', ' (dynamic module: ', magick_module, ')'],
-     'Magick API version': [magick_found ? 'magick' + magick_dep.version().split('.')[0] : 'none'],
-     'Magick load': [magick_found and 'load' in get_option('magick-features')],
-     'Magick save': [magick_found and 'save' in get_option('magick-features')],
+    {'JPEG load/save with libjpeg':
+        [libjpeg_dep.found(), libjpeg_dep.version()],
+     'JXL load/save with libjxl':
+        [libjxl_found, libjxl_dep.version(),
+          'dynamic module:', libjxl_module],
+     'JPEG2000 load/save with OpenJPEG':
+        [libopenjp2_dep.found(), libopenjp2_dep.version()],
+     'PNG load/save with libspng':
+        [spng_found, spng_dep.version()],
+     'PNG load/save with libpng':
+        [png_dep.found(), png_dep.version()],
+     'selected quantisation package':
+        [quantisation_package.found() ?
+          quantisation_package.name() : 'none',
+         quantisation_package.version()],
+     'TIFF load/save with libtiff':
+        [libtiff_dep.found(), libtiff_dep.version()],
+     'image pyramid save with libarchive':
+        [libarchive_dep.found(), libarchive_dep.version()],
+     'HEIC/AVIF load/save with libheif':
+        [libheif_dep.found(), libheif_dep.version(),
+          'dynamic module:', libheif_module],
+     'WebP load/save with libwebp':
+        [libwebp_dep.found(), libwebp_dep.version()],
+     'PDF load with PDFium':
+        [pdfium_dep.found(), pdfium_dep.version()],
+     'PDF load with poppler-glib':
+        [libpoppler_found, libpoppler_dep.version(),
+          'dynamic module:', libpoppler_module],
+     'SVG load with librsvg':
+        [librsvg_found, librsvg_dep.version()],
+     'EXR load with OpenEXR':
+        [openexr_dep.found(), openexr_dep.version()],
+     'OpenSlide load':
+        [openslide_dep.found(), openslide_dep.version(),
+          'dynamic module:', openslide_module],
+     'Matlab load with libmatio':
+        [matio_dep.found(), matio_dep.version()],
+     'NIfTI load/save with niftiio':
+        [libnifti_found, libnifti_dep.version()],
+     'FITS load/save with cfitsio':
+        [cfitsio_dep.found(), cfitsio_dep.version()],
+     'GIF save with cgif':
+        [cgif_dep.found(), cgif_dep.version()],
+     'selected Magick package':
+        [magick_found ? magick_dep.name() : 'none', magick_dep.version(),
+          'dynamic module:', magick_module],
+     'Magick API version':
+        [magick_found ?
+          'magick' + magick_dep.version().split('.')[0] : 'none'],
+     'Magick load':
+        [magick_found and 'load' in get_option('magick-features')],
+     'Magick save':
+        [magick_found and 'save' in get_option('magick-features')],
     },
 }
 
 foreach section_title, section : build_summary
-    summary(section, bool_yn: true, list_sep: '', section: section_title)
+    summary(section, bool_yn: true, list_sep: ' ', section: section_title)
 endforeach
 
 subdir('libvips')

--- a/meson.build
+++ b/meson.build
@@ -733,6 +733,15 @@ build_features = {
     },
 }
 
+foreach _, section: build_features
+    foreach _, arr : section
+        if not arr[1].found()
+            continue
+        endif
+
+        summary(arr[1].name(), arr[1].version(), section: 'Dependency versions')
+    endforeach
+endforeach
 foreach section_title, section : build_summary
     summary(section, bool_yn: true, section: section_title)
 endforeach

--- a/meson.build
+++ b/meson.build
@@ -690,22 +690,30 @@ build_summary = {
      'enable GIF load': [get_option('nsgif')],
     },
   'Optional external packages':
-    {'use fftw for FFTs':
-        [fftw_dep.found(), fftw_dep.version()],
-     'SIMD support with highway':
-        [libhwy_dep.found(), libhwy_dep.version()],
+    {'FFTs with fftw':
+        [fftw_dep.found(), fftw_dep.found() ?
+          fftw_dep.name() + ' ' + fftw_dep.version() : ''],
+     'SIMD support with Highway':
+        [libhwy_dep.found(), libhwy_dep.found() ?
+          libhwy_dep.name() + ' ' + libhwy_dep.version() : ''],
      'accelerate loops with ORC':
-        [orc_dep.found(), orc_dep.version()],
+        [orc_dep.found(), orc_dep.found() ?
+          orc_dep.name() + orc_dep.version() : ''],
      'ICC profile support with lcms':
-        [lcms_dep.found(), lcms_dep.version()],
-     'zlib':
-        [zlib_dep.found(), zlib_dep.version()],
+        [lcms_dep.found(), lcms_dep.found() ?
+          lcms_dep.name() + ' ' + lcms_dep.version() : ''],
+     'deflate compression with zlib':
+        [zlib_dep.found(), zlib_dep.found() ?
+          zlib_dep.name() + ' ' + zlib_dep.version() : ''],
      'text rendering with pangocairo':
-        [pangocairo_dep.found(), pangocairo_dep.version()],
+        [pangocairo_dep.found(), pangocairo_dep.found() ?
+          pangocairo_dep.name() + ' ' + pangocairo_dep.version() : ''],
      'font file support with fontconfig':
-        [fontconfig_found, fontconfig_dep.version()],
+        [fontconfig_found, fontconfig_found ?
+          fontconfig_dep.name() + ' ' + fontconfig_dep.version() : ''],
      'EXIF metadata support with libexif':
-        [libexif_dep.found(), libexif_dep.version()],
+        [libexif_dep.found(), libexif_dep.found() ?
+          libexif_dep.name() + ' ' + libexif_dep.version() : ''],
     },
   'External image format libraries':
     {'JPEG load/save with libjpeg':
@@ -766,7 +774,7 @@ build_summary = {
 }
 
 foreach section_title, section : build_summary
-    summary(section, bool_yn: true, list_sep: ' ', section: section_title)
+    summary(section, bool_yn: true, list_sep: '\t', section: section_title)
 endforeach
 
 subdir('libvips')

--- a/meson.build
+++ b/meson.build
@@ -62,15 +62,23 @@ expat_dep = dependency('expat')
 thread_dep = dependency('threads')
 m_dep = cc.find_library('m', required: false)
 
-libvips_deps = [
+# Start to form our dependencies
+
+# External dependencies we've detected
+external_deps = [
     glib_dep,
     gio_dep,
     gobject_dep,
     gmodule_dep,
     expat_dep,
+]
+
+# Required deps that may or may not be external versioned libraries
+other_deps = [
     thread_dep,
     m_dep,
 ]
+
 nodelete_link_args = cc.get_supported_link_arguments('-Wl,-z,nodelete')
 
 prefix_dir = get_option('prefix')
@@ -163,19 +171,19 @@ endif
 # needed by rsvg and others
 zlib_dep = dependency('zlib', version: '>=0.4', required: get_option('zlib'))
 if zlib_dep.found()
-    libvips_deps += zlib_dep
+    external_deps += zlib_dep
     cfg_var.set('HAVE_ZLIB', '1')
 endif
 
 libarchive_dep = dependency('libarchive', version: '>=3.0.0', required: get_option('archive'))
 if libarchive_dep.found()
-    libvips_deps += libarchive_dep
+    external_deps += libarchive_dep
     cfg_var.set('HAVE_LIBARCHIVE', '1')
 endif
 
 fftw_dep = dependency('fftw3', required: get_option('fftw'))
 if fftw_dep.found()
-    libvips_deps += fftw_dep
+    external_deps += fftw_dep
     cfg_var.set('HAVE_FFTW', '1')
 endif
 
@@ -192,7 +200,7 @@ if magick_found
     if magick_module
         cfg_var.set('MAGICK_MODULE', '1')
     else
-        libvips_deps += magick_dep
+        external_deps += magick_dep
     endif
     magick7 = magick_dep.version().version_compare('>=7.0')
     # IM7 uses <MagickCore/MagickCore.h>
@@ -242,7 +250,7 @@ endif
 
 cfitsio_dep = dependency('cfitsio', required: get_option('cfitsio'))
 if cfitsio_dep.found()
-    libvips_deps += cfitsio_dep
+    external_deps += cfitsio_dep
     cfg_var.set('HAVE_CFITSIO', '1')
 endif
 
@@ -251,7 +259,7 @@ quantisation_package = disabler()
 
 imagequant_dep = dependency('imagequant', required: get_option('imagequant'))
 if imagequant_dep.found()
-    libvips_deps += imagequant_dep
+    external_deps += imagequant_dep
     cfg_var.set('HAVE_IMAGEQUANT', '1')
     quantisation_package = imagequant_dep
 endif
@@ -261,7 +269,7 @@ quantizr_dep = disabler()
 if not quantisation_package.found()
     quantizr_dep = dependency('quantizr', required: get_option('quantizr'))
     if quantizr_dep.found()
-        libvips_deps += quantizr_dep
+        external_deps += quantizr_dep
         cfg_var.set('HAVE_QUANTIZR', '1')
         quantisation_package = quantizr_dep
     endif
@@ -271,7 +279,7 @@ cgif_dep = disabler()
 if quantisation_package.found()
     cgif_dep = dependency('cgif', version: '>=0.2.0', required: get_option('cgif'))
     if cgif_dep.found()
-        libvips_deps += cgif_dep
+        external_deps += cgif_dep
         cfg_var.set('HAVE_CGIF', '1')
         if cc.compiles('#include <cgif.h>\nint i = CGIF_ATTR_NO_LOOP;', name: 'Has CGIF_ATTR_NO_LOOP', dependencies: cgif_dep)
             cfg_var.set('HAVE_CGIF_ATTR_NO_LOOP', '1')
@@ -284,7 +292,7 @@ endif
 
 libexif_dep = dependency('libexif', version: '>=0.6', required: get_option('exif'))
 if libexif_dep.found()
-    libvips_deps += libexif_dep
+    external_deps += libexif_dep
     cfg_var.set('HAVE_EXIF', '1')
     # some libexif packages need include <libexif/poop.h>, some just <poop.h>
     # how annoying
@@ -304,7 +312,7 @@ endif
 
 libjpeg_dep = dependency('libjpeg', required: get_option('jpeg'))
 if libjpeg_dep.found()
-    libvips_deps += libjpeg_dep
+    external_deps += libjpeg_dep
     cfg_var.set('HAVE_JPEG', '1')
     # features like trellis quant are exposed as extension parameters ...
     # mozjpeg 3.2 and later have #define JPEG_C_PARAM_SUPPORTED, but we must
@@ -327,7 +335,7 @@ if not spng_dep.found()
     spng_dep = dependency('libspng', version: '>=0.7', required: get_option('spng'))
 endif
 if not get_option('spng').disabled() and spng_dep.found()
-    libvips_deps += spng_dep
+    external_deps += spng_dep
     cfg_var.set('HAVE_SPNG', '1')
     png_package = spng_dep
 endif
@@ -336,7 +344,7 @@ endif
 if not png_package.found()
     png_dep = dependency('libpng', version: '>=1.2.9', required: get_option('png'))
     if png_dep.found()
-        libvips_deps += png_dep
+        external_deps += png_dep
         cfg_var.set('HAVE_PNG', '1')
         if cc.has_function('png_set_chunk_malloc_max', prefix: '#include <png.h>', dependencies: png_dep)
             cfg_var.set('HAVE_PNG_SET_CHUNK_MALLOC_MAX', '1')
@@ -350,15 +358,15 @@ endif
 # insist on having both of them
 libwebp_dep = dependency('libwebp', version: '>=0.6', required: get_option('webp'))
 if libwebp_dep.found()
-    libvips_deps += libwebp_dep
-    libvips_deps += dependency('libwebpmux', version: '>=0.6')
-    libvips_deps += dependency('libwebpdemux', version: '>=0.6')
+    external_deps += libwebp_dep
+    external_deps += dependency('libwebpmux', version: '>=0.6')
+    external_deps += dependency('libwebpdemux', version: '>=0.6')
     cfg_var.set('HAVE_LIBWEBP', '1')
 endif
 
 pangocairo_dep = dependency('pangocairo', version: '>=1.32.6', required: get_option('pangocairo'))
 if pangocairo_dep.found()
-    libvips_deps += pangocairo_dep
+    external_deps += pangocairo_dep
     cfg_var.set('HAVE_PANGOCAIRO', '1')
 endif
 
@@ -367,14 +375,14 @@ pangoft2_dep = dependency('pangoft2', version: '>=1.32.6', required: get_option(
 fontconfig_dep = dependency('fontconfig', required: get_option('fontconfig'))
 fontconfig_found = pangoft2_dep.found() and fontconfig_dep.found() and pangocairo_dep.found()
 if fontconfig_found
-    libvips_deps += pangoft2_dep
-    libvips_deps += fontconfig_dep
+    external_deps += pangoft2_dep
+    external_deps += fontconfig_dep
     cfg_var.set('HAVE_FONTCONFIG', '1')
 endif
 
 libtiff_dep = dependency('libtiff-4', required: get_option('tiff'))
 if libtiff_dep.found()
-    libvips_deps += libtiff_dep
+    external_deps += libtiff_dep
     cfg_var.set('HAVE_TIFF', '1')
     # ZSTD and WEBP in TIFF added in libtiff 4.0.10
     if cc.get_define('COMPRESSION_WEBP', prefix: '#include <tiff.h>', dependencies: libtiff_dep) != ''
@@ -387,8 +395,8 @@ librsvg_dep = dependency('librsvg-2.0', version: '>=2.40.3', required: get_optio
 cairo_dep = dependency('cairo', version: '>=1.2', required: get_option('rsvg'))
 librsvg_found = librsvg_dep.found() and cairo_dep.found()
 if librsvg_found
-    libvips_deps += librsvg_dep
-    libvips_deps += cairo_dep
+    external_deps += librsvg_dep
+    external_deps += cairo_dep
     cfg_var.set('HAVE_RSVG', '1')
 endif
 
@@ -399,7 +407,7 @@ if openslide_dep.found()
     if openslide_module
         cfg_var.set('OPENSLIDE_MODULE', '1')
     else
-        libvips_deps += openslide_dep
+        external_deps += openslide_dep
     endif
     cfg_var.set('HAVE_OPENSLIDE', '1')
     if openslide_dep.version().version_compare('>=3.4.0')
@@ -413,28 +421,28 @@ endif
 
 matio_dep = dependency('matio', required: get_option('matio'))
 if matio_dep.found()
-    libvips_deps += matio_dep
+    external_deps += matio_dep
     cfg_var.set('HAVE_MATIO', '1')
 endif
 
 # lcms ... refuse to use lcms1
 lcms_dep = dependency('lcms2', required: get_option('lcms'))
 if lcms_dep.found()
-    libvips_deps += lcms_dep
+    external_deps += lcms_dep
     cfg_var.set('HAVE_LCMS2', '1')
 endif
 
 # require 1.2.2 since 1.2.1 has a broken ImfCloseTiledInputFile()
 openexr_dep = dependency('OpenEXR', version: '>=1.2.2', required: get_option('openexr'))
 if openexr_dep.found()
-    libvips_deps += openexr_dep
+    external_deps += openexr_dep
     cfg_var.set('HAVE_OPENEXR', '1')
 endif
 
 # 2.4 is the first one to have working threading and tiling
 libopenjp2_dep = dependency('libopenjp2', version: '>=2.4', required: get_option('openjpeg'))
 if libopenjp2_dep.found()
-    libvips_deps += libopenjp2_dep
+    external_deps += libopenjp2_dep
     cfg_var.set('HAVE_LIBOPENJP2', '1')
 endif
 
@@ -445,7 +453,7 @@ simd_package = disabler()
 # See: https://github.com/google/highway/pull/1247
 libhwy_dep = dependency('libhwy', version: '>=1.0.5', required: get_option('highway'))
 if libhwy_dep.found()
-    libvips_deps += libhwy_dep
+    external_deps += libhwy_dep
     cfg_var.set('HAVE_HWY', '1')
     # Always disable SSSE3 since it is rare to have SSSE3 but not SSE4
     disabled_targets = ['HWY_SSSE3']
@@ -462,7 +470,7 @@ if not simd_package.found()
     # we use loadpw etc.
     orc_dep = dependency('orc-0.4', version: '>=0.4.11', required: get_option('orc'))
     if orc_dep.found()
-        libvips_deps += orc_dep
+        external_deps += orc_dep
         cfg_var.set('HAVE_ORC', '1')
         # orc 0.4.30+ works with cf-protection, but 0.4.30 has a bug with multiple
         # definitions of OrcTargetPowerPCFlags, so insist on 0.4.31
@@ -480,7 +488,7 @@ pdf_loader = disabler()
 # probably work with much older versions
 pdfium_dep = dependency('pdfium', version: '>=4200', required: get_option('pdfium'))
 if pdfium_dep.found()
-    libvips_deps += pdfium_dep
+    external_deps += pdfium_dep
     cfg_var.set('HAVE_PDFIUM', '1')
     pdf_loader = pdfium_dep
 endif
@@ -492,7 +500,7 @@ if libheif_dep.found()
     if libheif_module
         cfg_var.set('HEIF_MODULE', '1')
     else
-        libvips_deps += libheif_dep
+        external_deps += libheif_dep
     endif
     cfg_var.set('HAVE_HEIF', '1')
     # added in 1.6.0
@@ -531,8 +539,8 @@ if libjxl_found
     if libjxl_module
         cfg_var.set('LIBJXL_MODULE', '1')
     else
-        libvips_deps += libjxl_dep
-        libvips_deps += libjxl_threads_dep
+        external_deps += libjxl_dep
+        external_deps += libjxl_threads_dep
     endif
     cfg_var.set('HAVE_LIBJXL', '1')
     if libjxl_dep.version().version_compare('>=0.7')
@@ -555,8 +563,8 @@ if not pdf_loader.found()
         if libpoppler_module
             cfg_var.set('POPPLER_MODULE', '1')
         else
-            libvips_deps += libpoppler_dep
-            libvips_deps += cairo_dep
+            external_deps += libpoppler_dep
+            external_deps += cairo_dep
         endif
         cfg_var.set('HAVE_POPPLER', '1')
         pdf_loader = libpoppler_dep
@@ -600,7 +608,7 @@ if nifti_prefix_dir != '' and not libnifti_dep.found()
 endif
 libnifti_found = not get_option('nifti').disabled() and libnifti_dep.found()
 if libnifti_found
-    libvips_deps += libnifti_dep
+    external_deps += libnifti_dep
     cfg_var.set('HAVE_NIFTI', '1')
 endif
 
@@ -648,7 +656,7 @@ if cc.has_function('ngettext')
 else
     libintl_dep = cc.find_library('intl', required: false)
     if libintl_dep.found()
-        libvips_deps += libintl_dep
+        other_deps += libintl_dep
         cfg_var.set('ENABLE_NLS', 1)
         have_bind_textdomain_codeset = cc.has_function('bind_textdomain_codeset', prefix: '#include <libintl.h>', dependencies: libintl_dep)
     else
@@ -680,7 +688,7 @@ config_dep = declare_dependency(
     compile_args: '-DHAVE_CONFIG_H=1',
 )
 
-libvips_deps += config_dep
+libvips_deps = [config_dep] + external_deps + other_deps
 
 gir = find_program('g-ir-scanner', required: get_option('introspection'))
 enable_introspection = gir.found() and (not meson.is_cross_build() or get_option('introspection').enabled())
@@ -733,14 +741,8 @@ build_features = {
     },
 }
 
-foreach _, section: build_features
-    foreach _, arr : section
-        if not arr[1].found()
-            continue
-        endif
-
-        summary(arr[1].name(), arr[1].version(), section: 'Dependency versions')
-    endforeach
+foreach dep: external_deps
+    summary(dep.name(), dep.version(), section: 'External dependency versions')
 endforeach
 foreach section_title, section : build_summary
     summary(section, bool_yn: true, section: section_title)


### PR DESCRIPTION
I often find myself checking the version number of detected packages, it might be useful to have this in the summary.

Sample output:

```
    enable RAD load/save              : YES
    enable Analyze7 load/save         : YES
    enable PPM load/save              : YES
    enable GIF load                   : YES

  Optional external packages
    use fftw for FFTs                 : YES 3.3.10
    SIMD support with highway         : YES 1.0.7
    accelerate loops with ORC         : NO NO
    ICC profile support with lcms     : YES 2.14
    zlib                              : YES 1.2.13
    text rendering with pangocairo    : YES 1.51.0
    font file support with fontconfig : YES 2.14.2
    EXIF metadata support with libexif: YES 0.6.24

  External image format libraries
    JPEG load/save with libjpeg       : YES 2.1.5
    JXL load/save with libjxl         : YES 0.7.0 dynamic module: YES
    JPEG2000 load/save with OpenJPEG  : YES 2.5.0
    PNG load/save with libspng        : NO unknown
    PNG load/save with libpng         : YES 1.6.40
    selected quantisation package     : imagequant 2.17.0
    TIFF load/save with libtiff       : YES 4.5.1
```

etc.

It could be a bit prettier, and it does make the output rather busy. Any thoughts?