### PR TITLE
tiff: add thread-safe warning/error handlers, requires libtiff 4.5.0+

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -2,6 +2,7 @@
 
 - add `keep_duplicate_frames` option to GIF save [dloebl]
 - add Magic Kernel support [akimon658]
+- tiff: add threadsafe warning/error handlers (requires libtiff 4.5.0+) [lovell]
 
 8.16.1
 

--- a/libvips/foreign/tiff.c
+++ b/libvips/foreign/tiff.c
@@ -59,6 +59,11 @@
 
 #include "tiff.h"
 
+#ifdef HAVE_TIFF_OPEN_OPTIONS
+void
+vips__tiff_init(void) {}
+#else
+
 /* Handle TIFF errors here. Shared with vips2tiff.c. These can be called from
  * more than one thread.
  */
@@ -89,6 +94,7 @@ vips__tiff_init(void)
 	TIFFSetErrorHandler(vips__thandler_error);
 	TIFFSetWarningHandler(vips__thandler_warning);
 }
+#endif /*HAVE_TIFF_OPEN_OPTIONS*/
 
 /* TIFF input from a vips source.
  */
@@ -157,7 +163,8 @@ openin_source_unmap(thandle_t st, tdata_t start, toff_t len)
 }
 
 TIFF *
-vips__tiff_openin_source(VipsSource *source)
+vips__tiff_openin_source(VipsSource *source, VipsTiffErrorHandler error_fn,
+	VipsTiffErrorHandler warning_fn, void *user_data)
 {
 	TIFF *tiff;
 
@@ -175,6 +182,28 @@ vips__tiff_openin_source(VipsSource *source)
 	 * chopped into c. 8kb chunks. This can reduce peak memory use for
 	 * this type of file.
 	 */
+
+#ifdef HAVE_TIFF_OPEN_OPTIONS
+	TIFFOpenOptions *opts = TIFFOpenOptionsAlloc();
+	TIFFOpenOptionsSetErrorHandlerExtR(opts, error_fn, user_data);
+	TIFFOpenOptionsSetWarningHandlerExtR(opts, warning_fn, user_data);
+	if (!(tiff = TIFFClientOpenExt("source input", "rmC",
+			  (thandle_t) source,
+			  openin_source_read,
+			  openin_source_write,
+			  openin_source_seek,
+			  openin_source_close,
+			  openin_source_length,
+			  openin_source_map,
+			  openin_source_unmap,
+			  opts))) {
+	    TIFFOpenOptionsFree(opts);
+		vips_error("vips__tiff_openin_source", "%s",
+			_("unable to open source for input"));
+		return NULL;
+	}
+	TIFFOpenOptionsFree(opts);
+#else
 	if (!(tiff = TIFFClientOpen("source input", "rmC",
 			  (thandle_t) source,
 			  openin_source_read,
@@ -188,6 +217,7 @@ vips__tiff_openin_source(VipsSource *source)
 			_("unable to open source for input"));
 		return NULL;
 	}
+#endif /*HAVE_TIFF_OPEN_OPTIONS*/
 
 	/* Unreffed on close(), see above.
 	 */
@@ -264,7 +294,9 @@ openout_target_unmap(thandle_t st, tdata_t start, toff_t len)
 }
 
 TIFF *
-vips__tiff_openout_target(VipsTarget *target, gboolean bigtiff)
+vips__tiff_openout_target(VipsTarget *target, gboolean bigtiff,
+	VipsTiffErrorHandler error_fn, VipsTiffErrorHandler warning_fn,
+	void *user_data)
 {
 	const char *mode = bigtiff ? "w8" : "w";
 
@@ -274,6 +306,27 @@ vips__tiff_openout_target(VipsTarget *target, gboolean bigtiff)
 	printf("vips__tiff_openout_buffer:\n");
 #endif /*DEBUG*/
 
+#ifdef HAVE_TIFF_OPEN_OPTIONS
+	TIFFOpenOptions *opts = TIFFOpenOptionsAlloc();
+	TIFFOpenOptionsSetErrorHandlerExtR(opts, error_fn, user_data);
+	TIFFOpenOptionsSetWarningHandlerExtR(opts, warning_fn, user_data);
+	if (!(tiff = TIFFClientOpenExt("target output", mode,
+			  (thandle_t) target,
+			  openout_target_read,
+			  openout_target_write,
+			  openout_target_seek,
+			  openout_target_close,
+			  openout_target_length,
+			  openout_target_map,
+			  openout_target_unmap,
+			  opts))) {
+		TIFFOpenOptionsFree(opts);
+		vips_error("vips__tiff_openout_target", "%s",
+			_("unable to open target for output"));
+		return NULL;
+	}
+	TIFFOpenOptionsFree(opts);
+#else
 	if (!(tiff = TIFFClientOpen("target output", mode,
 			  (thandle_t) target,
 			  openout_target_read,
@@ -287,6 +340,7 @@ vips__tiff_openout_target(VipsTarget *target, gboolean bigtiff)
 			_("unable to open target for output"));
 		return NULL;
 	}
+#endif /*HAVE_TIFF_OPEN_OPTIONS*/
 
 	return tiff;
 }

--- a/libvips/foreign/tiff.h
+++ b/libvips/foreign/tiff.h
@@ -37,10 +37,17 @@
 extern "C" {
 #endif /*__cplusplus*/
 
-TIFF *vips__tiff_openin_source(VipsSource *source);
+typedef int (*VipsTiffErrorHandler)(TIFF *tiff, void* user_data,
+	const char *module, const char *fmt, va_list ap);
+
+TIFF *vips__tiff_openin_source(VipsSource *source,
+	VipsTiffErrorHandler error_fn, VipsTiffErrorHandler warning_fn,
+	void *user_data);
 
 TIFF *vips__tiff_openout(const char *path, gboolean bigtiff);
-TIFF *vips__tiff_openout_target(VipsTarget *target, gboolean bigtiff);
+TIFF *vips__tiff_openout_target(VipsTarget *target, gboolean bigtiff,
+	VipsTiffErrorHandler error_fn, VipsTiffErrorHandler warning_fn,
+	void *user_data);
 
 #ifdef __cplusplus
 }

--- a/libvips/foreign/tiffload.c
+++ b/libvips/foreign/tiffload.c
@@ -215,6 +215,7 @@ vips_foreign_load_tiff_class_init(VipsForeignLoadTiffClass *class)
 		VIPS_ARGUMENT_OPTIONAL_INPUT,
 		G_STRUCT_OFFSET(VipsForeignLoadTiff, subifd),
 		-1, 100000, -1);
+
 }
 
 static void
@@ -470,6 +471,7 @@ vips_foreign_load_tiff_buffer_init(VipsForeignLoadTiffBuffer *buffer)
  * * @autorotate: %gboolean, use orientation tag to rotate the image
  *   during load
  * * @subifd: %gint, select this subifd index
+ * * @fail_on: #VipsFailOn, types of read error to fail on
  *
  * Read a TIFF file into a VIPS image. It is a full baseline TIFF 6 reader,
  * with extensions for tiled images, multipage images, XYZ and LAB colour
@@ -501,6 +503,9 @@ vips_foreign_load_tiff_buffer_init(VipsForeignLoadTiffBuffer *buffer)
  * If it is 0 or greater and there is a SUBIFD tag, the indexed SUBIFD is
  * selected. This can be used to read lower resolution layers from
  * bioformats-style image pyramids.
+ *
+ * Use @fail_on to set the type of error that will cause load to fail. By
+ * default, loaders are permissive, that is, #VIPS_FAIL_ON_NONE.
  *
  * Any ICC profile is read and attached to the VIPS image as
  * #VIPS_META_ICC_NAME. Any XMP metadata is read and attached to the image
@@ -540,6 +545,7 @@ vips_tiffload(const char *filename, VipsImage **out, ...)
  * * @autorotate: %gboolean, use orientation tag to rotate the image
  *   during load
  * * @subifd: %gint, select this subifd index
+ * * @fail_on: #VipsFailOn, types of read error to fail on
  *
  * Read a TIFF-formatted memory block into a VIPS image. Exactly as
  * vips_tiffload(), but read from a memory source.
@@ -584,6 +590,7 @@ vips_tiffload_buffer(void *buf, size_t len, VipsImage **out, ...)
  * * @autorotate: %gboolean, use orientation tag to rotate the image
  *   during load
  * * @subifd: %gint, select this subifd index
+ * * @fail_on: #VipsFailOn, types of read error to fail on
  *
  * Exactly as vips_tiffload(), but read from a source.
  *

--- a/meson.build
+++ b/meson.build
@@ -414,6 +414,10 @@ if libtiff_dep.found()
     if cc.get_define('COMPRESSION_WEBP', prefix: '#include <tiff.h>', dependencies: libtiff_dep) != ''
         cfg_var.set('HAVE_TIFF_COMPRESSION_WEBP', '1')
     endif
+    # TIFFOpenOptions added in libtiff 4.5.0
+    if cc.has_function('TIFFOpenOptionsAlloc', prefix: '#include <tiffio.h>', dependencies: libtiff_dep)
+        cfg_var.set('HAVE_TIFF_OPEN_OPTIONS', '1')
+    endif
 endif
 
 # 2.40.3 so we get the UNLIMITED open flag

--- a/test/test-suite/test_foreign.py
+++ b/test/test-suite/test_foreign.py
@@ -662,6 +662,15 @@ class TestForeign:
         assert x1.xres == 100
         assert x1.yres == 200
 
+        if sys.platform == "darwin":
+            with open(TIF2_FILE, 'rb') as f:
+                buf = bytearray(f.read())
+            buf = buf[:-4]
+            source = pyvips.Source.new_from_memory(buf)
+            im = pyvips.Image.tiffload_source(source, fail_on="warning")
+            with pytest.raises(Exception) as e_info:
+                im.avg() > 0
+
         # OME support in 8.5
         x = pyvips.Image.new_from_file(OME_FILE)
         assert x.width == 439


### PR DESCRIPTION
Adds a compile-time test for libtiff `OpenOptions` feature, when present sets the use of new, re-entrant error and warning handlers.

Defining these (and having them `return 1`) prevents the default behaviour of libtiff to call global, not thread-safe handlers shared between all users.

The handlers also support user data, so `tiffload` can now start to respect the `fail_on` option. Homebrew currently provides libtiff 4.7.0 so we can test for this on macOS.

I also investigated the various new memory limit safety features of `OpenOptions` discussed in https://github.com/libvips/libvips/discussions/3892 but these only cover libtiff allocations e.g. parsing headers, and exclude allocations in its dependencies. Newer versions of libtiff already introduce more sanity checks around these anyway so the example from https://issues.oss-fuzz.com/issues/42531230 no longer fails.

~~This PR targets the 8.16 branch as it fixes a long-standing potential thread-safety issue with libtiff. I guess this might be considered a breaking change only if someone is currently setting `fail_on=warning` but expecting it not to.~~