### PR TITLE
WebP Save: add argument for using "auto-filter"/"smart_deblock" encoding feature.

### DIFF
--- a/libvips/foreign/webpsave.c
+++ b/libvips/foreign/webpsave.c
@@ -120,6 +120,10 @@ typedef struct _VipsForeignSaveWebp {
 	 */
 	gboolean smart_subsample;
 
+	/* Enable smart deblock filter adjusting.
+	 */
+	gboolean smart_deblock;
+
 	/* Use preprocessing in lossless mode.
 	 */
 	gboolean near_lossless;
@@ -611,6 +615,8 @@ vips_foreign_save_webp_init_config(VipsForeignSaveWebp *webp)
 		webp->config.near_lossless = webp->Q;
 	if (webp->smart_subsample)
 		webp->config.use_sharp_yuv = 1;
+	if (webp->smart_deblock)
+		webp->config.autofilter = 1;
 
 	if (!WebPValidateConfig(&webp->config)) {
 		vips_foreign_save_webp_unset(webp);
@@ -908,6 +914,13 @@ vips_foreign_save_webp_class_init(VipsForeignSaveWebpClass *class)
 		VIPS_ARGUMENT_OPTIONAL_INPUT,
 		G_STRUCT_OFFSET(VipsForeignSaveWebp, mixed),
 		FALSE);
+
+	VIPS_ARG_BOOL(class, "smart_deblock", 23,
+		_("Smart deblocking"),
+		_("Enable auto-adjusting of the deblocking filter"),
+		VIPS_ARGUMENT_OPTIONAL_INPUT,
+		G_STRUCT_OFFSET(VipsForeignSaveWebp, smart_deblock),
+		FALSE);
 }
 
 static void
@@ -1158,6 +1171,7 @@ vips_foreign_save_webp_mime_init(VipsForeignSaveWebpMime *mime)
  * * @lossless: %gboolean, enables lossless compression
  * * @preset: #VipsForeignWebpPreset, choose lossy compression preset
  * * @smart_subsample: %gboolean, enables high quality chroma subsampling
+ * * @smart_deblock: %gboolean, enables auto-adjusting of the deblocking filter
  * * @near_lossless: %gboolean, preprocess in lossless mode (controlled by Q)
  * * @alpha_q: %gint, set alpha quality in lossless mode
  * * @effort: %gint, level of CPU effort to reduce file size
@@ -1176,6 +1190,8 @@ vips_foreign_save_webp_mime_init(VipsForeignSaveWebpMime *mime)
  * #VIPS_FOREIGN_WEBP_PRESET_DEFAULT.
  *
  * Set @smart_subsample to enable high quality chroma subsampling.
+ *
+ * Set @smart_deblock to enable auto-adjusting of the deblocking filter.
  *
  * Use @alpha_q to set the quality for the alpha channel in lossy mode. It has
  * the range 1 - 100, with the default 100.
@@ -1231,6 +1247,7 @@ vips_webpsave(VipsImage *in, const char *filename, ...)
  * * @lossless: %gboolean, enables lossless compression
  * * @preset: #VipsForeignWebpPreset, choose lossy compression preset
  * * @smart_subsample: %gboolean, enables high quality chroma subsampling
+ * * @smart_deblock: %gboolean, enables auto-adjusting of the deblocking filter
  * * @near_lossless: %gboolean, preprocess in lossless mode (controlled by Q)
  * * @alpha_q: %gint, set alpha quality in lossless mode
  * * @effort: %gint, level of CPU effort to reduce file size
@@ -1288,6 +1305,7 @@ vips_webpsave_buffer(VipsImage *in, void **buf, size_t *len, ...)
  * * @lossless: %gboolean, enables lossless compression
  * * @preset: #VipsForeignWebpPreset, choose lossy compression preset
  * * @smart_subsample: %gboolean, enables high quality chroma subsampling
+ * * @smart_deblock: %gboolean, enables auto-adjusting of the deblocking filter
  * * @near_lossless: %gboolean, preprocess in lossless mode (controlled by Q)
  * * @alpha_q: %gint, set alpha quality in lossless mode
  * * @effort: %gint, level of CPU effort to reduce file size
@@ -1327,6 +1345,7 @@ vips_webpsave_mime(VipsImage *in, ...)
  * * @lossless: %gboolean, enables lossless compression
  * * @preset: #VipsForeignWebpPreset, choose lossy compression preset
  * * @smart_subsample: %gboolean, enables high quality chroma subsampling
+ * * @smart_deblock: %gboolean, enables auto-adjusting of the deblocking filter
  * * @near_lossless: %gboolean, preprocess in lossless mode (controlled by Q)
  * * @alpha_q: %gint, set alpha quality in lossless mode
  * * @effort: %gint, level of CPU effort to reduce file size


### PR DESCRIPTION
Adds the ability to configure whether or not the "auto-filter" feature from libwebp is used when encoding lossy WebPs, This is put behind a new optional argument/toggle called/named "smart_deblock" in libvips.
It's described by Google as doing the following: "This algorithm will spend additional time optimizing the filtering strength to reach a well-balanced quality."
Note this process is quite slow for the quality gains it achieves.

Also a warning I must give that I apologize for is I am not in a proper position to actually compile libvips and test it with this new code, however this all seems straight forward enough and anyone who is able to can confirm if this works by checking the outputs when changing the `smart_deblock` boolean.

If there's anything I missed or concerns about details in this pull request then feel free to say.