### PR TITLE
don't install meson with brew

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -70,8 +70,15 @@ jobs:
       - name: Install macOS dependencies
         if: runner.os == 'macOS'
         run: |
-          brew install meson ninja fftw fontconfig glib libexif libarchive little-cms2 highway pango pkg-config
-          brew install cfitsio cgif jpeg-xl libheif libimagequant mozjpeg libmatio librsvg libspng libtiff openexr openjpeg openslide poppler webp
+          brew install python ninja
+          pip3 install meson
+          brew install fftw fontconfig glib libexif libarchive little-cms2
+          brew install highway pango pkg-config cfitsio cgif jpeg-xl libheif
+          brew install libimagequant mozjpeg libmatio librsvg libspng libtiff
+          brew install openexr openjpeg openslide poppler webp
+          brew install cfitsio cgif jpeg-xl libheif libimagequant mozjpeg
+          brew install libmatio librsvg libspng libtiff openexr openjpeg
+          brew install openslide poppler webp
 
       - name: Install Clang 15
         if: runner.os == 'Linux' && matrix.build.cc == 'clang-15'


### PR DESCRIPTION
The brew meson might not be using the same python as the rest of brew, so installing it that way can conflict. Instead, install meson with pip so we get a version for our python.