### PR TITLE
heifsave: prevent use of AV1 intra block copy feature

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -6,6 +6,7 @@
 - morph: fix C-paths with masks containing zero [kleisauke]
 - fix `--vips-info` CLI flag with GLib >= 2.80 [kleisauke]
 - make `subsample-mode=on` and `lossless=true` mutually exclusive [kleisauke]
+- heifsave: prevent use of AV1 intra block copy feature [lovell]
 
 10/10/24 8.16.0
 

--- a/libvips/foreign/heifsave.c
+++ b/libvips/foreign/heifsave.c
@@ -657,6 +657,17 @@ vips_foreign_save_heif_build(VipsObject *object)
 		return -1;
 	}
 
+	/* Try to prevent the AVIF encoder from using intra block copy,
+	 * helps ensure encoding time is more predictable.
+	 */
+	error = heif_encoder_set_parameter_boolean(heif->encoder,
+		"intra-block-copy", FALSE);
+	if (error.code &&
+		error.subcode != heif_suberror_Unsupported_parameter) {
+		vips__heif_error(&error);
+		return -1;
+	}
+
 	/* TODO .. support extra per-encoder params with
 	 * heif_encoder_list_parameters().
 	 */


### PR DESCRIPTION
Helps ensure AVIF encoding time is more predictable and consistent, fixes https://github.com/libvips/libvips/issues/2983

Remains backwards/forwards compatible with or without the upstream change at https://github.com/strukturag/libheif/pull/1408 as it will fail gracefully when the parameter is unavailable.

We might want consider exposing this as an option, either now or later.