### PR TITLE
Jpegload, put the max shrink value to 8 instead of 16

### DIFF
--- a/libvips/foreign/jpegload.c
+++ b/libvips/foreign/jpegload.c
@@ -192,7 +192,7 @@ vips_foreign_load_jpeg_class_init(VipsForeignLoadJpegClass *class)
 		_("Shrink factor on load"),
 		VIPS_ARGUMENT_OPTIONAL_INPUT,
 		G_STRUCT_OFFSET(VipsForeignLoadJpeg, shrink),
-		1, 16, 1);
+		1, 8, 1);
 
 	VIPS_ARG_BOOL(class, "autorotate", 21,
 		_("Autorotate"),


### PR DESCRIPTION
Hello,

The `jpegload` doc displayed in CLI states that the max shrink value is 16
```bash
   shrink       - Shrink factor on load, input gint
			default: 1
			min: 1, max: 16
```

Trying to put a shrink factor > 8 and <= 16 triggers a `error buffer: VipsFormatLoadJpeg: bad shrink factor 16`

From other parts of the doc, it seems that the max shrink factor should be 8.