### PR TITLE
tiffsave: honor disc threshold during pyramid save

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -15,6 +15,7 @@
 - fix MSVC compile error [na-trium-144]
 - exif: ensure enumerated entries can to converted to string values [lovell]
 - gifsave: add support for eval callback, ensure correct return code [lovell]
+- tiffsave: honor disc threshold during pyramid save [kleisauke]
 
 10/10/24 8.16.0
 

--- a/libvips/foreign/vips2tiff.c
+++ b/libvips/foreign/vips2tiff.c
@@ -475,9 +475,16 @@ wtiff_layer_init(Wtiff *wtiff, Layer **layer, Layer *above,
 			(*layer)->target = wtiff->target;
 			g_object_ref((*layer)->target);
 		}
-		else
-			(*layer)->target =
-				vips_target_new_temp(wtiff->target);
+		else {
+			const guint64 disc_threshold = vips_get_disc_threshold();
+			const guint64 layer_size =
+				VIPS_IMAGE_SIZEOF_PEL(wtiff->ready) * width * height;
+
+			if (layer_size > disc_threshold)
+				(*layer)->target = vips_target_new_temp(wtiff->target);
+			else
+				(*layer)->target = vips_target_new_to_memory();
+		}
 
 		/*
 		printf("wtiff_layer_init: sub = %d, width = %d, height = %d\n",

--- a/libvips/iofuncs/target.c
+++ b/libvips/iofuncs/target.c
@@ -382,7 +382,7 @@ vips_target_new_to_file(const char *filename)
  *
  * See also: vips_target_new_to_file().
  *
- * Returns: a new #VipsConnection
+ * Returns: a new target.
  */
 VipsTarget *
 vips_target_new_to_memory(void)


### PR DESCRIPTION
See: https://github.com/kleisauke/net-vips/issues/245.

Test case:
```console
$ curl -LO https://github.com/weserv/images/raw/5.x/test/api/fixtures/PalaisDuLouvre.tif
$ TMPDIR=/doesnotexist vips copy PalaisDuLouvre.tif x.tif[pyramid]
```

Targets the 8.16 branch.