### PR TITLE
fix dzsave associated images with openslide4

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -6,6 +6,7 @@
 - morph: fix C-paths with masks containing zero [kleisauke]
 - fix `--vips-info` CLI flag with GLib >= 2.80 [kleisauke]
 - make `subsample-mode=on` and `lossless=true` mutually exclusive [kleisauke]
+- fix SZI write with openslide4 [goran-hc]
 
 10/10/24 8.16.0
 

--- a/libvips/foreign/dzsave.c
+++ b/libvips/foreign/dzsave.c
@@ -970,7 +970,8 @@ write_associated_images(VipsImage *image,
 {
 	VipsForeignSaveDz *dz = (VipsForeignSaveDz *) a;
 
-	if (vips_isprefix("openslide.associated.", field)) {
+	if (vips_isprefix("openslide.associated.", field) &&
+		vips_image_get_typeof(image, field) == VIPS_TYPE_IMAGE) {
 		VipsImage *associated;
 		const char *p;
 		const char *q;


### PR DESCRIPTION
openslide4 adds some new metadata items (eg.
openslide.associated.label.width) which confuse the test for associated images.

This PR adds another check to ensure only image-valued tags are written.

Test with eg.:

	vips dzsave CMU-1.svs[attach-associated] x.szi

unzip the SZI and verify that the associated images are correct:

	$ unzip -qq ../x.szi
	$ ls x/associated_images/
	label.jpg  macro.jpg  thumbnail.jpg

Thanks to @goran-hc

See https://github.com/libvips/libvips/issues/4278