### PR TITLE
add an imagemagick blocklist

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -6,6 +6,7 @@ master 8.16
 - jxl load and save now support exif, xmp, animation [DarthSim]
 - improved configure output
 - don't build loaders as modules by default
+- add a filetype blocker for imagemagick
 
 date-tbd 8.15.2
 


### PR DESCRIPTION
Some files types are very slow to detect in imagemagick, and not very useful. Block them.

Example:

```
$ /usr/bin/time -f %M:%e vipsheader frank.avi 
frank.avi: 720x576 uchar, 3 bands, srgb, magickload
10691072:16.09
```

10gb of memory and 16s of wall clock time.

See https://github.com/libvips/libvips/issues/3838