### PR TITLE
Revert "lsan: suppress leak warnings from libheif (#3481)"

### DIFF
--- a/suppressions/lsan.supp
+++ b/suppressions/lsan.supp
@@ -5,4 +5,3 @@ leak:libIlmImf-2_5.so
 leak:libIlmThread-2_5.so
 leak:libMagickCore-6.Q16.so
 leak:libx265.so
-leak:libheif.so


### PR DESCRIPTION
This reverts commit 62f68fc136e9bc65ef005c9395c165e049ce4a41, as it became redundant after strukturag/libheif#891 (libheif v1.17.0).

Targets the 8.15 branch.