### PR TITLE
call jpeg_set_colorspace for jpeg in tiff

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -6,6 +6,7 @@
 - heifsave: ensure NCLX profile is freed in lossless mode [kleisauke]
 - threadpool: fix a race condition in error handling [kleisauke]
 - disable GLib cast checks and asserts for plain builds [kleisauke]
+- fix jpeg in tiff for high [nahilsobh]
 
 11/8/24 8.15.3
 

--- a/ChangeLog
+++ b/ChangeLog
@@ -6,7 +6,7 @@
 - heifsave: ensure NCLX profile is freed in lossless mode [kleisauke]
 - threadpool: fix a race condition in error handling [kleisauke]
 - disable GLib cast checks and asserts for plain builds [kleisauke]
-- fix jpeg in tiff for high [nahilsobh]
+- fix jpeg in tiff for high Q [nahilsobh]
 
 11/8/24 8.15.3
 

--- a/libvips/foreign/vips2tiff.c
+++ b/libvips/foreign/vips2tiff.c
@@ -700,7 +700,7 @@ wtiff_compress_jpeg_header(Wtiff *wtiff,
 	}
 
 	/* For low Q, we write YCbCr, for high Q, RGB. The jpeg coeffs don't
-	 * encode the photometic interpretation, the tiff header does that,
+	 * encode the photometric interpretation, the tiff header does that,
 	 * so this code must be kept synced with wtiff_write_header().
 	 */
 	if (image->Bands == 3 &&


### PR DESCRIPTION
JPEG in TIFF compression needs the jpeg encoding colourspace set to match the enclosing tiff file.

fixes regression in 8.15.3 from https://github.com/libvips/libvips/pull/3924

see https://github.com/libvips/pyvips/issues/490

reproduce error with

```
vips copy x.jpg x.tif[compression=jpeg,Q=90,pyramid]
```

thanks nahilsobh