### PR TITLE
colour: use suggested rendering intent as fallback

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -17,6 +17,7 @@
 - gifsave: add support for eval callback, ensure correct return code [lovell]
 - tiffsave: honor disc threshold during pyramid save [kleisauke]
 - fill_nearest: fix a leak
+- colour: use suggested rendering intent as fallback [kleisauke]
 
 10/10/24 8.16.0
 

--- a/libvips/include/vips/colour.h
+++ b/libvips/include/vips/colour.h
@@ -93,6 +93,8 @@ extern "C" {
 #define VIPS_D3250_Y0 (100.0)
 #define VIPS_D3250_Z0 (45.8501)
 
+/* Note: constants align with those defined in lcms2.h.
+ */
 typedef enum {
 	VIPS_INTENT_PERCEPTUAL = 0,
 	VIPS_INTENT_RELATIVE,

--- a/test/test-suite/test_resample.py
+++ b/test/test-suite/test_resample.py
@@ -239,7 +239,7 @@ class TestResample:
     @pytest.mark.skipif(not pyvips.at_least_libvips(8, 5),
                         reason="requires libvips >= 8.5")
     def test_thumbnail_icc(self):
-        im = pyvips.Image.thumbnail(JPEG_FILE_XYB, 442, export_profile="srgb", intent="perceptual")
+        im = pyvips.Image.thumbnail(JPEG_FILE_XYB, 442, export_profile="srgb")
 
         assert im.width == 290
         assert im.height == 442


### PR DESCRIPTION
When the requested rendering intent is not supported by the profile, fallback to the profile's suggested intent. An error will only be raised if the suggested intent is also unsupported.

Resolves: #3475.

Targets the 8.16 branch.