### PR TITLE
Backport 117c554, #3760 and #4052 to 8.15

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -7,6 +7,8 @@
 - fix pipe read limit
 - fix a rare crash on Windows in highly threaded applications [Julianiolo]
 - vipssave: fix infinite loop on Windows with large images [pdbourke]
+- fix vips_image_get_string
+- heifsave: fix lossless mode [kleisauke]
 
 12/3/24 8.15.2
 

--- a/libvips/foreign/heifsave.c
+++ b/libvips/foreign/heifsave.c
@@ -289,6 +289,19 @@ vips_foreign_save_heif_write_page(VipsForeignSaveHeif *heif, int page)
 	if (vips_image_hasalpha(save->ready))
 		options->save_alpha_channel = 1;
 
+#ifdef HAVE_HEIF_ENCODING_OPTIONS_OUTPUT_NCLX_PROFILE
+	/* Matrix coefficients have to be identity (CICP x/y/0) in lossless mode.
+	 */
+	if (heif->lossless) {
+		struct heif_color_profile_nclx *nclx = heif_nclx_color_profile_alloc();
+		if (!nclx)
+			return -1;
+
+		nclx->matrix_coefficients = heif_matrix_coefficients_RGB_GBR;
+		options->output_nclx_profile = nclx;
+	}
+#endif /*HAVE_HEIF_ENCODING_OPTIONS_OUTPUT_NCLX_PROFILE*/
+
 #ifdef DEBUG
 	{
 		GTimer *timer = g_timer_new();

--- a/libvips/foreign/heifsave.c
+++ b/libvips/foreign/heifsave.c
@@ -501,6 +501,13 @@ vips_foreign_save_heif_build(VipsObject *object)
 		!vips_object_argument_isset(object, "effort"))
 		heif->effort = 9 - heif->speed;
 
+	/* Disable chroma subsampling by default when the "lossless" param
+	 * is being used.
+	 */
+	if (vips_object_argument_isset(object, "lossless") &&
+		!vips_object_argument_isset(object, "subsample_mode"))
+		heif->subsample_mode = VIPS_FOREIGN_SUBSAMPLE_OFF;
+
 	/* Default 12 bit save for 16-bit images. HEIC (for example) implements
 	 * 8 / 10 / 12.
 	 */

--- a/libvips/iofuncs/header.c
+++ b/libvips/iofuncs/header.c
@@ -1295,7 +1295,10 @@ vips_set_value_from_pointer(GValue *value, void *data)
 	else if (fundamental == G_TYPE_ENUM)
 		g_value_set_enum(value, *((int *) data));
 	else if (fundamental == G_TYPE_STRING)
-		g_value_set_string(value, *((char **) data));
+		// we don't want to copy the string (ie. the filename, usually) since
+		// it'll then be freed when the value is unset ... instead we must
+		// directly use the pointer owned by the VipsImage
+		g_value_set_static_string(value, *((char **) data));
 	else
 		g_warning("%s: unimplemented vips_set_value_from_pointer() type %s",
 			G_STRLOC,
@@ -1360,6 +1363,7 @@ vips_image_get(const VipsImage *image, const char *name, GValue *value_copy)
 			g_value_init(value_copy, gtype);
 			vips_set_value_from_pointer(value_copy,
 				G_STRUCT_MEMBER_P(image, field->offset));
+
 			return 0;
 		}
 	}
@@ -1373,6 +1377,7 @@ vips_image_get(const VipsImage *image, const char *name, GValue *value_copy)
 			g_value_init(value_copy, gtype);
 			vips_set_value_from_pointer(value_copy,
 				G_STRUCT_MEMBER_P(image, field->offset));
+
 			return 0;
 		}
 	}

--- a/meson.build
+++ b/meson.build
@@ -520,8 +520,12 @@ if libheif_dep.found()
     if libheif_dep.version().version_compare('>=1.7.0')
         cfg_var.set('HAVE_HEIF_AVIF', '1')
     endif
+    # added in 1.11.0
+    if cpp.has_member('struct heif_encoding_options', 'output_nclx_profile', prefix: '#include <libheif/heif.h>', dependencies: libheif_dep)
+        cfg_var.set('HAVE_HEIF_ENCODING_OPTIONS_OUTPUT_NCLX_PROFILE', '1')
+    endif
 
-    # heif_init in 1.13
+    # heif_init added in 1.13.0
     if libheif_dep.version().version_compare('>=1.13.0')
         cfg_var.set('HAVE_HEIF_INIT', '1')
     endif

--- a/test/test-suite/test_foreign.py
+++ b/test/test-suite/test_foreign.py
@@ -847,7 +847,7 @@ class TestForeign:
         im = pyvips.Image.new_from_file(WEBP_FILE)
         buf = im.webpsave_buffer(lossless=True)
         im2 = pyvips.Image.new_from_buffer(buf, "")
-        assert (im - im2).abs().max() < 1
+        assert (im - im2).abs().max() == 0
 
         # higher Q should mean a bigger buffer
         b1 = im.webpsave_buffer(Q=10)
@@ -1373,15 +1373,11 @@ class TestForeign:
         self.save_load("%s.avif", self.colour)
 
     @skip_if_no("heifsave")
-    @pytest.mark.skip()
     def test_avifsave_lossless(self):
-        # this takes FOREVER
         im = pyvips.Image.new_from_file(AVIF_FILE)
-        buf = im.heifsave_buffer(lossless=True, compression="av1")
+        buf = im.heifsave_buffer(effort=0, lossless=True, compression="av1")
         im2 = pyvips.Image.new_from_buffer(buf, "")
-        # FIXME: needs matrix_coefficients=0 for true lossless, see:
-        # https://github.com/strukturag/libheif/pull/1039
-        assert (im - im2).abs().max() < 1
+        assert (im - im2).abs().max() == 0
 
     @skip_if_no("heifsave")
     def test_avifsave_Q(self):

--- a/test/test-suite/test_foreign.py
+++ b/test/test-suite/test_foreign.py
@@ -847,7 +847,7 @@ class TestForeign:
         im = pyvips.Image.new_from_file(WEBP_FILE)
         buf = im.webpsave_buffer(lossless=True)
         im2 = pyvips.Image.new_from_buffer(buf, "")
-        assert abs(im.avg() - im2.avg()) < 1
+        assert (im - im2).abs().max() < 1
 
         # higher Q should mean a bigger buffer
         b1 = im.webpsave_buffer(Q=10)
@@ -864,7 +864,7 @@ class TestForeign:
             p2 = im.get("icc-profile-data")
             assert p1 == p2
 
-            # add tests for exif, xmp, ipct
+            # add tests for exif, xmp, iptc
             # the exif test will need us to be able to walk the header,
             # we can't just check exif-data
 
@@ -1340,7 +1340,7 @@ class TestForeign:
         # test keep=pyvips.ForeignKeep.ICC ... icc profiles should be
         # passed down
         filename = temp_filename(self.tempdir, '')
-        self.colour.dzsave(filename, keep=1 << 3) # pyvips.ForeignKeep.ICC - https://github.com/libvips/pyvips/pull/429
+        self.colour.dzsave(filename, keep=1 << 3) # pyvips.ForeignKeep.ICC
 
         y = pyvips.Image.new_from_file(filename + "_files/0/0_0.jpeg")
         assert y.get_typeof("icc-profile-data") != 0
@@ -1367,27 +1367,23 @@ class TestForeign:
         assert im.avg() == 0.0
 
     @skip_if_no("heifsave")
-    @pytest.mark.skipif(sys.platform == "darwin", reason="fails with latest libheif/aom from Homebrew")
     def test_avifsave(self):
-        # TODO: Reduce the threshold once https://github.com/strukturag/libheif/issues/533 is resolved.
         self.save_load_buffer("heifsave_buffer", "heifload_buffer",
-                              self.colour, 80, compression="av1",
-                              lossless=True)
+                              self.colour, compression="av1", lossless=True)
         self.save_load("%s.avif", self.colour)
 
     @skip_if_no("heifsave")
-    @pytest.mark.skipif(sys.platform == "darwin", reason="fails with latest libheif/aom from Homebrew")
     @pytest.mark.skip()
     def test_avifsave_lossless(self):
         # this takes FOREVER
         im = pyvips.Image.new_from_file(AVIF_FILE)
         buf = im.heifsave_buffer(lossless=True, compression="av1")
         im2 = pyvips.Image.new_from_buffer(buf, "")
-        # not in fact quite lossless
-        assert abs(im.avg() - im2.avg()) < 3
+        # FIXME: needs matrix_coefficients=0 for true lossless, see:
+        # https://github.com/strukturag/libheif/pull/1039
+        assert (im - im2).abs().max() < 1
 
     @skip_if_no("heifsave")
-    @pytest.mark.skipif(sys.platform == "darwin", reason="fails with latest libheif/aom from Homebrew")
     def test_avifsave_Q(self):
         # higher Q should mean a bigger buffer, needs libheif >= v1.8.0,
         # see: https://github.com/libvips/libvips/issues/1757
@@ -1396,7 +1392,6 @@ class TestForeign:
         assert len(b2) > len(b1)
 
     @skip_if_no("heifsave")
-    @pytest.mark.skipif(sys.platform == "darwin", reason="fails with latest libheif/aom from Homebrew")
     def test_avifsave_chroma(self):
         # Chroma subsampling should produce smaller file size for same Q
         b1 = self.colour.heifsave_buffer(compression="av1", subsample_mode="on")
@@ -1404,7 +1399,6 @@ class TestForeign:
         assert len(b2) > len(b1)
 
     @skip_if_no("heifsave")
-    @pytest.mark.skipif(sys.platform == "darwin", reason="fails with latest libheif/aom from Homebrew")
     def test_avifsave_icc(self):
         # try saving an image with an ICC profile and reading it back
         # not all libheif have profile support, so put it in an if
@@ -1415,12 +1409,11 @@ class TestForeign:
             p2 = im.get("icc-profile-data")
             assert p1 == p2
 
-        # add tests for xmp, ipct
+        # add tests for xmp, iptc
         # the exif test will need us to be able to walk the header,
         # we can't just check exif-data
 
     @skip_if_no("heifsave")
-    @pytest.mark.skipif(sys.platform == "darwin", reason="fails with latest libheif/aom from Homebrew")
     def test_avifsave_exif(self):
         # first make sure we have exif support
         x = pyvips.Image.new_from_file(JPEG_FILE)
@@ -1432,7 +1425,6 @@ class TestForeign:
             assert y.get("exif-ifd0-XPComment").startswith("banana")
 
     @skip_if_no("heifsave")
-    @pytest.mark.skipif(sys.platform == "darwin", reason="fails with latest libheif/aom from Homebrew")
     def test_heicsave_16_to_12(self):
         rgb16 = self.colour.colourspace("rgb16")
         data = rgb16.heifsave_buffer(lossless=True)
@@ -1446,7 +1438,6 @@ class TestForeign:
         assert((im - rgb16).abs().max() < 4500)
 
     @skip_if_no("heifsave")
-    @pytest.mark.skipif(sys.platform == "darwin", reason="fails with latest libheif/aom from Homebrew")
     def test_heicsave_16_to_8(self):
         rgb16 = self.colour.colourspace("rgb16")
         data = rgb16.heifsave_buffer(lossless=True, bitdepth=8)
@@ -1460,7 +1451,6 @@ class TestForeign:
         assert((im - rgb16 / 256).abs().max() < 80)
 
     @skip_if_no("heifsave")
-    @pytest.mark.skipif(sys.platform == "darwin", reason="fails with latest libheif/aom from Homebrew")
     def test_heicsave_8_to_16(self):
         data = self.colour.heifsave_buffer(lossless=True, bitdepth=12)
         im = pyvips.Image.heifload_buffer(data)


### PR DESCRIPTION
Trivial backport of 117c554, #3760 and #4052 to [`8.15`](https://github.com/libvips/libvips/tree/8.15).

Note: rebase merge, don't squash.