### PR TITLE
Fix `vips_isprefix()` argument order

### DIFF
--- a/libvips/foreign/foreign.c
+++ b/libvips/foreign/foreign.c
@@ -1722,8 +1722,8 @@ vips_foreign_save_remove_metadata(VipsImage *image,
 	VipsForeignKeep keep = *((VipsForeignKeep *) user_data);
 
 	// we are only interested in metadata
-	if (!vips_isprefix(field, "png-comment-") &&
-		!vips_isprefix(field, "magickprofile-") &&
+	if (!vips_isprefix("png-comment-", field) &&
+		!vips_isprefix("magickprofile-", field) &&
 		strcmp(field, VIPS_META_IMAGEDESCRIPTION) != 0 &&
 		!g_str_has_suffix(field, "-data"))
 		return NULL;


### PR DESCRIPTION
The arguments were reversed, likely due to confusion with `g_str_has_prefix()`. Ensures all metadata is removed when saving with `keep=none`.

See: #4224.

Targets the 8.16 branch.