### PR TITLE
heifsave: ensure true lossless with libheif < v1.17.2

### DIFF
--- a/libvips/foreign/heifsave.c
+++ b/libvips/foreign/heifsave.c
@@ -299,6 +299,10 @@ vips_foreign_save_heif_write_page(VipsForeignSaveHeif *heif, int page)
 
 		nclx->matrix_coefficients = heif_matrix_coefficients_RGB_GBR;
 		options->output_nclx_profile = nclx;
+
+		/* Ensure nclx profile is actually written with libheif < v1.17.2.
+		 */
+		options->macOS_compatibility_workaround_no_nclx_profile = 0;
 	}
 #endif /*HAVE_HEIF_ENCODING_OPTIONS_OUTPUT_NCLX_PROFILE*/
 

--- a/test/test-suite/test_foreign.py
+++ b/test/test-suite/test_foreign.py
@@ -1377,7 +1377,9 @@ class TestForeign:
         im = pyvips.Image.new_from_file(AVIF_FILE)
         buf = im.heifsave_buffer(effort=0, lossless=True, compression="av1")
         im2 = pyvips.Image.new_from_buffer(buf, "")
-        assert (im - im2).abs().max() == 0
+        # requires libheif >= 1.13.0 for true lossless:
+        # see: https://github.com/strukturag/libheif/commit/b2612dd9c63f8835cf2047960b8cacd464a325a4
+        assert (im - im2).abs().max() <= 1.0
 
     @skip_if_no("heifsave")
     def test_avifsave_Q(self):


### PR DESCRIPTION
In accordance with commit https://github.com/strukturag/libheif/commit/136cf0173ffb52a92842736fec47c83e69475327.

However, it still requires libheif >= 1.13.0 for true lossless, so update `test_avifsave_lossless` accordingly to fix CI on the 8.15 branch (which still uses Ubuntu 22.04 as the runner image).

Targets the 8.15 branch.