### PR TITLE
fix vips_vsnprintf()

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -5,6 +5,7 @@
 - pngload: disable ADLER32/CRC checking in non-fail mode [kleisauke]
 - improve target_clones support check [kleisauke]
 - fix pipe read limit
+- fix a rare crash on windows in highly threaded applications [Julianiolo]
 
 12/3/24 8.15.2
 

--- a/libvips/iofuncs/util.c
+++ b/libvips/iofuncs/util.c
@@ -460,28 +460,8 @@ vips_vsnprintf(char *str, size_t size, const char *format, va_list ap)
 {
 #ifdef HAVE_VSNPRINTF
 	return vsnprintf(str, size, format, ap);
-#else  /*HAVE_VSNPRINTF*/
-	/* Bleurg!
-	 */
-	int n;
-	static char buf[MAX_BUF];
-
-	/* We can't return an error code, we may already have trashed the
-	 * stack. We must stop immediately.
-	 */
-	if (size > MAX_BUF)
-		vips_error_exit("panic: buffer overflow "
-						"(request to write %lu bytes to buffer of %d bytes)",
-			(unsigned long) size, MAX_BUF);
-	n = vsprintf(buf, format, ap);
-	if (n > MAX_BUF)
-		vips_error_exit("panic: buffer overflow "
-						"(%d bytes written to buffer of %d bytes)",
-			n, MAX_BUF);
-
-	vips_strncpy(str, buf, size);
-
-	return n;
+#else  /*!HAVE_VSNPRINTF*/
+	return g_vsnprintf(str, size, format, ap);
 #endif /*HAVE_VSNPRINTF*/
 }
 

--- a/meson.build
+++ b/meson.build
@@ -157,7 +157,19 @@ if have_target_clones
     cfg_var.set('HAVE_TARGET_CLONES', '1')
 endif
 
-func_names = [ 'vsnprintf', '_aligned_malloc', 'posix_memalign', 'memalign', 'cbrt', 'hypot', 'atan2', 'asinh' ]
+# windows needs to include stdio.h to find vsnprintf()
+if cc.has_function('vsnprintf', prefix: '#include <stdio.h>')
+    cfg_var.set('HAVE_VSNPRINTF', '1')
+endif
+
+func_names = [ '_aligned_malloc', 'posix_memalign', 'memalign' ]
+foreach func_name : func_names
+    if cc.has_function(func_name)
+        cfg_var.set('HAVE_' + func_name.to_upper(), '1')
+    endif
+endforeach
+
+func_names = [ 'cbrt', 'hypot', 'atan2', 'asinh' ]
 foreach func_name : func_names
     if cc.has_function(func_name, dependencies: m_dep)
         cfg_var.set('HAVE_' + func_name.to_upper(), '1')


### PR DESCRIPTION
- vsnprintf() detection with meson was not working on windows
- the vips_vsnprintf() fallback was not threadsafe

This PR changes the fallback to g_vsnprintf() and improves detection in meson.

See https://github.com/libvips/libvips/issues/4003 and https://github.com/libvips/libvips/issues/4001

Thanks Julianiolo