### PR TITLE
tiffsave: ensure large file support (>2GB) on MSVC

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -7,6 +7,7 @@ date-tbd 8.15.2
 - ppmload: ensure multi-line comments are skipped [lovell]
 - fix arrayjoin with some pipelines [TheEssem]
 - fix high Q mono JPEG TIFF write with mozjpeg [cavenel]
+- tiffsave: ensure large file support (>2GB) on MSVC [kleisauke]
 
 18/12/23 8.15.1
 

--- a/libvips/include/vips/connection.h
+++ b/libvips/include/vips/connection.h
@@ -428,8 +428,11 @@ struct _VipsTarget {
 	int write_point;
 
 	/* Write position in memory_buffer.
+	 *
+	 * off_t can be 32 bits on some platforms, so make sure we have a
+	 * full 64.
 	 */
-	off_t position;
+	gint64 position;
 
 	/* Temp targets on the filesystem need deleting, sometimes.
 	 */
@@ -466,8 +469,11 @@ typedef struct _VipsTargetClass {
 	gint64 (*read)(VipsTarget *, void *, size_t);
 
 	/* Seek output. Args exactly as lseek(2).
+	 *
+	 * We have to use int64 rather than off_t, since we must work on
+	 * Windows, where off_t can be 32-bits.
 	 */
-	off_t (*seek)(VipsTarget *, off_t offset, int whence);
+	gint64 (*seek)(VipsTarget *, gint64 offset, int whence);
 
 	/* Output has been generated, so do any clearing up,
 	 * eg. copy the bytes we saved in memory to the target blob.
@@ -492,7 +498,7 @@ int vips_target_write(VipsTarget *target, const void *data, size_t length);
 VIPS_API
 gint64 vips_target_read(VipsTarget *target, void *buffer, size_t length);
 VIPS_API
-off_t vips_target_seek(VipsTarget *target, off_t offset, int whence);
+gint64 vips_target_seek(VipsTarget *target, gint64 offset, int whence);
 VIPS_API
 int vips_target_end(VipsTarget *target);
 VIPS_DEPRECATED_FOR(vips_target_end)


### PR DESCRIPTION
On MSVC, `off_t` and `lseek()` are limited to signed 32-bit offsets, which limits their capability to handle files larger than 2GB.

To support saving TIFF files that exceed this size, replace their use with `gint64` and `vips__seek()`, where the latter uses `_lseeki64()` internally.

See: https://github.com/conan-io/conan/issues/15578.

Targets the 8.15 branch.