### PR TITLE
svgload: allow smaller scale factor

### DIFF
--- a/libvips/foreign/svgload.c
+++ b/libvips/foreign/svgload.c
@@ -725,7 +725,7 @@ vips_foreign_load_svg_class_init(VipsForeignLoadSvgClass *class)
 		_("Scale output by this factor"),
 		VIPS_ARGUMENT_OPTIONAL_INPUT,
 		G_STRUCT_OFFSET(VipsForeignLoadSvg, scale),
-		0.001, 100000.0, 1.0);
+		0.00001, 100000.0, 1.0);
 
 	VIPS_ARG_BOOL(class, "unlimited", 23,
 		_("Unlimited"),

--- a/test/test-suite/test_foreign.py
+++ b/test/test-suite/test_foreign.py
@@ -1172,6 +1172,18 @@ class TestForeign:
         assert im.width == 1
         assert im.height == 1
 
+        # scale up
+        svg = b'<svg xmlns="http://www.w3.org/2000/svg" width="1" height="1"></svg>'
+        im = pyvips.Image.new_from_buffer(svg, "", scale=10000)
+        assert im.width == 10000
+        assert im.height == 10000
+
+        # scale down
+        svg = b'<svg xmlns="http://www.w3.org/2000/svg" width="100000" height="100000"></svg>'
+        im = pyvips.Image.new_from_buffer(svg, "", scale=0.0001)
+        assert im.width == 10
+        assert im.height == 10
+
     def test_csv(self):
         self.save_load("%s.csv", self.mono)
 


### PR DESCRIPTION
By allowing smaller scale factors, this PR normalises the accepted range for `scale` from 1E-5 to 1E+5.

It also adds tests cases for both scale-up and scale-down (the latter would previously have failed).

Relates to https://github.com/lovell/sharp/issues/3964, where an input dimension of 333333 and target dimension of 250 results in a scale factor of 0.000750.