### PR TITLE
fuzz: add missing `vips_init()` call

### DIFF
--- a/fuzz/generic_buffer_fuzzer.cc
+++ b/fuzz/generic_buffer_fuzzer.cc
@@ -11,6 +11,9 @@
 extern "C" int
 LLVMFuzzerInitialize(int *argc, char ***argv)
 {
+	if (VIPS_INIT(*argv[0]))
+		return -1;
+
 	vips_concurrency_set(1);
 
 #ifdef DEBUG

--- a/fuzz/jpegsave_file_fuzzer.cc
+++ b/fuzz/jpegsave_file_fuzzer.cc
@@ -3,6 +3,9 @@
 extern "C" int
 LLVMFuzzerInitialize(int *argc, char ***argv)
 {
+	if (VIPS_INIT(*argv[0]))
+		return -1;
+
 	vips_concurrency_set(1);
 	return 0;
 }

--- a/fuzz/mosaic_fuzzer.cc
+++ b/fuzz/mosaic_fuzzer.cc
@@ -20,6 +20,9 @@ PACK(struct mosaic_opt {
 extern "C" int
 LLVMFuzzerInitialize(int *argc, char ***argv)
 {
+	if (VIPS_INIT(*argv[0]))
+		return -1;
+
 	vips_concurrency_set(1);
 	return 0;
 }

--- a/fuzz/sharpen_fuzzer.cc
+++ b/fuzz/sharpen_fuzzer.cc
@@ -3,6 +3,9 @@
 extern "C" int
 LLVMFuzzerInitialize(int *argc, char ***argv)
 {
+	if (VIPS_INIT(*argv[0]))
+		return -1;
+
 	vips_concurrency_set(1);
 	return 0;
 }

--- a/fuzz/smartcrop_fuzzer.cc
+++ b/fuzz/smartcrop_fuzzer.cc
@@ -3,6 +3,9 @@
 extern "C" int
 LLVMFuzzerInitialize(int *argc, char ***argv)
 {
+	if (VIPS_INIT(*argv[0]))
+		return -1;
+
 	vips_concurrency_set(1);
 	return 0;
 }

--- a/fuzz/thumbnail_fuzzer.cc
+++ b/fuzz/thumbnail_fuzzer.cc
@@ -3,6 +3,9 @@
 extern "C" int
 LLVMFuzzerInitialize(int *argc, char ***argv)
 {
+	if (VIPS_INIT(*argv[0]))
+		return -1;
+
 	vips_concurrency_set(1);
 	return 0;
 }


### PR DESCRIPTION
Non-functional change, previously the initialization occurred in `LLVMFuzzerTestOneInput()` automatically via `vips_check_init()`.