### PR TITLE
replace ssize_t with gint64 to fix msvc build #4088

### DIFF
--- a/libvips/iofuncs/generate.c
+++ b/libvips/iofuncs/generate.c
@@ -638,7 +638,7 @@ write_vips(VipsRegion *region, VipsRect *area, void *a)
 		// write() uses int not size_t on windows, so we need to chunk
 		// ... max 1gb, why not
 		int chunk_size = VIPS_MIN(1024 * 1024 * 1024, count);
-		ssize_t nwritten = write(region->im->fd, buf, chunk_size);
+		gint64 nwritten = write(region->im->fd, buf, chunk_size);
 
 		/* n == 0 isn't strictly an error, but we treat it as
 		 * one to make sure we don't get stuck in this loop.

--- a/libvips/iofuncs/util.c
+++ b/libvips/iofuncs/util.c
@@ -468,7 +468,7 @@ vips__write(int fd, const void *buf, size_t count)
 		// write() uses int not size_t on windows, so we need to chunk
 		// ... max 1gb, why not
 		int chunk_size = VIPS_MIN(1024 * 1024 * 1024, count);
-		ssize_t nwritten = write(fd, buf, chunk_size);
+		gint64 nwritten = write(fd, buf, chunk_size);
 
 		/* n == 0 isn't strictly an error, but we treat it as
 		 * one to make sure we don't get stuck in this loop.


### PR DESCRIPTION
This fixes #4088.
Replacing `ssize_t` with `gint64` should be a straigtforward solution and avoid problems with msvc.