### PR TITLE
convi/reducev: fix HWY >= 1.1.0 paths on AVX2/AVX3

### DIFF
--- a/libvips/resample/reducev_hwy.cpp
+++ b/libvips/resample/reducev_hwy.cpp
@@ -5,7 +5,7 @@
  * 29/11/22 kleisauke
  * 	- prefer use of RearrangeToOddPlusEven
  * 02/10/23 kleisauke
- * 	- prefer use of InterleaveWhole{Lower,Upper}
+ * 	- prefer use of InterleaveWhole{Lower,Upper} on RVV/SVE
  */
 
 /*
@@ -71,9 +71,10 @@ constexpr Rebind<uint8_t, DI32> du8x32;
 constexpr DI16 di16;
 constexpr DI32 di32;
 
-#ifndef HAVE_HWY_1_1_0
-#define InterleaveWholeLower InterleaveLower
-#define InterleaveWholeUpper InterleaveUpper
+#if defined(HAVE_HWY_1_1_0) && \
+	(HWY_ARCH_RVV || (HWY_ARCH_ARM_A64 && HWY_TARGET <= HWY_SVE))
+#define InterleaveLower InterleaveWholeLower
+#define InterleaveUpper InterleaveWholeUpper
 #endif
 
 HWY_ATTR void
@@ -133,24 +134,24 @@ vips_reducev_uchar_hwy(VipsPel *pout, VipsPel *pin,
 			auto bottom = LoadU(du8, p); /* bottom line */
 			p += l1;
 
-			auto source = InterleaveWholeLower(top, bottom);
-			auto pix = BitCast(di16, InterleaveWholeLower(source, zero));
+			auto source = InterleaveLower(top, bottom);
+			auto pix = BitCast(di16, InterleaveLower(source, zero));
 
 			sum0 = ReorderWidenMulAccumulate(di32, pix, mmk, sum0,
 				/* byref */ sum1);
 
-			pix = BitCast(di16, InterleaveWholeUpper(du8, source, zero));
+			pix = BitCast(di16, InterleaveUpper(du8, source, zero));
 
 			sum2 = ReorderWidenMulAccumulate(di32, pix, mmk, sum2,
 				/* byref */ sum3);
 
-			source = InterleaveWholeUpper(du8, top, bottom);
-			pix = BitCast(di16, InterleaveWholeLower(source, zero));
+			source = InterleaveUpper(du8, top, bottom);
+			pix = BitCast(di16, InterleaveLower(source, zero));
 
 			sum4 = ReorderWidenMulAccumulate(di32, pix, mmk, sum4,
 				/* byref */ sum5);
 
-			pix = BitCast(di16, InterleaveWholeUpper(du8, source, zero));
+			pix = BitCast(di16, InterleaveUpper(du8, source, zero));
 
 			sum6 = ReorderWidenMulAccumulate(di32, pix, mmk, sum6,
 				/* byref */ sum7);
@@ -161,24 +162,24 @@ vips_reducev_uchar_hwy(VipsPel *pout, VipsPel *pin,
 			auto top = LoadU(du8, p);
 			p += l1;
 
-			auto source = InterleaveWholeLower(top, zero);
-			auto pix = BitCast(di16, InterleaveWholeLower(source, zero));
+			auto source = InterleaveLower(top, zero);
+			auto pix = BitCast(di16, InterleaveLower(source, zero));
 
 			sum0 = ReorderWidenMulAccumulate(di32, pix, mmk, sum0,
 				/* byref */ sum1);
 
-			pix = BitCast(di16, InterleaveWholeUpper(du8, source, zero));
+			pix = BitCast(di16, InterleaveUpper(du8, source, zero));
 
 			sum2 = ReorderWidenMulAccumulate(di32, pix, mmk, sum2,
 				/* byref */ sum3);
 
-			source = InterleaveWholeUpper(du8, top, zero);
-			pix = BitCast(di16, InterleaveWholeLower(source, zero));
+			source = InterleaveUpper(du8, top, zero);
+			pix = BitCast(di16, InterleaveLower(source, zero));
 
 			sum4 = ReorderWidenMulAccumulate(di32, pix, mmk, sum4,
 				/* byref */ sum5);
 
-			pix = BitCast(di16, InterleaveWholeUpper(du8, source, zero));
+			pix = BitCast(di16, InterleaveUpper(du8, source, zero));
 
 			sum6 = ReorderWidenMulAccumulate(di32, pix, mmk, sum6,
 				/* byref */ sum7);
@@ -254,7 +255,7 @@ vips_reducev_uchar_hwy(VipsPel *pout, VipsPel *pin,
 			auto bottom = LoadU(du8x16, p); /* bottom line */
 			p += l1;
 
-			auto source = InterleaveWholeLower(top, bottom);
+			auto source = InterleaveLower(top, bottom);
 			auto pix = PromoteTo(di16, source);
 
 			sum0 = ReorderWidenMulAccumulate(di32, pix, mmk, sum0,
@@ -288,6 +289,9 @@ vips_reducev_uchar_hwy(VipsPel *pout, VipsPel *pin,
 	}
 #endif
 }
+
+#undef InterleaveLower
+#undef InterleaveUpper
 
 } /*namespace HWY_NAMESPACE*/
 


### PR DESCRIPTION
On AVX2 and AVX3 architectures, for vectors of 32 bytes or larger, the semantics of the `InterleaveWhole{Lower,Upper}` operations do not align with the non-whole variants.
https://github.com/google/highway/blob/1.1.0/hwy/ops/generic_ops-inl.h#L392-L399

Ensure we only use `InterleaveWhole*` on RVV/SVE.

This partially reverts commit 9924904cc3146bdd41bfcd2a3beaf075c4f76966.