### PR TITLE
vips7compat.h: remove `OrcProgram` and `OrcExecutor` stubs

### DIFF
--- a/libvips/include/vips/vips7compat.h
+++ b/libvips/include/vips/vips7compat.h
@@ -36,20 +36,9 @@
 
 #include <vips/mask.h>
 
-/* The old deprecated VipsVector/VipsExecutor API required orc.
- * Avoid a possible ABI/API break with the adoption of highway.
- */
 #ifdef HAVE_ORC
 #include <orc/orc.h>
-#else
-typedef struct _OrcProgram {
-	/* Opaque */
-} OrcProgram;
-
-typedef struct _OrcExecutor {
-	char data[808];
-} OrcExecutor;
-#endif
+#endif /* HAVE_ORC */
 
 #ifdef __cplusplus
 extern "C" {
@@ -1694,13 +1683,17 @@ typedef struct {
 
 	int d1;
 
+#ifdef HAVE_ORC
 	OrcProgram *program;
+#endif /*HAVE_ORC*/
 
 	gboolean compiled;
 } VipsVector;
 
 typedef struct {
+#ifdef HAVE_ORC
 	OrcExecutor executor;
+#endif /*HAVE_ORC*/
 
 	VipsVector *vector;
 } VipsExecutor;


### PR DESCRIPTION
Remove the confusing `OrcProgram` and `OrcExecutor` stubs to avoid conflicts with `orc.h`. Should be safe, the deprecated `VipsVector` and `VipsExecutor` APIs was tightly coupled to liborc and became no-op after the adoption of Highway.

While this is a potential ABI break, this API was likely not used outside libvips. The same ABI break could also occur in versions prior to 8.15 when a binary was built with `-Dorc=disabled` instead of `-Dorc=enabled`.

<details>
  <summary>Details</summary>

```c
#include <orc/orc.h>
#include <vips/vips.h>

int main(void)
{
    return 0;
}
```

```console
$ gcc test-orc-vips.c `pkg-config vips orc-0.4 --cflags --libs` -o test-orc-vips
In file included from /usr/include/vips/vips.h:139,
                 from test-orc-vips.c:5:
/usr/include/vips/vips7compat.h:45:16: error: redefinition of ‘struct _OrcProgram’
   45 | typedef struct _OrcProgram {
      |                ^~~~~~~~~~~
In file included from /usr/include/orc-0.4/orc/orc.h:5,
                 from test-orc-vips.c:4:
/usr/include/orc-0.4/orc/orcprogram.h:26:8: note: originally defined here
   26 | struct _OrcProgram {
      |        ^~~~~~~~~~~
/usr/include/vips/vips7compat.h:47:3: error: conflicting types for ‘OrcProgram’; have ‘struct _OrcProgram’
   47 | } OrcProgram;
      |   ^~~~~~~~~~
In file included from /usr/include/orc-0.4/orc/orc.h:4:
/usr/include/orc-0.4/orc/orcutils.h:36:28: note: previous declaration of ‘OrcProgram’ with type ‘OrcProgram’ {aka ‘struct _OrcProgram’}
   36 | typedef struct _OrcProgram OrcProgram;
      |                            ^~~~~~~~~~
/usr/include/vips/vips7compat.h:49:16: error: redefinition of ‘struct _OrcExecutor’
   49 | typedef struct _OrcExecutor {
      |                ^~~~~~~~~~~~
In file included from /usr/include/orc-0.4/orc/orcprogram.h:6:
/usr/include/orc-0.4/orc/orcexecutor.h:43:8: note: originally defined here
   43 | struct _OrcExecutor {
      |        ^~~~~~~~~~~~
/usr/include/vips/vips7compat.h:51:3: error: conflicting types for ‘OrcExecutor’; have ‘struct _OrcExecutor’
   51 | } OrcExecutor;
      |   ^~~~~~~~~~~
/usr/include/orc-0.4/orc/orcexecutor.h:13:29: note: previous declaration of ‘OrcExecutor’ with type ‘OrcExecutor’ {aka ‘struct _OrcExecutor’}
   13 | typedef struct _OrcExecutor OrcExecutor;
      |                             ^~~~~~~~~~~
```
</details>

/cc @remicollet FYI.