### PR TITLE
fix arrayjoin with some pipelines

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -5,6 +5,7 @@ date-tbd 8.15.2
 - thumbnail always writes 8-bit thumbnails [turtletowerz]
 - lower min scale factor to 0.0 in svgload and pdfload [lovell]
 - heifload: don't warn on images with nclx profiles [kleisauke]
+- fix arrayjoin with some pipelines [TheEssem]
 
 18/12/23 8.15.1
 

--- a/libvips/conversion/insert.c
+++ b/libvips/conversion/insert.c
@@ -116,10 +116,8 @@ typedef VipsConversionClass VipsInsertClass;
 G_DEFINE_TYPE(VipsInsert, vips_insert, VIPS_TYPE_CONVERSION);
 
 /* Trivial case: we just need pels from one of the inputs.
- *
- * Also used by vips_arrayjoin.
  */
-int
+static int
 vips__insert_just_one(VipsRegion *out_region, VipsRegion *ir, int x, int y)
 {
 	VipsRect need;

--- a/libvips/foreign/foreign.c
+++ b/libvips/foreign/foreign.c
@@ -1029,7 +1029,7 @@ vips_foreign_load_start(VipsImage *out, void *a, void *b)
 		 * Some versions of ImageMagick give different results between
 		 * Ping and Load for some formats, for example.
 		 *
-		 * If the load fails, we need to stop
+		 * If the load fails, we need to stop.
 		 */
 		if (class->load(load) ||
 			vips_image_pio_input(load->real) ||

--- a/libvips/include/vips/internal.h
+++ b/libvips/include/vips/internal.h
@@ -291,7 +291,6 @@ void vips__draw_line_direct(VipsImage *image, int x1, int y1, int x2, int y2,
 void vips__draw_circle_direct(VipsImage *image, int cx, int cy, int r,
 	VipsDrawScanline draw_scanline, void *client);
 
-int vips__insert_just_one(VipsRegion *out, VipsRegion *in, int x, int y);
 int vips__insert_paste_region(VipsRegion *out, VipsRegion *in, VipsRect *pos);
 
 /* Register base vips interpolators, called during startup.

--- a/libvips/iofuncs/sinkdisc.c
+++ b/libvips/iofuncs/sinkdisc.c
@@ -371,10 +371,11 @@ wbuffer_allocate_fn(VipsThreadState *state, void *a, gboolean *stop)
 				return -1;
 			}
 
-			/* This will be the first tile of a new buffer ...
-			 * stall for a moment to stress the caching system.
+			/* This will be the first tile of a new buffer ... mark this as a
+			 * good place to stall for a moment if we want to stress the
+			 * caching system. See threadpool.c.
 			 */
-			state->stall = TRUE;
+            state->stall = TRUE;
 		}
 	}
 


### PR DESCRIPTION
If the operation before arrayjoin was something that just forwarded a pointer, we could be left with dangling memory references in some cases.

Also some tiny comment adjustment and formatting changes.

thanks TheEssem

see https://github.com/libvips/libvips/issues/3835