### PR TITLE
Migrate to SPDX license in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,8 +12,8 @@ threaded](https://github.com/libvips/libvips/wiki/Why-is-libvips-quick)
 image processing library. Compared to similar
 libraries, [libvips runs quickly and uses little
 memory](https://github.com/libvips/libvips/wiki/Speed-and-memory-use).
-libvips is licensed under the [LGPL
-2.1+](https://www.gnu.org/licenses/old-licenses/lgpl-2.1.en.html).
+libvips is licensed under the [LGPL-2.1-or-later](
+https://spdx.org/licenses/LGPL-2.1-or-later).
 
 It has around [300
 operations](https://libvips.github.io/libvips/API/current/func-list.html)


### PR DESCRIPTION
Noticed this while working on https://src.fedoraproject.org/rpms/vips/pull-request/9.