### PR TITLE
Increase EXIF size limit to 32Mb

### DIFF
--- a/libvips/foreign/exif.c
+++ b/libvips/foreign/exif.c
@@ -193,13 +193,13 @@ vips_exif_load_data_without_fix(const void *data, size_t length)
 	ExifData *ed;
 
 	/* exif_data_load_data() only allows uint for length. Limit it to less
-	 * than that: 2**20 should be enough for anyone.
+	 * than that: 2**23 should be enough for anyone.
 	 */
 	if (length < 4) {
 		vips_error("exif", "%s", _("exif too small"));
 		return NULL;
 	}
-	if (length > 1 << 20) {
+	if (length > 1 << 23) {
 		vips_error("exif", "%s", _("exif too large"));
 		return NULL;
 	}


### PR DESCRIPTION
Hey there 👋

Some of our users showed us AI-generated images that have pretty large EXIF data (around 4 Mb). All-in-all the images are ok, and their EXIF can be decoded successfully with higher limits, so I'd offer to increase the EXIF size limit to 32 Mb.