### PR TITLE
gifsave: ensure return code is propagated

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -14,6 +14,7 @@
 - XYZ2Yxy: guard against divide by zero
 - fix MSVC compile error [na-trium-144]
 - exif: ensure enumerated entries can to converted to string values [lovell]
+- gifsave: add support for eval callback, ensure correct return code [lovell]
 
 10/10/24 8.16.0
 

--- a/libvips/foreign/cgifsave.c
+++ b/libvips/foreign/cgifsave.c
@@ -48,6 +48,7 @@
 #include <string.h>
 
 #include <vips/vips.h>
+#include <vips/internal.h>
 
 #include "pforeign.h"
 #include "quantise.h"
@@ -588,6 +589,12 @@ vips_foreign_save_cgif_write_frame(VipsForeignSaveCgif *cgif)
 	}
 
 	VIPS_FREEF(vips__quantise_image_destroy, image);
+
+	/* Remapping is relatively slow, trigger eval callbacks.
+	 */
+	vips_image_eval(cgif->in, n_pels);
+	if (vips_image_iskilled(cgif->in))
+		return -1;
 
 	/* Set up cgif on first use.
 	 */

--- a/libvips/iofuncs/sinkdisc.c
+++ b/libvips/iofuncs/sinkdisc.c
@@ -533,6 +533,10 @@ vips_sink_disc(VipsImage *im, VipsRegionWrite write_fn, void *a)
 
 	vips_image_posteval(im);
 
+	/* The final write might have failed, pick up any error code.
+	 */
+	result |= write.buf->write_errno;
+
 	write_free(&write);
 
 	vips_image_minimise_all(im);

--- a/test/meson.build
+++ b/test/meson.build
@@ -89,3 +89,14 @@ test('webpsave_timeout',
     depends: test_timeout_webpsave,
     workdir: meson.current_build_dir(),
 )
+
+test_timeout_gifsave = executable('test_timeout_gifsave',
+    'test_timeout_gifsave.c',
+    dependencies: libvips_dep,
+)
+
+test('gifsave_timeout',
+    test_timeout_gifsave,
+    depends: test_timeout_gifsave,
+    workdir: meson.current_build_dir(),
+)

--- a/test/test_timeout_gifsave.c
+++ b/test/test_timeout_gifsave.c
@@ -1,0 +1,49 @@
+#include <vips/vips.h>
+
+#define TIMEOUT_SECONDS 2
+
+static void
+eval_callback(VipsImage *image, VipsProgress *progress, gboolean *is_killed)
+{
+	if (progress->run >= TIMEOUT_SECONDS) {
+		*is_killed = TRUE;
+		vips_image_set_kill(image, TRUE);
+	}
+}
+
+int
+main(int argc, char **argv)
+{
+	VipsImage *im;
+	void *buf;
+	size_t len;
+	gboolean is_killed = FALSE;
+	int ret;
+
+	if (VIPS_INIT(argv[0]))
+		vips_error_exit(NULL);
+
+	if (!vips_type_find("VipsOperation", "gifsave"))
+		/* gifsave not available, skip test with return code 77.
+		 */
+		return 77;
+
+	if (vips_gaussnoise(&im, 8192, 8192, NULL))
+		vips_error_exit(NULL);
+
+	vips_image_set_progress(im, TRUE);
+	g_signal_connect(im, "eval",
+		G_CALLBACK(eval_callback), &is_killed);
+
+	buf = NULL;
+	ret = vips_gifsave_buffer(im, &buf, &len, NULL);
+	if (!ret)
+		printf("expected error return from vips_gifsave_buffer()\n");
+
+	g_object_unref(im);
+	if (buf)
+		g_free(buf);
+	g_assert(is_killed);
+
+	return !ret;
+}


### PR DESCRIPTION
Whilst investigating https://github.com/lovell/sharp/issues/4257 I discovered that `vips_sink_disc` appears to always return zero during `vips_foreign_save_cgif_build` even when `vips_foreign_save_cgif_sink_disc` returns a non-zero return code. It feels like a bit of a race condition, and I think this is because we need to have the entire input in memory before the CPU-intensive quantisation takes place.

This PR adds a new `aborted` property to track any non-zero return code, which then allows for things like an `eval` callback. The call to `vips_image_eval` occurs for each frame just after the image is remapped to the new palette as this is the most CPU-intensive section. I'd be happy to move the `vips_image_eval` call to a different location if required, or perhaps it might be better to add multiple calls given the CPU-intensive nature of quantisation as a whole.