### PR TITLE
tilecache: only call `vips_tile_move()` when reusing a tile

### DIFF
--- a/libvips/conversion/tilecache.c
+++ b/libvips/conversion/tilecache.c
@@ -223,7 +223,7 @@ vips_tile_new(VipsBlockCache *cache, int x, int y)
 
 	vips__region_no_ownership(tile->region);
 
-	if (vips_tile_move(tile, x, y)) {
+	if (vips_region_buffer(tile->region, &tile->pos)) {
 		g_hash_table_remove(cache->tiles, &tile->pos);
 		return NULL;
 	}


### PR DESCRIPTION
Avoids an unnecessary call to `g_hash_table_{steal,insert}()` when creating a new tile.