### PR TITLE
Make `subsample-mode=on` and `lossless=true` mutually exclusive

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -5,6 +5,7 @@
 - morph: fix erode Highway path [kleisauke]
 - morph: fix C-paths with masks containing zero [kleisauke]
 - fix `--vips-info` CLI flag with GLib >= 2.80 [kleisauke]
+- make `subsample-mode=on` and `lossless=true` mutually exclusive [kleisauke]
 
 10/10/24 8.16.0
 

--- a/libvips/foreign/heifsave.c
+++ b/libvips/foreign/heifsave.c
@@ -526,11 +526,9 @@ vips_foreign_save_heif_build(VipsObject *object)
 		!vips_object_argument_isset(object, "effort"))
 		heif->effort = 9 - heif->speed;
 
-	/* Disable chroma subsampling by default when the "lossless" param
-	 * is being used.
+	/* The "lossless" param implies no chroma subsampling.
 	 */
-	if (vips_object_argument_isset(object, "lossless") &&
-		!vips_object_argument_isset(object, "subsample_mode"))
+	if (heif->lossless)
 		heif->subsample_mode = VIPS_FOREIGN_SUBSAMPLE_OFF;
 
 	/* Default 12 bit save for 16-bit images.

--- a/libvips/foreign/jp2ksave.c
+++ b/libvips/foreign/jp2ksave.c
@@ -819,11 +819,14 @@ vips_foreign_save_jp2k_build(VipsObject *object)
 		return -1;
 	}
 
+	/* The "lossless" param implies no chroma subsampling.
+	 */
+	if (jp2k->lossless)
+		jp2k->subsample_mode = VIPS_FOREIGN_SUBSAMPLE_OFF;
+
 	switch (jp2k->subsample_mode) {
 	case VIPS_FOREIGN_SUBSAMPLE_AUTO:
-		jp2k->subsample =
-			!jp2k->lossless &&
-			jp2k->Q < 90 &&
+		jp2k->subsample = jp2k->Q < 90 &&
 			(save->ready->Type == VIPS_INTERPRETATION_sRGB ||
 				save->ready->Type == VIPS_INTERPRETATION_RGB16) &&
 			save->ready->Bands == 3;


### PR DESCRIPTION
i.e. always disable chroma subsampling when saving lossless.

See: #4232.

Targets the 8.16 branch.