### PR TITLE
composite: fix dest-atop blend mode

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -10,6 +10,7 @@
 - conva: fix a crash with {u,}{short,int} images [erdmann]
 - fix vips_image_get_string
 - heifsave: fix lossless mode [kleisauke]
+- composite: fix dest-atop blend mode [kleisauke]
 
 12/3/24 8.15.2
 

--- a/libvips/conversion/composite.cpp
+++ b/libvips/conversion/composite.cpp
@@ -583,7 +583,7 @@ vips_composite_base_blend(VipsCompositeBase *composite,
 
 	case VIPS_BLEND_MODE_DEST_ATOP:
 		aR = aA;
-		t1 = 1 - aA;
+		t1 = 1 - aB;
 		for (int b = 0; b < bands; b++)
 			B[b] = t1 * A[b] + B[b];
 		break;
@@ -827,7 +827,7 @@ vips_composite_base_blend3(VipsCompositeSequence *seq,
 
 	case VIPS_BLEND_MODE_DEST_ATOP:
 		aR = aA;
-		t1 = 1 - aA;
+		t1 = 1 - aB;
 		B = t1 * A + B;
 		break;
 


### PR DESCRIPTION
The dest-atop blend mode should function like atop, but with the drawing operations reversed. Therefore, t1 must be `1 - aB`.

Found using this test script:
```python
import pyvips

base = (pyvips.Image.black(120, 90)
        .copy(interpretation='srgb')
        .new_from_image([179, 0, 0, 204])
        .embed(0, 0, 160, 120))

overlay = (pyvips.Image.black(120, 190)
           .copy(interpretation='srgb')
           .new_from_image([0, 0, 230, 204])
           .embed(40, 30, 160, 120))

im = base.composite2(overlay, 'dest-atop')
im.write_to_file('vips.png')
```

| Expected image | Actual image |
| :--: | :--: |
| ![vips](https://github.com/user-attachments/assets/ea7c788d-c743-4b12-87ef-fb7d77d0015d) |![vips-before](https://github.com/user-attachments/assets/cfbad025-f215-450a-9575-c84be5a370e9) |

Targets the 8.15 branch.