### PR TITLE
heifsave: set `matrix_coefficients=0` by default in lossless mode

### DIFF
--- a/libvips/foreign/heifsave.c
+++ b/libvips/foreign/heifsave.c
@@ -289,6 +289,19 @@ vips_foreign_save_heif_write_page(VipsForeignSaveHeif *heif, int page)
 	if (vips_image_hasalpha(save->ready))
 		options->save_alpha_channel = 1;
 
+#ifdef HAVE_HEIF_ENCODING_OPTIONS_OUTPUT_NCLX_PROFILE
+	/* Matrix coefficients have to be identity (CICP x/y/0) in lossless mode.
+	 */
+	if (heif->lossless) {
+		struct heif_color_profile_nclx *nclx = heif_nclx_color_profile_alloc();
+		if (!nclx)
+			return -1;
+
+		nclx->matrix_coefficients = heif_matrix_coefficients_RGB_GBR;
+		options->output_nclx_profile = nclx;
+	}
+#endif /*HAVE_HEIF_ENCODING_OPTIONS_OUTPUT_NCLX_PROFILE*/
+
 #ifdef DEBUG
 	{
 		GTimer *timer = g_timer_new();

--- a/meson.build
+++ b/meson.build
@@ -548,8 +548,12 @@ if libheif_dep.found()
     if libheif_dep.version().version_compare('>=1.7.0')
         cfg_var.set('HAVE_HEIF_AVIF', '1')
     endif
+    # added in 1.11.0
+    if cpp.has_member('struct heif_encoding_options', 'output_nclx_profile', prefix: '#include <libheif/heif.h>', dependencies: libheif_dep)
+        cfg_var.set('HAVE_HEIF_ENCODING_OPTIONS_OUTPUT_NCLX_PROFILE', '1')
+    endif
 
-    # heif_init in 1.13
+    # heif_init added in 1.13.0
     if libheif_dep.version().version_compare('>=1.13.0')
         cfg_var.set('HAVE_HEIF_INIT', '1')
     endif

--- a/test/test-suite/test_foreign.py
+++ b/test/test-suite/test_foreign.py
@@ -879,7 +879,7 @@ class TestForeign:
         im = pyvips.Image.new_from_file(WEBP_FILE)
         buf = im.webpsave_buffer(lossless=True)
         im2 = pyvips.Image.new_from_buffer(buf, "")
-        assert (im - im2).abs().max() < 1
+        assert (im - im2).abs().max() == 0
 
         # higher Q should mean a bigger buffer
         b1 = im.webpsave_buffer(Q=10)
@@ -1433,15 +1433,11 @@ class TestForeign:
         self.save_load("%s.avif", self.colour)
 
     @skip_if_no("heifsave")
-    @pytest.mark.skip()
     def test_avifsave_lossless(self):
-        # this takes FOREVER
         im = pyvips.Image.new_from_file(AVIF_FILE)
-        buf = im.heifsave_buffer(lossless=True, compression="av1")
+        buf = im.heifsave_buffer(effort=0, lossless=True, compression="av1")
         im2 = pyvips.Image.new_from_buffer(buf, "")
-        # FIXME: needs matrix_coefficients=0 for true lossless, see:
-        # https://github.com/strukturag/libheif/pull/1039
-        assert (im - im2).abs().max() < 1
+        assert (im - im2).abs().max() == 0
 
     @skip_if_no("heifsave")
     def test_avifsave_Q(self):


### PR DESCRIPTION
Resolves: #4051.

Context: https://github.com/strukturag/libheif/pull/1039#issuecomment-1866023028.