### PR TITLE
Improve `target_clones` support check

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -3,6 +3,7 @@
 - fix dzsave of >8-bit images to JPEG
 - jpegsave: fix chrominance subsampling mode with jpegli [kleisauke]
 - pngload: disable ADLER32/CRC checking in non-fail mode [kleisauke]
+- improve target_clones support check [kleisauke]
 
 12/3/24 8.15.2
 

--- a/meson.build
+++ b/meson.build
@@ -141,8 +141,10 @@ static int __attribute__((target_clones("default,avx")))
 has_target_clones(void) {
     return 0;
 }
+
 int main(void) {
-    return has_target_clones();
+    int (*func)(void) = has_target_clones;
+    return func();
 }
 '''
 if cc.links(target_clones_check, args: '-Werror', name: 'Has target_clones attribute')


### PR DESCRIPTION
```console
$ cat reduced.c
static int __attribute__((target_clones("default,avx")))
has_target_clones(void) {
    return 0;
}

int main(void) {
    int (*func)(void) = has_target_clones;
    return func();
}
$ clang -O0 -g reduced.c
$ clang -O0 -flto -g reduced.c
clang: error: unable to execute command: Segmentation fault (core dumped)
clang: error: linker command failed due to signal (use -v to see invocation)
$  clang --version
clang version 18.1.1 (Fedora 18.1.1-1.fc40)
Target: x86_64-redhat-linux-gnu
Thread model: posix
InstalledDir: /usr/bin
Configuration file: /etc/clang/clang.cfg
```

Resolves: #3874

Targets the 8.15 branch.