### PR TITLE
heifsave: set image orientation using irot and imir transformations

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -10,6 +10,7 @@
 - heifsave: prevent use of AV1 intra block copy feature [lovell]
 - threadpool: improve cooperative downsizing [kleisauke]
 - fix alpha shift during colourspace conversions [frederikrosenberg]
+- heifsave: set image orientation using irot and imir transformations [lovell]
 
 10/10/24 8.16.0
 

--- a/libvips/foreign/heifsave.c
+++ b/libvips/foreign/heifsave.c
@@ -311,6 +311,14 @@ vips_foreign_save_heif_write_page(VipsForeignSaveHeif *heif, int page)
 	}
 #endif /*HAVE_HEIF_ENCODING_OPTIONS_OUTPUT_NCLX_PROFILE*/
 
+#ifdef HAVE_HEIF_ENCODING_OPTIONS_IMAGE_ORIENTATION
+	/* EXIF orientation is informational in the HEIF specification.
+	 * Orientation is defined using irot and imir transformations.
+	 */
+	options->image_orientation = vips_image_get_orientation(save->ready);
+	vips_autorot_remove_angle(save->ready);
+#endif
+
 #ifdef DEBUG
 	{
 		GTimer *timer = g_timer_new();

--- a/meson.build
+++ b/meson.build
@@ -561,6 +561,10 @@ if libheif_dep.found()
     if libheif_dep.version().version_compare('>=1.13.0')
         cfg_var.set('HAVE_HEIF_INIT', '1')
     endif
+    # heif_encoding_options.image_orientation added in 1.14.0
+    if cpp.has_member('struct heif_encoding_options', 'image_orientation', prefix: '#include <libheif/heif.h>', dependencies: libheif_dep)
+        cfg_var.set('HAVE_HEIF_ENCODING_OPTIONS_IMAGE_ORIENTATION', '1')
+    endif
     # heif_error_success added in 1.17.0
     if libheif_dep.version().version_compare('>=1.17.0')
         cfg_var.set('HAVE_HEIF_ERROR_SUCCESS', '1')


### PR DESCRIPTION
There's previously been some confusion around HEIF and orientation so https://github.com/libvips/libvips/pull/1681 made the sensible decision to let libheif deal with this on the input side.

More recently, commit https://github.com/strukturag/libheif/commit/4d9f13b8e00220193dc3e0b2bcd655ca0e9fa02d has added support for a similar feature to the output side, which this PR takes advantage of.

Originally reported at https://github.com/lovell/sharp/issues/4289, which includes a sample image.

```
$ vipsheader --field=orientation in.jpg 
8
$ vips copy in.jpg out.avif
```
Before:
```
$ heif-info out.avif 
MIME type: image/avif
main brand: avif
compatible brands: avif, mif1, miaf

image: 810x1080 (id=1), primary
  colorspace: YCbCr, 4:2:0
  bit depth: 8
  color profile: rICC
  alpha channel: no 
  depth channel: no
metadata:
  Exif: 5128 bytes
transformations:
  none
region annotations:
  none
```
After:
```
$ heif-info out.avif 
MIME type: image/avif
main brand: avif
compatible brands: avif, mif1, miaf

image: 1080x810 (id=1), primary
  colorspace: YCbCr, 4:2:0
  bit depth: 8
  color profile: rICC
  alpha channel: no 
  depth channel: no
metadata:
  Exif: 5128 bytes
transformations:
  angle (ccw): 90
region annotations:
  none
```
