### PR TITLE
Fix `--vips-info` CLI flag with GLib >= 2.80

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -4,6 +4,7 @@
 - fix PFM byte order on big-endian machines [agoode]
 - morph: fix erode Highway path [kleisauke]
 - morph: fix C-paths with masks containing zero [kleisauke]
+- fix `--vips-info` CLI flag with GLib >= 2.80 [kleisauke]
 
 10/10/24 8.16.0
 

--- a/libvips/iofuncs/init.c
+++ b/libvips/iofuncs/init.c
@@ -363,24 +363,18 @@ set_stacksize(guint64 size)
 #endif /*HAVE_PTHREAD_DEFAULT_NP*/
 }
 
+/**
+ * Equivalent to setting the `G_MESSAGES_DEBUG=VIPS` environment variable.
+ */
 static void
 vips_verbose(void)
 {
-	const char *old;
-
-	old = g_getenv("G_MESSAGES_DEBUG");
-
-	if (!old)
-		g_setenv("G_MESSAGES_DEBUG", G_LOG_DOMAIN, TRUE);
-	else if (!g_str_equal(old, "all") &&
-		!g_strrstr(old, G_LOG_DOMAIN)) {
-		char *new;
-
-		new = g_strconcat(old, " ", G_LOG_DOMAIN, NULL);
-		g_setenv("G_MESSAGES_DEBUG", new, TRUE);
-
-		g_free(new);
-	}
+#if GLIB_CHECK_VERSION(2, 80, 0)
+	const char *domains[] = { G_LOG_DOMAIN, NULL };
+	g_log_writer_default_set_debug_domains(domains);
+#else
+	g_setenv("G_MESSAGES_DEBUG", G_LOG_DOMAIN, TRUE);
+#endif
 }
 
 static int


### PR DESCRIPTION
Use `g_log_writer_default_set_debug_domains()` since resetting `G_MESSAGES_DEBUG` at runtime has no effect for GLib >= 2.80.

Also, remove any checks for the old `G_MESSAGES_DEBUG` env variable and overwrite it directly instead. This means the `--vips-info` CLI flag and the `VIPS_INFO=1` env variable now take precedence over `G_MESSAGES_DEBUG`.

See: https://gitlab.gnome.org/GNOME/glib/-/merge_requests/3710.

Targets the 8.16 branch.