### PR TITLE
heifsave: check availability of heif_encoder_parameter_get_valid_integer_values

### DIFF
--- a/libvips/foreign/heifsave.c
+++ b/libvips/foreign/heifsave.c
@@ -620,6 +620,7 @@ vips_foreign_save_heif_build(VipsObject *object)
 		return -1;
 	}
 
+#ifdef HAVE_HEIF_ENCODER_PARAMETER_GET_VALID_INTEGER_VALUES
 	for (param = heif_encoder_list_parameters(heif->encoder);
 		*param; param++) {
 		int have_minimum;
@@ -645,6 +646,7 @@ vips_foreign_save_heif_build(VipsObject *object)
 			return -1;
 		}
 	}
+#endif /*HAVE_HEIF_ENCODER_PARAMETER_GET_VALID_INTEGER_VALUES*/
 
 	/* TODO .. support extra per-encoder params with
 	 * heif_encoder_list_parameters().

--- a/meson.build
+++ b/meson.build
@@ -548,6 +548,10 @@ if libheif_dep.found()
     if libheif_dep.version().version_compare('>=1.7.0')
         cfg_var.set('HAVE_HEIF_AVIF', '1')
     endif
+    # added in 1.10.0
+    if cpp.has_function('heif_encoder_parameter_get_valid_integer_values', prefix: '#include <libheif/heif.h>', dependencies: libheif_dep)
+        cfg_var.set('HAVE_HEIF_ENCODER_PARAMETER_GET_VALID_INTEGER_VALUES', '1')
+    endif
     # added in 1.11.0
     if cpp.has_member('struct heif_encoding_options', 'output_nclx_profile', prefix: '#include <libheif/heif.h>', dependencies: libheif_dep)
         cfg_var.set('HAVE_HEIF_ENCODING_OPTIONS_OUTPUT_NCLX_PROFILE', '1')


### PR DESCRIPTION
Should fix https://github.com/libvips/libvips/issues/4192