### PR TITLE
CI: macOS runners no longer include deprecated pkg-config

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -54,7 +54,6 @@ jobs:
         if: runner.os == 'macOS'
         run: |
           pip3 install meson --break-system-packages
-          brew unlink pkg-config@0.29.2
           brew install \
             ninja pkgconf \
             cfitsio cgif fftw fontconfig glib \


### PR DESCRIPTION
See https://github.com/actions/runner-images/pull/11015

Relates to https://github.com/libvips/libvips/pull/4285