### PR TITLE
Added ability to specify Deflate (zlib) compression level through 'level' parameter

### DIFF
--- a/libvips/foreign/tiffsave.c
+++ b/libvips/foreign/tiffsave.c
@@ -362,10 +362,10 @@ vips_foreign_save_tiff_class_init(VipsForeignSaveTiffClass *class)
 
 	VIPS_ARG_INT(class, "level", 23,
 		_("Level"),
-		_("ZSTD compression level"),
+		_("Deflate (1-9, default 6) or ZSTD (1-22, default 9) compression level"),
 		VIPS_ARGUMENT_OPTIONAL_INPUT,
 		G_STRUCT_OFFSET(VipsForeignSaveTiff, level),
-		1, 22, 10);
+		1, 22, 6);
 
 	VIPS_ARG_BOOL(class, "lossless", 24,
 		_("Lossless"),
@@ -422,7 +422,7 @@ vips_foreign_save_tiff_init(VipsForeignSaveTiff *tiff)
 	tiff->xres = 1.0;
 	tiff->yres = 1.0;
 	tiff->region_shrink = VIPS_REGION_SHRINK_MEAN;
-	tiff->level = 10;
+	tiff->level = 0;
 	tiff->lossless = FALSE;
 	tiff->depth = VIPS_FOREIGN_DZ_DEPTH_ONETILE;
 	tiff->bitdepth = 0;
@@ -622,7 +622,7 @@ vips_foreign_save_tiff_buffer_init(VipsForeignSaveTiffBuffer *buffer)
  * * @bigtiff: %gboolean, write a BigTiff file
  * * @properties: %gboolean, set %TRUE to write an IMAGEDESCRIPTION tag
  * * @region_shrink: #VipsRegionShrink How to shrink each 2x2 region.
- * * @level: %gint, Zstd compression level
+ * * @level: %gint, Zstd or Deflate (zlib) compression level
  * * @lossless: %gboolean, WebP lossless mode
  * * @depth: #VipsForeignDzDepth how deep to make the pyramid
  * * @subifd: %gboolean write pyr layers as sub-ifds
@@ -647,7 +647,7 @@ vips_foreign_save_tiff_buffer_init(VipsForeignSaveTiffBuffer *buffer)
  *
  * Use @Q to set the JPEG compression factor. Default 75.
  *
- * User @level to set the ZSTD compression level. Use @lossless to
+ * User @level to set the ZSTD (1-22) or Deflate (1-9) compression level. Use @lossless to
  * set WEBP lossless mode on. Use @Q to set the WEBP compression level.
  *
  * Use @predictor to set the predictor for lzw, deflate and zstd compression.
@@ -753,7 +753,7 @@ vips_tiffsave(VipsImage *in, const char *filename, ...)
  * * @bigtiff: %gboolean, write a BigTiff file
  * * @properties: %gboolean, set %TRUE to write an IMAGEDESCRIPTION tag
  * * @region_shrink: #VipsRegionShrink How to shrink each 2x2 region.
- * * @level: %gint, Zstd compression level
+ * * @level: %gint, Zstd or Deflate (zlib) compression level
  * * @lossless: %gboolean, WebP lossless mode
  * * @depth: #VipsForeignDzDepth how deep to make the pyramid
  * * @subifd: %gboolean write pyr layers as sub-ifds
@@ -820,7 +820,7 @@ vips_tiffsave_buffer(VipsImage *in, void **buf, size_t *len, ...)
  * * @bigtiff: %gboolean, write a BigTiff file
  * * @properties: %gboolean, set %TRUE to write an IMAGEDESCRIPTION tag
  * * @region_shrink: #VipsRegionShrink How to shrink each 2x2 region.
- * * @level: %gint, Zstd compression level
+ * * @level: %gint, Zstd or Deflate (zlib) compression level
  * * @lossless: %gboolean, WebP lossless mode
  * * @depth: #VipsForeignDzDepth how deep to make the pyramid
  * * @subifd: %gboolean write pyr layers as sub-ifds

--- a/libvips/foreign/vips2tiff.c
+++ b/libvips/foreign/vips2tiff.c
@@ -856,8 +856,8 @@ wtiff_write_header(Wtiff *wtiff, Layer *layer)
 	}
 	if (wtiff->compression == COMPRESSION_ZSTD) {
 		// Set zstd compression level - only accept valid values (1-22)
-		if ((wtiff->level>=1) && (wtiff->level<=22))
-			TIFFSetField(tif, TIFFTAG_ZSTD_LEVEL, wtiff->level);
+		if (wtiff->level)
+			TIFFSetField(tif, TIFFTAG_ZSTD_LEVEL, VIPS_CLIP(1, wtiff->level, 22));
 		if (wtiff->predictor != VIPS_FOREIGN_TIFF_PREDICTOR_NONE)
 			TIFFSetField(tif,
 				TIFFTAG_PREDICTOR, wtiff->predictor);
@@ -865,8 +865,8 @@ wtiff_write_header(Wtiff *wtiff, Layer *layer)
 #endif /*HAVE_TIFF_COMPRESSION_WEBP*/
 
 	// Set zlib compression level - only accept valid values (1-9)
-	if ((wtiff->compression == COMPRESSION_ADOBE_DEFLATE) && (wtiff->level>=1) && (wtiff->level<=9))
-		TIFFSetField(tif, TIFFTAG_ZIPQUALITY, wtiff->level);
+	if ((wtiff->compression == COMPRESSION_ADOBE_DEFLATE) && (wtiff->level))
+		TIFFSetField(tif, TIFFTAG_ZIPQUALITY, VIPS_CLIP(1, wtiff->level, 9));
 
 	if ((wtiff->compression == COMPRESSION_ADOBE_DEFLATE ||
 			wtiff->compression == COMPRESSION_LZW) &&

--- a/libvips/foreign/vips2tiff.c
+++ b/libvips/foreign/vips2tiff.c
@@ -367,7 +367,7 @@ struct _Wtiff {
 	int rgbjpeg;					/* True for RGB not YCbCr */
 	int properties;					/* Set to save XML props */
 	VipsRegionShrink region_shrink; /* How to shrink regions */
-	int level;						/* zstd compression level */
+	int level;						/* Deflate (zlib) / zstd compression level */
 	gboolean lossless;				/* lossless mode */
 	VipsForeignDzDepth depth;		/* Pyr depth */
 	gboolean subifd;				/* Write pyr layers into subifds */
@@ -855,12 +855,18 @@ wtiff_write_header(Wtiff *wtiff, Layer *layer)
 		TIFFSetField(tif, TIFFTAG_WEBP_LOSSLESS, wtiff->lossless);
 	}
 	if (wtiff->compression == COMPRESSION_ZSTD) {
-		TIFFSetField(tif, TIFFTAG_ZSTD_LEVEL, wtiff->level);
+		// Set zstd compression level - only accept valid values (1-22)
+		if ((wtiff->level>=1) && (wtiff->level<=22))
+			TIFFSetField(tif, TIFFTAG_ZSTD_LEVEL, wtiff->level);
 		if (wtiff->predictor != VIPS_FOREIGN_TIFF_PREDICTOR_NONE)
 			TIFFSetField(tif,
 				TIFFTAG_PREDICTOR, wtiff->predictor);
 	}
 #endif /*HAVE_TIFF_COMPRESSION_WEBP*/
+
+	// Set zlib compression level - only accept valid values (1-9)
+	if ((wtiff->compression == COMPRESSION_ADOBE_DEFLATE) && (wtiff->level>=1) && (wtiff->level<=9))
+		TIFFSetField(tif, TIFFTAG_ZIPQUALITY, wtiff->level);
 
 	if ((wtiff->compression == COMPRESSION_ADOBE_DEFLATE ||
 			wtiff->compression == COMPRESSION_LZW) &&


### PR DESCRIPTION
There is currently no way to set the deflate compression level (through the TIFFTAG_ZIPQUALITY tag) when saving to TIFF. All deflate-encoded TIFFs, therefore, are compressed using the default level of 6.

This pull requests allows the existing `level` parameter, which is currently only used for zstd to also be usable for deflate.
If this parameter is not set, the compression level defaults to the libtiff default of 6 for Deflate and 9 for Zstd.