### PR TITLE
threadpool: fix a race condition during downsizing

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -5,6 +5,7 @@
 - webpsave: fix memory leak on error [dloebl]
 - heifsave: ensure NCLX profile is freed in lossless mode [kleisauke]
 - threadpool: fix a race condition in error handling [kleisauke]
+- threadpool: fix a race condition during downsizing [kleisauke]
 
 11/8/24 8.15.3
 


### PR DESCRIPTION
Under certain conditions, particularly with short-lived pipelines and high thread concurrency, a race condition could occur between decrementing and restoring the `exit` flag atomically, potentially causing more threads to cooperatively exit than intended.

Fix this race by using a single atomic compare-and-exchange, which only resets the flag when it is set. Additionally, the flag's type has been changed from `int` to `gboolean` for clarity.

Context: #4069.