### PR TITLE
heifsave: ensure NCLX profile is freed in lossless mode

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,7 @@
+8.15.4
+
+- heifsave: ensure NCLX profile is freed in lossless mode [kleisauke]
+
 11/8/24 8.15.3
 
 - fix dzsave of >8-bit images to JPEG

--- a/libvips/foreign/heifsave.c
+++ b/libvips/foreign/heifsave.c
@@ -271,7 +271,7 @@ vips_foreign_save_heif_write_page(VipsForeignSaveHeif *heif, int page)
 	struct heif_error error;
 	struct heif_encoding_options *options;
 #ifdef HAVE_HEIF_ENCODING_OPTIONS_OUTPUT_NCLX_PROFILE
-	struct heif_color_profile_nclx *nclx;
+	struct heif_color_profile_nclx *nclx = NULL;
 #endif
 
 #ifdef HAVE_HEIF_COLOR_PROFILE

--- a/libvips/foreign/heifsave.c
+++ b/libvips/foreign/heifsave.c
@@ -270,6 +270,9 @@ vips_foreign_save_heif_write_page(VipsForeignSaveHeif *heif, int page)
 
 	struct heif_error error;
 	struct heif_encoding_options *options;
+#ifdef HAVE_HEIF_ENCODING_OPTIONS_OUTPUT_NCLX_PROFILE
+	struct heif_color_profile_nclx *nclx;
+#endif
 
 #ifdef HAVE_HEIF_COLOR_PROFILE
 	/* A profile supplied as an argument overrides an embedded
@@ -293,9 +296,10 @@ vips_foreign_save_heif_write_page(VipsForeignSaveHeif *heif, int page)
 	/* Matrix coefficients have to be identity (CICP x/y/0) in lossless mode.
 	 */
 	if (heif->lossless) {
-		struct heif_color_profile_nclx *nclx = heif_nclx_color_profile_alloc();
-		if (!nclx)
+		if (!(nclx = heif_nclx_color_profile_alloc())) {
+			heif_encoding_options_free(options);
 			return -1;
+		}
 
 		nclx->matrix_coefficients = heif_matrix_coefficients_RGB_GBR;
 		options->output_nclx_profile = nclx;
@@ -324,6 +328,9 @@ vips_foreign_save_heif_write_page(VipsForeignSaveHeif *heif, int page)
 #endif /*DEBUG*/
 
 	heif_encoding_options_free(options);
+#ifdef HAVE_HEIF_ENCODING_OPTIONS_OUTPUT_NCLX_PROFILE
+	VIPS_FREEF(heif_nclx_color_profile_free, nclx);
+#endif
 
 	if (error.code) {
 		vips__heif_error(&error);


### PR DESCRIPTION
```
Done 6822012 runs in 7201 second(s)

=================================================================
==8==ERROR: LeakSanitizer: detected memory leaks

Direct leak of 6812 byte(s) in 131 object(s) allocated from:
    #0 0x560f6e1998ee in malloc /src/llvm-project/compiler-rt/lib/asan/asan_malloc_linux.cpp:69:3
    #1 0x560f6f16b7c4 in color_profile_nclx::alloc_nclx_color_profile() /src/libheif/libheif/nclx.cc:294:45
    #2 0x560f6e316319 in vips_foreign_save_heif_write_page /src/libvips/build/../libvips/foreign/heifsave.c:299:16
    #3 0x560f6e316319 in vips_foreign_save_heif_write_block /src/libvips/build/../libvips/foreign/heifsave.c:470:8
    #4 0x560f6e1f3999 in wbuffer_write /src/libvips/build/../libvips/iofuncs/sinkdisc.c:174:25
    #5 0x560f6e1f3999 in wbuffer_write_thread /src/libvips/build/../libvips/iofuncs/sinkdisc.c:199:3
    #6 0x560f6e5c3693 in vips_threadset_work /src/libvips/build/../libvips/iofuncs/threadset.c:134:3
    #7 0x560f6e1d91d0 in vips_thread_run /src/libvips/build/../libvips/iofuncs/thread.c:148:11
    #8 0x560f6e5f16a0 in g_thread_proxy (/out/generic_buffer_with_args_fuzzer+0xbe26a0)

DEDUP_TOKEN: __interceptor_malloc--color_profile_nclx::alloc_nclx_color_profile()--vips_foreign_save_heif_write_page
SUMMARY: AddressSanitizer: 6812 byte(s) leaked in 131 allocation(s).
```

Targets the 8.15 branch.