### PR TITLE
Fix GIR error after #4251

### DIFF
--- a/libvips/iofuncs/init.c
+++ b/libvips/iofuncs/init.c
@@ -363,8 +363,7 @@ set_stacksize(guint64 size)
 #endif /*HAVE_PTHREAD_DEFAULT_NP*/
 }
 
-/**
- * Equivalent to setting the `G_MESSAGES_DEBUG=VIPS` environment variable.
+/* Equivalent to setting the `G_MESSAGES_DEBUG=VIPS` environment variable.
  */
 static void
 vips_verbose(void)


### PR DESCRIPTION
```
../libvips/iofuncs/init.c:367: Error: Vips: identifier not found on the first line:
 * Equivalent to setting the `G_MESSAGES_DEBUG=VIPS` environment variable.
   ^
```

Targets the 8.16 branch.