### PR TITLE
Make `vips_addalpha` a VipsOperation

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -13,6 +13,7 @@ master 8.16
 - add configurable max coordinate and vips_max_coord_get()
 - improve kill handling
 - PFM save and load now uses scRGB (ie. linear 0-1) [NiHoel]
+- turn `vips_addalpha` into a VipsOperation [RiskoZoSlovenska]
 
 date-tbd 8.15.2
 

--- a/libvips/conversion/addalpha.c
+++ b/libvips/conversion/addalpha.c
@@ -1,0 +1,122 @@
+/* Add an appropriate alpha band.
+ */
+
+/*
+
+	This file is part of VIPS.
+
+	VIPS is free software; you can redistribute it and/or modify
+	it under the terms of the GNU Lesser General Public License as published by
+	the Free Software Foundation; either version 2 of the License, or
+	(at your option) any later version.
+
+	This program is distributed in the hope that it will be useful,
+	but WITHOUT ANY WARRANTY; without even the implied warranty of
+	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+	GNU Lesser General Public License for more details.
+
+	You should have received a copy of the GNU Lesser General Public License
+	along with this program; if not, write to the Free Software
+	Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+	02110-1301  USA
+
+ */
+
+/*
+
+	These files are distributed with VIPS - http://www.vips.ecs.soton.ac.uk
+
+ */
+
+#ifdef HAVE_CONFIG_H
+#include <config.h>
+#endif /*HAVE_CONFIG_H*/
+#include <glib/gi18n-lib.h>
+
+#include <stdio.h>
+#include <stdlib.h>
+
+#include <vips/vips.h>
+#include <vips/internal.h>
+
+#include "pconversion.h"
+
+typedef struct _VipsAddAlpha {
+	VipsConversion parent_instance;
+
+	VipsImage *in;
+
+} VipsAddAlpha;
+
+typedef VipsConversionClass VipsAddAlphaClass;
+
+G_DEFINE_TYPE(VipsAddAlpha, vips_addalpha, VIPS_TYPE_CONVERSION);
+
+static int
+vips_addalpha_build(VipsObject *object)
+{
+	VipsAddAlpha *addalpha = (VipsAddAlpha *) object;
+	VipsConversion *conversion = VIPS_CONVERSION(object);
+
+	if (VIPS_OBJECT_CLASS(vips_addalpha_parent_class)->build(object))
+		return -1;
+
+	if (vips_bandjoin_const1(addalpha->in, &conversion->out,
+			vips_interpretation_max_alpha(addalpha->in->Type), NULL))
+		return -1;
+
+	return 0;
+}
+
+static void
+vips_addalpha_class_init(VipsAddAlphaClass *class)
+{
+	GObjectClass *gobject_class = G_OBJECT_CLASS(class);
+	VipsObjectClass *vobject_class = VIPS_OBJECT_CLASS(class);
+	VipsOperationClass *operation_class = VIPS_OPERATION_CLASS(class);
+
+	gobject_class->set_property = vips_object_set_property;
+	gobject_class->get_property = vips_object_get_property;
+
+	vobject_class->nickname = "addalpha";
+	vobject_class->description = _("append an alpha channel");
+	vobject_class->build = vips_addalpha_build;
+
+	operation_class->flags = VIPS_OPERATION_SEQUENTIAL;
+
+	VIPS_ARG_IMAGE(class, "in", 0,
+		_("Input"),
+		_("Input image"),
+		VIPS_ARGUMENT_REQUIRED_INPUT,
+		G_STRUCT_OFFSET(VipsAddAlpha, in));
+}
+
+static void
+vips_addalpha_init(VipsAddAlpha *addalpha)
+{
+}
+
+/**
+ * vips_addalpha: (method)
+ * @in: input image
+ * @out: (out): output image
+ * @...: %NULL-terminated list of optional named arguments
+ *
+ * Append an alpha channel.
+ *
+ * See also: vips_image_hasalpha().
+ *
+ * Returns: 0 on success, -1 on error
+ */
+int
+vips_addalpha(VipsImage *in, VipsImage **out, ...)
+{
+	va_list ap;
+	int result;
+
+	va_start(ap, out);
+	result = vips_call_split("addalpha", ap, in, out);
+	va_end(ap);
+
+	return result;
+}

--- a/libvips/conversion/bandjoin.c
+++ b/libvips/conversion/bandjoin.c
@@ -517,25 +517,3 @@ vips_bandjoin_const1(VipsImage *in, VipsImage **out, double c, ...)
 
 	return result;
 }
-
-/**
- * vips_addalpha: (method)
- * @in: input image
- * @out: (out): output image
- * @...: %NULL-terminated list of optional named arguments
- *
- * Append an alpha channel.
- *
- * See also: vips_image_hasalpha().
- *
- * Returns: 0 on success, -1 on error
- */
-int
-vips_addalpha(VipsImage *in, VipsImage **out, ...)
-{
-	if (vips_bandjoin_const1(in, out,
-		vips_interpretation_max_alpha(in->Type), NULL))
-		return -1;
-
-	return 0;
-}

--- a/libvips/conversion/conversion.c
+++ b/libvips/conversion/conversion.c
@@ -408,6 +408,7 @@ vips_conversion_operation_init(void)
 	extern GType vips_gamma_get_type(void);
 	extern GType vips_composite_get_type(void);
 	extern GType vips_composite2_get_type(void);
+	extern GType vips_addalpha_get_type(void);
 
 	vips_copy_get_type();
 	vips_tile_cache_get_type();
@@ -457,4 +458,5 @@ vips_conversion_operation_init(void)
 	vips_gamma_get_type();
 	vips_composite_get_type();
 	vips_composite2_get_type();
+	vips_addalpha_get_type();
 }

--- a/libvips/conversion/meson.build
+++ b/libvips/conversion/meson.build
@@ -40,6 +40,7 @@ conversion_sources = files(
     'wrap.c',
     'subsample.c',
     'zoom.c',
+    'addalpha.c',
 )
 
 conversion_headers = files(

--- a/test/test-suite/test_conversion.py
+++ b/test/test-suite/test_conversion.py
@@ -121,6 +121,11 @@ class TestConversion:
         assert x[3].avg() == 1
         assert x[4].avg() == 2
 
+    def test_addalpha(self):
+        x = self.colour.addalpha()
+        assert x.bands == 4
+        assert x[3].avg() == 255  # self.colour is srgb
+
     def test_bandmean(self):
         def bandmean(x):
             if isinstance(x, pyvips.Image):


### PR DESCRIPTION
This PR turns `vips_addalpha` into a fully-fledged VipsOperation so that bindings may call it using the same mechanisms they use to call other operations. See https://github.com/libvips/lua-vips/pull/46#issuecomment-1983202875 for a discussion as to why this may be desired.

I'm largely new to C and the GObject system, so I'm not sure whether this is the correct (let alone the best) way to implement this change. For example, I'm not sure whether the new operation should subclass VipsBandary or VipsConversion — on one hand, it is an operation of the same type as the other bandary operations (it simply manipulates bands); on the other, it doesn't use any of the machinery defined by VipsBandary and subclassing VipsConversion would be sufficient.