### PR TITLE
heifsave: limit bitdepth to supported values

### DIFF
--- a/libvips/foreign/heifsave.c
+++ b/libvips/foreign/heifsave.c
@@ -532,8 +532,7 @@ vips_foreign_save_heif_build(VipsObject *object)
 		!vips_object_argument_isset(object, "subsample_mode"))
 		heif->subsample_mode = VIPS_FOREIGN_SUBSAMPLE_OFF;
 
-	/* Default 12 bit save for 16-bit images. HEIC (for example) implements
-	 * 8 / 10 / 12.
+	/* Default 12 bit save for 16-bit images.
 	 */
 	if (!vips_object_argument_isset(object, "bitdepth"))
 		heif->bitdepth =
@@ -541,6 +540,16 @@ vips_foreign_save_heif_build(VipsObject *object)
 				save->ready->Type == VIPS_INTERPRETATION_GREY16
 			? 12
 			: 8;
+
+	/* HEIC and AVIF only implements 8 / 10 / 12 bit depth.
+	 */
+	if (heif->bitdepth != 12 &&
+		heif->bitdepth != 10 &&
+		heif->bitdepth != 8) {
+		vips_error("heifsave", _("%d-bit colour depth not supported"),
+			heif->bitdepth);
+		return -1;
+	}
 
 	/* Try to find the selected encoder.
 	 */
@@ -724,7 +733,7 @@ vips_foreign_save_heif_class_init(VipsForeignSaveHeifClass *class)
 		_("Number of bits per pixel"),
 		VIPS_ARGUMENT_OPTIONAL_INPUT,
 		G_STRUCT_OFFSET(VipsForeignSaveHeif, bitdepth),
-		1, 16, 12);
+		1, 12, 12);
 
 	VIPS_ARG_BOOL(class, "lossless", 13,
 		_("Lossless"),

--- a/libvips/foreign/heifsave.c
+++ b/libvips/foreign/heifsave.c
@@ -733,7 +733,7 @@ vips_foreign_save_heif_class_init(VipsForeignSaveHeifClass *class)
 		_("Number of bits per pixel"),
 		VIPS_ARGUMENT_OPTIONAL_INPUT,
 		G_STRUCT_OFFSET(VipsForeignSaveHeif, bitdepth),
-		1, 12, 12);
+		8, 12, 12);
 
 	VIPS_ARG_BOOL(class, "lossless", 13,
 		_("Lossless"),


### PR DESCRIPTION
Context: https://github.com/libvips/libvips/pull/4110#issuecomment-2308786358, hence let's reuse this existing changelog entry:
https://github.com/libvips/libvips/blob/4f26536730f9d6cfb7b9a4a30fe4844f00264a94/ChangeLog#L4

Targets the 8.15 branch.