### PR TITLE
heifload: don't warn on images with nclx profiles

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -4,6 +4,7 @@ date-tbd 8.15.2
 - better no-chroma-subsample switching for jpeg in tiff [kleisauke]
 - thumbnail always writes 8-bit thumbnails [turtletowerz]
 - lower min scale factor to 0.0 in svgload and pdfload [lovell]
+- heifload: don't warn on images with nclx profiles [kleisauke]
 
 18/12/23 8.15.1
 

--- a/libvips/foreign/heifload.c
+++ b/libvips/foreign/heifload.c
@@ -708,7 +708,7 @@ vips_foreign_load_heif_set_header(VipsForeignLoadHeif *heif, VipsImage *out)
 			(VipsCallbackFn) vips_area_free_cb, data, length);
 	}
 	else if (profile_type == heif_color_profile_type_nclx) {
-		g_warning("heifload: ignoring nclx profile");
+		g_info("heifload: ignoring nclx profile");
 	}
 #endif /*HAVE_HEIF_COLOR_PROFILE*/
 

--- a/libvips/include/vips/util.h
+++ b/libvips/include/vips/util.h
@@ -164,15 +164,6 @@ extern "C" {
 	} \
 	G_STMT_END
 
-/* The g_info() macro was added in 2.40.
- */
-#ifndef g_info
-/* Hopefully we have varargs macros. Maybe revisit this.
- */
-#define g_info(...) \
-	g_log(G_LOG_DOMAIN, G_LOG_LEVEL_INFO, __VA_ARGS__)
-#endif
-
 /* Various integer range clips. Record over/under flows.
  */
 #define VIPS_CLIP_UCHAR(V, SEQ) \


### PR DESCRIPTION
Since this message is emitted during an AVIF roundtrip, its severity does not warrant a warning. So, let's downgrade it to a `g_info()`.

See: #2734 and kleisauke/wasm-vips#62.

Targets the 8.15 branch.