### PR TITLE
OSS-Fuzz: fix seed corpus link

### DIFF
--- a/fuzz/oss_fuzz_build.sh
+++ b/fuzz/oss_fuzz_build.sh
@@ -201,8 +201,8 @@ find \
 zip -jrq $OUT/seed_corpus.zip fuzz/corpus
 
 # Link corpus
-for fuzzer in fuzz/*_fuzzer.cc; do
-  target=$(basename "$fuzzer" .cc)
+for fuzzer in $OUT/*_fuzzer; do
+  target=$(basename "$fuzzer")
   ln -sf "seed_corpus.zip" "$OUT/${target}_seed_corpus.zip"
 done
 


### PR DESCRIPTION
After PR #4092, the buffer save fuzzers source file was generalized, so we need to ensure that the seed corpus remains correctly linked to each individual fuzz target.