### PR TITLE
Avoid `const`-qualifiers for input string arguments

### DIFF
--- a/libvips/colour/profile_load.c
+++ b/libvips/colour/profile_load.c
@@ -49,7 +49,7 @@
 typedef struct _VipsProfileLoad {
 	VipsOperation parent_instance;
 
-	const char *name;
+	char *name;
 	VipsBlob *profile;
 
 } VipsProfileLoad;

--- a/libvips/foreign/csvload.c
+++ b/libvips/foreign/csvload.c
@@ -72,8 +72,8 @@ typedef struct _VipsForeignLoadCsv {
 	 */
 	int skip;
 	int lines;
-	const char *whitespace;
-	const char *separator;
+	char *whitespace;
+	char *separator;
 
 	/* Current position in file for error messages.
 	 */

--- a/libvips/foreign/csvsave.c
+++ b/libvips/foreign/csvsave.c
@@ -56,7 +56,7 @@ typedef struct _VipsForeignSaveCsv {
 
 	VipsTarget *target;
 
-	const char *separator;
+	char *separator;
 } VipsForeignSaveCsv;
 
 typedef VipsForeignSaveClass VipsForeignSaveCsvClass;

--- a/libvips/foreign/pdfiumload.c
+++ b/libvips/foreign/pdfiumload.c
@@ -142,7 +142,7 @@ typedef struct _VipsForeignLoadPdf {
 
 	/* Decrypt with this.
 	 */
-	const char *password;
+	char *password;
 
 	FPDF_FILEACCESS file_access;
 	FPDF_DOCUMENT doc;

--- a/libvips/foreign/popplerload.c
+++ b/libvips/foreign/popplerload.c
@@ -134,7 +134,7 @@ typedef struct _VipsForeignLoadPdf {
 
 	/* Decrypt with this.
 	 */
-	const char *password;
+	char *password;
 
 	/* Poppler is not thread-safe, so we run inside a single-threaded
 	 * cache. On the plus side, this means we only need one @page pointer,


### PR DESCRIPTION
These arguments cannot be `const`, see for example:
https://github.com/libvips/libvips/blob/aa6db7679d04df777fe39e4823bbf6a432c1fcc3/libvips/iofuncs/object.c#L1240-L1247