### PR TITLE
Clean up dist tarball

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -3,3 +3,13 @@
 
 # Ignore repository language statistics and hide diffs for generated files
 libvips/colour/profiles.c linguist-generated=true
+
+# Omit from release tarball
+.clang-format export-ignore
+.codespellrc export-ignore
+.editorconfig export-ignore
+.git-blame-ignore-revs export-ignore
+.gitattributes export-ignore
+.gitignore export-ignore
+.gitkeep export-ignore
+.github/ export-ignore


### PR DESCRIPTION
Ensure we distribute only files that are relevant for a dist tarball, excluding any Git/IDE specific files.

Tested with:
```console
$ meson setup release_build -Ddoxygen=true -Dgtk_doc=true -Dvapi=true
$ meson compile -Crelease_build
$ meson dist -Crelease_build
$ ls release_build/meson-dist
vips-8.16.0.tar.xz  vips-8.16.0.tar.xz.sha256sum
$ tar -tf release_build/meson-dist/vips-8.16.0.tar.xz | grep -q ".git" || echo ".git not found in dist tarball"
.git not found in dist tarball
```