### PR TITLE
Fix divide by zero in xyz2yxy

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -11,6 +11,7 @@
 - threadpool: improve cooperative downsizing [kleisauke]
 - fix alpha shift during colourspace conversions [frederikrosenberg]
 - heifsave: set image orientation using irot and imir transformations [lovell]
+- XYZ2Yxy: guard against divide by zero
 
 10/10/24 8.16.0
 

--- a/libvips/colour/XYZ2Yxy.c
+++ b/libvips/colour/XYZ2Yxy.c
@@ -72,8 +72,14 @@ vips_XYZ2Yxy_line(VipsColour *colour, VipsPel *out, VipsPel **in, int width)
 
 		p += 3;
 
-		x = X / total;
-		y = Y / total;
+		if (total == 0.0) {
+			x = 0;
+			y = 0;
+		}
+		else {
+			x = X / total;
+			y = Y / total;
+		}
 
 		q[0] = Y;
 		q[1] = x;


### PR DESCRIPTION
Before this PR, converting to Yxy could leave -nan in pixels, eg.:

	$ vips colourspace k2.jpg x.v yxy
	$ vips avg x.v

	(vips:231364): GLib-GObject-CRITICAL **: 16:02:54.674: value "-nan" of type 'gdouble' is invalid or out of range for property 'out' of type 'gdouble'
	avg: parameter out not set

This PR adds a check for 0 before divide.