### PR TITLE
Improve build summary for internal dependencies

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -772,7 +772,7 @@ build_features = {
 # which will make summary fail
 seen_deps = []
 foreach dep: external_deps + module_deps
-    if dep.name() not in seen_deps
+    if dep.type_name() != 'internal' and dep.name() not in seen_deps
        summary(dep.name(), dep.version(), section: 'Dependencies')
        seen_deps += dep.name()
     endif
@@ -782,8 +782,11 @@ foreach section_title, section : build_summary
 endforeach
 foreach section_title, section: build_features
     foreach key, arr : section
+        dep_name = arr[0]
         found = arr[1].found()
-        dep_name = found ? arr[1].name() : arr[0]
+        if found and arr[1].type_name() != 'internal'
+            dep_name = arr[1].name()
+        endif
         dynamic_module = arr.length() > 2 ? [' (dynamic module: ', arr[2], ')'] : []
         summary('@0@ with @1@'.format(key, dep_name), [found] + dynamic_module, bool_yn: true, list_sep: '', section: section_title)
     endforeach


### PR DESCRIPTION
Specifically for those created with `declare_dependency()`, which do not have a version number or name.

Diff when building with libnifti found without pkg-config (i.e. `-Dnifti-prefix-dir=/usr`).
```diff
@@ -29,7 +29,6 @@ vips 8.16.0
     OpenEXR                           : 3.1.10
     libopenjp2                        : 2.5.2
     libhwy                            : 1.1.0
-    dep139870032254528                     : 8.16.0
     MagickCore                        : 7.1.1
     openslide                         : 4.0.0
     libheif                           : 1.17.5
@@ -75,7 +74,7 @@ vips 8.16.0
     EXR load with OpenEXR             : YES
     WSI load with openslide           : YES (dynamic module: YES)
     Matlab load with matio            : YES
-    NIfTI load/save with dep139870032254528: YES
+    NIfTI load/save with libnifti     : YES
     FITS load/save with cfitsio       : YES
     GIF save with cgif                : YES
     Magick load/save with MagickCore  : YES (dynamic module: YES)
```