### PR TITLE
Check linker supports target_clones attribute

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -8,6 +8,7 @@ date-tbd 8.15.2
 - fix arrayjoin with some pipelines [TheEssem]
 - fix high Q mono JPEG TIFF write with mozjpeg [cavenel]
 - tiffsave: ensure large file support (>2GB) on MSVC [kleisauke]
+- check linker for target_clones support [lovell]
 
 18/12/23 8.15.1
 

--- a/meson.build
+++ b/meson.build
@@ -145,7 +145,7 @@ int main(void) {
     return has_target_clones();
 }
 '''
-if cc.compiles(target_clones_check, args: '-Werror', name: 'Has target_clones attribute')
+if cc.links(target_clones_check, args: '-Werror', name: 'Has target_clones attribute')
     cfg_var.set('HAVE_TARGET_CLONES', '1')
 endif
 


### PR DESCRIPTION
Fixes https://github.com/libvips/libvips/issues/3876

This allows libvips to be built with buggy versions of LLVM where the compiler but not linker supports this feature, and therefore prevents an "undefined symbol: __cpu_model" error at link time.

CI before:

- Linux/gcc: Checking if "Has target_clones attribute" compiles: YES 
- Linux/clang14: Checking if "Has target_clones attribute" compiles: YES 
- macOS/xcode14: Checking if "Has target_clones attribute" compiles: NO 

CI after:

- Linux/gcc: Checking if "Has target_clones attribute" : links: YES 
- Linux/clang14: Checking if "Has target_clones attribute" : links: YES 
- macOS/xcode14: Checking if "Has target_clones attribute" : links: NO 

Targets the 8.15 branch.
