### PR TITLE
OSS-Fuzz: increase max file size limit of seed corpus

### DIFF
--- a/fuzz/oss_fuzz_build.sh
+++ b/fuzz/oss_fuzz_build.sh
@@ -190,13 +190,13 @@ find build/fuzz -maxdepth 1 -executable -type f -exec cp -v '{}' $OUT \;
 mkdir -p $OUT/lib
 cp $WORK/lib/*.so $OUT/lib
 
-# Merge the seed corpus in a single directory, exclude files larger than 2k
+# Merge the seed corpus in a single directory, exclude files larger than 4k
 mkdir -p fuzz/corpus
 find \
   $SRC/afl-testcases/{gif*,jpeg*,png,tiff,webp}/full/images \
   fuzz/*_fuzzer_corpus \
   test/test-suite/images \
-  -type f -size -2k \
+  -type f -size -4k \
   -exec bash -c 'hash=($(sha1sum {})); mv {} fuzz/corpus/$hash' \;
 zip -jrq $OUT/seed_corpus.zip fuzz/corpus
 


### PR DESCRIPTION
This matches the default behavior of libFuzzer, which adjusts the input size based on the largest file in the corpus. If no seed corpus is provided or if all files are smaller than 4096 bytes, it uses a minimum limit of 4096 bytes.
```
INFO: -max_len is not provided; libFuzzer will not generate inputs larger than 4096 bytes
```

Found this while working on PR https://github.com/google/oss-fuzz/pull/12256.