### PR TITLE
Add jxl cmyk support

### DIFF
--- a/libvips/foreign/jxlsave.c
+++ b/libvips/foreign/jxlsave.c
@@ -34,8 +34,8 @@
  */
 
 /*
-#define DEBUG
  */
+#define DEBUG
 
 #ifdef HAVE_CONFIG_H
 #include <config.h>
@@ -251,12 +251,8 @@ vips_foreign_save_jxl_print_status(JxlEncoderStatus status)
 		printf("JXL_ENC_NEED_MORE_OUTPUT\n");
 		break;
 
-	case JXL_ENC_NOT_SUPPORTED:
-		printf("JXL_ENC_NOT_SUPPORTED\n");
-		break;
-
 	default:
-		printf("JXL_ENC_<unknown>\n");
+		printf("JXL_ENC_<unknown %d>\n", status);
 		break;
 	}
 }
@@ -285,8 +281,7 @@ vips_foreign_save_jxl_process_output(VipsForeignSaveJxl *jxl)
 			break;
 
 		default:
-			vips_foreign_save_jxl_error(jxl,
-				"JxlEncoderProcessOutput");
+			vips_foreign_save_jxl_error(jxl, "JxlEncoderProcessOutput");
 #ifdef DEBUG
 			vips_foreign_save_jxl_print_status(status);
 #endif /*DEBUG*/
@@ -497,14 +492,12 @@ vips_foreign_save_jxl_build(VipsObject *object)
 	if (jxl->distance == 0)
 		jxl->lossless = TRUE;
 
-	jxl->runner = JxlThreadParallelRunnerCreate(NULL,
-		vips_concurrency_get());
+	jxl->runner = JxlThreadParallelRunnerCreate(NULL, vips_concurrency_get());
 	jxl->encoder = JxlEncoderCreate(NULL);
 
 	if (JxlEncoderSetParallelRunner(jxl->encoder,
 			JxlThreadParallelRunner, jxl->runner)) {
-		vips_foreign_save_jxl_error(jxl,
-			"JxlDecoderSetParallelRunner");
+		vips_foreign_save_jxl_error(jxl, "JxlDecoderSetParallelRunner");
 		return -1;
 	}
 
@@ -526,12 +519,11 @@ vips_foreign_save_jxl_build(VipsObject *object)
 	in = t[0];
 
 	/* Mimics VIPS_SAVEABLE_RGBA.
+	 *
 	 * FIXME: add support encoding images with > 4 bands.
 	 */
 	if (in->Bands > 4) {
-		if (vips_extract_band(in, &t[1], 0,
-				"n", 4,
-				NULL))
+		if (vips_extract_band(in, &t[1], 0, "n", 4, NULL))
 			return -1;
 		in = t[1];
 	}
@@ -574,6 +566,12 @@ vips_foreign_save_jxl_build(VipsObject *object)
 		jxl->info.num_color_channels = VIPS_MIN(3, in->Bands);
 		break;
 
+	case VIPS_INTERPRETATION_CMYK:
+		// CMYK is respresented as CMY plus a kBlack extra channel ... this is
+		// set just after SetBasicInfo
+		jxl->info.num_color_channels = VIPS_MIN(3, in->Bands);
+		break;
+
 	default:
 		jxl->info.num_color_channels = in->Bands;
 	}
@@ -603,8 +601,7 @@ vips_foreign_save_jxl_build(VipsObject *object)
 
 	if (vips_image_hasalpha(in)) {
 		jxl->info.alpha_bits = jxl->info.bits_per_sample;
-		jxl->info.alpha_exponent_bits =
-			jxl->info.exponent_bits_per_sample;
+		jxl->info.alpha_exponent_bits = jxl->info.exponent_bits_per_sample;
 	}
 	else {
 		jxl->info.alpha_exponent_bits = 0;
@@ -629,23 +626,36 @@ vips_foreign_save_jxl_build(VipsObject *object)
 		return -1;
 	}
 
+	/* For CMYK, we need to tag the first extra channel as kBlack. Other extra
+	 * channels default to alpha.
+	 */
+	if (in->Type == VIPS_INTERPRETATION_CMYK &&
+		jxl->info.num_extra_channels > 0) {
+		JxlExtraChannelInfo info;
+
+		JxlEncoderInitExtraChannelInfo(JXL_CHANNEL_BLACK, &info);
+		info.bits_per_sample = jxl->info.bits_per_sample;
+		info.dim_shift = 1;
+		if (JxlEncoderSetExtraChannelInfo(jxl->encoder, 0, &info)) {
+		  vips_foreign_save_jxl_error(jxl, "JxlEncoderSetExtraChannelInfo");
+		  return -1;
+		}
+	}
+
 	/* Set any ICC profile.
 	 */
 	if (vips_image_get_typeof(in, VIPS_META_ICC_NAME)) {
 		const void *data;
 		size_t length;
 
-		if (vips_image_get_blob(in,
-				VIPS_META_ICC_NAME, &data, &length))
+		if (vips_image_get_blob(in, VIPS_META_ICC_NAME, &data, &length))
 			return -1;
 
 #ifdef DEBUG
 		printf("attaching %zd bytes of ICC\n", length);
 #endif /*DEBUG*/
-		if (JxlEncoderSetICCProfile(jxl->encoder,
-				(guint8 *) data, length)) {
-			vips_foreign_save_jxl_error(jxl,
-				"JxlEncoderSetColorEncoding");
+		if (JxlEncoderSetICCProfile(jxl->encoder, (guint8 *) data, length)) {
+			vips_foreign_save_jxl_error(jxl, "JxlEncoderSetColorEncoding");
 			return -1;
 		}
 	}
@@ -670,10 +680,8 @@ vips_foreign_save_jxl_build(VipsObject *object)
 				jxl->format.num_channels < 3);
 		}
 
-		if (JxlEncoderSetColorEncoding(jxl->encoder,
-				&jxl->color_encoding)) {
-			vips_foreign_save_jxl_error(jxl,
-				"JxlEncoderSetColorEncoding");
+		if (JxlEncoderSetColorEncoding(jxl->encoder, &jxl->color_encoding)) {
+			vips_foreign_save_jxl_error(jxl, "JxlEncoderSetColorEncoding");
 			return -1;
 		}
 	}
@@ -861,7 +869,8 @@ vips_foreign_save_jxl_file_build(VipsObject *object)
 	if (!(jxl->target = vips_target_new_to_file(file->filename)))
 		return -1;
 
-	if (VIPS_OBJECT_CLASS(vips_foreign_save_jxl_file_parent_class)->build(object))
+	if (VIPS_OBJECT_CLASS(vips_foreign_save_jxl_file_parent_class)->
+		build(object))
 		return -1;
 
 	return 0;


### PR DESCRIPTION
I had a quick go, but it fails with:

```
$ vips copy cmyk.jpg x.jxl
attaching 961644 bytes of ICC
attaching exif-data ..
JxlBasicInfo:
    have_container = 0
    xsize = 1450
    ysize = 2048
    bits_per_sample = 8
    exponent_bits_per_sample = 0
    intensity_target = 0
    min_nits = 0
    relative_to_max_display = 0
    linear_below = 0
    uses_original_profile = 0
    have_preview = 0
    have_animation = 0
    orientation = 1
    num_color_channels = 3
    num_extra_channels = 1
    alpha_bits = 8
    alpha_exponent_bits = 0
    alpha_premultiplied = 0
    preview.xsize = 0
    preview.ysize = 0
    animation.tps_numerator = 10
    animation.tps_denominator = 1
    animation.num_loops = 0
    animation.have_timecodes = 0
JxlPixelFormat:
    num_channels = 4
    data_type = JXL_TYPE_UINT8
    endianness = 0
    align = 0
JxlEncoderFrameSettings:
    tier = 0
    distance = 2.35
    effort = 7
    lossless = 0
./lib/jxl/encode.cc:820: Extra channel 0 is not initialized
JXL_ENC_ERROR
```

ie. we are passing a 4 channel buffer with 1 extra channel. 

We use `JxlEncoderSetExtraChannelInfo()` to tag the extra channel as black. I'd think this ought to work, how do we encode an interleaved CMYK image?