### PR TITLE
shrink{h,v}: improve performance

### DIFF
--- a/libvips/resample/shrinkh.c
+++ b/libvips/resample/shrinkh.c
@@ -162,10 +162,10 @@ vips_shrinkh_gen2(VipsShrinkh *shrink, VipsRegion *out_region, VipsRegion *ir,
 		ISHRINK(int, short, bands);
 		break;
 	case VIPS_FORMAT_UINT:
-		ISHRINK(double, unsigned int, bands);
+		ISHRINK(gint64, unsigned int, bands);
 		break;
 	case VIPS_FORMAT_INT:
-		ISHRINK(double, int, bands);
+		ISHRINK(gint64, int, bands);
 		break;
 	case VIPS_FORMAT_FLOAT:
 		FSHRINK(float);

--- a/libvips/resample/shrinkh.c
+++ b/libvips/resample/shrinkh.c
@@ -72,10 +72,6 @@ typedef VipsResampleClass VipsShrinkhClass;
 
 G_DEFINE_TYPE(VipsShrinkh, vips_shrinkh, VIPS_TYPE_RESAMPLE);
 
-#define INNER(BANDS) \
-	sum += p[x1]; \
-	x1 += BANDS;
-
 /* Integer shrink.
  */
 #define ISHRINK(ACC_TYPE, TYPE, BANDS) \
@@ -88,8 +84,8 @@ G_DEFINE_TYPE(VipsShrinkh, vips_shrinkh, VIPS_TYPE_RESAMPLE);
 				ACC_TYPE sum; \
 \
 				sum = 0; \
-				x1 = b; \
-				VIPS_UNROLL(shrink->hshrink, INNER(BANDS)); \
+				for (x1 = b; x1 < ne; x1 += BANDS) \
+					sum += p[x1]; \
 				q[b] = (sum + shrink->hshrink / 2) / \
 					shrink->hshrink; \
 			} \
@@ -110,8 +106,8 @@ G_DEFINE_TYPE(VipsShrinkh, vips_shrinkh, VIPS_TYPE_RESAMPLE);
 				double sum; \
 \
 				sum = 0.0; \
-				x1 = b; \
-				VIPS_UNROLL(shrink->hshrink, INNER(bands)); \
+				for (x1 = b; x1 < ne; x1 += bands) \
+					sum += p[x1]; \
 				q[b] = sum / shrink->hshrink; \
 			} \
 			p += ne; \

--- a/libvips/resample/shrinkh.c
+++ b/libvips/resample/shrinkh.c
@@ -81,13 +81,10 @@ G_DEFINE_TYPE(VipsShrinkh, vips_shrinkh, VIPS_TYPE_RESAMPLE);
 \
 		for (x = 0; x < width; x++) { \
 			for (b = 0; b < BANDS; b++) { \
-				ACC_TYPE sum; \
-\
-				sum = 0; \
+				ACC_TYPE sum = amend; \
 				for (x1 = b; x1 < ne; x1 += BANDS) \
 					sum += p[x1]; \
-				q[b] = (sum + shrink->hshrink / 2) / \
-					shrink->hshrink; \
+				q[b] = sum / shrink->hshrink; \
 			} \
 			p += ne; \
 			q += BANDS; \
@@ -103,9 +100,7 @@ G_DEFINE_TYPE(VipsShrinkh, vips_shrinkh, VIPS_TYPE_RESAMPLE);
 \
 		for (x = 0; x < width; x++) { \
 			for (b = 0; b < bands; b++) { \
-				double sum; \
-\
-				sum = 0.0; \
+				double sum = 0.0; \
 				for (x1 = b; x1 < ne; x1 += bands) \
 					sum += p[x1]; \
 				q[b] = sum / shrink->hshrink; \
@@ -127,6 +122,8 @@ vips_shrinkh_gen2(VipsShrinkh *shrink, VipsRegion *out_region, VipsRegion *ir,
 	const int ne = shrink->hshrink * bands;
 	VipsPel *out = VIPS_REGION_ADDR(out_region, left, top);
 	VipsPel *in = VIPS_REGION_ADDR(ir, left * shrink->hshrink, top);
+
+	int amend = shrink->hshrink / 2;
 
 	int x;
 	int x1, b;

--- a/libvips/resample/shrinkv.c
+++ b/libvips/resample/shrinkv.c
@@ -204,10 +204,10 @@ vips_shrinkv_gen2(VipsShrinkv *shrink, VipsRegion *out_region, VipsRegion *ir,
 		ISHRINK(int, short, bands);
 		break;
 	case VIPS_FORMAT_UINT:
-		ISHRINK(double, unsigned int, bands);
+		ISHRINK(gint64, unsigned int, bands);
 		break;
 	case VIPS_FORMAT_INT:
-		ISHRINK(double, int, bands);
+		ISHRINK(gint64, int, bands);
 		break;
 	case VIPS_FORMAT_FLOAT:
 		FSHRINK(float);


### PR DESCRIPTION
- Commit 4395dd0a098ac626bef5b8f1673272e18fa3010c is a revert of commit 9b968491d366a68ea1008ed29a74f7293501e4c4. See https://gist.github.com/kleisauke/dcf24beb95cdf2b3037ff63f71b7f9bd for the rationale behind this.
- Commit e1698911402a2f3caac7131e37a8e438e1ab0827 takes a similiar approach as PR #3052 in `shrinkh`.
- Commit 77e8451f13c0aeb949648b299a4148eaec2584a9 removes the `shrinkv` sum buffer in favor of a local, ~7% faster. In line with commit 2e5880b69cf79715ac84abb28b8482aefe7df532.
- Commit 3d28a9222fcf8cd4b49f5b20e716096e60c22b38 uses `gint64` as accumulator type for the uint/int paths. In line with PR #3514.
- Commit 2d8f1c6a1b31e3cb6aef2282f83ce0f66d66778a adds a fixed-point arithmetic path for uchar images, ~9% faster.

<details>
  <summary>Test script</summary>

Test image: https://github.com/kleisauke/vips-microbench/blob/master/images/x.jpg
```python
#!/usr/bin/env python

import sys
import pyvips

im = pyvips.Image.new_from_file(sys.argv[1])

for fac in [2, 4, 8, 16]:
    for fmt in ["uchar", "ushort", "uint",
                "char", "short", "int",
                "float", "double",
                "complex", "dpcomplex"]:
        x = im.cast(fmt, shift=True)
        s = x.shrink(fac, fac)
        d = abs(s.avg() - x.avg())
        print(d, fmt)
        assert d < 2
```
</details>

