### PR TITLE
Improve scrgb handling for ppmsave

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -116,7 +116,9 @@ jobs:
         run: meson compile -C build
 
       - name: Check libvips
-        run: meson test -C build --print-errorlogs
+        run: |
+          meson test -C build \
+          || (cat build/meson-logs/testlog.txt && exit 1)
 
       - name: Install libvips
         run: sudo meson install -C build

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -110,7 +110,9 @@ jobs:
         run: meson compile -C build
 
       - name: Check libvips
-        run: meson test -C build
+        run: |
+          meson test -C build \
+          || (cat build/meson-logs/testlog.txt && exit 1)
 
       - name: Install libvips
         run: sudo meson install -C build

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -116,9 +116,7 @@ jobs:
         run: meson compile -C build
 
       - name: Check libvips
-        run: |
-          meson test -C build \
-          || (cat build/meson-logs/testlog.txt && exit 1)
+        run: meson test -C build --print-errorlogs
 
       - name: Install libvips
         run: sudo meson install -C build

--- a/ChangeLog
+++ b/ChangeLog
@@ -12,6 +12,7 @@ master 8.16
 - better system error messages on windows [kleisauke]
 - add configurable max coordinate and vips_max_coord_get()
 - improve kill handling
+- save and load PFM now uses scRGB (ie. linear 0-1) [NiHoel]
 
 date-tbd 8.15.2
 

--- a/ChangeLog
+++ b/ChangeLog
@@ -12,7 +12,7 @@ master 8.16
 - better system error messages on windows [kleisauke]
 - add configurable max coordinate and vips_max_coord_get()
 - improve kill handling
-- save and load PFM now uses scRGB (ie. linear 0-1) [NiHoel]
+- PFM save and load now uses scRGB (ie. linear 0-1) [NiHoel]
 
 date-tbd 8.15.2
 

--- a/libvips/conversion/byteswap.c
+++ b/libvips/conversion/byteswap.c
@@ -4,6 +4,8 @@
  * 	- from copy.c
  * 27/1/16
  * 	- don't swap coded images
+ * 11/3/24
+ *	- support unaligned images
  */
 
 /*
@@ -77,6 +79,9 @@ vips_byteswap_swap2(VipsPel *in, VipsPel *out, int width, VipsImage *im)
 
 	int x;
 
+	// must be 2-byte aligned, or behaviour is undefined
+	g_assert(VIPS_ALIGNED(p, 2) && VIPS_ALIGNED(q, 2));
+
 	for (x = 0; x < sz; x++)
 		q[x] = GUINT16_SWAP_LE_BE(p[x]);
 }
@@ -92,6 +97,9 @@ vips_byteswap_swap4(VipsPel *in, VipsPel *out, int width, VipsImage *im)
 
 	int x;
 
+	// must be 4-byte aligned, or behaviour is undefined
+	g_assert(VIPS_ALIGNED(p, 4) && VIPS_ALIGNED(q, 4));
+
 	for (x = 0; x < sz; x++)
 		q[x] = GUINT32_SWAP_LE_BE(p[x]);
 }
@@ -106,6 +114,9 @@ vips_byteswap_swap8(VipsPel *in, VipsPel *out, int width, VipsImage *im)
 	int sz = (VIPS_IMAGE_SIZEOF_PEL(im) * width) / 8;
 
 	int x;
+
+	// must be 8-byte aligned, or behaviour is undefined
+	g_assert(VIPS_ALIGNED(p, 8) && VIPS_ALIGNED(q, 8));
 
 	for (x = 0; x < sz; x++)
 		q[x] = GUINT64_SWAP_LE_BE(p[x]);
@@ -126,6 +137,19 @@ static SwapFn vips_byteswap_swap_fn[] = {
 	vips_byteswap_swap8	 /* VIPS_FORMAT_DPCOMPLEX = 9, */
 };
 
+static void
+vips_byteswap_swap_unaligned(VipsPel *in, VipsPel *out, int n, int size)
+{
+
+	for (int x = 0; x < n; x++) {
+		for (int i = 0; i < size; i++)
+			out[i] = in[size - i - 1];
+
+		in += size;
+		out += size;
+	}
+}
+
 /* Byteswap, turning bands into the x axis.
  */
 static int
@@ -135,11 +159,12 @@ vips_byteswap_gen(VipsRegion *out_region,
 	VipsRegion *ir = (VipsRegion *) seq;
 	VipsImage *im = ir->im;
 	VipsRect *r = &out_region->valid;
-	SwapFn swap = vips_byteswap_swap_fn[im->BandFmt];
+	SwapFn swap_aligned = vips_byteswap_swap_fn[im->BandFmt];
+	int size = vips_format_sizeof(im->BandFmt);
 
 	int y;
 
-	g_assert(swap);
+	g_assert(swap_aligned);
 
 	if (vips_region_prepare(ir, r))
 		return -1;
@@ -148,7 +173,15 @@ vips_byteswap_gen(VipsRegion *out_region,
 		VipsPel *p = VIPS_REGION_ADDR(ir, r->left, r->top + y);
 		VipsPel *q = VIPS_REGION_ADDR(out_region, r->left, r->top + y);
 
-		swap(p, q, r->width, im);
+		if (VIPS_ALIGNED(p, size) && VIPS_ALIGNED(q, size))
+			swap_aligned(p, q, r->width, im);
+		else
+			/* Ouch!! horribly slow.
+			 *
+			 * This can be necessary for formats like PFM, where the data
+			 * offset in the file can have any alignment.
+			 */
+			vips_byteswap_swap_unaligned(p, q, r->width * im->Bands, size);
 	}
 
 	return 0;

--- a/libvips/conversion/byteswap.c
+++ b/libvips/conversion/byteswap.c
@@ -140,7 +140,6 @@ static SwapFn vips_byteswap_swap_fn[] = {
 static void
 vips_byteswap_swap_unaligned(VipsPel *in, VipsPel *out, int n, int size)
 {
-
 	for (int x = 0; x < n; x++) {
 		for (int i = 0; i < size; i++)
 			out[i] = in[size - i - 1];

--- a/libvips/foreign/foreign.c
+++ b/libvips/foreign/foreign.c
@@ -1483,10 +1483,6 @@ vips__foreign_convert_saveable(VipsImage *in, VipsImage **ready,
 		VipsImage *out;
 		VipsInterpretation interpretation;
 
-		maybe handle scRGB as well?
-
-			or ppmsave could be ANY and do more things like CMYK import etc.
-
 		/* Do we make RGB or RGB16? We don't want to squash a 16-bit
 		 * RGB down to 8 bits if the saver supports 16.
 		 */

--- a/libvips/foreign/foreign.c
+++ b/libvips/foreign/foreign.c
@@ -1433,8 +1433,7 @@ vips__foreign_convert_saveable(VipsImage *in, VipsImage **ready,
 			in->Type != VIPS_INTERPRETATION_XYZ) {
 			VipsImage *out;
 
-			if (vips_colourspace(in, &out,
-					VIPS_INTERPRETATION_scRGB, NULL)) {
+			if (vips_colourspace(in, &out, VIPS_INTERPRETATION_scRGB, NULL)) {
 				g_object_unref(in);
 				return -1;
 			}
@@ -1483,6 +1482,10 @@ vips__foreign_convert_saveable(VipsImage *in, VipsImage **ready,
 			saveable == VIPS_SAVEABLE_RGB_CMYK)) {
 		VipsImage *out;
 		VipsInterpretation interpretation;
+
+		maybe handle scRGB as well?
+
+			or ppmsave could be ANY and do more things like CMYK import etc.
 
 		/* Do we make RGB or RGB16? We don't want to squash a 16-bit
 		 * RGB down to 8 bits if the saver supports 16.

--- a/libvips/foreign/ppmload.c
+++ b/libvips/foreign/ppmload.c
@@ -45,6 +45,8 @@
  * 	- don't byteswap ascii formats
  * 	- set metadata for map loads
  * 	- byteswap binary loads
+ * 9/3/23
+ *	- pfm assumes linear 0-1 [NiHoel]
  */
 
 /*
@@ -75,8 +77,8 @@
  */
 
 /*
-#define DEBUG
  */
+#define DEBUG
 
 #ifdef HAVE_CONFIG_H
 #include <config.h>
@@ -353,6 +355,8 @@ vips_foreign_load_ppm_parse_header(VipsForeignLoadPpm *ppm)
 	else {
 		if (ppm->format == VIPS_FORMAT_USHORT)
 			ppm->interpretation = VIPS_INTERPRETATION_RGB16;
+		else if (ppm->format == VIPS_FORMAT_FLOAT)
+			ppm->interpretation = VIPS_INTERPRETATION_scRGB;
 		else
 			ppm->interpretation = VIPS_INTERPRETATION_sRGB;
 	}
@@ -365,11 +369,9 @@ vips_foreign_load_ppm_parse_header(VipsForeignLoadPpm *ppm)
 	printf("\theight = %d\n", ppm->height);
 	printf("\tbands = %d\n", ppm->bands);
 	printf("\tformat = %s\n",
-		vips_enum_nick(VIPS_TYPE_BAND_FORMAT,
-			ppm->format));
+		vips_enum_nick(VIPS_TYPE_BAND_FORMAT, ppm->format));
 	printf("\tinterpretation = %s\n",
-		vips_enum_nick(VIPS_TYPE_INTERPRETATION,
-			ppm->interpretation));
+		vips_enum_nick(VIPS_TYPE_INTERPRETATION, ppm->interpretation));
 	printf("\tscale = %g\n", ppm->scale);
 	printf("\tmax_value = %d\n", ppm->max_value);
 	printf("\tbits = %d\n", ppm->bits);

--- a/libvips/foreign/ppmload.c
+++ b/libvips/foreign/ppmload.c
@@ -308,15 +308,10 @@ vips_foreign_load_ppm_parse_header(VipsForeignLoadPpm *ppm)
 		}
 	}
 
-	/* For binary images, there is always exactly 1 more whitespace
-	 * character before the data starts.
+	/* Read the end of line character after the scale so we are positioned
+	 * exactly at the start of the data. This matters for binary formats.
 	 */
-	if (!ppm->ascii &&
-		!isspace(VIPS_SBUF_GETC(ppm->sbuf))) {
-		vips_error(class->nickname, "%s",
-			_("no whitespace before start of binary data"));
-		return -1;
-	}
+	(void) vips_sbuf_get_line(ppm->sbuf);
 
 	/* Choose a VIPS bandfmt.
 	 */
@@ -480,6 +475,8 @@ vips_foreign_load_ppm_map(VipsForeignLoadPpm *ppm)
 
 	vips_sbuf_unbuffer(ppm->sbuf);
 	header_offset = vips_source_seek(ppm->source, 0, SEEK_CUR);
+	printf("vips_foreign_load_ppm_map: header_offset = %" G_GINT64_FORMAT "\n",
+		header_offset);
 	data = vips_source_map(ppm->source, &length);
 	if (header_offset < 0 ||
 		!data)

--- a/libvips/foreign/ppmload.c
+++ b/libvips/foreign/ppmload.c
@@ -77,8 +77,8 @@
  */
 
 /*
- */
 #define DEBUG
+ */
 
 #ifdef HAVE_CONFIG_H
 #include <config.h>

--- a/libvips/foreign/ppmload.c
+++ b/libvips/foreign/ppmload.c
@@ -475,8 +475,6 @@ vips_foreign_load_ppm_map(VipsForeignLoadPpm *ppm)
 
 	vips_sbuf_unbuffer(ppm->sbuf);
 	header_offset = vips_source_seek(ppm->source, 0, SEEK_CUR);
-	printf("vips_foreign_load_ppm_map: header_offset = %" G_GINT64_FORMAT "\n",
-		header_offset);
 	data = vips_source_map(ppm->source, &length);
 	if (header_offset < 0 ||
 		!data)

--- a/libvips/include/vips/util.h
+++ b/libvips/include/vips/util.h
@@ -61,6 +61,9 @@ extern "C" {
 
 #define VIPS_ABS(X) (((X) >= 0) ? (X) : -(X))
 
+// is something (eg. a pointer) N aligned
+#define VIPS_ALIGNED(P, N) ((((guint64) (P)) & ((N) - 1)) == 0)
+
 /* The built-in isnan and isinf functions provided by gcc 4+ and clang are
  * up to 7x faster than their libc equivalent included from <math.h>.
  */

--- a/libvips/iofuncs/target.c
+++ b/libvips/iofuncs/target.c
@@ -583,8 +583,7 @@ vips_target_seek(VipsTarget *target, gint64 position, int whence)
 
 	gint64 new_position;
 
-	VIPS_DEBUG_MSG(
-		"vips_target_seek: pos = %" G_GINT64_FORMAT
+	VIPS_DEBUG_MSG("vips_target_seek: pos = %" G_GINT64_FORMAT
 		", whence = %d\n",
 		position, whence);
 
@@ -593,8 +592,7 @@ vips_target_seek(VipsTarget *target, gint64 position, int whence)
 
 	new_position = class->seek(target, position, whence);
 
-	VIPS_DEBUG_MSG(
-		"vips_target_seek: new_position = %" G_GINT64_FORMAT "\n",
+	VIPS_DEBUG_MSG("vips_target_seek: new_position = %" G_GINT64_FORMAT "\n",
 		new_position);
 
 	return new_position;

--- a/test/test-suite/helpers/helpers.py
+++ b/test/test-suite/helpers/helpers.py
@@ -8,6 +8,7 @@ import pytest
 import pyvips
 
 IMAGES = os.path.join(os.path.dirname(__file__), os.pardir, 'images')
+RAD_FILE = os.path.join(IMAGES, "sample.hdr")
 JPEG_FILE = os.path.join(IMAGES, "sample.jpg")
 JPEG_FILE_XYB = os.path.join(IMAGES, "sample-xyb.jpg")
 TRUNCATED_FILE = os.path.join(IMAGES, "truncated.jpg")

--- a/test/test-suite/test_foreign.py
+++ b/test/test-suite/test_foreign.py
@@ -1192,18 +1192,16 @@ class TestForeign:
 
     @skip_if_no("ppmload")
     def test_ppm(self):
-        self.save_load("%s.ppm", self.mono)
         self.save_load("%s.ppm", self.colour)
 
-        self.save_load_file("%s.ppm", "[ascii]", self.mono, 0)
+        self.save_load_file("%s.pgm", "[ascii]", self.mono, 0)
         self.save_load_file("%s.ppm", "[ascii]", self.colour, 0)
 
-        self.save_load_file("%s.ppm", "[ascii,bitdepth=1]", self.onebit, 0)
+        self.save_load_file("%s.pbm", "[ascii]", self.onebit, 0)
 
         rgb16 = self.colour.colourspace("rgb16")
         grey16 = self.mono.colourspace("rgb16")
 
-        self.save_load("%s.ppm", grey16)
         self.save_load("%s.ppm", rgb16)
 
         self.save_load_file("%s.ppm", "[ascii]", grey16, 0)

--- a/test/test_formats.sh
+++ b/test/test_formats.sh
@@ -171,6 +171,7 @@ fi
 
 # csv can only do mono
 test_format $mono csv 0
+test_format $rad hdr 0
 
 # cmyk jpg is a special path
 if test_supported jpegload; then
@@ -182,8 +183,6 @@ if test_supported tiffload; then
 	test_format $cmyk tif 90 [compression=jpeg,tile]
 	test_format $cmyk tif 90 [compression=jpeg,tile,pyramid]
 fi
-
-test_rad $rad
 
 test_raw $mono
 test_raw $image

--- a/test/test_formats.sh
+++ b/test/test_formats.sh
@@ -67,24 +67,6 @@ test_format() {
 	echo "ok"
 }
 
-# as above, but hdr format
-# this is a coded format, so we need to rad2float before we can test for
-# differences
-test_rad() {
-	in=$1
-
-	printf "testing $(basename $in) hdr ... "
-
-	save_load $in hdr
-
-	$vips rad2float $in $tmp/before.v
-	$vips rad2float $tmp/back.v $tmp/after.v
-
-	test_difference $tmp/before.v $tmp/after.v 0
-
-	echo "ok"
-}
-
 # as above, but raw format
 # we can't use suffix stuff to pick the load/save
 test_raw() {

--- a/test/test_formats.sh
+++ b/test/test_formats.sh
@@ -25,7 +25,7 @@ $vips extract_band $image $tmp/mono.v 1
 mono=$tmp/mono.v
 
 # make a radiance image
-$vips float2rad $image $tmp/rad.v 
+$vips float2rad $image $tmp/rad.v
 rad=$tmp/rad.v
 
 # make a cmyk image
@@ -183,10 +183,10 @@ if test_supported tiffload; then
 	test_format $cmyk tif 90 [compression=jpeg,tile,pyramid]
 fi
 
-test_rad $rad 
+test_rad $rad
 
-test_raw $mono 
-test_raw $image 
+test_raw $mono
+test_raw $image
 
 if test_supported pdfload; then
 	test_loader $poppler_ref $poppler pdfload 0

--- a/test/variables.sh.in
+++ b/test/variables.sh.in
@@ -49,8 +49,12 @@ test_difference() {
 	after=$2
 	threshold=$3
 
-	$vips subtract $before $after $tmp/difference.v
-	$vips abs $tmp/difference.v $tmp/abs.v 
+  # compare in srgb space
+	$vips colourspace $before $tmp/b-rgb.v srgb
+	$vips colourspace $after $tmp/a-rgb.v srgb
+
+	$vips subtract $tmp/b-rgb.v $tmp/a-rgb.v $tmp/difference.v
+	$vips abs $tmp/difference.v $tmp/abs.v
 	dif=$($vips max $tmp/abs.v)
 
 	if break_threshold $dif $threshold; then


### PR DESCRIPTION
Saving a scrgb image as `x.pfm` ought to save as scrgb.

Referring issue https://github.com/libvips/libvips/issues/3885

See also https://github.com/libvips/libvips/pull/3623 for when we improved scrgb for `tiffsave`.