### PR TITLE
Fix CI failures

### DIFF
--- a/test/test-suite/test_iofuncs.py
+++ b/test/test-suite/test_iofuncs.py
@@ -63,7 +63,8 @@ class TestIofuncs:
 
         assert s == t
 
-    @pytest.mark.skipif(pyvips.cache_get_max() == 0)
+    @pytest.mark.skipif(pyvips.cache_get_max() == 0,
+                        reason="requires a functional operation cache")
     def test_revalidate(self):
         filename = temp_filename(self.tempdir, '.v')
 


### PR DESCRIPTION
```
==================================== ERRORS ====================================
________________ ERROR at setup of TestIofuncs.test_revalidate _________________
Error evaluating 'skipif': you need to specify reason=STRING when using booleans as conditions.
```
https://github.com/libvips/libvips/actions/runs/10123138814/job/27996075308#step:14:671