### PR TITLE
heifsave: rename intrabc parameter to match upstream

### DIFF
--- a/libvips/foreign/heifsave.c
+++ b/libvips/foreign/heifsave.c
@@ -661,7 +661,7 @@ vips_foreign_save_heif_build(VipsObject *object)
 	 * helps ensure encoding time is more predictable.
 	 */
 	error = heif_encoder_set_parameter_boolean(heif->encoder,
-		"intra-block-copy", FALSE);
+		"enable-intrabc", FALSE);
 	if (error.code &&
 		error.subcode != heif_suberror_Unsupported_parameter) {
 		vips__heif_error(&error);


### PR DESCRIPTION
The previous name was not part of any published release so this isn't a breaking change.

Relates to https://github.com/libvips/libvips/pull/4284#issuecomment-2502346704

Upstream libheif commit https://github.com/strukturag/libheif/commit/8c82e2eb8b0bfa8dd0306289c2632ad31815965e
