### PR TITLE
ppmload: ensure multi-line comments are skipped

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -5,6 +5,7 @@ date-tbd 8.15.2
 - thumbnail always writes 8-bit thumbnails [turtletowerz]
 - lower min scale factor to 0.0 in svgload and pdfload [lovell]
 - heifload: don't warn on images with nclx profiles [kleisauke]
+- ppmload: ensure multi-line comments are skipped [lovell]
 
 18/12/23 8.15.1
 

--- a/libvips/iofuncs/sbuf.c
+++ b/libvips/iofuncs/sbuf.c
@@ -522,7 +522,7 @@ vips_sbuf_skip_whitespace(VipsSbuf *sbuf)
 
 		/* # skip comments too.
 		 */
-		if (ch == '#') {
+		while (ch == '#') {
 			/* Probably EOF.
 			 */
 			if (!vips_sbuf_get_line(sbuf))

--- a/test/test-suite/test_foreign.py
+++ b/test/test-suite/test_foreign.py
@@ -1172,6 +1172,11 @@ class TestForeign:
         self.save_load_file("%s.ppm", "[ascii]", grey16, 0)
         self.save_load_file("%s.ppm", "[ascii]", rgb16, 0)
 
+        source = pyvips.Source.new_from_memory(b'P1\n#\n#\n1 1\n0\n')
+        im = pyvips.Image.ppmload_source(source)
+        assert im.height == 1
+        assert im.width == 1
+
     @skip_if_no("radload")
     def test_rad(self):
         self.save_load("%s.hdr", self.colour)


### PR DESCRIPTION
Fixes https://github.com/libvips/libvips/issues/3842 and adds the provided example as a test case.