### PR TITLE
Add missing FIXMEs

### DIFF
--- a/libvips/arithmetic/find_trim.c
+++ b/libvips/arithmetic/find_trim.c
@@ -93,7 +93,7 @@ vips_find_trim_build(VipsObject *object)
 	 * for this interpretation.
 	 */
 	if (!vips_object_argument_isset(object, "background"))
-		find_trim->background = vips_array_double_newv(1,
+		find_trim->background = vips_array_double_newv(1, // FIXME: Invalidates operation cache
 			vips_interpretation_max_alpha(find_trim->in->Type));
 
 	/* Flatten out alpha, if any.

--- a/libvips/colour/icc_transform.c
+++ b/libvips/colour/icc_transform.c
@@ -1000,7 +1000,7 @@ vips_icc_export_build(VipsObject *object)
 	if (!vips_object_argument_isset(object, "pcs") &&
 		code->in &&
 		code->in->Type == VIPS_INTERPRETATION_XYZ)
-		icc->pcs = VIPS_PCS_XYZ;
+		icc->pcs = VIPS_PCS_XYZ; // FIXME: Invalidates operation cache
 
 	if (icc->pcs == VIPS_PCS_LAB) {
 		cmsCIExyY white;

--- a/libvips/foreign/magick7load.c
+++ b/libvips/foreign/magick7load.c
@@ -310,7 +310,7 @@ vips_foreign_load_magick7_build(VipsObject *object)
 		return -1;
 
 	if (magick7->all_frames)
-		magick7->n = -1;
+		magick7->n = -1; // FIXME: Invalidates operation cache
 
 	/* Canvas resolution for rendering vector formats like SVG.
 	 */

--- a/libvips/foreign/webpload.c
+++ b/libvips/foreign/webpload.c
@@ -104,7 +104,7 @@ vips_foreign_load_webp_build(VipsObject *object)
 	if (!vips_object_argument_isset(VIPS_OBJECT(webp), "scale") &&
 		vips_object_argument_isset(VIPS_OBJECT(webp), "shrink") &&
 		webp->shrink != 0)
-		webp->scale = 1.0 / webp->shrink;
+		webp->scale = 1.0 / webp->shrink; // FIXME: Invalidates operation cache
 
 	if (VIPS_OBJECT_CLASS(vips_foreign_load_webp_parent_class)->build(object))
 		return -1;

--- a/libvips/resample/thumbnail.c
+++ b/libvips/resample/thumbnail.c
@@ -680,10 +680,10 @@ vips_thumbnail_build(VipsObject *object)
 	 * auto_rotate.
 	 */
 	if (vips_object_argument_isset(object, "no_rotate"))
-		thumbnail->auto_rotate = !thumbnail->no_rotate;
+		thumbnail->auto_rotate = !thumbnail->no_rotate; // FIXME: Invalidates operation cache
 
 	if (!vips_object_argument_isset(object, "height"))
-		thumbnail->height = thumbnail->width;
+		thumbnail->height = thumbnail->width; // FIXME: Invalidates operation cache
 
 	/* Open and do any pre-shrinking.
 	 */


### PR DESCRIPTION
Found in the https://github.com/libvips/libvips/compare/HEAD...kleisauke:parameters-constify changeset.

<details>
  <summary>Details</summary>

```
../libvips/arithmetic/find_trim.c: In function ‘vips_find_trim_build’:
../libvips/arithmetic/find_trim.c:96:39: error: assignment of read-only member ‘background’
   96 |                 find_trim->background = vips_array_double_newv(1,
      |                                       ^
../libvips/colour/icc_transform.c: In function ‘vips_icc_export_build’:
../libvips/colour/icc_transform.c:1003:26: error: assignment of read-only member ‘pcs’
 1003 |                 icc->pcs = VIPS_PCS_XYZ;
      |                          ^
../libvips/foreign/magick7load.c: In function ‘vips_foreign_load_magick7_build’:
../libvips/foreign/magick7load.c:313:28: error: assignment of read-only member ‘n’
  313 |                 magick7->n = -1;
      |                            ^
../libvips/foreign/webpload.c: In function ‘vips_foreign_load_webp_build’:
../libvips/foreign/webpload.c:107:29: error: assignment of read-only member ‘scale’
  107 |                 webp->scale = 1.0 / webp->shrink;
      |                             ^
../libvips/resample/thumbnail.c: In function ‘vips_thumbnail_build’:
../libvips/resample/thumbnail.c:683:40: error: assignment of read-only member ‘auto_rotate’
  683 |                 thumbnail->auto_rotate = !thumbnail->no_rotate;
      |                                        ^
../libvips/resample/thumbnail.c:686:35: error: assignment of read-only member ‘height’
  686 |                 thumbnail->height = thumbnail->width;
      |                                   ^
```
</details>