### PR TITLE
OSS-Fuzz: disable build of cruft

### DIFF
--- a/fuzz/oss_fuzz_build.sh
+++ b/fuzz/oss_fuzz_build.sh
@@ -5,10 +5,12 @@ export PKG_CONFIG_PATH="$WORK/lib/pkgconfig"
 export CPPFLAGS="-I$WORK/include"
 export LDFLAGS="-L$WORK/lib"
 
+# Run as many parallel jobs as there are available CPU cores
+export MAKEFLAGS="-j$(nproc)"
+
 # libz
 pushd $SRC/zlib
 ./configure --static --prefix=$WORK
-make -j$(nproc) all
 make install
 popd
 
@@ -22,20 +24,14 @@ autoreconf -fi
   --disable-docs \
   --disable-dependency-tracking \
   --prefix=$WORK
-make -j$(nproc)
-make install
+make install doc_DATA=
 popd
 
 # lcms
 pushd $SRC/lcms
-./autogen.sh
-./configure \
-  --enable-static \
-  --disable-shared \
-  --disable-dependency-tracking \
-  --prefix=$WORK
-make -j$(nproc)
-make install
+meson setup build --prefix=$WORK --libdir=lib --default-library=static --buildtype=debugoptimized \
+  -Djpeg=disabled -Dtiff=disabled
+meson install -C build --tag devel
 popd
 
 # aom
@@ -44,6 +40,7 @@ mkdir -p build/linux
 cd build/linux
 extra_libaom_flags='-DAOM_MAX_ALLOCABLE_MEMORY=536870912 -DDO_RANGE_CHECK_CLAMP=1'
 cmake \
+  -GNinja \
   -DCMAKE_BUILD_TYPE=RelWithDebInfo \
   -DCMAKE_INSTALL_PREFIX=$WORK \
   -DCONFIG_PIC=1 \
@@ -58,14 +55,13 @@ cmake \
   -DAOM_EXTRA_CXX_FLAGS="$extra_libaom_flags" \
   -DAOM_TARGET_CPU=generic \
   ../../
-make clean
-make -j$(nproc)
-make install
+cmake --build . --target install
 popd
 
 # libheif
 pushd $SRC/libheif
 cmake \
+  -GNinja \
   -DCMAKE_BUILD_TYPE=RelWithDebInfo \
   -DCMAKE_INSTALL_PREFIX=$WORK \
   -DBUILD_SHARED_LIBS=FALSE \
@@ -73,29 +69,29 @@ cmake \
   -DWITH_EXAMPLES=FALSE \
   -DENABLE_PLUGIN_LOADING=FALSE \
   .
-make -j$(nproc)
-make install
+cmake --build . --target install
 popd
 
 # libjpeg-turbo
 pushd $SRC/libjpeg-turbo
 cmake \
+  -GNinja \
   -DCMAKE_BUILD_TYPE=RelWithDebInfo \
   -DCMAKE_INSTALL_PREFIX=$WORK \
   -DENABLE_STATIC=TRUE \
   -DENABLE_SHARED=FALSE \
   -DWITH_TURBOJPEG=FALSE \
   .
-make -j$(nproc)
-make install
+cmake --build . --target jpeg-static
+cmake --install . --component lib
+cmake --install . --component include
 popd
 
 # libspng
 pushd $SRC/libspng
 meson setup build --prefix=$WORK --libdir=lib --default-library=static --buildtype=debugoptimized \
   -Dstatic_zlib=true
-ninja -C build
-ninja -C build install
+meson install -C build --tag devel
 popd
 
 # libwebp
@@ -112,8 +108,7 @@ autoreconf -fi
   --disable-threading \
   --disable-dependency-tracking \
   --prefix=$WORK
-make -j$(nproc)
-make install
+make install bin_PROGRAMS= noinst_PROGRAMS= man_MANS=
 popd
 
 # libtiff ... a bug in libtiff master as of 20 Nov 2019 means we have to
@@ -121,26 +116,27 @@ popd
 pushd $SRC/libtiff
 autoreconf -fi
 ./configure \
+  --disable-tools \
+  --disable-tests \
+  --disable-contrib \
+  --disable-docs \
   --disable-lzma \
   --disable-shared \
   --disable-dependency-tracking \
   --prefix=$WORK
-make -j$(nproc)
-make install
+make install noinst_PROGRAMS= dist_doc_DATA=
 popd
 
 # libimagequant
 pushd $SRC/libimagequant
 meson setup build --prefix=$WORK --libdir=lib --default-library=static --buildtype=debugoptimized
-ninja -C build
-ninja -C build install
+meson install -C build --tag devel
 popd
 
 # cgif
 pushd $SRC/cgif
 meson setup build --prefix=$WORK --libdir=lib --default-library=static --buildtype=debugoptimized
-ninja -C build
-ninja -C build install
+meson install -C build --tag devel
 popd
 
 # pdfium doesn't need fuzzing, but we want to fuzz the libvips/pdfium link
@@ -152,21 +148,21 @@ popd
 # make a pdfium.pc that libvips can use ... the version number just needs to
 # be higher than 4200 to satisfy libvips
 cat > $WORK/lib/pkgconfig/pdfium.pc << EOF
-  prefix=$WORK
-  exec_prefix=\${prefix}
-  libdir=\${exec_prefix}/lib
-  includedir=\${prefix}/include
-  Name: pdfium
-  Description: pdfium
-  Version: 4901
-  Requires:
-  Libs: -L\${libdir} -lpdfium
-  Cflags: -I\${includedir}
+prefix=$WORK
+libdir=\${prefix}/lib
+includedir=\${prefix}/include
+
+Name: pdfium
+Description: pdfium
+Version: 4901
+Libs: -L\${libdir} -lpdfium
+Cflags: -I\${includedir}
 EOF
 
 # highway
 pushd $SRC/highway
 cmake \
+  -GNinja \
   -DCMAKE_BUILD_TYPE=RelWithDebInfo \
   -DCMAKE_INSTALL_PREFIX=$WORK \
   -DBUILD_SHARED_LIBS=0 \
@@ -175,19 +171,17 @@ cmake \
   -DHWY_ENABLE_EXAMPLES=0 \
   -DHWY_ENABLE_TESTS=0 \
   .
-make -j$(nproc)
-make install
+cmake --build . --target install
 popd
 
 # libvips
 # Disable building man pages, gettext po files, tools, and tests
 sed -i "/subdir('man')/{N;N;N;d;}" meson.build
-meson setup build --prefix=$WORK --libdir=lib --prefer-static --default-library=static \
+meson setup build --prefix=$WORK --libdir=lib --prefer-static --default-library=static --buildtype=debugoptimized \
   -Ddeprecated=false -Dexamples=false -Dcplusplus=false -Dmodules=disabled \
   -Dfuzzing_engine=oss-fuzz -Dfuzzer_ldflags="$LIB_FUZZING_ENGINE" \
   -Dcpp_link_args="$LDFLAGS -Wl,-rpath=\$ORIGIN/lib"
-ninja -C build
-ninja -C build install
+meson install -C build --tag devel
 
 # Copy fuzz executables to $OUT
 find build/fuzz -maxdepth 1 -executable -type f -exec cp -v '{}' $OUT \;


### PR DESCRIPTION
For the same reason as mentioned in PR #3929:
https://oss-fuzz-build-logs.storage.googleapis.com/log-ba5392d5-fe65-462a-b134-e6b38c228b08.txt

~~Uses a patch from: https://github.com/libjpeg-turbo/libjpeg-turbo/pull/756.~~ 