### PR TITLE
Revert "block fuzz data over 100kb"

### DIFF
--- a/fuzz/gifsave_buffer_fuzzer.cc
+++ b/fuzz/gifsave_buffer_fuzzer.cc
@@ -14,9 +14,6 @@ LLVMFuzzerTestOneInput(const guint8 *data, size_t size)
 	void *buf;
 	size_t len;
 
-	if (size > 100 * 1024 * 1024)
-		return 0;
-
 	if (!(image = vips_image_new_from_buffer(data, size, "", nullptr)))
 		return 0;
 

--- a/fuzz/jpegsave_buffer_fuzzer.cc
+++ b/fuzz/jpegsave_buffer_fuzzer.cc
@@ -14,9 +14,6 @@ LLVMFuzzerTestOneInput(const guint8 *data, size_t size)
 	void *buf;
 	size_t len;
 
-	if (size > 100 * 1024 * 1024)
-		return 0;
-
 	if (!(image = vips_image_new_from_buffer(data, size, "", nullptr)))
 		return 0;
 

--- a/fuzz/jpegsave_file_fuzzer.cc
+++ b/fuzz/jpegsave_file_fuzzer.cc
@@ -42,9 +42,6 @@ LLVMFuzzerTestOneInput(const guint8 *data, size_t size)
 {
 	char *name;
 
-	if (size > 100 * 1024 * 1024)
-		return 0;
-
 	if (!(name = vips__temp_name("%s")))
 		return 0;
 

--- a/fuzz/mosaic_fuzzer.cc
+++ b/fuzz/mosaic_fuzzer.cc
@@ -34,9 +34,6 @@ LLVMFuzzerTestOneInput(const guint8 *data, size_t size)
 	if (size < sizeof(mosaic_opt))
 		return 0;
 
-	if (size > 100 * 1024 * 1024)
-		return 0;
-
 	/* The tail of `data` is treated as mosaic configuration
 	 */
 	size -= sizeof(mosaic_opt);

--- a/fuzz/pngsave_buffer_fuzzer.cc
+++ b/fuzz/pngsave_buffer_fuzzer.cc
@@ -14,9 +14,6 @@ LLVMFuzzerTestOneInput(const guint8 *data, size_t size)
 	void *buf;
 	size_t len;
 
-	if (size > 100 * 1024 * 1024)
-		return 0;
-
 	if (!(image = vips_image_new_from_buffer(data, size, "", nullptr)))
 		return 0;
 

--- a/fuzz/sharpen_fuzzer.cc
+++ b/fuzz/sharpen_fuzzer.cc
@@ -13,9 +13,6 @@ LLVMFuzzerTestOneInput(const guint8 *data, size_t size)
 	VipsImage *image, *out;
 	double d;
 
-	if (size > 100 * 1024 * 1024)
-		return 0;
-
 	if (!(image = vips_image_new_from_buffer(data, size, "", nullptr)))
 		return 0;
 

--- a/fuzz/smartcrop_fuzzer.cc
+++ b/fuzz/smartcrop_fuzzer.cc
@@ -13,9 +13,6 @@ LLVMFuzzerTestOneInput(const guint8 *data, size_t size)
 	VipsImage *image, *out;
 	double d;
 
-	if (size > 100 * 1024 * 1024)
-		return 0;
-
 	if (!(image = vips_image_new_from_buffer(data, size, "", nullptr)))
 		return 0;
 

--- a/fuzz/thumbnail_fuzzer.cc
+++ b/fuzz/thumbnail_fuzzer.cc
@@ -13,9 +13,6 @@ LLVMFuzzerTestOneInput(const guint8 *data, size_t size)
 	VipsImage *image, *out;
 	double d;
 
-	if (size > 100 * 1024 * 1024)
-		return 0;
-
 	if (!(image = vips_image_new_from_buffer(data, size, "", nullptr)))
 		return 0;
 

--- a/fuzz/webpsave_buffer_fuzzer.cc
+++ b/fuzz/webpsave_buffer_fuzzer.cc
@@ -14,9 +14,6 @@ LLVMFuzzerTestOneInput(const guint8 *data, size_t size)
 	void *buf;
 	size_t len;
 
-	if (size > 100 * 1024 * 1024)
-		return 0;
-
 	if (!(image = vips_image_new_from_buffer(data, size, "", nullptr)))
 		return 0;
 


### PR DESCRIPTION
This reverts commit cb1634dd31866bdb6cf3554bbc87e01f87f49f25 since https://bugs.chromium.org/p/oss-fuzz/issues/detail?id=24383 was fixed with commit df26bd1e46c67ed7745996627ca0d83e5a6d678d instead.

---

Note that timeouts and OOMs are only reported once per fuzz target, so this may cause duplicate reports.
https://google.github.io/oss-fuzz/faq/#how-do-you-handle-timeouts-and-ooms