### PR TITLE
Fix build with orc

### DIFF
--- a/libvips/include/vips/vips7compat.h
+++ b/libvips/include/vips/vips7compat.h
@@ -1656,13 +1656,17 @@ size_t vips__get_sizeof_vipsobject(void);
 
 /* This is deprecated to make room for highway.
  */
+#ifndef OrcProgram
 typedef struct _OrcProgram {
 	/* Opaque */
 } OrcProgram;
+#endif
 
+#ifndef OrcExecutor
 typedef struct _OrcExecutor {
 	char data[808];
 } OrcExecutor;
+#endif
 
 #define VIPS_VECTOR_SOURCE_MAX (10)
 


### PR DESCRIPTION
Regressed since 71d356b.

See: https://github.com/libvips/libvips/actions/runs/11304572685/job/31443113383

<details>
  <summary>Details</summary>

```
In file included from /usr/include/orc-0.4/orc/orcprogram.h:7,
                 from /usr/include/orc-0.4/orc/orc.h:6,
                 from ../libvips/resample/reducev.cpp:80:
/usr/include/orc-0.4/orc/orcexecutor.h:42:8: error: redefinition of ‘struct _OrcExecutor’
   42 | struct _OrcExecutor {
      |        ^~~~~~~~~~~~
In file included from ../libvips/include/vips/vips.h:139,
                 from ../libvips/resample/reducev.cpp:71:
../libvips/include/vips/vips7compat.h:1665:16: note: previous definition of ‘struct _OrcExecutor’
 1665 | typedef struct _OrcExecutor {
      |                ^~~~~~~~~~~~
In file included from /usr/include/orc-0.4/orc/orc.h:6,
                 from ../libvips/resample/reducev.cpp:80:
/usr/include/orc-0.4/orc/orcprogram.h:27:8: error: redefinition of ‘struct _OrcProgram’
   27 | struct _OrcProgram {
      |        ^~~~~~~~~~~
In file included from ../libvips/include/vips/vips.h:139,
                 from ../libvips/resample/reducev.cpp:71:
../libvips/include/vips/vips7compat.h:1661:16: note: previous definition of ‘struct _OrcProgram’
 1661 | typedef struct _OrcProgram {
      |                ^~~~~~~~~~~
```
</details>
