### PR TITLE
matrixsave: ensure `matrixprint` will write to stdout

### DIFF
--- a/libvips/foreign/matrixsave.c
+++ b/libvips/foreign/matrixsave.c
@@ -305,7 +305,7 @@ vips_foreign_print_matrix_build(VipsObject *object)
 {
 	VipsForeignSaveMatrix *matrix = (VipsForeignSaveMatrix *) object;
 
-	if (!(matrix->target = vips_target_new_to_descriptor(0)))
+	if (!(matrix->target = vips_target_new_to_descriptor(1)))
 		return -1;
 
 	if (VIPS_OBJECT_CLASS(vips_foreign_print_matrix_parent_class)->build(object))


### PR DESCRIPTION
The integer file descriptors associated with the streams stdin, stdout, and stderr are 0, 1, and 2, respectively.