### PR TITLE
Ensure `target_clones` support is checked at runtime

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -147,7 +147,13 @@ int main(void) {
     return func();
 }
 '''
-if cc.links(target_clones_check, args: '-Werror', name: 'Has target_clones attribute')
+if meson.can_run_host_binaries()
+    rres = cc.run(target_clones_check, args: '-Werror', name: 'Has target_clones attribute')
+    have_target_clones = rres.compiled() and rres.returncode() == 0
+else
+    have_target_clones = cc.links(target_clones_check, args: '-Werror', name: 'Has target_clones attribute')
+endif
+if have_target_clones
     cfg_var.set('HAVE_TARGET_CLONES', '1')
 endif
 


### PR DESCRIPTION
```console
$ cat reduced.c
static int __attribute__((target_clones("default,avx")))
has_target_clones(void) {
    return 0;
}

int main(void) {
    int (*func)(void) = has_target_clones;
    return func();
}
$ cc reduced.c -o repro -Wl,-z,now,-z,relro
$ ./repro
[1]   Segmentation fault (core dumped) ./repro
$ uname -mrs
NetBSD 10.0 amd64
```

Resolves: #3977
Upstream issue: https://gnats.netbsd.org/57792

Targets the 8.15 branch.