### PR TITLE
CI: Homebrew has switched from pkg-config to pkgconf

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -54,8 +54,9 @@ jobs:
         if: runner.os == 'macOS'
         run: |
           pip3 install meson --break-system-packages
+          brew unlink pkg-config@0.29.2
           brew install \
-            ninja pkg-config \
+            ninja pkgconf \
             cfitsio cgif fftw fontconfig glib \
             highway jpeg-xl libarchive libexif \
             libheif libimagequant libmatio librsvg \


### PR DESCRIPTION
The macOS CI jobs are failing due to the current GitHub Action runner images containing `pkg-config`, which conflicts with https://github.com/Homebrew/homebrew-core/pull/194885
```
The formula built, but is not symlinked into /opt/homebrew
Could not symlink bin/pkg-config
Target /opt/homebrew/bin/pkg-config
```
This PR allows CI to install dependencies, compile and run most of the tests, however one of the tests will still fail on macOS due to https://github.com/strukturag/libheif/issues/1389