### PR TITLE
exif: ensure enum entries can be converted to string

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -13,6 +13,7 @@
 - heifsave: set image orientation using irot and imir transformations [lovell]
 - XYZ2Yxy: guard against divide by zero
 - fix MSVC compile error [na-trium-144]
+- exif: ensure enumerated entries can to converted to string values [lovell]
 
 10/10/24 8.16.0
 

--- a/libvips/foreign/exif.c
+++ b/libvips/foreign/exif.c
@@ -86,7 +86,7 @@ entry_to_s(ExifEntry *entry)
 	 * for formats like float. Ban crazy size values.
 	 */
 	int size = VIPS_MIN(entry->size, 10000);
-	int max_size = size * 5;
+	int max_size = size * 3 + 32;
 	char *text = VIPS_MALLOC(NULL, max_size + 1);
 
 	// this renders floats as eg. "12.2345", enums as "Inch", etc.


### PR DESCRIPTION
Enumerated EXIF entries are often 1 byte in length but when represented as a string are up to around 30 chars in length.

This PR ensures support for this fairly common case by, when calculating the maximum length of the string, reducing the multiplier and adding a constant.

Fixes https://github.com/libvips/libvips/issues/4336 and also tested with the original image from https://github.com/libvips/libvips/issues/3857

Before:
```
exif-ifd2-SceneType: Dire (Dire, Undefined, 1 components, 1 bytes)
exif-ifd3-GPSAltitudeRef: Sea  (Sea , Byte, 1 components, 1 bytes)
```
After:
```
exif-ifd2-SceneType: Directly photographed (Directly photographed, Undefined, 1 components, 1 bytes)
exif-ifd3-GPSAltitudeRef: Sea level (Sea level, Byte, 1 components, 1 bytes)
```