### PR TITLE
Fix vips_source_map for zero-length sources

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -11,6 +11,7 @@
 - fix vips_image_get_string
 - heifsave: fix lossless mode [kleisauke]
 - composite: fix dest-atop blend mode [kleisauke]
+- fix vips_source_map for zero-length sources [kleisauke]
 
 12/3/24 8.15.2
 

--- a/libvips/iofuncs/source.c
+++ b/libvips/iofuncs/source.c
@@ -1084,7 +1084,7 @@ vips_source_map(VipsSource *source, size_t *length_out)
 
 	/* We don't know the length and must read and assemble in chunks.
 	 */
-	if (!source->data &&
+	if (source->is_pipe &&
 		vips_source_pipe_read_to_position(source, -1))
 		return NULL;
 


### PR DESCRIPTION
Use `vips_source_pipe_read_to_position()` only for pipes; otherwise, a zero-length memory or file source may cause an assertion failure.

Test program:
```c
#include <vips/vips.h>

int
main(int argc, char *argv[])
{
	VipsSource *source;
	const void *buf;
	size_t len;

	if (VIPS_INIT(argv[0]))
		return -1;

	if (argc != 2)
		vips_error_exit("usage: %s in-file", argv[0]);

	if (!(source = vips_source_new_from_file(argv[1])))
		vips_error_exit("unable to load from %s", argv[1]);

	/* Map the whole source into memory.
	 */
	if (!(buf = vips_source_map(source, &len))) {
		g_object_unref(source);
		vips_error_exit("unable to map %s", argv[1]);
	}

	g_object_unref(source);

	return 0;
}

```

Before:
```console
$ gcc -g -Wall test-source.c `pkg-config vips --cflags --libs` -o test-source
$ touch empty.jpg
$ ./test-source empty.jpg
./test-source empty.jpg

(process:30607): VIPS-WARNING **: 13:56:55.885: map failed (No such file or directory), running very low on system resources, expect a crash soon
**
VIPS:ERROR:../libvips/iofuncs/source.c:871:vips_source_pipe_read_to_position: assertion failed: (source->length == -1)
Bail out! VIPS:ERROR:../libvips/iofuncs/source.c:871:vips_source_pipe_read_to_position: assertion failed: (source->length == -1)
Aborted (core dumped)
```

After:
```console
$ ./test-source empty.jpg

(process:30682): VIPS-WARNING **: 13:57:29.727: map failed (No such file or directory), running very low on system resources, expect a crash soon
test-source: unable to map empty.jpg
vips_mapfile: unable to mmap
unix error: Invalid argument
```

Targets the 8.15 branch.