### PR TITLE
Silence a clang warning

### DIFF
--- a/tools/vipsheader.c
+++ b/tools/vipsheader.c
@@ -218,7 +218,7 @@ main(int argc, char *argv[])
 	result = 0;
 
 	for (i = 1; argv[i]; i++) {
-		VipsImage *image;
+		VipsImage *image = NULL;
 		char filename[VIPS_PATH_MAX];
 		char option_string[VIPS_PATH_MAX];
 


### PR DESCRIPTION
<details>
  <summary>Details</summary>

```console
[371/416] Compiling C object tools/vipsheader.p/vipsheader.c.o
../tools/vipsheader.c:229:8: warning: variable 'image' is used uninitialized whenever '||' condition is true [-Wsometimes-uninitialized]
  229 |                         if (!(source = vips_source_new_from_descriptor(0)) ||
      |                             ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
../tools/vipsheader.c:241:7: note: uninitialized use occurs here
  241 |                 if (image &&
      |                     ^~~~~
../tools/vipsheader.c:229:8: note: remove the '||' if its condition is always false
  229 |                         if (!(source = vips_source_new_from_descriptor(0)) ||
      |                             ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
../tools/vipsheader.c:221:19: note: initialize the variable 'image' to silence this warning
  221 |                 VipsImage *image;
      |                                 ^
      |                                  = NULL
1 warning generated.
```
</details>

Targets the 8.15 branch in case someone compiles with `-Werror`.

