### PR TITLE
heifsave: fix crash when passing an invalid bitdepth

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,7 @@
+8.15.4
+
+- heifsave: fix crash when passing an invalid bitdepth
+
 11/8/24 8.15.3
 
 - fix dzsave of >8-bit images to JPEG

--- a/libvips/foreign/heifsave.c
+++ b/libvips/foreign/heifsave.c
@@ -426,10 +426,10 @@ vips_foreign_save_heif_pack(VipsForeignSaveHeif *heif,
 		}
 	}
 	else {
-		VipsObjectClass *class = VIPS_OBJECT_CLASS(heif);
+		VipsObjectClass *class = VIPS_OBJECT_GET_CLASS(heif);
 
 		vips_error(class->nickname,
-			"%s", _("unimplemeted format conversion"));
+			"%s", _("unimplemented format conversion"));
 		return -1;
 	}
 


### PR DESCRIPTION
Reproducer:
```console
$ vips copy test/test-suite/images/favicon.ico x.avif[bitdepth=1]
Segmentation fault (core dumped)
```

Targets the 8.15 branch.