### PR TITLE
Migrate to GLib-provided `g_ascii_is*` functions

### DIFF
--- a/libvips/deprecated/vips7compat.c
+++ b/libvips/deprecated/vips7compat.c
@@ -93,9 +93,9 @@ im_filename_split(const char *path, char *name, char *mode)
 			char *q;
 
 			/* We are skipping back over the file extension,
-			 * isalnum() is probably sufficient.
+			 * g_ascii_isalnum() is probably sufficient.
 			 */
-			for (q = p - 1; isalnum(*q) && q > name; q -= 1)
+			for (q = p - 1; g_ascii_isalnum(*q) && q > name; q -= 1)
 				;
 
 			if (*q == '.') {

--- a/libvips/foreign/exif.c
+++ b/libvips/foreign/exif.c
@@ -1264,7 +1264,7 @@ vips_exif_image_field(VipsImage *image,
 	p = field + strlen("exif-ifd");
 	ifd = atoi(p);
 
-	for (; isdigit(*p); p++)
+	for (; g_ascii_isdigit(*p); p++)
 		;
 	if (*p != '-') {
 		g_warning(_("bad exif meta \"%s\""), field);

--- a/libvips/foreign/radiance.c
+++ b/libvips/foreign/radiance.c
@@ -319,7 +319,7 @@ formatval(char fmt[MAXFMTLEN], const char *s)
 	while (*cp)
 		if (*cp++ != *s++)
 			return 0;
-	while (isspace(*s))
+	while (g_ascii_isspace(*s))
 		s++;
 	if (!*s)
 		return 0;
@@ -331,7 +331,7 @@ formatval(char fmt[MAXFMTLEN], const char *s)
 
 	do /* remove trailing white space */
 		*r-- = '\0';
-	while (r > fmt && isspace(*r));
+	while (r > fmt && g_ascii_isspace(*r));
 
 	return 1;
 }

--- a/libvips/iofuncs/sbuf.c
+++ b/libvips/iofuncs/sbuf.c
@@ -478,7 +478,7 @@ vips_sbuf_get_non_whitespace(VipsSbuf *sbuf)
 	int i;
 
 	for (i = 0; i < VIPS_SBUF_BUFFER_SIZE &&
-		 !isspace(ch = VIPS_SBUF_GETC(sbuf)) &&
+		 !g_ascii_isspace(ch = VIPS_SBUF_GETC(sbuf)) &&
 		 ch != EOF;
 		 i++)
 		sbuf->line[i] = ch;
@@ -487,15 +487,15 @@ vips_sbuf_get_non_whitespace(VipsSbuf *sbuf)
 	/* If we stopped before seeing any whitespace, skip to the end of the
 	 * block of non-whitespace.
 	 */
-	if (!isspace(ch))
-		while (!isspace(ch = VIPS_SBUF_GETC(sbuf)) &&
+	if (!g_ascii_isspace(ch))
+		while (!g_ascii_isspace(ch = VIPS_SBUF_GETC(sbuf)) &&
 			ch != EOF)
 			;
 
 	/* If we finally stopped on whitespace, step back one so the next get
 	 * will be whitespace (or EOF).
 	 */
-	if (isspace(ch))
+	if (g_ascii_isspace(ch))
 		VIPS_SBUF_UNGETC(sbuf);
 
 	return (const char *) sbuf->line;
@@ -529,7 +529,7 @@ vips_sbuf_skip_whitespace(VipsSbuf *sbuf)
 				return -1;
 			ch = VIPS_SBUF_GETC(sbuf);
 		}
-	} while (isspace(ch));
+	} while (g_ascii_isspace(ch));
 
 	VIPS_SBUF_UNGETC(sbuf);
 

--- a/libvips/iofuncs/util.c
+++ b/libvips/iofuncs/util.c
@@ -1245,7 +1245,7 @@ vips__token_get(const char *p, VipsToken *token, char *string, int size)
 		 * hasn't been truncated.
 		 */
 		if (i != size)
-			while (i > 0 && isspace(string[i - 1])) {
+			while (i > 0 && g_ascii_isspace(string[i - 1])) {
 				string[i - 1] = '\0';
 				i--;
 			}
@@ -1749,10 +1749,10 @@ vips__substitute(char *buf, size_t len, char *sub)
 	sub_start = NULL;
 	sub_end = NULL;
 	for (p = buf; (p = strchr(p, '%')); p++)
-		if (isdigit(p[1])) {
+		if (g_ascii_isdigit(p[1])) {
 			char *q;
 
-			for (q = p + 1; isdigit(*q); q++)
+			for (q = p + 1; g_ascii_isdigit(*q); q++)
 				;
 			if (q[0] == 's') {
 				int n;
@@ -1960,7 +1960,7 @@ vips_strtod(const char *str, double *out)
 	 * a number and getting zero.
 	 */
 	for (p = str; *p; p++)
-		if (isdigit(*p))
+		if (g_ascii_isdigit(*p))
 			break;
 	if (!*p)
 		return -1;

--- a/tools/vipsedit.c
+++ b/tools/vipsedit.c
@@ -280,7 +280,7 @@ main(int argc, char **argv)
 		/* Strip trailing whitespace ... we can get stray \n at the
 		 * end, eg. "echo | vipsedit --setext fred.v".
 		 */
-		while (size > 0 && isspace(xml[size - 1]))
+		while (size > 0 && g_ascii_isspace(xml[size - 1]))
 			size -= 1;
 
 		if (vips__write_extension_block(im, xml, size))

--- a/tools/vipsthumbnail.c
+++ b/tools/vipsthumbnail.c
@@ -401,39 +401,39 @@ thumbnail_parse_geometry(const char *geometry)
 
 	/* Get the width.
 	 */
-	while (isspace(*p))
+	while (g_ascii_isspace(*p))
 		p++;
-	if (isdigit(*p)) {
+	if (g_ascii_isdigit(*p)) {
 		thumbnail_width = atoi(p);
 
-		while (isdigit(*p))
+		while (g_ascii_isdigit(*p))
 			p++;
 	}
 
 	/* Get the optional 'x'.
 	 */
-	while (isspace(*p))
+	while (g_ascii_isspace(*p))
 		p++;
 	had_x = FALSE;
 	if (*p == 'x') {
 		p += 1;
 		had_x = TRUE;
 	}
-	while (isspace(*p))
+	while (g_ascii_isspace(*p))
 		p++;
 
 	/* Get the height.
 	 */
-	if (isdigit(*p)) {
+	if (g_ascii_isdigit(*p)) {
 		thumbnail_height = atoi(p);
 
-		while (isdigit(*p))
+		while (g_ascii_isdigit(*p))
 			p++;
 	}
 
 	/* Get the final <>!
 	 */
-	while (isspace(*p))
+	while (g_ascii_isspace(*p))
 		p++;
 	if (*p == '<')
 		size_restriction = VIPS_SIZE_UP;


### PR DESCRIPTION
Should be a non-functional change, except that `g_ascii_isspace()` returns `FALSE` for vertical tab (`\v`), see:
https://bugzilla.gnome.org/show_bug.cgi?id=59388#c5

Resolves: #4015.