### PR TITLE
lsan: revise suppressions

### DIFF
--- a/suppressions/lsan.supp
+++ b/suppressions/lsan.supp
@@ -1,8 +1,26 @@
-leak:python3
-leak:bash
-leak:libfontconfig.so
-leak:libIlmImf-2_5.so
-leak:libIlmThread-2_5.so
-leak:libMagickCore-6.Q16.so
-leak:libx265.so
-leak:libimagequant.so
+# Likely false positives
+leak:PyMem_Malloc
+leak:PyObject_Malloc
+
+# Known leaks in Fontconfig, most likely false positives due to
+# missing instrumentation (i.e. it's build without ASan/LSan).
+leak:FcConfigSubstituteWithPat
+leak:FcDefaultSubstitute
+leak:FcFontSetList
+leak:FcFontSetMatch
+leak:FcInit
+leak:FcPatternBuild
+leak:FcValueSave
+
+# Freed on exit, see:
+# https://gcc.gnu.org/bugzilla/show_bug.cgi?id=36298#c1
+leak:___kmp_allocate
+
+# Fixed in libheif >= v1.18.0, see:
+# https://github.com/strukturag/libheif/pull/1061
+# TODO: Does this requires calling heif_deinit()?
+leak:x265::x265_malloc
+leak:x265_12bit::x265_malloc
+
+# TODO: Remove after PR https://github.com/libvips/pyvips/pull/497
+leak:vips_filename_get_filename

--- a/suppressions/ubsan.supp
+++ b/suppressions/ubsan.supp
@@ -1,1 +1,2 @@
+# https://github.com/libexif/libexif/pull/147
 undefined:libexif.so


### PR DESCRIPTION
Avoid suppressing shared libraries, as this could mask actual leaks.