### PR TITLE
OSS-Fuzz: fix Meson compile tests in introspector builds

### DIFF
--- a/fuzz/oss_fuzz_build.sh
+++ b/fuzz/oss_fuzz_build.sh
@@ -5,6 +5,19 @@ export PKG_CONFIG_PATH="$WORK/lib/pkgconfig"
 export CPPFLAGS="-I$WORK/include"
 export LDFLAGS="-L$WORK/lib"
 
+# `-fuse-ld=gold` can't be passed via `CFLAGS` and `CXXFLAGS` as Meson
+# injects `-Werror=ignored-optimization-argument` during compile tests.
+# https://github.com/google/oss-fuzz/issues/12167
+# https://github.com/mesonbuild/meson/issues/6377#issuecomment-575977919
+if [[ "$CFLAGS" == *"-fuse-ld=gold"* ]]; then
+  export CFLAGS="${CFLAGS//-fuse-ld=gold/}"
+  export CC_LD=gold
+fi
+if [[ "$CXXFLAGS" == *"-fuse-ld=gold"* ]]; then
+  export CXXFLAGS="${CXXFLAGS//-fuse-ld=gold/}"
+  export CXX_LD=gold
+fi
+
 # Run as many parallel jobs as there are available CPU cores
 export MAKEFLAGS="-j$(nproc)"
 


### PR DESCRIPTION
See: https://github.com/google/oss-fuzz/issues/12167.

<details>
  <summary>Details</summary>

```diff
@@ -11,16 +11,15 @@ C compiler for the host machine: clang (clang 18.0.0 "clang version 18.0.0 (http
 C linker for the host machine: clang ld.gold 2.34
 Host machine cpu family: x86_64
 Host machine cpu: x86_64
-Compiler for C supports function attribute visibility:hidden: NO 
-Header "time.h" has symbol "gmtime_r" : NO 
-Header "time.h" has symbol "gmtime_s" : NO 
+Compiler for C supports function attribute visibility:hidden: YES 
+Header "time.h" has symbol "gmtime_r" : YES 
 Dependency libjpeg skipped: feature jpeg disabled
 Dependency libtiff-4 skipped: feature tiff disabled
-Checking if "supports SSE2 intrinsics" compiles: NO 
+Checking if "supports SSE2 intrinsics" compiles: YES 
 Library m found: YES
 Run-time dependency threads found: YES
 Checking for function "pthread_mutex_lock" with dependency threads: YES 
-Header "time.h" has symbol "timespec_get" : NO 
+Header "time.h" has symbol "timespec_get" : YES 
 Found pkg-config: YES (--static) 0.29.1
 Build targets in project: 2
 
@@ -50,7 +49,7 @@ C++ compiler for the host machine: clang++ (clang 18.0.0 "clang version 18.0.0 (
 C++ linker for the host machine: clang++ ld.gold 2.34
 Host machine cpu family: x86_64
 Host machine cpu: x86_64
-Compiler for C supports arguments -Werror=pointer-arith: NO 
+Compiler for C supports arguments -Werror=pointer-arith: YES 
 Found pkg-config: YES (--static) 0.29.1
 Run-time dependency glib-2.0 found: YES 2.64.6
 Run-time dependency gio-2.0 found: YES 2.64.6
@@ -60,8 +59,9 @@ Run-time dependency expat found: YES 2.2.9
 Run-time dependency threads found: YES
 Library m found: YES
 Compiler for C supports link arguments -Wl,-z,nodelete: YES 
-Compiler for C supports function attribute visibility:hidden: NO 
-Checking if "Has vector arithmetic" with dependency -lm compiles: NO 
+Compiler for C supports function attribute visibility:hidden: YES 
+Checking if "Has vector arithmetic" with dependency -lm compiles: YES 
+Checking if "Has signed constants in vector templates" with dependency -lm compiles: YES 
 Checking if "Has target_clones attribute" runs: DID NOT COMPILE
 Checking for function "_aligned_malloc" : NO 
 Checking for function "posix_memalign" : YES 
@@ -76,8 +76,8 @@ Run-time dependency imagemagick found: NO (tried pkgconfig and cmake)
 Run-time dependency cfitsio found: NO (tried pkgconfig and cmake)
 Run-time dependency imagequant found: YES 2.4.1
 Run-time dependency cgif found: YES 0.5.0
-Checking if "Has CGIF_ATTR_NO_LOOP" with dependency cgif compiles: NO 
-Checking if "Has CGIF_FRAME_ATTR_INTERLACED" with dependency cgif compiles: NO 
+Checking if "Has CGIF_ATTR_NO_LOOP" with dependency cgif compiles: YES 
+Checking if "Has CGIF_FRAME_ATTR_INTERLACED" with dependency cgif compiles: YES 
 Run-time dependency libexif found: YES 0.6.24.1
 Has header "exif-data.h" with dependency libexif: NO 
 Run-time dependency libjpeg found: YES 3.0.4
@@ -104,8 +104,8 @@ Run-time dependency pdfium found: YES 4901
 Run-time dependency libheif found: YES 1.18.2
 Checking for function "heif_image_handle_get_raw_color_profile" with dependency libheif: YES 
 Checking for function "heif_context_set_maximum_image_size_limit" with dependency libheif: YES 
-Checking whether type "struct heif_decoding_options" has member "convert_hdr_to_8bit" with dependency libheif: NO 
-Checking whether type "struct heif_encoding_options" has member "output_nclx_profile" with dependency libheif: NO 
+Checking whether type "struct heif_decoding_options" has member "convert_hdr_to_8bit" with dependency libheif: YES 
+Checking whether type "struct heif_encoding_options" has member "output_nclx_profile" with dependency libheif: YES 
 Run-time dependency libjxl found: NO (tried pkgconfig and cmake)
 Run-time dependency libjxl_threads found: NO (tried pkgconfig and cmake)
 Run-time dependency niftiio found: NO (tried pkgconfig)
```
</details>

Context: https://github.com/google/oss-fuzz/issues/12213#issuecomment-2307013192.