### PR TITLE
Replace carrierwave-vips with CarrierWave in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ libvips is used as an image processing engine by:
 | [bimg](https://github.com/h2non/bimg) |
 | [sharp for Go](https://github.com/DAddYE/vips) |
 | [Ruby on Rails](https://edgeguides.rubyonrails.org/active_storage_overview.html) |
-| [carrierwave-vips](https://github.com/eltiare/carrierwave-vips) |
+| [CarrierWave](https://github.com/carrierwaveuploader/carrierwave#using-vips) |
 | [mediawiki](https://www.mediawiki.org/wiki/Extension:VipsScaler) |
 | [PhotoFlow](https://github.com/aferrero2707/PhotoFlow) |
 | [JVips](https://github.com/criteo/JVips) |


### PR DESCRIPTION
`carrierwave-vips` has not been updated in over 5 years, so its usage is not recommended.
However, [`CarrierWave` now supports a method to directly integrate with `libvips`](https://github.com/carrierwaveuploader/carrierwave#using-vips).
Therefore, I replaced `carrierwave-vips` with `CarrierWave` in README.md.