### PR TITLE
Fix typos

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1692,7 +1692,7 @@ _ add vips_foreign_get_suffixes()
   im_vips2raw(), im_magick2vips(), im_png2vips(), im_png2*(), im_ppm2vips(),
   im_vips2ppm(), im_mat2vips(), im_rad2vips(), im_vips2rad()
   redone as classes
-- added argument priorites to help control arg ordering
+- added argument priorities to help control arg ordering
 - generate has a 'stop' param to signal successful early termination
 - added optional output args, eg. x/y for min
 - CLI supports optional output args

--- a/libvips/resample/nohalo.cpp
+++ b/libvips/resample/nohalo.cpp
@@ -917,7 +917,7 @@ lbbicubic(const double c00,
 	 * const double m13 = NOHALO_MIN(m7, qua_fou);
 	 * const double M13 = NOHALO_MAX(M7, qua_fou);
 	 *
-	 * This also allows reodering the comparisons to put space between
+	 * This also allows reordering the comparisons to put space between
 	 * the computation of a result and its use.
 	 */
 	const double m9 = NOHALO_MIN(m5, m4);


### PR DESCRIPTION
Found by codespell v2.3.0.

Targets the 8.15 branch to appease CI there as well.