### PR TITLE
cplusplus: simplify symbol visibility

### DIFF
--- a/cplusplus/include/vips/vips8
+++ b/cplusplus/include/vips/vips8
@@ -40,19 +40,14 @@
 
 #include <glib-object.h>
 
-/* Define VIPS_CPLUSPLUS_EXPORTS to build a DLL using MSVC.
+/* Note: when building without Meson, it may be necessary to define
+ * _VIPS_PUBLIC as __declspec(dllexport) when building a DLL.
  */
-#ifdef _VIPS_PUBLIC
-#  define VIPS_CPLUSPLUS_API _VIPS_PUBLIC
-#elif defined(_MSC_VER)
-#  ifdef VIPS_CPLUSPLUS_EXPORTS
-#    define VIPS_CPLUSPLUS_API __declspec(dllexport)
-#  else
-#    define VIPS_CPLUSPLUS_API __declspec(dllimport)
-#  endif
-#else
-#  define VIPS_CPLUSPLUS_API
+#ifndef _VIPS_PUBLIC
+#define _VIPS_PUBLIC
 #endif
+
+#define VIPS_CPLUSPLUS_API _VIPS_PUBLIC
 
 #define VIPS_NAMESPACE_START namespace vips {
 #define VIPS_NAMESPACE_END }

--- a/libvips/arithmetic/meson.build
+++ b/libvips/arithmetic/meson.build
@@ -57,9 +57,8 @@ libvips_sources += arithmetic_sources
 arithmetic_lib = static_library('arithmetic',
     arithmetic_sources,
     arithmetic_headers,
-    dependencies : libvips_deps,
-    gnu_symbol_visibility : 'hidden',
+    dependencies: libvips_deps,
+    gnu_symbol_visibility: 'hidden',
 )
 
 libvips_components += arithmetic_lib
-

--- a/libvips/create/meson.build
+++ b/libvips/create/meson.build
@@ -43,8 +43,8 @@ libvips_sources += create_sources
 create_lib = static_library('create',
     create_sources,
     create_headers,
-    dependencies : libvips_deps,
-    gnu_symbol_visibility : 'hidden',
+    dependencies: libvips_deps,
+    gnu_symbol_visibility: 'hidden',
 )
 
 libvips_components += create_lib

--- a/libvips/include/vips/basic.h
+++ b/libvips/include/vips/basic.h
@@ -36,11 +36,11 @@
 
 /* Defined in config.h
  */
-#ifdef _VIPS_PUBLIC
-#define VIPS_API _VIPS_PUBLIC extern
-#else
-#define VIPS_API extern
+#ifndef _VIPS_PUBLIC
+#define _VIPS_PUBLIC
 #endif
+
+#define VIPS_API _VIPS_PUBLIC extern
 
 /* VIPS_DISABLE_DEPRECATION_WARNINGS:
  *

--- a/meson.build
+++ b/meson.build
@@ -122,10 +122,10 @@ endif
 # Detect and set symbol visibility
 if get_option('default_library') == 'shared' and host_os in ['windows', 'cygwin']
     cfg_var.set('DLL_EXPORT', true)
-    if cc.get_id() == 'msvc' or cc.get_id() == 'clang-cl'
-        cfg_var.set('_VIPS_PUBLIC', '__declspec(dllexport)')
-    elif cc.has_function_attribute('visibility:hidden')
+    if cc.has_function_attribute('visibility:hidden')
         cfg_var.set('_VIPS_PUBLIC', '__attribute__((visibility("default"))) __declspec(dllexport)')
+    else
+        cfg_var.set('_VIPS_PUBLIC', '__declspec(dllexport)')
     endif
 elif cc.has_function_attribute('visibility:hidden')
     cfg_var.set('_VIPS_PUBLIC', '__attribute__((visibility("default")))')


### PR DESCRIPTION
Always define `VIPS_CPLUSPLUS_API` as `_VIPS_PUBLIC`, since this is usually built with Meson.

Resolves: #3975.