### PR TITLE
fix: punctuation in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# libvips : an image processing library
+# libvips: an image processing library
 
 [![CI](https://github.com/libvips/libvips/workflows/CI/badge.svg)](https://github.com/libvips/libvips/actions)
 [![Fuzzing Status](https://oss-fuzz-build-logs.storage.googleapis.com/badges/libvips.svg)](https://bugs.chromium.org/p/oss-fuzz/issues/list?sort=-opened&can=2&q=proj:libvips)


### PR DESCRIPTION
There shouldn't be a space in front of a colon. This practice even has a name ("Plenken"), see: https://en.m.wikipedia.org/wiki/Plenken