### PR TITLE
thumbnail should always export as 8 bit

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -2,6 +2,7 @@ date-tbd 8.15.2
 
 - fix deflate compression of tiff pyramids [manthey]
 - better no-chroma-subsample switching for jpeg in tiff [kleisauke]
+- thumbnail always writes 8-bit thumbnails [turtletowerz]
 
 18/12/23 8.15.1
 

--- a/test/test-suite/test_resample.py
+++ b/test/test-suite/test_resample.py
@@ -200,7 +200,7 @@ class TestResample:
         im2 = pyvips.Image.thumbnail(OME_FILE + "[page=1]", 100)
         assert im2.width == 100
         assert im2.height == 38
-        assert (im1 - im2).abs().max() != 0 
+        assert (im1 - im2).abs().max() != 0
 
         # should be able to thumbnail entire many-page tiff as a toilet-roll
         # image
@@ -220,12 +220,20 @@ class TestResample:
         im2 = pyvips.Image.new_from_file(RGBA_CORRECT_FILE)
         assert abs(im1.flatten(background=255).avg() - im2.avg()) < 1
 
+        # thumbnailing a 16-bit image should always make an 8-bit image
+        rgb16_buffer = pyvips.Image \
+                .new_from_file(JPEG_FILE) \
+                .colourspace("rgb16") \
+                .write_to_buffer(".png")
+        thumb = pyvips.Image.thumbnail_buffer(rgb16_buffer, 128)
+        assert thumb.format == "uchar"
+
         if have("heifload"):
             # this image is orientation 6 ... thumbnail should flip it
             im = pyvips.Image.new_from_file(AVIF_FILE)
             thumb = pyvips.Image.thumbnail(AVIF_FILE, 100)
 
-            # thumb should be portrait 
+            # thumb should be portrait
             assert thumb.width < thumb.height
             assert thumb.height == 100
 


### PR DESCRIPTION
After #f807d7b, `icc_export` and `icc_transform` would keep 16 bit images as 16-bit images. We didn't make a matching change to `thumbnail`, so 8.15 started making 16-bit thumbnails of 16-bit images, with no way to request 8 bits.

This PR adds `depth 8` to all `icc_*()` to make the behaviour match 8.14 (and tries to improve line breaks).

See https://github.com/libvips/libvips/issues/3830