### PR TITLE
Add support for VIPS_JP2K_ONESHOT environment variable

### DIFF
--- a/libvips/foreign/jp2kload.c
+++ b/libvips/foreign/jp2kload.c
@@ -284,6 +284,9 @@ static VipsForeignFlags
 vips_foreign_load_jp2k_get_flags(VipsForeignLoad *load)
 {
 	VipsForeignLoadJp2k *jp2k = (VipsForeignLoadJp2k *) load;
+	if (g_getenv("VIPS_JP2K_ONESHOT")) {
+		jp2k->oneshot = TRUE;
+	};
 
 	if (jp2k->oneshot)
 		return VIPS_FOREIGN_SEQUENTIAL;


### PR DESCRIPTION
Related to #4205 

I'm not 100% sure this is the best place to check for the environment override, but it's working consistently in my project.