### PR TITLE
fix alpha shift during colourspace conversion

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -9,7 +9,7 @@
 - fix SZI write with openslide4 [goran-hc]
 - heifsave: prevent use of AV1 intra block copy feature [lovell]
 - threadpool: improve cooperative downsizing [kleisauke]
-- fix alpha shift during colourspace conversions
+- fix alpha shift during colourspace conversions [frederikrosenberg]
 
 10/10/24 8.16.0
 

--- a/ChangeLog
+++ b/ChangeLog
@@ -9,6 +9,7 @@
 - fix SZI write with openslide4 [goran-hc]
 - heifsave: prevent use of AV1 intra block copy feature [lovell]
 - threadpool: improve cooperative downsizing [kleisauke]
+- fix alpha shift during colourspace conversions
 
 10/10/24 8.16.0
 

--- a/libvips/colour/colour.c
+++ b/libvips/colour/colour.c
@@ -371,6 +371,7 @@ vips_colour_build(VipsObject *object)
 			 */
 
 			if (vips_cast(extra_bands[i], &t1, out->BandFmt,
+					"shift", TRUE,
 					NULL)) {
 				g_object_unref(out);
 				return -1;


### PR DESCRIPTION
The colour functions were not shifting alpha channels, just casting them, so
operations which changed depth, like `icc_transform --depth 8` on a
16-bit image, could have an incorrectly scaled alpha.

See https://github.com/libvips/libvips/issues/4301

Thanks frederikrosenberg