### PR TITLE
jxlload: various improvements

### DIFF
--- a/libvips/foreign/jxlload.c
+++ b/libvips/foreign/jxlload.c
@@ -320,10 +320,6 @@ vips_foreign_load_jxl_print_status(JxlDecoderStatus status)
 		printf("JXL_DEC_NEED_PREVIEW_OUT_BUFFER\n");
 		break;
 
-	case JXL_DEC_NEED_DC_OUT_BUFFER:
-		printf("JXL_DEC_NEED_DC_OUT_BUFFER\n");
-		break;
-
 	case JXL_DEC_NEED_IMAGE_OUT_BUFFER:
 		printf("JXL_DEC_NEED_IMAGE_OUT_BUFFER\n");
 		break;
@@ -354,10 +350,6 @@ vips_foreign_load_jxl_print_status(JxlDecoderStatus status)
 
 	case JXL_DEC_FRAME:
 		printf("JXL_DEC_FRAME\n");
-		break;
-
-	case JXL_DEC_DC_IMAGE:
-		printf("JXL_DEC_DC_IMAGE\n");
 		break;
 
 	case JXL_DEC_FULL_IMAGE:

--- a/libvips/foreign/jxlload.c
+++ b/libvips/foreign/jxlload.c
@@ -223,7 +223,9 @@ vips_foreign_load_jxl_is_a_source(VipsSource *source)
 static VipsForeignFlags
 vips_foreign_load_jxl_get_flags(VipsForeignLoad *load)
 {
-	return VIPS_FOREIGN_PARTIAL;
+	/* FIXME .. could support random access for non-animated images.
+	 */
+	return VIPS_FOREIGN_SEQUENTIAL;
 }
 
 static int

--- a/libvips/foreign/jxlload.c
+++ b/libvips/foreign/jxlload.c
@@ -707,21 +707,20 @@ vips_foreign_load_jxl_set_header(VipsForeignLoadJxl *jxl, VipsImage *out)
 
 		vips_image_set_int(out, VIPS_META_N_PAGES, jxl->frame_count);
 
-		if (jxl->n > 1) {
+		if (jxl->n > 1)
 			vips_image_set_int(out,
 				VIPS_META_PAGE_HEIGHT, jxl->info.ysize);
 
-			g_assert(jxl->delay_count >= jxl->frame_count);
-			vips_image_set_array_int(out,
-				"delay", &jxl->delay[jxl->page], jxl->n);
+		g_assert(jxl->delay_count >= jxl->frame_count);
+		vips_image_set_array_int(out,
+			"delay", jxl->delay, jxl->frame_count);
 
-			/* gif uses centiseconds for delays
-			 */
-			vips_image_set_int(out, "gif-delay",
-				VIPS_RINT(jxl->delay[0] / 10.0));
+		/* gif uses centiseconds for delays
+		 */
+		vips_image_set_int(out, "gif-delay",
+			VIPS_RINT(jxl->delay[0] / 10.0));
 
-			vips_image_set_int(out, "loop", jxl->info.animation.num_loops);
-		}
+		vips_image_set_int(out, "loop", jxl->info.animation.num_loops);
 	}
 	else {
 		jxl->n = 1;

--- a/libvips/foreign/jxlload.c
+++ b/libvips/foreign/jxlload.c
@@ -1057,6 +1057,11 @@ vips_foreign_load_jxl_load(VipsForeignLoad *load)
 	if (vips_image_write(out, load->real))
 		return -1;
 
+	/* Switch to pixel decode.
+	 */
+	if (vips_source_decode(jxl->source))
+		return -1;
+
 	return 0;
 }
 


### PR DESCRIPTION
See the individual commits for more details.
- Commit fd18fd071a524edd7ab7531c904ba6a256035995 removes the deprecated `JXL_DEC_NEED_DC_OUT_BUFFER` and `JXL_DEC_DC_IMAGE` events to ensure compilation when building with `-DDEBUG`.
- Commit ac28876af1491073d097ab03fcff96f87a962f63 ensures animation frames are skipped more efficiently by using `JxlDecoderSkipFrames()`.
- Commit aac68afb92f0c1892c49aac4ef19e978e82a3282 always set the frame delays metadata, similar to the GIF and WebP loader.
    ```console
    $ vipsheader -f delay x.gif
    50 20 20 20 20 20 20 20 20 40 20 20 20 20 20 20 20 20 50 20 20 20 20 20 20 20 20 40 20 20 20 20 20 20 20 20 
    $ vipsheader -f delay x.webp
    50 20 20 20 20 20 20 20 20 40 20 20 20 20 20 20 20 20 50 20 20 20 20 20 20 20 20 40 20 20 20 20 20 20 20 20 
    $ vipsheader -f delay newtons_cradle.jxl 
    50 20 20 20 20 20 20 20 20 40 20 20 20 20 20 20 20 20 50 20 20 20 20 20 20 20 20 40 20 20 20 20 20 20 20 20 
    ```
- Commit a1221c840f7eb3a76d8b5a255918271d47f66b2d adds a missing call to `vips_source_decode()`.
- Commit 6afef40bf72a0b54ca0dc1539bcb7a08fe499593 marks `jxlload` as sequential loader to fix loading animated images in vipsdisp, see: https://github.com/jcupitt/vipsdisp/pull/34.