### PR TITLE
avoid direct include of almostdeprecated.h

### DIFF
--- a/libvips/include/vips/almostdeprecated.h
+++ b/libvips/include/vips/almostdeprecated.h
@@ -36,7 +36,7 @@
 #define IM_ALMOSTDEPRECATED_H
 
 #ifndef VIPS_VIPS7COMPAT_H
-#error Should not be inclued directly use vips7compat.h instead
+#error Should not be included directly use vips7compat.h instead
 #endif
 
 #ifdef __cplusplus

--- a/libvips/include/vips/almostdeprecated.h
+++ b/libvips/include/vips/almostdeprecated.h
@@ -35,6 +35,10 @@
 #ifndef IM_ALMOSTDEPRECATED_H
 #define IM_ALMOSTDEPRECATED_H
 
+#ifndef VIPS_VIPS7COMPAT_H
+#error Should not be inclued directly use vips7compat.h instead
+#endif
+
 #ifdef __cplusplus
 extern "C" {
 #endif /*__cplusplus*/


### PR DESCRIPTION
In https://github.com/libvips/libvips/issues/4193#issuecomment-2407195135

> almostdeprecated.h cannot be included directly