### PR TITLE
Add option to opt-out of `vips7compat.h` inclusion

### DIFF
--- a/libvips/include/vips/vips.h
+++ b/libvips/include/vips/vips.h
@@ -135,7 +135,14 @@ extern "C" {
 #include <vips/colour.h>
 #include <vips/draw.h>
 #include <vips/create.h>
-#if VIPS_ENABLE_DEPRECATED
+
+/* VIPS_DISABLE_COMPAT:
+ *
+ * Disable automatically inclusion of `vips7compat.h`.
+ *
+ * This has no effect when building with `-Ddeprecated=false`.
+ */
+#if VIPS_ENABLE_DEPRECATED && !defined(VIPS_DISABLE_COMPAT)
 #include <vips/vips7compat.h>
 #endif
 


### PR DESCRIPTION
Via the `VIPS_DISABLE_COMPAT` definition. 

See: https://github.com/libvips/libvips/issues/4190#issuecomment-2422526756.

<details>
  <summary>Test case</summary>

`test-deprecated.c`:
```c
#include <vips/vips.h>

int
main(void)
{
	char version[256];

	vips_snprintf(version, 256, "%d.%d.%d",
		VIPS_MAJOR_VERSION, VIPS_MINOR_VERSION, VIPS_MICRO_VERSION);
	printf("%s\n", version);

	return 0;
}
```

```console
$ gcc test-deprecated.c `pkg-config vips --cflags --libs` -o test-deprecated
test-deprecated.c: In function ‘main’:
test-deprecated.c:8:9: warning: ‘vips_snprintf’ is deprecated: Use 'g_snprintf' instead [-Wdeprecated-declarations]
    8 |         vips_snprintf(version, 256, "%d.%d.%d",
      |         ^~~~~~~~~~~~~
In file included from /usr/include/vips/vips7compat.h:1771,
                 from /usr/include/vips/vips.h:139,
                 from test-deprecated.c:2:
/usr/include/vips/almostdeprecated.h:460:5: note: declared here
  460 | int vips_snprintf(char *str, size_t size, const char *format, ...)
      |     ^~~~~~~~~~~~~
$ gcc test-deprecated.c -DVIPS_DISABLE_COMPAT `pkg-config vips --cflags --libs` -o test-deprecated
test-deprecated.c: In function ‘main’:
test-deprecated.c:8:9: error: implicit declaration of function ‘vips_snprintf’; did you mean ‘vips_shrinkv’? [-Wimplicit-function-declaration]
    8 |         vips_snprintf(version, 256, "%d.%d.%d",
      |         ^~~~~~~~~~~~~
      |         vips_shrinkv
```
</details>
