### PR TITLE
CI: build without *magick

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -113,6 +113,7 @@ jobs:
           meson setup build
             -Ddebug=true
             -Ddeprecated=false
+            -Dmagick=disabled
           || (cat build/meson-logs/meson-log.txt && exit 1)
 
       - name: Build libvips


### PR DESCRIPTION
In line with commit 23998b42ce25987714e117d480bb30d718767529. This is pre-installed only on `macos-12` and `ubuntu-22.04`. Newer images no longer include it due to maintenance concerns, see:
https://github.com/actions/runner-images/issues/7899#issuecomment-1632115075

Context: https://github.com/libvips/libvips/pull/4128#issuecomment-2317374277.

Targets the 8.15 branch.