### PR TITLE
Disable GLib cast checks and asserts for plain builds

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -5,6 +5,7 @@
 - webpsave: fix memory leak on error [dloebl]
 - heifsave: ensure NCLX profile is freed in lossless mode [kleisauke]
 - threadpool: fix a race condition in error handling [kleisauke]
+- disable GLib cast checks and asserts for plain builds [kleisauke]
 
 11/8/24 8.15.3
 

--- a/meson.build
+++ b/meson.build
@@ -35,7 +35,7 @@ pkg = import('pkgconfig')
 i18n = import('i18n')
 
 # if we're optimising (eg. release mode) we turn off cast checks and g_asserts
-if get_option('optimization') in ['2', '3', 's']
+if get_option('optimization') not in ['0', 'g']
     add_project_arguments('-DG_DISABLE_CAST_CHECKS', language : ['cpp', 'c'])
     add_project_arguments('-DG_DISABLE_CHECKS', language : ['cpp', 'c'])
     add_project_arguments('-DG_DISABLE_ASSERT', language : ['cpp', 'c'])


### PR DESCRIPTION
Plain builds are typically used by distro builds; make sure to disable GLib cast checks and assertions there as well, see: https://gitlab.gnome.org/GNOME/glib/-/commit/61a843564de7a4727b9707f205649f848125ba91

Targets the 8.15 branch.