### PR TITLE
Feature/webp target size

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -16,6 +16,10 @@ master 8.16
 - turn `vips_addalpha` into a VipsOperation [RiskoZoSlovenska]
 - add vips_rawsave_target(), vips_rawsave_buffer() [akash-akya]
 - vipsheader supports multiple "-f field" arguments [sergeevabc]
+- webpsave has @target_size parameter to set desired size 
+  in bytes. [john-parton]
+- webpsave has @passes parameter to set number of passes to achieve
+  desired target_size. [john-parton]
 
 26/3/24 8.15.3
 

--- a/test/test-suite/test_foreign.py
+++ b/test/test-suite/test_foreign.py
@@ -937,6 +937,11 @@ class TestForeign:
         assert x.height == 16731
         buf = x.webpsave_buffer()
 
+        # target_size should reasonably work, +/- 2% is fine
+        x = pyvips.Image.new_from_file(WEBP_FILE)
+        buf_size = len(x.webpsave_buffer(target_size=20_000, keep='none'))
+        assert 19600 < buf_size < 20400
+
     @skip_if_no("analyzeload")
     def test_analyzeload(self):
         def analyze_valid(im):


### PR DESCRIPTION
This is the initial work to close https://github.com/libvips/libvips/issues/3824

It works, but there's one "gotcha." The `target_size` parameter doesn't do anything unless `pass` is 2 or greater. The more passes, the closer it will get to `target_size`. In my non-scientific tests, 4 to 6 seem to be reasonable numbers.

I did a basic 'smoke test' with the CLI tool:

```bash
vips rot myfile.jpg out.webp[Q=100,target_size=2500000,pass=4] d90
```

and python
```python
with open("myfile.jpg", "rb") as f:
    buffer = f.read()

image = pyvips.Image.new_from_buffer(buffer, "")

buff = image.webpsave_buffer(target_size=1_000_000, **{"pass": 4})

with open("out.webp", "wb") as f:
    f.write(buff)
```

Note that 'pass' is a keyword in python, so I have to pass it by unpacking a dictionary. Very not fun.

Does this general approach seem reasonable?