### PR TITLE
make MAX_COORD configurable

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -10,6 +10,7 @@ master 8.16
 - add basic g_auto support
 - support for long EXIF values [MarcosAndre]
 - better system error messages on windows [kleisauke]
+- add configurable max coordinate and vips_max_coord_get()
 
 date-tbd 8.15.2
 

--- a/libvips/include/vips/image.h
+++ b/libvips/include/vips/image.h
@@ -59,9 +59,14 @@ extern "C" {
  * for width/height so we could go up to 2bn, but it's good to have a lower
  * value set so we can see crazy numbers early.
  *
- * This was 1m for a while, but someone found a use for a 4m wide image.
+ * This can be overridden with the `VIPS_MAX_COORD` env var, or the
+ * `--vips-max-coord` CLI arg.
  */
-#define VIPS_MAX_COORD (10000000)
+#define VIPS_DEFAULT_MAX_COORD (100000000)
+
+/* Fetch the overriden value.
+ */
+#define VIPS_MAX_COORD (vips_max_coord_get())
 
 typedef enum {
 	VIPS_DEMAND_STYLE_ERROR = -1,

--- a/libvips/include/vips/image.h
+++ b/libvips/include/vips/image.h
@@ -64,7 +64,7 @@ extern "C" {
  */
 #define VIPS_DEFAULT_MAX_COORD (100000000)
 
-/* Fetch the overriden value.
+/* Fetch the overridden value.
  */
 #define VIPS_MAX_COORD (vips_max_coord_get())
 

--- a/libvips/include/vips/vips.h
+++ b/libvips/include/vips/vips.h
@@ -159,6 +159,8 @@ extern "C" {
 			: vips_init(ARGV0))
 
 VIPS_API
+int vips_max_coord_get(void);
+VIPS_API
 int vips_init(const char *argv0);
 VIPS_API
 const char *vips_get_argv0(void);

--- a/libvips/iofuncs/init.c
+++ b/libvips/iofuncs/init.c
@@ -137,6 +137,41 @@ GQuark vips__image_pixels_quark = 0;
 
 static gint64 vips_pipe_read_limit = 1024 * 1024 * 1024;
 
+/* The maximum coordinate (ie. dimension) value we allow. This can be
+ * overridden with the `--vips-max-coord` CLI arg, or the `VIPS_MAX_COORD` env
+ * var.
+ */
+static char *vips__max_coord_arg = NULL;
+
+/**
+ * vips_max_coord_get:
+ *
+ * Return the maximum coordinate value. This can be the default, a value set
+ * set by the `--vips-max-coord` CLI arg, or a value set in the `VIPS_MAX_COORD`
+ * environment variable.
+ *
+ * These strings can include unit specifiers, eg. "10m" for 10 million pixels.
+ * Values above 2b are not supported.
+ *
+ * Returns: The maximum value a coordinate, or image dimension, can have.
+ */
+int
+vips_max_coord_get(void)
+{
+	// CLI overrides env var
+	const char *as_str = vips__max_coord_arg ?
+		vips__max_coord_arg : g_getenv("VIPS_MAX_COORD");
+
+	guint64 size;
+
+	if (as_str &&
+		(size = vips__parse_size(as_str)) > 100 &&
+		size < INT_MAX - 1000)
+		return size;
+	else
+		return VIPS_DEFAULT_MAX_COORD;
+}
+
 /**
  * vips_get_argv0:
  *
@@ -832,6 +867,9 @@ static GOptionEntry option_entries[] = {
 	{ "vips-concurrency", 0, 0,
 		G_OPTION_ARG_INT, &vips__concurrency,
 		N_("evaluate with N concurrent threads"), "N" },
+	{ "vips-max-coord", 0, 0,
+		G_OPTION_ARG_STRING, &vips__max_coord_arg,
+		N_("maximum coordinate"), NULL },
 	{ "vips-tile-width", 0, G_OPTION_FLAG_HIDDEN,
 		G_OPTION_ARG_INT, &vips__tile_width,
 		N_("set tile width to N (DEBUG)"), "N" },

--- a/libvips/iofuncs/init.c
+++ b/libvips/iofuncs/init.c
@@ -162,12 +162,11 @@ vips_max_coord_get(void)
 	const char *as_str = vips__max_coord_arg ?
 		vips__max_coord_arg : g_getenv("VIPS_MAX_COORD");
 
-	guint64 size;
+	if (as_str) {
+		guint64 size = vips__parse_size(as_str);
 
-	if (as_str &&
-		(size = vips__parse_size(as_str)) > 100 &&
-		size < INT_MAX - 1000)
-		return size;
+		return VIPS_CLIP(100, size, INT_MAX);
+	}
 	else
 		return VIPS_DEFAULT_MAX_COORD;
 }

--- a/libvips/iofuncs/util.c
+++ b/libvips/iofuncs/util.c
@@ -1707,23 +1707,20 @@ vips__parse_size(const char *size_string)
 
 	guint64 size;
 	int n;
-	int i;
 	char *unit;
 
 	/* An easy way to alloc a buffer large enough.
 	 */
 	unit = g_strdup(size_string);
-	n = sscanf(size_string, "%d %s", &i, unit);
-	size = i;
-	if (n > 1) {
-		int j;
 
-		for (j = 0; j < VIPS_NUMBER(units); j++)
+	n = sscanf(size_string, "%" G_GUINT64_FORMAT " %s", &size, unit);
+	if (n > 1)
+		for (int j = 0; j < VIPS_NUMBER(units); j++)
 			if (tolower(unit[0]) == units[j].unit) {
 				size *= units[j].multiplier;
 				break;
 			}
-	}
+
 	g_free(unit);
 
 	VIPS_DEBUG_MSG("parse_size: parsed \"%s\" as %" G_GUINT64_FORMAT "\n",

--- a/libvips/iofuncs/util.c
+++ b/libvips/iofuncs/util.c
@@ -1701,7 +1701,8 @@ vips__parse_size(const char *size_string)
 	static Unit units[] = {
 		{ 'k', 1024 },
 		{ 'm', 1024 * 1024 },
-		{ 'g', 1024 * 1024 * 1024 }
+		{ 'g', 1024 * 1024 * 1024 },
+		{ 'b', 1024 * 1024 * 1024 }
 	};
 
 	guint64 size;

--- a/test/test_cli.sh
+++ b/test/test_cli.sh
@@ -13,7 +13,7 @@ test_rotate() {
 
 	printf "testing $inter ... "
 
-	# 90 degree clockwise rotate 
+	# 90 degree clockwise rotate
 	trn="0 1 1 0"
 
 	$vips affine $im $tmp/t1.v "$trn" --interpolate $inter
@@ -81,3 +81,24 @@ test_size $tmp/t1.jpg 66 100
 cat $image | $vipsthumbnail stdin -s 100 -o .jpg | cat > $tmp/t1.jpg
 echo ok
 test_size $tmp/t1.jpg 66 100
+
+# test max-coord
+# this will coredumop on an assert fail in debug builds, so block coredumps
+ulimit -c 0
+echo -n "testing --vips-max-coord ... "
+if $vips black $tmp/t1.v 1000 1000 --vips-max-coord 120 > /dev/null 2>&1; then
+  echo "FAIL"
+  echo "--vips-max-coord CLI arg test failed"
+  exit 1
+fi
+echo ok
+
+echo -n "testing VIPS_MAX_COORD ... "
+export VIPS_MAX_COORD=120
+if $vips black $tmp/t1.v 1000 1000 > /dev/null 2>&1; then
+  echo "FAIL"
+  echo "VIPS_MAX_COORD env var test failed"
+  exit 1
+fi
+echo ok
+unset VIPS_MAX_COORD


### PR DESCRIPTION
and bump the default to 100m

see https://github.com/libvips/libvips/issues/3865

thanks @AKlaus

Usage:

```
$ VIPS_MAX_COORD=120 vips black x.v 1000 1000
```

Will fail with a range of terrible errors. You can use unit dimensions in the size, for example:

```
$ VIPS_MAX_COORD=1g vips black x.v 1000 1000
```

Or use:

```
$ vips black x.v 1000 1000 --vips-max-coord 1g
```
