### PR TITLE
fix(pdfium): render pdf annotations

### DIFF
--- a/libvips/foreign/pdfiumload.c
+++ b/libvips/foreign/pdfiumload.c
@@ -622,7 +622,7 @@ vips_foreign_load_pdf_generate(VipsRegion *out_region,
 			pdf->pages[i].left - rect.left,
 			pdf->pages[i].top - rect.top,
 			pdf->pages[i].width, pdf->pages[i].height,
-			0, 0);
+			0, FPDF_ANNOT);
 
 		FPDFBitmap_Destroy(bitmap);
 


### PR DESCRIPTION
Currently annotations are not rendered, this is very unexpected behavior as with other tools (imagemagick) or dependencies (poppler) it will be drawn. 

The flag `FPDF_ANNOT` enables render of annotations, this results in the same behavior as with poppler.

I used the annotation example files from pdfium to test it: https://pdfium.googlesource.com/pdfium_tests/+/refs/heads/main/pdfium/annots/