### PR TITLE
Improve `--vips-config` for internal dependencies

### DIFF
--- a/libvips/include/vips/meson.build
+++ b/libvips/include/vips/meson.build
@@ -106,8 +106,11 @@ foreach _, section : build_summary
 endforeach
 foreach _, section : build_features
     foreach key, arr : section
+        dep_name = arr[0]
         found = arr[1].found()
-        dep_name = found ? arr[1].name() : arr[0]
+        if found and arr[1].type_name() != 'internal'
+            dep_name = arr[1].name()
+        endif
         dynamic_module = arr.length() > 2 ? ' (dynamic module: @0@)'.format(arr[2]) : ''
         vips_verbose_config += '@0@ with @1@: @2@@3@'.format(key, dep_name, found, dynamic_module)
     endforeach


### PR DESCRIPTION
Dependencies created using `declare_dependency()` does not have a version number or name.

Mirrors commit ec432a5.

Diff when building with libnifti found without pkg-config (i.e. `-Dnifti-prefix-dir=/usr`).
```diff
@@ -27,7 +27,7 @@ SVG load with librsvg-2.0: true
 EXR load with OpenEXR: true
 WSI load with openslide: true (dynamic module: true)
 Matlab load with matio: true
-NIfTI load/save with dep140163777216928: true
+NIfTI load/save with libnifti: true
 FITS load/save with cfitsio: true
 GIF save with cgif: true
 Magick load/save with MagickCore: true (dynamic module: true)
```

Targets the 8.16 branch.