### PR TITLE
pngload: disable ADLER32/CRC checking in non-fail mode

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,6 +1,7 @@
 26/3/24 8.15.3
 
 - fix dzsave of >8-bit images to JPEG
+- pngload: disable ADLER32/CRC checking in non-fail mode [kleisauke]
 
 12/3/24 8.15.2
 

--- a/libvips/foreign/spngload.c
+++ b/libvips/foreign/spngload.c
@@ -337,10 +337,10 @@ vips_foreign_load_png_header(VipsForeignLoad *load)
 	/* In non-fail mode, ignore CRC errors.
 	 */
 	flags = 0;
-	if (load->fail_on >= VIPS_FAIL_ON_ERROR)
+	if (load->fail_on < VIPS_FAIL_ON_ERROR)
 		flags |= SPNG_CTX_IGNORE_ADLER32;
 	png->ctx = spng_ctx_new(flags);
-	if (load->fail_on >= VIPS_FAIL_ON_ERROR)
+	if (load->fail_on < VIPS_FAIL_ON_ERROR)
 		/* Ignore and don't calculate checksums.
 		 */
 		spng_set_crc_action(png->ctx, SPNG_CRC_USE, SPNG_CRC_USE);

--- a/libvips/foreign/vipspng.c
+++ b/libvips/foreign/vipspng.c
@@ -305,20 +305,18 @@ read_new(VipsSource *source, VipsImage *out,
 		PNG_SKIP_sRGB_CHECK_PROFILE, PNG_OPTION_ON);
 #endif /*PNG_SKIP_sRGB_CHECK_PROFILE*/
 
-	/* Don't verify ADLER32 checksums (this can produce a lot of
-	 * warnings).
+	/* In non-fail mode, ignore CRC errors.
 	 */
+	if (read->fail_on < VIPS_FAIL_ON_ERROR) {
 #ifdef PNG_IGNORE_ADLER32
-	png_set_option(read->pPng, PNG_IGNORE_ADLER32, PNG_OPTION_ON);
+		png_set_option(read->pPng, PNG_IGNORE_ADLER32, PNG_OPTION_ON);
 #endif /*PNG_IGNORE_ADLER32*/
 
-	/* Disable CRC checking in fuzzing mode. Most fuzzed images will have
-	 * bad CRCs so this check would break fuzzing.
-	 */
-#ifdef FUZZING_BUILD_MODE_UNSAFE_FOR_PRODUCTION
-	png_set_crc_action(read->pPng,
-		PNG_CRC_QUIET_USE, PNG_CRC_QUIET_USE);
-#endif /*FUZZING_BUILD_MODE_UNSAFE_FOR_PRODUCTION*/
+		/* Ignore and don't calculate checksums.
+		 */
+		png_set_crc_action(read->pPng,
+			PNG_CRC_QUIET_USE, PNG_CRC_QUIET_USE);
+	}
 
 	/* libpng has a default soft limit of 1m pixels per axis.
 	 */


### PR DESCRIPTION
The condition was inverted for spng, also sync libpng load while we are here.

Targets the 8.15 branch.