### PR TITLE
Modification to resolution handling in TIFF reader / writer

### DIFF
--- a/libvips/foreign/tiff2vips.c
+++ b/libvips/foreign/tiff2vips.c
@@ -541,8 +541,8 @@ get_resolution(TIFF *tiff, VipsImage *out)
 		/* We used to warn about missing res data, but it happens so
 		 * often and is so harmless, why bother.
 		 */
-		x = 1.0;
-		y = 1.0;
+		x = 0.0;
+		y = 0.0;
 	}
 
 	out->Xres = x;

--- a/libvips/foreign/vips2tiff.c
+++ b/libvips/foreign/vips2tiff.c
@@ -885,13 +885,15 @@ wtiff_write_header(Wtiff *wtiff, Layer *layer)
 		!wtiff->tile)
 		wtiff->we_compress = FALSE;
 
-	/* Don't write mad resolutions (eg. zero), it confuses some programs.
+	/* Only set resolution if we actually have one. Also, mad resolutions (eg. zero) confuse some programs.
 	 */
-	TIFFSetField(tif, TIFFTAG_RESOLUTIONUNIT, wtiff->resunit);
-	TIFFSetField(tif, TIFFTAG_XRESOLUTION,
-		VIPS_FCLIP(0.01, wtiff->xres, 1000000));
-	TIFFSetField(tif, TIFFTAG_YRESOLUTION,
-		VIPS_FCLIP(0.01, wtiff->yres, 1000000));
+	if(wtiff->xres || wtiff->yres){
+		TIFFSetField(tif, TIFFTAG_RESOLUTIONUNIT, wtiff->resunit);
+		/* Scale resolution by the subsampling factor of the current level
+		 */
+		if(wtiff->xres) TIFFSetField(tif, TIFFTAG_XRESOLUTION, (wtiff->xres/layer->sub));
+		if(wtiff->yres) TIFFSetField(tif, TIFFTAG_YRESOLUTION, (wtiff->yres/layer->sub));
+	}
 
 	if (wtiff_embed_xmp(wtiff, tif) ||
 		wtiff_embed_iptc(wtiff, tif) ||

--- a/libvips/foreign/vipspng.c
+++ b/libvips/foreign/vipspng.c
@@ -1163,11 +1163,13 @@ write_vips(Write *write,
 		in->Xsize, in->Ysize, bitdepth, color_type, interlace_type,
 		PNG_COMPRESSION_TYPE_DEFAULT, PNG_FILTER_TYPE_DEFAULT);
 
-	/* Set resolution. libpng uses pixels per meter.
+	/* Set resolution if known. libpng uses pixels per meter.
 	 */
-	png_set_pHYs(write->pPng, write->pInfo,
-		VIPS_RINT(in->Xres * 1000), VIPS_RINT(in->Yres * 1000),
-		PNG_RESOLUTION_METER);
+	if(in->Xres && in->Yres){
+		png_set_pHYs(write->pPng, write->pInfo,
+					 VIPS_RINT(in->Xres * 1000), VIPS_RINT(in->Yres * 1000),
+					 PNG_RESOLUTION_METER);
+	}
 
 	/* Metadata
 	 */

--- a/libvips/iofuncs/image.c
+++ b/libvips/iofuncs/image.c
@@ -1344,8 +1344,8 @@ vips_image_init(VipsImage *image)
 	image->Ysize = 1;
 	image->Bands = 1;
 
-	image->Xres = 1.0;
-	image->Yres = 1.0;
+	image->Xres = 0.0;
+	image->Yres = 0.0;
 
 	image->fd = -1; /* since 0 is stdout */
 	image->sslock = vips_g_mutex_new();


### PR DESCRIPTION
Vips currently sets a default X and Y resolution of 1.0 if no resolution information is found within an image file. Rather than write "fake" resolution information to a TIFF, this pull request modifies things so that the TIFF X/Y resolution is only written if this value is really known.

Also when writing a multi-resolution pyramid TIFF, identical resolution information is currently set for each layer in the pyramid. This information is now scaled by the sub-sampling factor so that the resolution now correctly represents what the resolution really is for each layer.

A similar change has also be made for PNG writing.
