### PR TITLE
Simplify `GPrivate` initialisation

### DIFF
--- a/libvips/iofuncs/thread.c
+++ b/libvips/iofuncs/thread.c
@@ -75,7 +75,7 @@ int vips__thinstrip_height = VIPS__THINSTRIP_HEIGHT;
 
 /* Set this GPrivate to indicate that is a libvips thread.
  */
-static GPrivate *is_vips_thread_key = NULL;
+static GPrivate is_vips_thread_key;
 
 /* TRUE if we are a vips thread. We sometimes manage resource allocation
  * differently for vips threads since we can cheaply free stuff on thread
@@ -84,7 +84,7 @@ static GPrivate *is_vips_thread_key = NULL;
 gboolean
 vips_thread_isvips(void)
 {
-	return g_private_get(is_vips_thread_key) != NULL;
+	return g_private_get(&is_vips_thread_key) != NULL;
 }
 
 /* Glib 2.32 revised the thread API. We need some compat functions.
@@ -143,7 +143,7 @@ vips_thread_run(gpointer data)
 	 * worker. No need to call g_private_replace as there is no
 	 * GDestroyNotify handler associated with a worker.
 	 */
-	g_private_set(is_vips_thread_key, info);
+	g_private_set(&is_vips_thread_key, info);
 
 	result = info->func(info->data);
 
@@ -361,10 +361,6 @@ vips_get_tile_size(VipsImage *im,
 void
 vips__thread_init(void)
 {
-	static GPrivate private = G_PRIVATE_INIT(NULL);
-
-	is_vips_thread_key = &private;
-
 	if (vips__concurrency == 0)
 		vips__concurrency = vips__concurrency_get_default();
 }


### PR DESCRIPTION
Revise the code to move the initialisation to the global file scope, aligning with the example outlined in the GLib documentation: https://docs.gtk.org/glib/func.PRIVATE_INIT.html

This should be considered a non-functional change, at least on Linux, on Windows I'm not sure how thread-local storage should be initialised, so it targets the 8.15 branch just to be sure.