### PR TITLE
tiffload: add support for unlimited flag, requires libtiff 4.7.0+

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -3,6 +3,7 @@
 - add `keep_duplicate_frames` option to GIF save [dloebl]
 - add Magic Kernel support [akimon658]
 - tiff: add threadsafe warning/error handlers (requires libtiff 4.5.0+) [lovell]
+- tiffload: add support for unlimited flag (requires libtiff 4.7.0+) [lovell]
 
 8.16.1
 

--- a/libvips/deprecated/im_tiff2vips.c
+++ b/libvips/deprecated/im_tiff2vips.c
@@ -75,7 +75,7 @@ im_tiff_read_header(const char *filename, VipsImage *out,
 	if (!(source = vips_source_new_from_file(filename)))
 		return -1;
 	if (vips__tiff_read_header_source(source, out,
-			page, n, autorotate, -1, VIPS_FAIL_ON_ERROR)) {
+			page, n, autorotate, -1, VIPS_FAIL_ON_ERROR, TRUE)) {
 		VIPS_UNREF(source);
 		return -1;
 	}
@@ -93,7 +93,7 @@ im_tiff_read(const char *filename, VipsImage *out,
 	if (!(source = vips_source_new_from_file(filename)))
 		return -1;
 	if (vips__tiff_read_source(source, out,
-			page, n, autorotate, -1, VIPS_FAIL_ON_ERROR)) {
+			page, n, autorotate, -1, VIPS_FAIL_ON_ERROR, TRUE)) {
 		VIPS_UNREF(source);
 		return -1;
 	}

--- a/libvips/foreign/pforeign.h
+++ b/libvips/foreign/pforeign.h
@@ -67,9 +67,11 @@ int vips__tiff_write_target(VipsImage *in, VipsTarget *target,
 gboolean vips__istiff_source(VipsSource *source);
 gboolean vips__istifftiled_source(VipsSource *source);
 int vips__tiff_read_header_source(VipsSource *source, VipsImage *out,
-	int page, int n, gboolean autorotate, int subifd, VipsFailOn fail_on);
+	int page, int n, gboolean autorotate, int subifd, VipsFailOn fail_on,
+	gboolean unlimited);
 int vips__tiff_read_source(VipsSource *source, VipsImage *out,
-	int page, int n, gboolean autorotate, int subifd, VipsFailOn fail_on);
+	int page, int n, gboolean autorotate, int subifd, VipsFailOn fail_on,
+	gboolean unlimited);
 
 extern const char *vips__foreign_tiff_suffs[];
 

--- a/libvips/foreign/tiff.c
+++ b/libvips/foreign/tiff.c
@@ -164,7 +164,7 @@ openin_source_unmap(thandle_t st, tdata_t start, toff_t len)
 
 TIFF *
 vips__tiff_openin_source(VipsSource *source, VipsTiffErrorHandler error_fn,
-	VipsTiffErrorHandler warning_fn, void *user_data)
+	VipsTiffErrorHandler warning_fn, void *user_data, gboolean unlimited)
 {
 	TIFF *tiff;
 
@@ -187,6 +187,11 @@ vips__tiff_openin_source(VipsSource *source, VipsTiffErrorHandler error_fn,
 	TIFFOpenOptions *opts = TIFFOpenOptionsAlloc();
 	TIFFOpenOptionsSetErrorHandlerExtR(opts, error_fn, user_data);
 	TIFFOpenOptionsSetWarningHandlerExtR(opts, warning_fn, user_data);
+#ifdef HAVE_TIFF_OPEN_OPTIONS_SET_MAX_CUMULATED_MEM_ALLOC
+	if (!unlimited) {
+		TIFFOpenOptionsSetMaxCumulatedMemAlloc(opts, 20 * 1024 * 1024);
+	}
+#endif /*HAVE_TIFF_OPEN_OPTIONS_SET_MAX_CUMULATED_MEM_ALLOC*/
 	if (!(tiff = TIFFClientOpenExt("source input", "rmC",
 			  (thandle_t) source,
 			  openin_source_read,

--- a/libvips/foreign/tiff.h
+++ b/libvips/foreign/tiff.h
@@ -42,7 +42,7 @@ typedef int (*VipsTiffErrorHandler)(TIFF *tiff, void* user_data,
 
 TIFF *vips__tiff_openin_source(VipsSource *source,
 	VipsTiffErrorHandler error_fn, VipsTiffErrorHandler warning_fn,
-	void *user_data);
+	void *user_data, gboolean unlimited);
 
 TIFF *vips__tiff_openout(const char *path, gboolean bigtiff);
 TIFF *vips__tiff_openout_target(VipsTarget *target, gboolean bigtiff,

--- a/libvips/foreign/tiff2vips.c
+++ b/libvips/foreign/tiff2vips.c
@@ -642,7 +642,8 @@ rtiff_handler_warning(TIFF *tiff, void* user_data,
 
 static Rtiff *
 rtiff_new(VipsSource *source, VipsImage *out,
-	int page, int n, gboolean autorotate, int subifd, VipsFailOn fail_on)
+	int page, int n, gboolean autorotate, int subifd, VipsFailOn fail_on,
+	gboolean unlimited)
 {
 	Rtiff *rtiff;
 
@@ -692,7 +693,7 @@ rtiff_new(VipsSource *source, VipsImage *out,
 	}
 
 	if (!(rtiff->tiff = vips__tiff_openin_source(source,
-		rtiff_handler_error, rtiff_handler_warning, rtiff)))
+		rtiff_handler_error, rtiff_handler_warning, rtiff, unlimited)))
 		return NULL;
 
 	return rtiff;
@@ -3435,7 +3436,7 @@ vips__testtiff_source(VipsSource *source, TiffPropertyFn fn)
 	vips__tiff_init();
 
 	if (!(tif = vips__tiff_openin_source(source, rtiff_handler_error,
-		rtiff_handler_warning, NULL))) {
+		rtiff_handler_warning, NULL, FALSE))) {
 		vips_error_clear();
 		return FALSE;
 	}
@@ -3461,14 +3462,15 @@ vips__istifftiled_source(VipsSource *source)
 
 int
 vips__tiff_read_header_source(VipsSource *source, VipsImage *out,
-	int page, int n, gboolean autorotate, int subifd, VipsFailOn fail_on)
+	int page, int n, gboolean autorotate, int subifd, VipsFailOn fail_on,
+	gboolean unlimited)
 {
 	Rtiff *rtiff;
 
 	vips__tiff_init();
 
 	if (!(rtiff = rtiff_new(source, out,
-			  page, n, autorotate, subifd, fail_on)) ||
+			  page, n, autorotate, subifd, fail_on, unlimited)) ||
 		rtiff_header_read_all(rtiff))
 		return -1;
 
@@ -3491,7 +3493,8 @@ vips__tiff_read_header_source(VipsSource *source, VipsImage *out,
 
 int
 vips__tiff_read_source(VipsSource *source, VipsImage *out,
-	int page, int n, gboolean autorotate, int subifd, VipsFailOn fail_on)
+	int page, int n, gboolean autorotate, int subifd, VipsFailOn fail_on,
+	gboolean unlimited)
 {
 	Rtiff *rtiff;
 
@@ -3502,7 +3505,7 @@ vips__tiff_read_source(VipsSource *source, VipsImage *out,
 	vips__tiff_init();
 
 	if (!(rtiff = rtiff_new(source, out,
-			  page, n, autorotate, subifd, fail_on)) ||
+			  page, n, autorotate, subifd, fail_on, unlimited)) ||
 		rtiff_header_read_all(rtiff))
 		return -1;
 

--- a/libvips/foreign/tiffload.c
+++ b/libvips/foreign/tiffload.c
@@ -77,6 +77,10 @@ typedef struct _VipsForeignLoadTiff {
 	 */
 	gboolean autorotate;
 
+	/* Remove denial of service limits.
+	 */
+	gboolean unlimited;
+
 } VipsForeignLoadTiff;
 
 typedef VipsForeignLoadClass VipsForeignLoadTiffClass;
@@ -137,7 +141,7 @@ vips_foreign_load_tiff_header(VipsForeignLoad *load)
 
 	if (vips__tiff_read_header_source(tiff->source, load->out,
 			tiff->page, tiff->n, tiff->autorotate, tiff->subifd,
-			load->fail_on))
+			load->fail_on, tiff->unlimited))
 		return -1;
 
 	return 0;
@@ -150,7 +154,7 @@ vips_foreign_load_tiff_load(VipsForeignLoad *load)
 
 	if (vips__tiff_read_source(tiff->source, load->real,
 			tiff->page, tiff->n, tiff->autorotate, tiff->subifd,
-			load->fail_on))
+			load->fail_on, tiff->unlimited))
 		return -1;
 
 	return 0;
@@ -209,13 +213,21 @@ vips_foreign_load_tiff_class_init(VipsForeignLoadTiffClass *class)
 		G_STRUCT_OFFSET(VipsForeignLoadTiff, autorotate),
 		FALSE);
 
-	VIPS_ARG_INT(class, "subifd", 21,
+	VIPS_ARG_INT(class, "subifd", 23,
 		_("subifd"),
 		_("Subifd index"),
 		VIPS_ARGUMENT_OPTIONAL_INPUT,
 		G_STRUCT_OFFSET(VipsForeignLoadTiff, subifd),
 		-1, 100000, -1);
 
+#ifndef FUZZING_BUILD_MODE_UNSAFE_FOR_PRODUCTION
+	VIPS_ARG_BOOL(class, "unlimited", 24,
+		_("Unlimited"),
+		_("Remove all denial of service limits"),
+		VIPS_ARGUMENT_OPTIONAL_INPUT,
+		G_STRUCT_OFFSET(VipsForeignLoadTiff, unlimited),
+		FALSE);
+#endif
 }
 
 static void
@@ -224,6 +236,7 @@ vips_foreign_load_tiff_init(VipsForeignLoadTiff *tiff)
 	tiff->page = 0;
 	tiff->n = 1;
 	tiff->subifd = -1;
+	tiff->unlimited = FALSE;
 }
 
 typedef struct _VipsForeignLoadTiffSource {
@@ -472,6 +485,7 @@ vips_foreign_load_tiff_buffer_init(VipsForeignLoadTiffBuffer *buffer)
  *   during load
  * * @subifd: %gint, select this subifd index
  * * @fail_on: #VipsFailOn, types of read error to fail on
+ * * @unlimited: %gboolean, remove all denial of service limits
  *
  * Read a TIFF file into a VIPS image. It is a full baseline TIFF 6 reader,
  * with extensions for tiled images, multipage images, XYZ and LAB colour
@@ -506,6 +520,10 @@ vips_foreign_load_tiff_buffer_init(VipsForeignLoadTiffBuffer *buffer)
  *
  * Use @fail_on to set the type of error that will cause load to fail. By
  * default, loaders are permissive, that is, #VIPS_FAIL_ON_NONE.
+ *
+ * When using libtiff 4.7.0+, the TIFF loader will limit memory allocation
+ * for tag processing to 20MB to prevent denial of service attacks.
+ * Set @unlimited to remove this limit.
  *
  * Any ICC profile is read and attached to the VIPS image as
  * #VIPS_META_ICC_NAME. Any XMP metadata is read and attached to the image
@@ -546,6 +564,7 @@ vips_tiffload(const char *filename, VipsImage **out, ...)
  *   during load
  * * @subifd: %gint, select this subifd index
  * * @fail_on: #VipsFailOn, types of read error to fail on
+ * * @unlimited: %gboolean, remove all denial of service limits
  *
  * Read a TIFF-formatted memory block into a VIPS image. Exactly as
  * vips_tiffload(), but read from a memory source.
@@ -591,6 +610,7 @@ vips_tiffload_buffer(void *buf, size_t len, VipsImage **out, ...)
  *   during load
  * * @subifd: %gint, select this subifd index
  * * @fail_on: #VipsFailOn, types of read error to fail on
+ * * @unlimited: %gboolean, remove all denial of service limits
  *
  * Exactly as vips_tiffload(), but read from a source.
  *

--- a/libvips/foreign/vips2tiff.c
+++ b/libvips/foreign/vips2tiff.c
@@ -2419,7 +2419,7 @@ wtiff_gather(Wtiff *wtiff)
 				return -1;
 
 			if (!(in = vips__tiff_openin_source(source, wtiff_handler_error,
-				wtiff_handler_warning, NULL))) {
+				wtiff_handler_warning, NULL, FALSE))) {
 				VIPS_UNREF(source);
 				return -1;
 			}

--- a/meson.build
+++ b/meson.build
@@ -418,6 +418,10 @@ if libtiff_dep.found()
     if cc.has_function('TIFFOpenOptionsAlloc', prefix: '#include <tiffio.h>', dependencies: libtiff_dep)
         cfg_var.set('HAVE_TIFF_OPEN_OPTIONS', '1')
     endif
+    # TIFFOpenOptionsSetMaxCumulatedMemAlloc added in libtiff 4.7.0
+    if cc.has_function('TIFFOpenOptionsSetMaxCumulatedMemAlloc', prefix: '#include <tiffio.h>', dependencies: libtiff_dep)
+        cfg_var.set('HAVE_TIFF_OPEN_OPTIONS_SET_MAX_CUMULATED_MEM_ALLOC', '1')
+    endif
 endif
 
 # 2.40.3 so we get the UNLIMITED open flag


### PR DESCRIPTION
Adds a default limit of 20MB for total maximum ("cumulated") memory allocation during tag processing, which should be enough for hundreds if not thousands of tags. I could easily be persuaded to reduce this default limit.

Given libtiff is rather over-zealous in the number of times it reallocates memory, an image containing many thousands of tags can quickly lead to fragmentation. Attempting to process the <1MB sample image at https://issues.oss-fuzz.com/issues/42531230 *with* this memory limitation in place still results in an RSS of ~1GB (the OSS Fuzz issue should auto-close after this PR is merged).

Builds on https://github.com/libvips/libvips/pull/4313 and implements https://github.com/libvips/libvips/discussions/3892 for inclusion in 8.17.