### PR TITLE
Fix null pointer dereference

### DIFF
--- a/libvips/foreign/foreign.c
+++ b/libvips/foreign/foreign.c
@@ -1956,8 +1956,10 @@ vips_foreign_find_save_sub(VipsForeignSaveClass *save_class,
 	/* All savers needs suffs defined since we use the suff to pick the
 	 * saver.
 	 */
-	if (!class->suffs)
+	if (!class->suffs) {
 		g_warning("no suffix defined for %s", object_class->nickname);
+		return NULL;
+	}
 
 	/* Skip non-file savers.
 	 */


### PR DESCRIPTION
The pointer ```class->suffs``` is dereferenced later in the function.
```
for (p = class->suffs; *p; p++)
	if (vips_iscasepostfix(filename, *p))
		return save_class;
```

I added ```return NULL``` to prevent NULL dereference.