### PR TITLE
CI: remove redundant step

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,10 +34,6 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v4
 
-      - name: Update apt
-        if: runner.os == 'Linux'
-        run: sudo apt-get update -qq
-
       - name: Install Ubuntu dependencies
         if: runner.os == 'Linux'
         run: |


### PR DESCRIPTION
This step was consolidated with the next one in commit 52698b8, but re-introduced due to the merge in commit 12dc3b4.