### PR TITLE
CI: install libheif-plugin-aomenc on the Ubuntu runner

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,13 +42,13 @@ jobs:
             meson pkg-config \
             libarchive-dev libcfitsio-dev libcgif-dev \
             libexif-dev libexpat1-dev libffi-dev \
-            libfftw3-dev libheif-dev libheif-plugin-x265 \
-            libhwy-dev libimagequant-dev libjpeg-dev \
-            libjxl-dev liblcms2-dev libmatio-dev \
-            libnifti-dev libopenexr-dev libopenjp2-7-dev \
-            libopenslide-dev libpango1.0-dev libpng-dev \
-            libpoppler-glib-dev librsvg2-dev libtiff5-dev \
-            libwebp-dev
+            libfftw3-dev libheif-dev libheif-plugin-aomenc \
+            libheif-plugin-x265 libhwy-dev libimagequant-dev \
+            libjpeg-dev libjxl-dev liblcms2-dev \
+            libmatio-dev libnifti-dev libopenexr-dev \
+            libopenjp2-7-dev libopenslide-dev libpango1.0-dev \
+            libpng-dev libpoppler-glib-dev librsvg2-dev \
+            libtiff5-dev libwebp-dev
 
       - name: Install macOS dependencies
         if: runner.os == 'macOS'


### PR DESCRIPTION
This should resolve the current CI failures.

It's unclear why this is now necessary, as `libheif-plugin-aomenc` is a "recommended dependency" of [`libheif1`](https://packages.ubuntu.com/noble/libheif1). Therefore, it should be installed automatically since we don't use the `--no-install-recommends` flag.