### PR TITLE
Fix libtiff 4.7 compat

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -10,6 +10,7 @@
 - heifsave: prevent use of AV1 intra block copy feature [lovell]
 - threadpool: improve cooperative downsizing [kleisauke]
 - fix alpha shift during colourspace conversions [frederikrosenberg]
+- improve error handling with libtiff 4.7 [CrispinStichartFNSB]
 
 10/10/24 8.16.0
 

--- a/libvips/foreign/tiff2vips.c
+++ b/libvips/foreign/tiff2vips.c
@@ -686,11 +686,10 @@ rtiff_strip_read(Rtiff *rtiff, int strip, tdata_t buf)
 		length = TIFFReadEncodedStrip(rtiff->tiff,
 			strip, buf, (tsize_t) -1);
 
-	if (length == -1) {
-		vips_foreign_load_invalidate(rtiff->out);
-		vips_error("tiff2vips", "%s", _("read error"));
-		return -1;
-	}
+	/* We get a length == -1 return for warnings with libtiff 4.7.0, we need
+	 * to ignore it.
+	 */
+	(void) length;
 
 	return 0;
 }


### PR DESCRIPTION
libtiff 4.7 now returns -1 for some warnings
    
Don't bail out if TIFFReadScanline() and TIFFReadEncodedStrip() return -1.
libtiff 4.7.0 and maybe earlier have started returning error values for
truncated strips.
    
Maybe other API points now return error codes for warnings too?
    
see https://github.com/libvips/libvips/issues/4317
