### PR TITLE
OSS-Fuzz: limit link jobs to 4

### DIFF
--- a/fuzz/oss_fuzz_build.sh
+++ b/fuzz/oss_fuzz_build.sh
@@ -178,7 +178,7 @@ popd
 # Disable building man pages, gettext po files, tools, and tests
 sed -i "/subdir('man')/{N;N;N;d;}" meson.build
 meson setup build --prefix=$WORK --libdir=lib --prefer-static --default-library=static --buildtype=debugoptimized \
-  -Ddeprecated=false -Dexamples=false -Dcplusplus=false -Dmodules=disabled \
+  -Dbackend_max_links=4 -Ddeprecated=false -Dexamples=false -Dcplusplus=false -Dmodules=disabled \
   -Dfuzzing_engine=oss-fuzz -Dfuzzer_ldflags="$LIB_FUZZING_ENGINE" \
   -Dcpp_link_args="$LDFLAGS -Wl,-rpath=\$ORIGIN/lib"
 meson install -C build --tag devel


### PR DESCRIPTION
For introspector builds using LTO, memory usage can become quite heavy. To prevent potential OOM errors, limit Ninja to use no more than 4 processes for linking.

Might fix the introspector build after PR #4092.

Context: https://github.com/google/oss-fuzz/issues/12213#issuecomment-2306951820.