### PR TITLE
lsan: suppress leak warnings from libimagequant

### DIFF
--- a/suppressions/lsan.supp
+++ b/suppressions/lsan.supp
@@ -6,3 +6,4 @@ leak:libIlmThread-2_5.so
 leak:libMagickCore-6.Q16.so
 leak:libx265.so
 leak:libheif.so
+leak:libimagequant.so


### PR DESCRIPTION
https://github.com/libvips/libvips/actions/runs/9530033062/job/26269434074#step:14:488