### PR TITLE
workaround C2124 error on MSVC

### DIFF
--- a/libvips/arithmetic/complex.c
+++ b/libvips/arithmetic/complex.c
@@ -455,7 +455,8 @@ G_DEFINE_TYPE(VipsComplex2, vips_complex2, VIPS_TYPE_BINARY);
 			Q[1] = 0.0; \
 		} \
 		else if (ABS(Y1) > ABS(Y2)) { \
-			double a = Y2 / Y1; \
+			double y1 = Y1; /* this suppress C2142 (division by zero) error on MSVC */ \
+			double a = Y2 / y1; \
 			double b = Y1 + Y2 * a; \
 			double re = (X1 + X2 * a) / b; \
 			double im = (X2 - X1 * a) / b; \
@@ -465,7 +466,8 @@ G_DEFINE_TYPE(VipsComplex2, vips_complex2, VIPS_TYPE_BINARY);
 			Q[1] = im / mod; \
 		} \
 		else { \
-			double a = Y1 / Y2; \
+			double y2 = Y2; \
+			double a = Y1 / y2; \
 			double b = Y2 + Y1 * a; \
 			double re = (X1 * a + X2) / b; \
 			double im = (X2 * a - X1) / b; \

--- a/libvips/arithmetic/complex.c
+++ b/libvips/arithmetic/complex.c
@@ -449,7 +449,8 @@ G_DEFINE_TYPE(VipsComplex2, vips_complex2, VIPS_TYPE_BINARY);
 #define CROSS(Q, X1, Y1, X2, Y2) \
 	{ \
 		if (((X1) == 0.0 && (Y1) == 0.0) || \
-			((X2) == 0.0 && (Y2) == 0.0)) { \
+			((X2) == 0.0 && (Y2) == 0.0) || \
+			((Y1) == 0.0 && (Y2) == 0.0)) { \
 			Q[0] = 0.0; \
 			Q[1] = 0.0; \
 		} \


### PR DESCRIPTION
fix #4330.

* Fix cross-phase operation when Y1 == 0 and Y2 == 0.
* Workaround to stop MSVC raising C2124 error. By putting Y1 and Y2 values into variable first, MSVC compiler somehow no longer finds division by zero.