### PR TITLE
support mutiple "-f" args to vipsheader

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -15,6 +15,7 @@ master 8.16
 - PFM save and load now uses scRGB (ie. linear 0-1) [NiHoel]
 - turn `vips_addalpha` into a VipsOperation [RiskoZoSlovenska]
 - add vips_rawsave_target(), vips_rawsave_buffer() [akash-akya]
+- vipsheader supports multiple "-f field" arguments [sergeevabc]
 
 26/3/24 8.15.3
 

--- a/man/vipsheader.1
+++ b/man/vipsheader.1
@@ -5,31 +5,34 @@ vipsheader \- prints information about an image file
 vipsheader [OPTIONS ...] files ...
 .SH DESCRIPTION
 .B vipsheader(1)
-prints image header fields to stdout. 
+prints image header fields to stdout.
 
 .SH OPTIONS
 
 .TP
 .B -a, --all
-Show all fields. Fields are displayed to be convenient for humans to read, so
-binary data, for example, is summarized rather than simply copied.
+Show all fields. Fields are displayed to be convenient for humans to
+read, so binary data, for example, is summarized rather than simply printed.
 
 .TP
 .B -f FIELD, --field=FIELD
-Print value of 
-.B FIELD 
-from image header. Fields are printed in a way suitable for programs to
+Print the value of
+.B FIELD
+from the image header. Fields are printed in a way suitable for programs to
 understand, so, for example, binary data is base64-encoded and printed as a
-stream of characters. 
+stream of characters.
 
-The special field name 
+The special field name
 .B getext
-prints the VIPS extension block: the XML defining the image metadata. You can 
-alter this, then reattach with 
+prints the VIPS extension block: the XML defining the image metadata. You can
+alter this, then reattach with
 .B vipsedit(1).
 
+You can use multiple "-f" arguments to print the values
+of many fields.
+
 .SH EXAMPLES
- $ vipsheader -f Xsize ~/pics/*.v   
+ $ vipsheader -f width ~/pics/*.v
  1024
  1279
  22865

--- a/tools/vipsheader.c
+++ b/tools/vipsheader.c
@@ -119,7 +119,7 @@ print_error(void)
 	vips_error_clear();
 }
 
-// complete dump of a field
+// complete dump of a field with "-f"
 static void *
 dump_field(void *data, void *a, void *b)
 {
@@ -132,7 +132,7 @@ dump_field(void *data, void *a, void *b)
 			int size;
 
 			if (!(buf = vips__read_extension_block(image, &size)))
-				print_error();
+				vips_error_exit(NULL);
 			else {
 				printf("%s", (char *) buf);
 				g_free(buf);
@@ -145,7 +145,7 @@ dump_field(void *data, void *a, void *b)
 		char *str;
 
 		if (vips_image_get_as_string(image, field, &str))
-			print_error();
+			vips_error_exit(NULL);
 		else {
 			printf("%s\n", str);
 			g_free(str);
@@ -180,7 +180,7 @@ static int
 print_header(VipsImage *image, gboolean many)
 {
 	if (main_option_fields)
-			vips_slist_map2(main_option_fields, dump_field, image, NULL);
+		vips_slist_map2(main_option_fields, dump_field, image, NULL);
 	else {
 		if (image->filename)
 			printf("%s: ", image->filename);
@@ -273,8 +273,7 @@ main(int argc, char *argv[])
 			VIPS_UNREF(source);
 		}
 		else {
-			if (!(image =
-						vips_image_new_from_file(argv[i], NULL))) {
+			if (!(image = vips_image_new_from_file(argv[i], NULL))) {
 				print_error();
 				result = 1;
 			}

--- a/tools/vipsheader.c
+++ b/tools/vipsheader.c
@@ -119,7 +119,7 @@ print_error(void)
 	vips_error_clear();
 }
 
-// compleete dump of a field
+// complete dump of a field
 static void *
 dump_field(void *data, void *a, void *b)
 {


### PR DESCRIPTION
With this PR you can use many "-f" arguments, for example:

	$ vipsheader -f width -f height k2.jpg
	1450
	2048

See https://github.com/libvips/libvips/issues/467