### PR TITLE
cpp: Fix build in Qt-using projects without changes

### DIFF
--- a/cplusplus/include/vips/vips8
+++ b/cplusplus/include/vips/vips8
@@ -3,7 +3,7 @@
 /*
 
     This file is part of VIPS.
-    
+
     VIPS is free software; you can redistribute it and/or modify
     it under the terms of the GNU Lesser General Public License as published by
     the Free Software Foundation; either version 2 of the License, or
@@ -29,6 +29,12 @@
 
 #ifndef VIPS_CPLUSPLUS
 #define VIPS_CPLUSPLUS
+
+/* avoid conflict with Qt definitions, if they exist */
+#if defined(signals) && defined(Q_SIGNALS)
+#define _VIPS_QT_SIGNALS_DEFINED
+#undef signals
+#endif
 
 #include <vips/version.h>
 
@@ -56,5 +62,11 @@
 #include "VInterpolate8.h"
 #include "VRegion8.h"
 #include "VConnection8.h"
+
+/* restore Qt keywords if they were disabled for GLib inclusion */
+#ifdef _VIPS_QT_SIGNALS_DEFINED
+#define signals Q_SIGNALS
+#undef _VIPS_QT_SIGNALS_DEFINED
+#endif
 
 #endif /*VIPS_CPLUSPLUS*/


### PR DESCRIPTION
Hi!

Currently, when including libvips in a Qt-Using C++ project, you may get errors like:
``` 
/usr/include/glib-2.0/gio/gdbusintrospection.h:155:24: error: expected ‘;’ at end of member declaration
   GDBusSignalInfo     **signals;
                        ^
/usr/include/glib-2.0/gio/gdbusintrospection.h:155:32: error: expected ‘:’ before ‘;’ token
   GDBusSignalInfo     **signals;
                                ^
``` 

This is due to Qt enabling special keywords which GLib uses as variable names. It can easily worked around with some preprocessor magic, but it's a bit jarring and also forces the addition of either a custom header to include VIPS, or to disable keywords entirely for the Qt project.

With this patch, libvips detects Qt when the C++ header is used and temporarily disables the keyword, just to enable it again after inclusion. It should have no drawbacks for non-Qt projects, but yield fewer surprises if someone wants to use VIPS from a Qt project.

Thanks for creating this useful library and considering this patch :-)
