### PR TITLE
jpeg: implement custom message codes and table

### DIFF
--- a/libvips/foreign/jpeg.h
+++ b/libvips/foreign/jpeg.h
@@ -62,6 +62,12 @@ extern "C" {
 #include <jpeglib.h>
 #include <jerror.h>
 
+/* Our custom error message codes.
+ */
+#define JERR_VIPS_IMAGE_EOF (1000)
+#define JWRN_VIPS_IMAGE_EOF JERR_VIPS_IMAGE_EOF
+#define JERR_VIPS_TARGET_WRITE (1001)
+
 /* Define a new error handler for when we bomb out.
  */
 typedef struct {
@@ -74,6 +80,8 @@ typedef struct {
 	jmp_buf jmp; /* longjmp() here to get back to VIPS */
 	FILE *fp;	 /* fclose() if non-NULL */
 } ErrorManager;
+
+extern const char *vips__jpeg_message_table[];
 
 void vips__new_output_message(j_common_ptr cinfo);
 void vips__new_error_exit(j_common_ptr cinfo);

--- a/libvips/foreign/jpeg2vips.c
+++ b/libvips/foreign/jpeg2vips.c
@@ -245,10 +245,10 @@ source_fill_input_buffer(j_decompress_ptr cinfo)
 			/* Knock the output out of cache.
 			 */
 			vips_foreign_load_invalidate(src->jpeg->out);
-			ERREXIT(cinfo, JERR_INPUT_EOF);
+			ERREXIT(cinfo, JERR_VIPS_IMAGE_EOF);
 		}
 		else
-			WARNMS(cinfo, JWRN_JPEG_EOF);
+			WARNMS(cinfo, JWRN_VIPS_IMAGE_EOF);
 
 		/* Insert a fake EOI marker.
 		 */
@@ -272,10 +272,10 @@ source_fill_input_buffer_mappable(j_decompress_ptr cinfo)
 		/* Knock the output out of cache.
 		 */
 		vips_foreign_load_invalidate(src->jpeg->out);
-		ERREXIT(cinfo, JERR_INPUT_EOF);
+		ERREXIT(cinfo, JERR_VIPS_IMAGE_EOF);
 	}
 	else
-		WARNMS(cinfo, JWRN_JPEG_EOF);
+		WARNMS(cinfo, JWRN_VIPS_IMAGE_EOF);
 
 	/* Insert a fake EOI marker.
 	 */
@@ -463,6 +463,9 @@ readjpeg_new(VipsSource *source, VipsImage *out,
 	jpeg->shrink = shrink;
 	jpeg->fail_on = fail_on;
 	jpeg->cinfo.err = jpeg_std_error(&jpeg->eman.pub);
+	jpeg->cinfo.err->addon_message_table = vips__jpeg_message_table;
+	jpeg->cinfo.err->first_addon_message = 1000;
+	jpeg->cinfo.err->last_addon_message = 1001;
 	jpeg->eman.pub.error_exit = vips__new_error_exit;
 	jpeg->eman.pub.emit_message = readjpeg_emit_message;
 	jpeg->eman.pub.output_message = vips__new_output_message;

--- a/libvips/foreign/tiff2vips.c
+++ b/libvips/foreign/tiff2vips.c
@@ -1973,7 +1973,7 @@ rtiff_decompress_jpeg_fill_input_buffer(j_decompress_ptr cinfo)
 	 * buffer, so any request for more data beyond the given buffer size
 	 * is treated as an error.
 	 */
-	WARNMS(cinfo, JWRN_JPEG_EOF);
+	WARNMS(cinfo, JWRN_VIPS_IMAGE_EOF);
 
 	/* Insert a fake EOI marker
 	 */
@@ -2163,6 +2163,9 @@ rtiff_decompress_jpeg(Rtiff *rtiff, void *data, size_t data_len, void *out)
 
 	if (setjmp(eman.jmp) == 0) {
 		cinfo.err = jpeg_std_error(&eman.pub);
+		cinfo.err->addon_message_table = vips__jpeg_message_table;
+		cinfo.err->first_addon_message = 1000;
+		cinfo.err->last_addon_message = 1001;
 		eman.pub.error_exit = vips__new_error_exit;
 		eman.pub.emit_message = rtiff_decompress_jpeg_emit_message;
 		eman.pub.output_message = vips__new_output_message;

--- a/libvips/foreign/vips2tiff.c
+++ b/libvips/foreign/vips2tiff.c
@@ -732,6 +732,9 @@ wtiff_compress_jpeg(Wtiff *wtiff,
 
 	// we could have one of these per thread and reuse it for a small speedup
 	cinfo.err = jpeg_std_error(&eman.pub);
+	cinfo.err->addon_message_table = vips__jpeg_message_table;
+	cinfo.err->first_addon_message = 1000;
+	cinfo.err->last_addon_message = 1001;
 	cinfo.dest = NULL;
 	eman.pub.error_exit = vips__new_error_exit;
 	eman.pub.output_message = vips__new_output_message;
@@ -740,7 +743,7 @@ wtiff_compress_jpeg(Wtiff *wtiff,
 	// we need a line buffer to pad edge tiles
 	line = VIPS_MALLOC(NULL, wtiff->tilew * sizeof_pel);
 
-	/* Error handling. The error message will have ben set by our handlers.
+	/* Error handling. The error message will have been set by our handlers.
 	 */
 	if (setjmp(eman.jmp)) {
 		jpeg_destroy_compress(&cinfo);
@@ -805,6 +808,9 @@ wtiff_compress_jpeg_tables(Wtiff *wtiff,
 	struct jpeg_error_mgr jerr;
 
 	cinfo.err = jpeg_std_error(&jerr);
+	cinfo.err->addon_message_table = vips__jpeg_message_table;
+	cinfo.err->first_addon_message = 1000;
+	cinfo.err->last_addon_message = 1001;
 	jpeg_create_compress(&cinfo);
 
 	/* Attach output.


### PR DESCRIPTION
Use the "add-on" message table to ensure compatibility with jpegli, which lacks its own message codes and table.
https://github.com/google/jpegli/blob/13dfbac5dc10b86b75a22a2bba293d8f974f43b9/lib/jpegli/error.cc#L93-L98

Resolves: #4206.

<details>
  <summary>Test case</summary>

```console
$ vips copy ~/Downloads/2d3c8299-5a81-4e01-abe1-f2879d76bef2.JPG x.jpg

(vips:12329): VIPS-WARNING **: 12:06:37.041: read gave 1 warnings

(vips:12329): VIPS-WARNING **: 12:06:37.041: VipsJpeg: premature end of JPEG image

$ LD_PRELOAD=/opt/jpegli/lib64/libjpeg.so.62.4.0 vips copy ~/Downloads/2d3c8299-5a81-4e01-abe1-f2879d76bef2.JPG x.jpg

(vips:12349): VIPS-WARNING **: 12:06:38.874: read gave 1 warnings

(vips:12349): VIPS-WARNING **: 12:06:38.874: VipsJpeg: premature end of JPEG image

```
</details>
