### PR TITLE
Make `vips7compat.h` part of `vips.h`

### DIFF
--- a/libvips/conversion/cache.c
+++ b/libvips/conversion/cache.c
@@ -48,12 +48,6 @@
 #include <vips/internal.h>
 #include <vips/debug.h>
 
-/* For the vips_cache() header decl.
- */
-#if ENABLE_DEPRECATED
-#include <vips/vips7compat.h>
-#endif
-
 #include "pconversion.h"
 
 typedef struct _VipsCache {

--- a/libvips/deprecated/arith_dispatch.c
+++ b/libvips/deprecated/arith_dispatch.c
@@ -38,7 +38,6 @@
 #include <stdio.h>
 
 #include <vips/vips.h>
-#include <vips/vips7compat.h>
 
 /* One image in, one out.
  */

--- a/libvips/deprecated/cimg_dispatch.c
+++ b/libvips/deprecated/cimg_dispatch.c
@@ -36,7 +36,6 @@
 #include <stdio.h>
 
 #include <vips/vips.h>
-#include <vips/vips7compat.h>
 
 static int
 greyc_vec(im_object *argv)

--- a/libvips/deprecated/colour_dispatch.c
+++ b/libvips/deprecated/colour_dispatch.c
@@ -38,7 +38,6 @@
 #include <stdio.h>
 
 #include <vips/vips.h>
-#include <vips/vips7compat.h>
 
 /* One image in, one out.
  */

--- a/libvips/deprecated/conver_dispatch.c
+++ b/libvips/deprecated/conver_dispatch.c
@@ -36,7 +36,6 @@
 #include <glib/gi18n-lib.h>
 
 #include <vips/vips.h>
-#include <vips/vips7compat.h>
 
 static int
 system_vec(im_object *argv)

--- a/libvips/deprecated/convol_dispatch.c
+++ b/libvips/deprecated/convol_dispatch.c
@@ -38,7 +38,6 @@
 #include <stdio.h>
 
 #include <vips/vips.h>
-#include <vips/vips7compat.h>
 
 /* One image in, one out.
  */

--- a/libvips/deprecated/cooc_funcs.c
+++ b/libvips/deprecated/cooc_funcs.c
@@ -75,7 +75,6 @@
 #include <math.h>
 
 #include <vips/vips.h>
-#include <vips/vips7compat.h>
 
 static int
 im_cooc_sym(IMAGE *im, IMAGE *m, int xpos, int ypos, int xsize, int ysize, int dx, int dy)

--- a/libvips/deprecated/deprecated_dispatch.c
+++ b/libvips/deprecated/deprecated_dispatch.c
@@ -36,7 +36,6 @@
 #include <stdio.h>
 
 #include <vips/vips.h>
-#include <vips/vips7compat.h>
 #include <vips/internal.h>
 
 /* One image in, one out.

--- a/libvips/deprecated/dispatch_types.c
+++ b/libvips/deprecated/dispatch_types.c
@@ -47,7 +47,6 @@
 #include <string.h>
 
 #include <vips/vips.h>
-#include <vips/vips7compat.h>
 #include <vips/internal.h>
 
 /* String containing each of the characters which can be used within a

--- a/libvips/deprecated/fits.c
+++ b/libvips/deprecated/fits.c
@@ -41,7 +41,6 @@
 #include <string.h>
 
 #include <vips/vips.h>
-#include <vips/vips7compat.h>
 #include <vips/internal.h>
 #include <vips/debug.h>
 

--- a/libvips/deprecated/format.c
+++ b/libvips/deprecated/format.c
@@ -36,7 +36,6 @@
 #include <stdio.h>
 
 #include <vips/vips.h>
-#include <vips/vips7compat.h>
 #include <vips/internal.h>
 
 /* To iterate over supported formats, we build a temp list of subclasses of

--- a/libvips/deprecated/format_dispatch.c
+++ b/libvips/deprecated/format_dispatch.c
@@ -36,7 +36,6 @@
 #include <stdio.h>
 
 #include <vips/vips.h>
-#include <vips/vips7compat.h>
 
 static int
 jpeg2vips_vec(im_object *argv)

--- a/libvips/deprecated/freq_dispatch.c
+++ b/libvips/deprecated/freq_dispatch.c
@@ -41,7 +41,6 @@
 #include <stdarg.h>
 
 #include <vips/vips.h>
-#include <vips/vips7compat.h>
 
 /* One image in, one out.
  */

--- a/libvips/deprecated/glds_funcs.c
+++ b/libvips/deprecated/glds_funcs.c
@@ -72,7 +72,6 @@
 #include <math.h>
 
 #include <vips/vips.h>
-#include <vips/vips7compat.h>
 
 /* Keep the greylevel difference matrix as a 256x1 double image */
 

--- a/libvips/deprecated/hist_dispatch.c
+++ b/libvips/deprecated/hist_dispatch.c
@@ -38,7 +38,6 @@
 #include <stdio.h>
 
 #include <vips/vips.h>
-#include <vips/vips7compat.h>
 
 /* One image in, one out.
  */

--- a/libvips/deprecated/im_align_bands.c
+++ b/libvips/deprecated/im_align_bands.c
@@ -39,7 +39,6 @@
 
 #include <glib/gi18n-lib.h>
 #include <vips/vips.h>
-#include <vips/vips7compat.h>
 
 /**
  * im_align_bands:

--- a/libvips/deprecated/im_analyze2vips.c
+++ b/libvips/deprecated/im_analyze2vips.c
@@ -41,7 +41,6 @@
 #include <glib/gi18n-lib.h>
 
 #include <vips/vips.h>
-#include <vips/vips7compat.h>
 
 static VipsFormatFlags
 analyze_flags(const char *filename)

--- a/libvips/deprecated/im_benchmark.c
+++ b/libvips/deprecated/im_benchmark.c
@@ -45,7 +45,6 @@
 #include <math.h>
 
 #include <vips/vips.h>
-#include <vips/vips7compat.h>
 
 /*
 

--- a/libvips/deprecated/im_bernd.c
+++ b/libvips/deprecated/im_bernd.c
@@ -52,7 +52,6 @@
 #include <stdlib.h>
 
 #include <vips/vips.h>
-#include <vips/vips7compat.h>
 
 static int
 extract(IMAGE *in, int x, int y, int w, int h)

--- a/libvips/deprecated/im_clamp.c
+++ b/libvips/deprecated/im_clamp.c
@@ -48,7 +48,6 @@
 #include <stdlib.h>
 
 #include <vips/vips.h>
-#include <vips/vips7compat.h>
 #include <vips/internal.h>
 
 int

--- a/libvips/deprecated/im_cmulnorm.c
+++ b/libvips/deprecated/im_cmulnorm.c
@@ -47,7 +47,6 @@
 #include <glib/gi18n-lib.h>
 
 #include <vips/vips.h>
-#include <vips/vips7compat.h>
 
 #include <stdio.h>
 #include <stdlib.h>

--- a/libvips/deprecated/im_convsub.c
+++ b/libvips/deprecated/im_convsub.c
@@ -55,7 +55,6 @@
 #include <stdlib.h>
 
 #include <vips/vips.h>
-#include <vips/vips7compat.h>
 #include <vips/internal.h>
 
 /* Create multiplication luts for all non zero elements  of the original mask;

--- a/libvips/deprecated/im_csv2vips.c
+++ b/libvips/deprecated/im_csv2vips.c
@@ -43,7 +43,6 @@
 #include <stdlib.h>
 
 #include <vips/vips.h>
-#include <vips/vips7compat.h>
 
 #include "../foreign/pforeign.h"
 

--- a/libvips/deprecated/im_debugim.c
+++ b/libvips/deprecated/im_debugim.c
@@ -57,7 +57,6 @@
 #include <stdio.h>
 
 #include <vips/vips.h>
-#include <vips/vips7compat.h>
 
 int
 im_debugim(IMAGE *in)

--- a/libvips/deprecated/im_dif_std.c
+++ b/libvips/deprecated/im_dif_std.c
@@ -45,7 +45,6 @@
 #include <math.h>
 
 #include <vips/vips.h>
-#include <vips/vips7compat.h>
 #include <vips/internal.h>
 
 static int

--- a/libvips/deprecated/im_exr2vips.c
+++ b/libvips/deprecated/im_exr2vips.c
@@ -46,7 +46,6 @@
 #include <string.h>
 
 #include <vips/vips.h>
-#include <vips/vips7compat.h>
 #include <vips/thread.h>
 #include <vips/internal.h>
 

--- a/libvips/deprecated/im_fav4.c
+++ b/libvips/deprecated/im_fav4.c
@@ -38,7 +38,6 @@ Copyright (C) 1992, Kirk Martinez, History of Art Dept, Birkbeck College
 #include <string.h>
 
 #include <vips/vips.h>
-#include <vips/vips7compat.h>
 
 #define ARGS "fav4: frame average 4 frames\nARGS: im1 im2 im3 im4 outfile"
 #define NFRAMES 4

--- a/libvips/deprecated/im_freq_mask.c
+++ b/libvips/deprecated/im_freq_mask.c
@@ -46,7 +46,6 @@
 #include <stdarg.h>
 
 #include <vips/vips.h>
-#include <vips/vips7compat.h>
 #include <vips/internal.h>
 
 /* Make a mask image.

--- a/libvips/deprecated/im_gadd.c
+++ b/libvips/deprecated/im_gadd.c
@@ -57,7 +57,6 @@
 #include <assert.h>
 
 #include <vips/vips.h>
-#include <vips/vips7compat.h>
 
 int im_gfadd(double a, IMAGE *in1, double b, IMAGE *in2, double c, IMAGE *out);
 int im_gaddim(double a, IMAGE *in1, double b, IMAGE *in2, double c, IMAGE *out);

--- a/libvips/deprecated/im_gaddim.c
+++ b/libvips/deprecated/im_gaddim.c
@@ -58,7 +58,6 @@
 #include <math.h>
 
 #include <vips/vips.h>
-#include <vips/vips7compat.h>
 
 /* This function works on either mmaped files or on images in buffer
  */

--- a/libvips/deprecated/im_gfadd.c
+++ b/libvips/deprecated/im_gfadd.c
@@ -61,7 +61,6 @@
 #include <math.h>
 
 #include <vips/vips.h>
-#include <vips/vips7compat.h>
 
 /*               uchar char ushort short uint   int float double */
 static int array[8][8] = {

--- a/libvips/deprecated/im_gradcor.c
+++ b/libvips/deprecated/im_gradcor.c
@@ -44,7 +44,6 @@
 #include <stdlib.h>
 
 #include <vips/vips.h>
-#include <vips/vips7compat.h>
 
 typedef struct {
 	REGION *reg;

--- a/libvips/deprecated/im_jpeg2vips.c
+++ b/libvips/deprecated/im_jpeg2vips.c
@@ -47,7 +47,6 @@
 #include <setjmp.h>
 
 #include <vips/vips.h>
-#include <vips/vips7compat.h>
 
 #include "../foreign/pforeign.h"
 

--- a/libvips/deprecated/im_lab_morph.c
+++ b/libvips/deprecated/im_lab_morph.c
@@ -45,7 +45,6 @@
 #include <stdlib.h>
 
 #include <vips/vips.h>
-#include <vips/vips7compat.h>
 #include <vips/internal.h>
 
 int

--- a/libvips/deprecated/im_line.c
+++ b/libvips/deprecated/im_line.c
@@ -52,7 +52,6 @@
 #include <math.h>
 
 #include <vips/vips.h>
-#include <vips/vips7compat.h>
 
 int
 im_line(IMAGE *image, int x1, int y1, int x2, int y2, int pelval)

--- a/libvips/deprecated/im_linreg.c
+++ b/libvips/deprecated/im_linreg.c
@@ -47,7 +47,6 @@
 #include <stdlib.h>
 #include <math.h>
 #include <vips/vips.h>
-#include <vips/vips7compat.h>
 
 typedef struct {
 

--- a/libvips/deprecated/im_litecor.c
+++ b/libvips/deprecated/im_litecor.c
@@ -66,7 +66,6 @@
 #include <stdlib.h>
 
 #include <vips/vips.h>
-#include <vips/vips7compat.h>
 
 /*   If maximum output is > 255 scale output between minout and maxout,
  * by normalising maxout to 255.

--- a/libvips/deprecated/im_magick2vips.c
+++ b/libvips/deprecated/im_magick2vips.c
@@ -41,7 +41,6 @@
 #include <glib/gi18n-lib.h>
 
 #include <vips/vips.h>
-#include <vips/vips7compat.h>
 
 #include "../foreign/pforeign.h"
 

--- a/libvips/deprecated/im_mask2vips.c
+++ b/libvips/deprecated/im_mask2vips.c
@@ -45,7 +45,6 @@
 #include <stdlib.h>
 
 #include <vips/vips.h>
-#include <vips/vips7compat.h>
 
 /**
  * im_mask2vips:

--- a/libvips/deprecated/im_matcat.c
+++ b/libvips/deprecated/im_matcat.c
@@ -42,7 +42,6 @@
 #include <string.h>
 
 #include <vips/vips.h>
-#include <vips/vips7compat.h>
 
 /**
  * im_matcat:

--- a/libvips/deprecated/im_matinv.c
+++ b/libvips/deprecated/im_matinv.c
@@ -52,7 +52,6 @@
 #include <stdlib.h>
 #include <stdio.h>
 #include <vips/vips.h>
-#include <vips/vips7compat.h>
 
 #define TOO_SMALL (2.0 * DBL_MIN)
 /* DBL_MIN is smallest *normalized* double precision float */

--- a/libvips/deprecated/im_matmul.c
+++ b/libvips/deprecated/im_matmul.c
@@ -41,7 +41,6 @@
 #include <stdio.h>
 
 #include <vips/vips.h>
-#include <vips/vips7compat.h>
 
 /**
  * im_matmul:

--- a/libvips/deprecated/im_mattrn.c
+++ b/libvips/deprecated/im_mattrn.c
@@ -39,7 +39,6 @@
 #include <stdio.h>
 
 #include <vips/vips.h>
-#include <vips/vips7compat.h>
 
 /**
  * im_mattrn:

--- a/libvips/deprecated/im_maxpos_avg.c
+++ b/libvips/deprecated/im_maxpos_avg.c
@@ -62,7 +62,6 @@
 #include <math.h>
 
 #include <vips/vips.h>
-#include <vips/vips7compat.h>
 #include <vips/internal.h>
 
 /* A position and maximum.

--- a/libvips/deprecated/im_maxpos_subpel.c
+++ b/libvips/deprecated/im_maxpos_subpel.c
@@ -42,7 +42,6 @@
 
 #include <stdlib.h>
 #include <vips/vips.h>
-#include <vips/vips7compat.h>
 
 #define MOST_OF(A, B) ((A) > 0.9 * (B))
 #define LITTLE_OF(A, B) ((B) < 0.1 * (B))

--- a/libvips/deprecated/im_measure.c
+++ b/libvips/deprecated/im_measure.c
@@ -60,7 +60,6 @@
 #include <math.h>
 
 #include <vips/vips.h>
-#include <vips/vips7compat.h>
 
 /* Measure into array.
  */

--- a/libvips/deprecated/im_nifti2vips.c
+++ b/libvips/deprecated/im_nifti2vips.c
@@ -46,7 +46,6 @@
 #include <string.h>
 
 #include <vips/vips.h>
-#include <vips/vips7compat.h>
 #include <vips/thread.h>
 #include <vips/internal.h>
 

--- a/libvips/deprecated/im_openslide2vips.c
+++ b/libvips/deprecated/im_openslide2vips.c
@@ -50,7 +50,6 @@
 #include <string.h>
 
 #include <vips/vips.h>
-#include <vips/vips7compat.h>
 #include <vips/thread.h>
 #include <vips/internal.h>
 

--- a/libvips/deprecated/im_png2vips.c
+++ b/libvips/deprecated/im_png2vips.c
@@ -43,7 +43,6 @@
 #include <stdio.h>
 
 #include <vips/vips.h>
-#include <vips/vips7compat.h>
 #include <vips/internal.h>
 
 #include "../foreign/pforeign.h"

--- a/libvips/deprecated/im_point_bilinear.c
+++ b/libvips/deprecated/im_point_bilinear.c
@@ -45,7 +45,6 @@
 #include <math.h>
 
 #include <vips/vips.h>
-#include <vips/vips7compat.h>
 
 /**
  * im_point:

--- a/libvips/deprecated/im_ppm2vips.c
+++ b/libvips/deprecated/im_ppm2vips.c
@@ -37,7 +37,6 @@
 #include <glib/gi18n-lib.h>
 
 #include <vips/vips.h>
-#include <vips/vips7compat.h>
 
 int
 im_ppm2vips(const char *filename, IMAGE *out)

--- a/libvips/deprecated/im_print.c
+++ b/libvips/deprecated/im_print.c
@@ -36,7 +36,6 @@
 #include <stdio.h>
 
 #include <vips/vips.h>
-#include <vips/vips7compat.h>
 
 /* Print a string to stdout, with a "\n". Sometimes useful for debugging
  * language bindings.

--- a/libvips/deprecated/im_printlines.c
+++ b/libvips/deprecated/im_printlines.c
@@ -54,7 +54,6 @@
 #include <stdio.h>
 
 #include <vips/vips.h>
-#include <vips/vips7compat.h>
 
 /* Useful: Call a macro with the name, type pairs for all VIPS functions.
  */

--- a/libvips/deprecated/im_resize_linear.c
+++ b/libvips/deprecated/im_resize_linear.c
@@ -48,7 +48,6 @@
 #include <math.h>
 
 #include <vips/vips.h>
-#include <vips/vips7compat.h>
 
 /* What we do for each pel.
  */

--- a/libvips/deprecated/im_setbox.c
+++ b/libvips/deprecated/im_setbox.c
@@ -48,7 +48,6 @@
 #include <sys/types.h>
 
 #include <vips/vips.h>
-#include <vips/vips7compat.h>
 
 void
 im_setbox(IMAGE_BOX *pbox, int xst, int yst, int xsiz, int ysiz, int ch_select)

--- a/libvips/deprecated/im_simcontr.c
+++ b/libvips/deprecated/im_simcontr.c
@@ -49,7 +49,6 @@
 #include <math.h>
 
 #include <vips/vips.h>
-#include <vips/vips7compat.h>
 
 /**
  * im_simcontr:

--- a/libvips/deprecated/im_slice.c
+++ b/libvips/deprecated/im_slice.c
@@ -55,7 +55,6 @@
 #include <math.h>
 
 #include <vips/vips.h>
-#include <vips/vips7compat.h>
 
 #define BRIGHT 255
 #define GREY 128

--- a/libvips/deprecated/im_spatres.c
+++ b/libvips/deprecated/im_spatres.c
@@ -52,7 +52,6 @@
 #include <math.h>
 
 #include <vips/vips.h>
-#include <vips/vips7compat.h>
 
 int
 im_spatres(IMAGE *in, IMAGE *out, int step)

--- a/libvips/deprecated/im_stretch3.c
+++ b/libvips/deprecated/im_stretch3.c
@@ -62,7 +62,6 @@
 #include <math.h>
 
 #include <vips/vips.h>
-#include <vips/vips7compat.h>
 
 /* Data for the cubic interpolation function.
  */

--- a/libvips/deprecated/im_thresh.c
+++ b/libvips/deprecated/im_thresh.c
@@ -51,7 +51,6 @@
 #include <stdlib.h>
 
 #include <vips/vips.h>
-#include <vips/vips7compat.h>
 
 /* Useful: Call a macro with the name, type pairs for all VIPS functions.  */
 #define BRIGHT 255

--- a/libvips/deprecated/im_tiff2vips.c
+++ b/libvips/deprecated/im_tiff2vips.c
@@ -46,7 +46,6 @@
 #include <string.h>
 
 #include <vips/vips.h>
-#include <vips/vips7compat.h>
 #include <vips/internal.h>
 #include <vips/thread.h>
 

--- a/libvips/deprecated/im_video_test.c
+++ b/libvips/deprecated/im_video_test.c
@@ -34,7 +34,6 @@
 #include <glib/gi18n-lib.h>
 
 #include <vips/vips.h>
-#include <vips/vips7compat.h>
 
 /**
  * im_video_test:

--- a/libvips/deprecated/im_vips2csv.c
+++ b/libvips/deprecated/im_vips2csv.c
@@ -37,7 +37,6 @@
 #include <glib/gi18n-lib.h>
 
 #include <vips/vips.h>
-#include <vips/vips7compat.h>
 
 int
 im_vips2csv(IMAGE *in, const char *filename)

--- a/libvips/deprecated/im_vips2dz.c
+++ b/libvips/deprecated/im_vips2dz.c
@@ -45,7 +45,6 @@
 #include <string.h>
 
 #include <vips/vips.h>
-#include <vips/vips7compat.h>
 
 int
 im_vips2dz(IMAGE *in, const char *filename)

--- a/libvips/deprecated/im_vips2jpeg.c
+++ b/libvips/deprecated/im_vips2jpeg.c
@@ -46,7 +46,6 @@
 #include <stdlib.h>
 
 #include <vips/vips.h>
-#include <vips/vips7compat.h>
 #include <vips/internal.h>
 
 int

--- a/libvips/deprecated/im_vips2mask.c
+++ b/libvips/deprecated/im_vips2mask.c
@@ -48,7 +48,6 @@
 #include <string.h>
 
 #include <vips/vips.h>
-#include <vips/vips7compat.h>
 
 /**
  * im_vips2mask:

--- a/libvips/deprecated/im_vips2png.c
+++ b/libvips/deprecated/im_vips2png.c
@@ -45,7 +45,6 @@
 #include <string.h>
 
 #include <vips/vips.h>
-#include <vips/vips7compat.h>
 #include <vips/internal.h>
 #include <vips/debug.h>
 

--- a/libvips/deprecated/im_vips2ppm.c
+++ b/libvips/deprecated/im_vips2ppm.c
@@ -39,7 +39,6 @@
 #include <string.h>
 
 #include <vips/vips.h>
-#include <vips/vips7compat.h>
 
 int
 im_vips2ppm(IMAGE *in, const char *filename)

--- a/libvips/deprecated/im_vips2tiff.c
+++ b/libvips/deprecated/im_vips2tiff.c
@@ -45,7 +45,6 @@
 #include <string.h>
 
 #include <vips/vips.h>
-#include <vips/vips7compat.h>
 
 int
 im_vips2tiff(IMAGE *in, const char *filename)

--- a/libvips/deprecated/im_vips2webp.c
+++ b/libvips/deprecated/im_vips2webp.c
@@ -39,7 +39,6 @@
 #include <string.h>
 
 #include <vips/vips.h>
-#include <vips/vips7compat.h>
 #include <vips/internal.h>
 #include <vips/debug.h>
 

--- a/libvips/deprecated/im_webp2vips.c
+++ b/libvips/deprecated/im_webp2vips.c
@@ -37,7 +37,6 @@
 #include <stdio.h>
 
 #include <vips/vips.h>
-#include <vips/vips7compat.h>
 #include <vips/internal.h>
 
 #include "../foreign/pforeign.h"

--- a/libvips/deprecated/im_zerox.c
+++ b/libvips/deprecated/im_zerox.c
@@ -51,7 +51,6 @@
 #include <stdlib.h>
 
 #include <vips/vips.h>
-#include <vips/vips7compat.h>
 
 #define LOOP(TYPE) \
 	{ \

--- a/libvips/deprecated/inplace_dispatch.c
+++ b/libvips/deprecated/inplace_dispatch.c
@@ -38,7 +38,6 @@
 #include <stdio.h>
 
 #include <vips/vips.h>
-#include <vips/vips7compat.h>
 
 /* Calculate a pixel for an image from a vec of double. Valid while im is
  * valid.

--- a/libvips/deprecated/lazy.c
+++ b/libvips/deprecated/lazy.c
@@ -46,7 +46,6 @@
 #include <string.h>
 
 #include <vips/vips.h>
-#include <vips/vips7compat.h>
 #include <vips/debug.h>
 #include <vips/internal.h>
 

--- a/libvips/deprecated/mask_dispatch.c
+++ b/libvips/deprecated/mask_dispatch.c
@@ -38,7 +38,6 @@
 #include <stdio.h>
 
 #include <vips/vips.h>
-#include <vips/vips7compat.h>
 
 /* One matrix in, one out.
  */

--- a/libvips/deprecated/matalloc.c
+++ b/libvips/deprecated/matalloc.c
@@ -13,7 +13,6 @@
 #include <math.h>
 
 #include <vips/vips.h>
-#include <vips/vips7compat.h>
 
 #define TINY 1.0e-200
 

--- a/libvips/deprecated/matlab.c
+++ b/libvips/deprecated/matlab.c
@@ -37,7 +37,6 @@
 #include <glib/gi18n-lib.h>
 
 #include <vips/vips.h>
-#include <vips/vips7compat.h>
 
 int
 im_mat2vips(const char *filename, IMAGE *out)

--- a/libvips/deprecated/morph_dispatch.c
+++ b/libvips/deprecated/morph_dispatch.c
@@ -38,7 +38,6 @@
 #include <stdio.h>
 
 #include <vips/vips.h>
-#include <vips/vips7compat.h>
 
 /* Args to im_profile.
  */

--- a/libvips/deprecated/mosaicing_dispatch.c
+++ b/libvips/deprecated/mosaicing_dispatch.c
@@ -38,7 +38,6 @@
 #include <stdio.h>
 
 #include <vips/vips.h>
-#include <vips/vips7compat.h>
 #include <vips/internal.h>
 #include <vips/transform.h>
 

--- a/libvips/deprecated/other_dispatch.c
+++ b/libvips/deprecated/other_dispatch.c
@@ -38,7 +38,6 @@
 #include <stdio.h>
 
 #include <vips/vips.h>
-#include <vips/vips7compat.h>
 
 /* Args for im_sines.
  */

--- a/libvips/deprecated/package.c
+++ b/libvips/deprecated/package.c
@@ -58,7 +58,6 @@
 #include <limits.h>
 
 #include <vips/vips.h>
-#include <vips/vips7compat.h>
 #include <vips/internal.h>
 #include <vips/debug.h>
 

--- a/libvips/deprecated/radiance.c
+++ b/libvips/deprecated/radiance.c
@@ -37,7 +37,6 @@
 #include <glib/gi18n-lib.h>
 
 #include <vips/vips.h>
-#include <vips/vips7compat.h>
 
 int
 im_rad2vips(const char *filename, IMAGE *out)

--- a/libvips/deprecated/raw.c
+++ b/libvips/deprecated/raw.c
@@ -41,7 +41,6 @@
 #include <glib/gi18n-lib.h>
 
 #include <vips/vips.h>
-#include <vips/vips7compat.h>
 
 int
 im_raw2vips(const char *filename, IMAGE *out,

--- a/libvips/deprecated/rename.c
+++ b/libvips/deprecated/rename.c
@@ -38,7 +38,6 @@
 #include <string.h>
 
 #include <vips/vips.h>
-#include <vips/vips7compat.h>
 #include <vips/internal.h>
 
 int

--- a/libvips/deprecated/resample_dispatch.c
+++ b/libvips/deprecated/resample_dispatch.c
@@ -38,7 +38,6 @@
 #include <stdio.h>
 
 #include <vips/vips.h>
-#include <vips/vips7compat.h>
 #include <vips/internal.h>
 #include <vips/transform.h>
 

--- a/libvips/deprecated/rotmask.c
+++ b/libvips/deprecated/rotmask.c
@@ -55,7 +55,6 @@
 #include <math.h>
 
 #include <vips/vips.h>
-#include <vips/vips7compat.h>
 
 /* The type of the vips operations we support.
  */

--- a/libvips/deprecated/rw_mask.c
+++ b/libvips/deprecated/rw_mask.c
@@ -95,7 +95,6 @@
 #include <math.h>
 
 #include <vips/vips.h>
-#include <vips/vips7compat.h>
 
 /**
  * INTMASK:

--- a/libvips/deprecated/tone.c
+++ b/libvips/deprecated/tone.c
@@ -52,7 +52,6 @@
 #include <math.h>
 
 #include <vips/vips.h>
-#include <vips/vips7compat.h>
 
 /**
  * im_tone_map:

--- a/libvips/deprecated/video_dispatch.c
+++ b/libvips/deprecated/video_dispatch.c
@@ -36,7 +36,6 @@
 #include <stdio.h>
 
 #include <vips/vips.h>
-#include <vips/vips7compat.h>
 
 /**
  * SECTION: video

--- a/libvips/deprecated/vips7compat.c
+++ b/libvips/deprecated/vips7compat.c
@@ -46,7 +46,6 @@
 #include <ctype.h>
 
 #include <vips/vips.h>
-#include <vips/vips7compat.h>
 #include <vips/internal.h>
 #include <vips/debug.h>
 #include <vips/transform.h>

--- a/libvips/foreign/vipsload.c
+++ b/libvips/foreign/vipsload.c
@@ -42,6 +42,9 @@
 #include <stdio.h>
 #include <stdlib.h>
 
+/* For vips_image_new_mode()
+ */
+#define VIPS_DISABLE_DEPRECATION_WARNINGS
 #include <vips/vips.h>
 #include <vips/internal.h>
 

--- a/libvips/foreign/vipssave.c
+++ b/libvips/foreign/vipssave.c
@@ -45,6 +45,9 @@
 #include <stdlib.h>
 #include <string.h>
 
+/* For vips_image_new_mode()
+ */
+#define VIPS_DISABLE_DEPRECATION_WARNINGS
 #include <vips/vips.h>
 #include <vips/internal.h>
 

--- a/libvips/include/vips/enumtypes.c.in
+++ b/libvips/include/vips/enumtypes.c.in
@@ -5,10 +5,6 @@
 #include <config.h>
 #endif /*HAVE_CONFIG_H*/
 #include <vips/vips.h>
-
-#if ENABLE_DEPRECATED
-#include <vips/vips7compat.h>
-#endif
 /*** END file-header ***/
 
 /*** BEGIN file-production ***/

--- a/libvips/include/vips/internal.h
+++ b/libvips/include/vips/internal.h
@@ -165,19 +165,12 @@ int vips__object_leak(void);
 int vips__open_image_read(const char *filename);
 int vips__open_image_write(const char *filename, gboolean temp);
 
-/* im_image_open_input() needs to have this visible.
+/* Defined in `vips.h`, unless building with `-Ddeprecated=false`
  */
-#if VIPS_ENABLE_DEPRECATED
-VIPS_API
-#endif
+#if !VIPS_ENABLE_DEPRECATED
 int vips_image_open_input(VipsImage *image);
-
-/* im_image_open_output() needs to have this visible.
- */
-#if VIPS_ENABLE_DEPRECATED
-VIPS_API
-#endif
 int vips_image_open_output(VipsImage *image);
+#endif
 
 void vips__link_break_all(VipsImage *im);
 void *vips__link_map(VipsImage *image, gboolean upstream,
@@ -187,26 +180,13 @@ gboolean vips__mmap_supported(int fd);
 void *vips__mmap(int fd, int writeable, size_t length, gint64 offset);
 int vips__munmap(const void *start, size_t length);
 
-/* im_mapfile() needs to have this visible.
+/* Defined in `vips.h`, unless building with `-Ddeprecated=false`
  */
-#if VIPS_ENABLE_DEPRECATED
-VIPS_API
-#endif
+#if !VIPS_ENABLE_DEPRECATED
 int vips_mapfile(VipsImage *image);
-
-/* im_mapfilerw() needs to have this visible.
- */
-#if VIPS_ENABLE_DEPRECATED
-VIPS_API
-#endif
 int vips_mapfilerw(VipsImage *image);
-
-/* im_remapfilerw() needs to have this visible.
- */
-#if VIPS_ENABLE_DEPRECATED
-VIPS_API
-#endif
 int vips_remapfilerw(VipsImage *image);
+#endif
 
 void vips__buffer_init(void);
 void vips__buffer_shutdown(void);
@@ -245,12 +225,11 @@ void vips_image_preeval(VipsImage *image);
 void vips_image_eval(VipsImage *image, guint64 processed);
 void vips_image_posteval(VipsImage *image);
 
-/* im_openout() needs to have this visible.
+/* Defined in `vips.h`, unless building with `-Ddeprecated=false`
  */
-#if VIPS_ENABLE_DEPRECATED
-VIPS_API
-#endif
+#if !VIPS_ENABLE_DEPRECATED
 VipsImage *vips_image_new_mode(const char *filename, const char *mode);
+#endif
 
 int vips__formatalike_vec(VipsImage **in, VipsImage **out, int n);
 int vips__sizealike_vec(VipsImage **in, VipsImage **out, int n);

--- a/libvips/include/vips/vips.h
+++ b/libvips/include/vips/vips.h
@@ -109,9 +109,6 @@ extern "C" {
 
 #include <vips/private.h>
 
-#if VIPS_ENABLE_DEPRECATED
-#include <vips/mask.h>
-#endif
 #include <vips/image.h>
 #include <vips/memory.h>
 #include <vips/error.h>
@@ -139,7 +136,7 @@ extern "C" {
 #include <vips/draw.h>
 #include <vips/create.h>
 #if VIPS_ENABLE_DEPRECATED
-#include <vips/video.h>
+#include <vips/vips7compat.h>
 #endif
 
 /* We can't use _ here since this will be compiled by our clients and they may

--- a/libvips/include/vips/vips7compat.h
+++ b/libvips/include/vips/vips7compat.h
@@ -34,6 +34,8 @@
 #ifndef VIPS_VIPS7COMPAT_H
 #define VIPS_VIPS7COMPAT_H
 
+#include <vips/mask.h>
+
 #ifdef __cplusplus
 extern "C" {
 #endif /*__cplusplus*/
@@ -1760,6 +1762,7 @@ void vips_vector_to_fixed_point(double *in, int *out, int n, int scale);
 
 #include <vips/dispatch.h>
 #include <vips/almostdeprecated.h>
+#include <vips/video.h>
 
 #ifdef __cplusplus
 }

--- a/libvips/iofuncs/header.c
+++ b/libvips/iofuncs/header.c
@@ -86,12 +86,6 @@
 #include <vips/internal.h>
 #include <vips/debug.h>
 
-/* For the vips__image_sizeof_bandformat declaration.
- */
-#if ENABLE_DEPRECATED
-#include <vips/vips7compat.h>
-#endif
-
 /**
  * SECTION: header
  * @short_description: get, set and walk image headers

--- a/libvips/iofuncs/image.c
+++ b/libvips/iofuncs/image.c
@@ -66,6 +66,7 @@
 #endif /*HAVE_UNISTD_H*/
 #include <ctype.h>
 
+#define VIPS_DISABLE_DEPRECATION_WARNINGS
 #include <vips/vips.h>
 #include <vips/internal.h>
 #include <vips/debug.h>

--- a/libvips/iofuncs/init.c
+++ b/libvips/iofuncs/init.c
@@ -100,10 +100,6 @@
 #include <vips/thread.h>
 #include <vips/internal.h>
 
-#if ENABLE_DEPRECATED
-#include <vips/vips7compat.h>
-#endif
-
 /* abort() on the first warning or error.
  */
 int vips__fatal = 0;

--- a/tools/vips.c
+++ b/tools/vips.c
@@ -103,10 +103,6 @@
 #include <vips/vector.h>
 #include <vips/internal.h>
 
-#if ENABLE_DEPRECATED
-#include <vips/vips7compat.h>
-#endif
-
 static char *main_option_plugin = NULL;
 static gboolean main_option_targets;
 static gboolean main_option_version;


### PR DESCRIPTION
This automatically includes `vips7compat.h` unless building with `-Ddeprecated=false`, preventing unexpected API breaks.

See: #4193.