### PR TITLE
heifsave: expose libheif/aom auto_tiles feature

### DIFF
--- a/cplusplus/include/vips/VImage8.h
+++ b/cplusplus/include/vips/VImage8.h
@@ -3446,6 +3446,7 @@ public:
 	 *   - **effort** -- CPU effort, int.
 	 *   - **subsample_mode** -- Select chroma subsample operation mode, VipsForeignSubsample.
 	 *   - **encoder** -- Select encoder to use, VipsForeignHeifEncoder.
+	 *   - **auto_tiles** -- Determine optimum tile count, bool.
 	 *   - **keep** -- Which metadata to retain, VipsForeignKeep.
 	 *   - **background** -- Background value, std::vector<double>.
 	 *   - **page_height** -- Set page height for multipage save, int.
@@ -3467,6 +3468,7 @@ public:
 	 *   - **effort** -- CPU effort, int.
 	 *   - **subsample_mode** -- Select chroma subsample operation mode, VipsForeignSubsample.
 	 *   - **encoder** -- Select encoder to use, VipsForeignHeifEncoder.
+	 *   - **auto_tiles** -- Determine optimum tile count, bool.
 	 *   - **keep** -- Which metadata to retain, VipsForeignKeep.
 	 *   - **background** -- Background value, std::vector<double>.
 	 *   - **page_height** -- Set page height for multipage save, int.
@@ -3488,6 +3490,7 @@ public:
 	 *   - **effort** -- CPU effort, int.
 	 *   - **subsample_mode** -- Select chroma subsample operation mode, VipsForeignSubsample.
 	 *   - **encoder** -- Select encoder to use, VipsForeignHeifEncoder.
+	 *   - **auto_tiles** -- Determine optimum tile count, bool.
 	 *   - **keep** -- Which metadata to retain, VipsForeignKeep.
 	 *   - **background** -- Background value, std::vector<double>.
 	 *   - **page_height** -- Set page height for multipage save, int.

--- a/libvips/foreign/foreign.c
+++ b/libvips/foreign/foreign.c
@@ -2366,6 +2366,7 @@ vips_heifload_source(VipsSource *source, VipsImage **out, ...)
  * * @effort: %gint, encoding effort
  * * @subsample_mode: #VipsForeignSubsample, chroma subsampling mode
  * * @encoder: #VipsForeignHeifEncoder, select encoder to use
+ * * @auto_tiles: %gboolean, determine optimum tile count
  *
  * Write a VIPS image to a file in HEIF format.
  *
@@ -2388,6 +2389,11 @@ vips_heifload_source(VipsSource *source, VipsImage **out, ...)
  * least 8, 10 and 12 bits; other codecs may support more or fewer options.
  *
  * Use @encoder to set the encode library to use, e.g. aom, SVT-AV1, rav1e etc.
+ *
+ * When using the aom encoder, set @auto_tiles to determine the optimum
+ * number of tiles based on dimensions and available threads. This can
+ * improve multi-core utilisation and/or reduce peak memory consumption
+ * at the expense of slightly increased file size.
  *
  * See also: vips_image_write_to_file(), vips_heifload().
  *
@@ -2422,6 +2428,7 @@ vips_heifsave(VipsImage *in, const char *filename, ...)
  * * @effort: %gint, encoding effort
  * * @subsample_mode: #VipsForeignSubsample, chroma subsampling mode
  * * @encoder: #VipsForeignHeifEncoder, select encoder to use
+ * * @auto_tiles: %gboolean, determine optimum tile count
  *
  * As vips_heifsave(), but save to a memory buffer.
  *
@@ -2476,6 +2483,7 @@ vips_heifsave_buffer(VipsImage *in, void **buf, size_t *len, ...)
  * * @effort: %gint, encoding effort
  * * @subsample_mode: #VipsForeignSubsample, chroma subsampling mode
  * * @encoder: #VipsForeignHeifEncoder, select encoder to use
+ * * @auto_tiles: %gboolean, determine optimum tile count
  *
  * As vips_heifsave(), but save to a target.
  *

--- a/libvips/foreign/heifsave.c
+++ b/libvips/foreign/heifsave.c
@@ -130,6 +130,10 @@ typedef struct _VipsForeignSaveHeif {
 	 */
 	int speed;
 
+	/* Auto tiles (currently aom only).
+	*/
+	gboolean auto_tiles;
+
 } VipsForeignSaveHeif;
 
 typedef VipsForeignSaveClass VipsForeignSaveHeifClass;
@@ -648,6 +652,14 @@ vips_foreign_save_heif_build(VipsObject *object)
 	}
 #endif /*HAVE_HEIF_ENCODER_PARAMETER_GET_VALID_INTEGER_VALUES*/
 
+	error = heif_encoder_set_parameter_boolean(heif->encoder,
+		"auto-tiles", heif->auto_tiles);
+	if (error.code &&
+		error.subcode != heif_suberror_Unsupported_parameter) {
+		vips__heif_error(&error);
+		return -1;
+	}
+
 	/* TODO .. support extra per-encoder params with
 	 * heif_encoder_list_parameters().
 	 */
@@ -807,6 +819,13 @@ vips_foreign_save_heif_class_init(VipsForeignSaveHeifClass *class)
 		G_STRUCT_OFFSET(VipsForeignSaveHeif, selected_encoder),
 		VIPS_TYPE_FOREIGN_HEIF_ENCODER,
 		VIPS_FOREIGN_HEIF_ENCODER_AUTO);
+
+	VIPS_ARG_BOOL(class, "auto_tiles", 19,
+		_("Auto-tiles"),
+		_("Determine optimum tile count"),
+		VIPS_ARGUMENT_OPTIONAL_INPUT,
+		G_STRUCT_OFFSET(VipsForeignSaveHeif, auto_tiles),
+		FALSE);
 }
 
 static void


### PR DESCRIPTION
I realise we don't want to expose every single possible underlying encoder feature, however given the relatively poor encoding times of AVIF images this one feels like the most useful addition to libaom I've seen in a while.

The `auto_tiles` property allows the aom encoder to determine the optimum tile count based on the output dimensions and available threads, which in my testing seriously improves multi-core utilisation. Elapsed time is almost halved in some cases. There are claims it reduces memory usage but I've not found much evidence of this yet. The cost of all this is very slightly increased file sizes, mostly from the additional metadata.

The upstream PR for this was https://github.com/strukturag/libheif/pull/1330 (requires libaom v3.10.0+ and the forthcoming libheif v1.18.3+).