### PR TITLE
tiffload: use fail_on to determine outcome of scanline read fail

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -3,6 +3,7 @@
 - add `keep_duplicate_frames` option to GIF save [dloebl]
 - add Magic Kernel support [akimon658]
 - tiff: add threadsafe warning/error handlers (requires libtiff 4.5.0+) [lovell]
+- tiffload: add support for fail_on flag [lovell]
 - tiffload: add support for unlimited flag (requires libtiff 4.7.0+) [lovell]
 
 8.16.1

--- a/libvips/foreign/tiff2vips.c
+++ b/libvips/foreign/tiff2vips.c
@@ -713,7 +713,7 @@ rtiff_strip_read(Rtiff *rtiff, int strip, tdata_t buf)
 	else
 		length = TIFFReadEncodedStrip(rtiff->tiff, strip, buf, (tsize_t) -1);
 
-	if (length == -1) {
+	if (length == -1 && rtiff->fail_on >= VIPS_FAIL_ON_WARNING) {
 		vips_foreign_load_invalidate(rtiff->out);
 		vips_error("tiff2vips", "%s", _("read error"));
 		return -1;
@@ -2316,7 +2316,7 @@ rtiff_read_tile(RtiffSeq *seq, tdata_t *buf, int page, int x, int y)
 
 		size = TIFFReadRawTile(rtiff->tiff, tile_no,
 			seq->compressed_buf, seq->compressed_buf_length);
-		if (size <= 0) {
+		if (size <= 0 && rtiff->fail_on >= VIPS_FAIL_ON_WARNING) {
 			vips_foreign_load_invalidate(rtiff->out);
 			g_rec_mutex_unlock(&rtiff->lock);
 			return -1;
@@ -2344,7 +2344,7 @@ rtiff_read_tile(RtiffSeq *seq, tdata_t *buf, int page, int x, int y)
 			result = rtiff_read_rgba_tile(rtiff, x, y, buf);
 		else
 			result = TIFFReadTile(rtiff->tiff, buf, x, y, 0, 0) < 0;
-		if (result) {
+		if (result && rtiff->fail_on >= VIPS_FAIL_ON_WARNING) {
 			vips_foreign_load_invalidate(rtiff->out);
 			g_rec_mutex_unlock(&rtiff->lock);
 			return -1;


### PR DESCRIPTION
As discussed in https://github.com/libvips/libvips/issues/4324

I also added a changelog note about the previously-added `fail_on` flag.

Tested with the sample image in https://github.com/libvips/libvips/issues/4317

Before:
```
$ vips avg error_tiff.tif 
...
(vips:183630): tiff2vips-WARNING **: 10:18:21.846: Premature EOL at line 7212 of strip 0 (got 0, expected 9600)
vips:183630): VIPS-WARNING **: 10:18:21.846: error in tile 0 x 7200
tiff2vips: read error
```
After:
```
$ vips avg error_tiff.tif 
...
(vips:185249): tiff2vips-WARNING **: 10:22:38.083: Premature EOF at line 7212 of strip 0 (x 0)
(vips:185249): tiff2vips-WARNING **: 10:22:38.083: Premature EOL at line 7212 of strip 0 (got 0, expected 9600)
233.888096
```
```
$ vips avg error_tiff.tif[fail_on=warning] 
...
(vips:187702): tiff2vips-WARNING **: 10:31:29.109: ASCII value for tag "Software" contains null byte in value; value incorrectly truncated during reading due to implementation limitations
(vips:187702): VIPS-WARNING **: 10:31:29.109: error in tile 0 x 0
```