### PR TITLE
Backport #4243 to 8.16

### DIFF
--- a/libvips/resample/templates.h
+++ b/libvips/resample/templates.h
@@ -361,8 +361,7 @@ static double inline filter(double x);
 template <>
 double inline filter<VIPS_KERNEL_LINEAR>(double x)
 {
-	if (x < 0.0)
-		x = -x;
+	x = VIPS_FABS(x);
 
 	if (x < 1.0)
 		return 1.0 - x;


### PR DESCRIPTION
Trivial backport of #4243 to [`8.16`](https://github.com/libvips/libvips/tree/8.16).

Note: rebase merge, don't squash.