### PR TITLE
tiffload: respect TIFFReadRawTile return code

### DIFF
--- a/libvips/foreign/tiff2vips.c
+++ b/libvips/foreign/tiff2vips.c
@@ -2316,7 +2316,7 @@ rtiff_read_tile(RtiffSeq *seq, tdata_t *buf, int page, int x, int y)
 
 		size = TIFFReadRawTile(rtiff->tiff, tile_no,
 			seq->compressed_buf, seq->compressed_buf_length);
-		if (size <= 0 && rtiff->fail_on >= VIPS_FAIL_ON_WARNING) {
+		if (size <= 0) {
 			vips_foreign_load_invalidate(rtiff->out);
 			g_rec_mutex_unlock(&rtiff->lock);
 			return -1;


### PR DESCRIPTION
It's too dangerous to ignore a `-1` return code from `TIFFReadRawTile` as we're responsible for decoding the data.

Partially reverts commit 7b47b07

Found by https://issues.oss-fuzz.com/issues/387317434