### PR TITLE
Disable `unlimited` flag in fuzzing builds

### DIFF
--- a/libvips/foreign/heifload.c
+++ b/libvips/foreign/heifload.c
@@ -1107,12 +1107,14 @@ vips_foreign_load_heif_class_init(VipsForeignLoadHeifClass *class)
 		G_STRUCT_OFFSET(VipsForeignLoadHeif, autorotate),
 		FALSE);
 
+#ifndef FUZZING_BUILD_MODE_UNSAFE_FOR_PRODUCTION
 	VIPS_ARG_BOOL(class, "unlimited", 22,
 		_("Unlimited"),
 		_("Remove all denial of service limits"),
 		VIPS_ARGUMENT_OPTIONAL_INPUT,
 		G_STRUCT_OFFSET(VipsForeignLoadHeif, unlimited),
 		FALSE);
+#endif
 }
 
 static gint64

--- a/libvips/foreign/jpegload.c
+++ b/libvips/foreign/jpegload.c
@@ -201,12 +201,14 @@ vips_foreign_load_jpeg_class_init(VipsForeignLoadJpegClass *class)
 		G_STRUCT_OFFSET(VipsForeignLoadJpeg, autorotate),
 		FALSE);
 
+#ifndef FUZZING_BUILD_MODE_UNSAFE_FOR_PRODUCTION
 	VIPS_ARG_BOOL(class, "unlimited", 22,
 		_("Unlimited"),
 		_("Remove all denial of service limits"),
 		VIPS_ARGUMENT_OPTIONAL_INPUT,
 		G_STRUCT_OFFSET(VipsForeignLoadJpeg, unlimited),
 		FALSE);
+#endif
 }
 
 static void

--- a/libvips/foreign/pngload.c
+++ b/libvips/foreign/pngload.c
@@ -166,12 +166,14 @@ vips_foreign_load_png_class_init(VipsForeignLoadPngClass *class)
 	load_class->header = vips_foreign_load_png_header;
 	load_class->load = vips_foreign_load_png_load;
 
+#ifndef FUZZING_BUILD_MODE_UNSAFE_FOR_PRODUCTION
 	VIPS_ARG_BOOL(class, "unlimited", 23,
 		_("Unlimited"),
 		_("Remove all denial of service limits"),
 		VIPS_ARGUMENT_OPTIONAL_INPUT,
 		G_STRUCT_OFFSET(VipsForeignLoadPng, unlimited),
 		FALSE);
+#endif
 }
 
 static void

--- a/libvips/foreign/spngload.c
+++ b/libvips/foreign/spngload.c
@@ -673,12 +673,14 @@ vips_foreign_load_png_class_init(VipsForeignLoadPngClass *class)
 	load_class->header = vips_foreign_load_png_header;
 	load_class->load = vips_foreign_load_png_load;
 
+#ifndef FUZZING_BUILD_MODE_UNSAFE_FOR_PRODUCTION
 	VIPS_ARG_BOOL(class, "unlimited", 23,
 		_("Unlimited"),
 		_("Remove all denial of service limits"),
 		VIPS_ARGUMENT_OPTIONAL_INPUT,
 		G_STRUCT_OFFSET(VipsForeignLoadPng, unlimited),
 		FALSE);
+#endif
 }
 
 static void

--- a/libvips/foreign/svgload.c
+++ b/libvips/foreign/svgload.c
@@ -727,12 +727,14 @@ vips_foreign_load_svg_class_init(VipsForeignLoadSvgClass *class)
 		G_STRUCT_OFFSET(VipsForeignLoadSvg, scale),
 		0.0, 100000.0, 1.0);
 
+#ifndef FUZZING_BUILD_MODE_UNSAFE_FOR_PRODUCTION
 	VIPS_ARG_BOOL(class, "unlimited", 23,
 		_("Unlimited"),
 		_("Allow SVG of any size"),
 		VIPS_ARGUMENT_OPTIONAL_INPUT,
 		G_STRUCT_OFFSET(VipsForeignLoadSvg, unlimited),
 		FALSE);
+#endif
 }
 
 static void

--- a/test/test-suite/test_foreign.py
+++ b/test/test-suite/test_foreign.py
@@ -1426,9 +1426,6 @@ class TestForeign:
             im = pyvips.Image.heifload(AVIF_FILE_HUGE)
             assert im.avg() == 0.0
 
-        im = pyvips.Image.heifload(AVIF_FILE_HUGE, unlimited=True)
-        assert im.avg() == 0.0
-
     @skip_if_no("heifsave")
     def test_avifsave(self):
         self.save_load_buffer("heifsave_buffer", "heifload_buffer",


### PR DESCRIPTION
The load-specific `unlimited` flag is known to be fuzzing-unfriendly.

Targets the 8.16 branch to prevent CIFuzz from fuzzing this flag as well.