### PR TITLE
Backport #4153 to 8.15

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -8,6 +8,7 @@
 - disable GLib cast checks and asserts for plain builds [kleisauke]
 - fix jpeg in tiff for high Q [nahilsobh]
 - threadset: fix a race condition during thread exit [kleisauke]
+- fix compatibility with MSVC [Julianiolo]
 
 11/8/24 8.15.3
 

--- a/libvips/iofuncs/generate.c
+++ b/libvips/iofuncs/generate.c
@@ -638,7 +638,7 @@ write_vips(VipsRegion *region, VipsRect *area, void *a)
 		// write() uses int not size_t on windows, so we need to chunk
 		// ... max 1gb, why not
 		int chunk_size = VIPS_MIN(1024 * 1024 * 1024, count);
-		ssize_t nwritten = write(region->im->fd, buf, chunk_size);
+		gint64 nwritten = write(region->im->fd, buf, chunk_size);
 
 		/* n == 0 isn't strictly an error, but we treat it as
 		 * one to make sure we don't get stuck in this loop.

--- a/libvips/iofuncs/util.c
+++ b/libvips/iofuncs/util.c
@@ -541,7 +541,7 @@ vips__write(int fd, const void *buf, size_t count)
 		// write() uses int not size_t on windows, so we need to chunk
 		// ... max 1gb, why not
 		int chunk_size = VIPS_MIN(1024 * 1024 * 1024, count);
-		ssize_t nwritten = write(fd, buf, chunk_size);
+		gint64 nwritten = write(fd, buf, chunk_size);
 
 		/* n == 0 isn't strictly an error, but we treat it as
 		 * one to make sure we don't get stuck in this loop.


### PR DESCRIPTION
Trivial backport of #4153 to [`8.15`](https://github.com/libvips/libvips/tree/8.15).

Note: rebase merge, don't squash.