### PR TITLE
Avoid using `vips_object_argument_isset()` to check for flags

### DIFF
--- a/libvips/foreign/dzsave.c
+++ b/libvips/foreign/dzsave.c
@@ -1955,7 +1955,7 @@ vips_foreign_save_dz_build(VipsObject *object)
 	 * or the deprecated "no_strip" turns this off.
 	 */
 	if (!vips_object_argument_isset(object, "keep") &&
-		!vips_object_argument_isset(object, "no_strip"))
+		!dz->no_strip)
 		save->keep = VIPS_FOREIGN_KEEP_NONE;
 
 	/* Google, zoomify and iiif default to zero overlap, ".jpg".

--- a/libvips/foreign/ppmsave.c
+++ b/libvips/foreign/ppmsave.c
@@ -324,7 +324,7 @@ vips_foreign_save_ppm_build(VipsObject *object)
 
 	/* Handle the deprecated squash parameter.
 	 */
-	if (vips_object_argument_isset(object, "squash"))
+	if (ppm->squash)
 		ppm->bitdepth = 1;
 
 	if (vips_check_uintorf("vips2ppm", image) ||


### PR DESCRIPTION
For example, this ensures that `[no_strip=false]` or `[squash=false]` is properly handled.

Targets the 8.16 branch without a changelog entry, as these arguments are already deprecated.