### PR TITLE
fix Vips-8.0.gir generation

### DIFF
--- a/libvips/include/vips/vips7compat.h
+++ b/libvips/include/vips/vips7compat.h
@@ -42,9 +42,7 @@
 #ifdef HAVE_ORC
 #include <orc/orc.h>
 #else
-typedef struct _OrcProgram {
-	/* Opaque */
-} OrcProgram;
+typedef struct _OrcProgram OrcProgram;
 
 typedef struct _OrcExecutor {
 	char data[808];


### PR DESCRIPTION
The empty struct for OrcProgram seems to confuse introspection, I see a lot of message like:

```
$ ninja
[4/551] Generating glib marshaller header libvips/iofuncs/vipsmarshal_h
INFO: Reading ../libvips/iofuncs/vipsmarshal.list...
[7/551] Generating glib marshaller source libvips/iofuncs/vipsmarshal_c
INFO: Reading ../libvips/iofuncs/vipsmarshal.list...
[550/551] Generating libvips/Vips-8.0.... command (wrapped by meson to set env)
/home/john/GIT/libvips/libvips/include/vips/vips7compat.h:47: syntax error, unexpected '}' in '} OrcProgram;' at '}'
```

Using a typdef to an anon struct seems to fix this.