### PR TITLE
use VIPS_FMAX()/FMIN() in maxpair/minpair

### DIFF
--- a/libvips/arithmetic/maxpair.c
+++ b/libvips/arithmetic/maxpair.c
@@ -63,6 +63,16 @@ G_DEFINE_TYPE(VipsMaxpair, vips_maxpair, VIPS_TYPE_BINARY);
 			q[x] = VIPS_MAX(left[x], right[x]); \
 	}
 
+#define FLOOP(TYPE) \
+	{ \
+		TYPE *restrict left = (TYPE *) in[0]; \
+		TYPE *restrict right = (TYPE *) in[1]; \
+		TYPE *restrict q = (TYPE *) out; \
+\
+		for (int x = 0; x < sz; x++) \
+			q[x] = VIPS_FMAX(left[x], right[x]); \
+	}
+
 static void
 maxpair_buffer(VipsArithmetic *arithmetic,
 	VipsPel *out, VipsPel **in, int width)
@@ -102,12 +112,12 @@ maxpair_buffer(VipsArithmetic *arithmetic,
 
 	case VIPS_FORMAT_FLOAT:
 	case VIPS_FORMAT_COMPLEX:
-		LOOP(float);
+		FLOOP(float);
 		break;
 
 	case VIPS_FORMAT_DOUBLE:
 	case VIPS_FORMAT_DPCOMPLEX:
-		LOOP(double);
+		FLOOP(double);
 		break;
 
 	default:

--- a/libvips/arithmetic/minpair.c
+++ b/libvips/arithmetic/minpair.c
@@ -63,6 +63,16 @@ G_DEFINE_TYPE(VipsMinpair, vips_minpair, VIPS_TYPE_BINARY);
 			q[x] = VIPS_MIN(left[x], right[x]); \
 	}
 
+#define FLOOP(TYPE) \
+	{ \
+		TYPE *restrict left = (TYPE *) in[0]; \
+		TYPE *restrict right = (TYPE *) in[1]; \
+		TYPE *restrict q = (TYPE *) out; \
+\
+		for (int x = 0; x < sz; x++) \
+			q[x] = VIPS_FMIN(left[x], right[x]); \
+	}
+
 static void
 minpair_buffer(VipsArithmetic *arithmetic,
 	VipsPel *out, VipsPel **in, int width)
@@ -102,12 +112,12 @@ minpair_buffer(VipsArithmetic *arithmetic,
 
 	case VIPS_FORMAT_FLOAT:
 	case VIPS_FORMAT_COMPLEX:
-		LOOP(float);
+		FLOOP(float);
 		break;
 
 	case VIPS_FORMAT_DOUBLE:
 	case VIPS_FORMAT_DPCOMPLEX:
-		LOOP(double);
+		FLOOP(double);
 		break;
 
 	default:


### PR DESCRIPTION
These macros are faster and more accurate than VIPS_MAX() and VIPS_MIN for float values, since they will call `builtin_fmax()` if possible.

See https://github.com/libvips/libvips/pull/4243