### PR TITLE
fix(pdfium): render annotations

### DIFF
--- a/libvips/foreign/pdfiumload.c
+++ b/libvips/foreign/pdfiumload.c
@@ -616,7 +616,7 @@ vips_foreign_load_pdf_generate(VipsRegion *out_region,
 			pdf->pages[i].left - rect.left,
 			pdf->pages[i].top - rect.top,
 			pdf->pages[i].width, pdf->pages[i].height,
-			0, 0);
+			0, FPDF_ANNOT);
 
 		FPDF_FFLDraw(pdf->form, bitmap, pdf->page,
 			pdf->pages[i].left - rect.left,


### PR DESCRIPTION
related to: https://github.com/libvips/libvips/pull/3790

Rendering all annotations is also required `FPDF_ANNOT` flags at FPDF_RenderPageBitmap.

Ref: https://pdfium.googlesource.com/pdfium/+/main/public/fpdfview.h#899

