### PR TITLE
Backport #3827 to 8.15

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -3,6 +3,7 @@ date-tbd 8.15.2
 - fix deflate compression of tiff pyramids [manthey]
 - better no-chroma-subsample switching for jpeg in tiff [kleisauke]
 - thumbnail always writes 8-bit thumbnails [turtletowerz]
+- lower min scale factor to 0.0 in svgload and pdfload [lovell]
 
 18/12/23 8.15.1
 

--- a/libvips/foreign/pdfiumload.c
+++ b/libvips/foreign/pdfiumload.c
@@ -739,7 +739,7 @@ vips_foreign_load_pdf_class_init(VipsForeignLoadPdfClass *class)
 		_("Factor to scale by"),
 		VIPS_ARGUMENT_OPTIONAL_INPUT,
 		G_STRUCT_OFFSET(VipsForeignLoadPdf, scale),
-		0.001, 100000.0, 1.0);
+		0.0, 100000.0, 1.0);
 
 	VIPS_ARG_BOXED(class, "background", 14,
 		_("Background"),

--- a/libvips/foreign/popplerload.c
+++ b/libvips/foreign/popplerload.c
@@ -567,7 +567,7 @@ vips_foreign_load_pdf_class_init(VipsForeignLoadPdfClass *class)
 		_("Factor to scale by"),
 		VIPS_ARGUMENT_OPTIONAL_INPUT,
 		G_STRUCT_OFFSET(VipsForeignLoadPdf, scale),
-		0.001, 100000.0, 1.0);
+		0.0, 100000.0, 1.0);
 
 	VIPS_ARG_BOXED(class, "background", 24,
 		_("Background"),

--- a/libvips/foreign/svgload.c
+++ b/libvips/foreign/svgload.c
@@ -725,7 +725,7 @@ vips_foreign_load_svg_class_init(VipsForeignLoadSvgClass *class)
 		_("Scale output by this factor"),
 		VIPS_ARGUMENT_OPTIONAL_INPUT,
 		G_STRUCT_OFFSET(VipsForeignLoadSvg, scale),
-		0.001, 100000.0, 1.0);
+		0.00001, 100000.0, 1.0);
 
 	VIPS_ARG_BOOL(class, "unlimited", 23,
 		_("Unlimited"),

--- a/libvips/foreign/svgload.c
+++ b/libvips/foreign/svgload.c
@@ -725,7 +725,7 @@ vips_foreign_load_svg_class_init(VipsForeignLoadSvgClass *class)
 		_("Scale output by this factor"),
 		VIPS_ARGUMENT_OPTIONAL_INPUT,
 		G_STRUCT_OFFSET(VipsForeignLoadSvg, scale),
-		0.00001, 100000.0, 1.0);
+		0.0, 100000.0, 1.0);
 
 	VIPS_ARG_BOOL(class, "unlimited", 23,
 		_("Unlimited"),

--- a/test/test-suite/test_foreign.py
+++ b/test/test-suite/test_foreign.py
@@ -1135,6 +1135,18 @@ class TestForeign:
         assert im.width == 1
         assert im.height == 1
 
+        # scale up
+        svg = b'<svg xmlns="http://www.w3.org/2000/svg" width="1" height="1"></svg>'
+        im = pyvips.Image.new_from_buffer(svg, "", scale=10000)
+        assert im.width == 10000
+        assert im.height == 10000
+
+        # scale down
+        svg = b'<svg xmlns="http://www.w3.org/2000/svg" width="100000" height="100000"></svg>'
+        im = pyvips.Image.new_from_buffer(svg, "", scale=0.0001)
+        assert im.width == 10
+        assert im.height == 10
+
     def test_csv(self):
         self.save_load("%s.csv", self.mono)
 


### PR DESCRIPTION
Trivial backport of #3827 to [`8.15`](https://github.com/libvips/libvips/tree/8.14). 

While doing this, I noticed that `webpload` and `resize` just uses `0.0` as minimum scale factor:
https://github.com/libvips/libvips/blob/3fb194893d0d4a37b5646e70da7b57fa4aabab01/libvips/foreign/webpload.c#L191-L196
https://github.com/libvips/libvips/blob/3fb194893d0d4a37b5646e70da7b57fa4aabab01/libvips/resample/resize.c#L328-L333

Which might be a bit simpler, so I also included commit  62eaf9db377cd0da682b42067a209c5ed16c9eb0 in this backport, which applies the same change to `pdfload` as well.