### PR TITLE
reduce: prefer use of `VIPS_FABS()`

### DIFF
--- a/libvips/resample/templates.h
+++ b/libvips/resample/templates.h
@@ -361,8 +361,7 @@ static double inline filter(double x);
 template <>
 double inline filter<VIPS_KERNEL_LINEAR>(double x)
 {
-	if (x < 0.0)
-		x = -x;
+	x = VIPS_FABS(x);
 
 	if (x < 1.0)
 		return 1.0 - x;
@@ -405,8 +404,7 @@ double inline filter<VIPS_KERNEL_LANCZOS3>(double x)
 template <>
 double inline filter<VIPS_KERNEL_MKS2013>(double x)
 {
-	if (x < 0.0)
-		x = -x;
+	x = VIPS_FABS(x);
 
 	if (x >= 2.5)
 		return 0.0;
@@ -423,8 +421,7 @@ double inline filter<VIPS_KERNEL_MKS2013>(double x)
 template <>
 double inline filter<VIPS_KERNEL_MKS2021>(double x)
 {
-	if (x < 0.0)
-		x = -x;
+	x = VIPS_FABS(x);
 
 	if (x >= 4.5)
 		return 0.0;


### PR DESCRIPTION
To ensure we handle negative zero (`-0.0`) correctly, see e.g:
https://stackoverflow.com/a/48609079