### PR TITLE
cplusplus: add `VImage::rawsave_fd` compat function

### DIFF
--- a/cplusplus/VImage.cpp
+++ b/cplusplus/VImage.cpp
@@ -1597,7 +1597,7 @@ operator>>=(VImage &a, const std::vector<double> b)
 void
 VImage::rawsave_fd(int fd, VOption *options) const
 {
-	this->rawsave_target(VTarget::new_to_descriptor(fd), options);
+	rawsave_target(VTarget::new_to_descriptor(fd), options);
 }
 
 VIPS_NAMESPACE_END

--- a/cplusplus/VImage.cpp
+++ b/cplusplus/VImage.cpp
@@ -1592,4 +1592,12 @@ operator>>=(VImage &a, const std::vector<double> b)
 	return a;
 }
 
+// Compat operations
+
+void
+VImage::rawsave_fd(int fd, VOption *options) const
+{
+	this->rawsave_target(VTarget::new_to_descriptor(fd), options);
+}
+
 VIPS_NAMESPACE_END

--- a/cplusplus/include/vips/VImage8.h
+++ b/cplusplus/include/vips/VImage8.h
@@ -2048,6 +2048,23 @@ public:
 	friend VIPS_CPLUSPLUS_API VImage &
 	operator>>=(VImage &a, const std::vector<double> b);
 
+	// Compat operations
+
+	/**
+	 * Write raw image to file descriptor.
+	 *
+	 * **Optional parameters**
+	 *   - **keep** -- Which metadata to retain, VipsForeignKeep.
+	 *   - **background** -- Background value, std::vector<double>.
+	 *   - **page_height** -- Set page height for multipage save, int.
+	 *   - **profile** -- Filename of ICC profile to embed, const char *.
+	 *
+	 * @param fd File descriptor to write to.
+	 * @param options Set of options.
+	 */
+	G_DEPRECATED_FOR(rawsave_target)
+	void rawsave_fd(int fd, VOption *options = nullptr) const;
+
 	/* Automatically generated members.
 	 *
 	 * Rebuild with:


### PR DESCRIPTION
Add a C++ compat function for `vips_rawsave_fd()` after the GObject class removal in commit 067b9f5.

The `abi-compliance-checker` results are available at:
https://kleisauke.nl/compat_reports/vips-cpp/8.15.5-rc1_to_rawsave_fd-compat/compat_report.html
https://kleisauke.nl/compat_reports/vips-cpp/8.15.5-rc1_to_master/compat_report.html

FWIW, I'm not sure if we could do anything about `VImage::new_from_memory_steal`, according to https://stackoverflow.com/a/5083976 changing to a const-qualified version would _not_ break ABI/API, at least in C99.