### PR TITLE
Prefer use of statically allocated mutexes

### DIFF
--- a/doc/using-threads.xml
+++ b/doc/using-threads.xml
@@ -216,8 +216,6 @@ main(int argc, char **argv)
     if (VIPS_INIT(argv[0]))
         vips_error_exit(NULL);
 
-    g_mutex_init(&amp;allocation_lock);
-
     for (i = 0; i &lt; NUM_IN_PARALLEL; i++)
         workers[i] = g_thread_new(NULL, (GThreadFunc) worker, argv[1]);
 

--- a/libvips/convolution/convi.c
+++ b/libvips/convolution/convi.c
@@ -498,9 +498,9 @@ vips_convi_compile_section(VipsConvi *convi, VipsImage *in, Pass *pass)
 
 	/* Some orcs seem to be unstable with many compilers active at once.
 	 */
-	g_mutex_lock(vips__global_lock);
+	g_mutex_lock(&vips__global_lock);
 	result = orc_program_compile(p);
-	g_mutex_unlock(vips__global_lock);
+	g_mutex_unlock(&vips__global_lock);
 
 	if (!ORC_COMPILE_RESULT_IS_SUCCESSFUL(result))
 		return -1;
@@ -549,9 +549,9 @@ vips_convi_compile_clip(VipsConvi *convi)
 
 	/* Some orcs seem to be unstable with many compilers active at once.
 	 */
-	g_mutex_lock(vips__global_lock);
+	g_mutex_lock(&vips__global_lock);
 	result = orc_program_compile(p);
-	g_mutex_unlock(vips__global_lock);
+	g_mutex_unlock(&vips__global_lock);
 
 	if (!ORC_COMPILE_RESULT_IS_SUCCESSFUL(result))
 		return -1;

--- a/libvips/deprecated/rename.c
+++ b/libvips/deprecated/rename.c
@@ -774,13 +774,13 @@ void
 vips_vinfo(const char *domain, const char *fmt, va_list ap)
 {
 	if (vips__info) {
-		g_mutex_lock(vips__global_lock);
+		g_mutex_lock(&vips__global_lock);
 		(void) fprintf(stderr, _("%s: "), _("info"));
 		if (domain)
 			(void) fprintf(stderr, _("%s: "), domain);
 		(void) vfprintf(stderr, fmt, ap);
 		(void) fprintf(stderr, "\n");
-		g_mutex_unlock(vips__global_lock);
+		g_mutex_unlock(&vips__global_lock);
 	}
 }
 
@@ -799,13 +799,13 @@ vips_vwarn(const char *domain, const char *fmt, va_list ap)
 {
 	if (!g_getenv("IM_WARNING") &&
 		!g_getenv("VIPS_WARNING")) {
-		g_mutex_lock(vips__global_lock);
+		g_mutex_lock(&vips__global_lock);
 		(void) fprintf(stderr, _("%s: "), _("vips warning"));
 		if (domain)
 			(void) fprintf(stderr, _("%s: "), domain);
 		(void) vfprintf(stderr, fmt, ap);
 		(void) fprintf(stderr, "\n");
-		g_mutex_unlock(vips__global_lock);
+		g_mutex_unlock(&vips__global_lock);
 	}
 
 	if (vips__fatal)

--- a/libvips/foreign/pdfiumload.c
+++ b/libvips/foreign/pdfiumload.c
@@ -182,7 +182,7 @@ static char *vips_pdfium_errors[] = {
 	"page not found or content error"
 };
 
-static GMutex *vips_pdfium_mutex = NULL;
+static GMutex vips_pdfium_mutex;
 
 static void
 vips_pdfium_error(void)
@@ -199,14 +199,14 @@ vips_pdfium_error(void)
 static void
 vips_foreign_load_pdf_close(VipsForeignLoadPdf *pdf)
 {
-	g_mutex_lock(vips_pdfium_mutex);
+	g_mutex_lock(&vips_pdfium_mutex);
 
 	VIPS_FREEF(FPDF_ClosePage, pdf->page);
 	VIPS_FREEF(FPDFDOC_ExitFormFillEnvironment, pdf->form);
 	VIPS_FREEF(FPDF_CloseDocument, pdf->doc);
 	VIPS_UNREF(pdf->source);
 
-	g_mutex_unlock(vips_pdfium_mutex);
+	g_mutex_unlock(&vips_pdfium_mutex);
 }
 
 static void
@@ -297,11 +297,11 @@ vips_foreign_load_pdf_build(VipsObject *object)
 		pdf->file_access.m_GetBlock = vips_pdfium_GetBlock;
 		pdf->file_access.m_Param = pdf;
 
-		g_mutex_lock(vips_pdfium_mutex);
+		g_mutex_lock(&vips_pdfium_mutex);
 
 		if (!(pdf->doc = FPDF_LoadCustomDocument(&pdf->file_access,
 				  pdf->password))) {
-			g_mutex_unlock(vips_pdfium_mutex);
+			g_mutex_unlock(&vips_pdfium_mutex);
 			vips_pdfium_error();
 			vips_error("pdfload",
 				_("%s: unable to load"),
@@ -312,7 +312,7 @@ vips_foreign_load_pdf_build(VipsObject *object)
 
 		if (!(pdf->form = FPDFDOC_InitFormFillEnvironment(pdf->doc,
 				  &pdf->form_callbacks))) {
-			g_mutex_unlock(vips_pdfium_mutex);
+			g_mutex_unlock(&vips_pdfium_mutex);
 			vips_pdfium_error();
 			vips_error("pdfload",
 				_("%s: unable to initialize form fill environment"),
@@ -321,7 +321,7 @@ vips_foreign_load_pdf_build(VipsObject *object)
 			return -1;
 		}
 
-		g_mutex_unlock(vips_pdfium_mutex);
+		g_mutex_unlock(&vips_pdfium_mutex);
 	}
 
 	if (VIPS_OBJECT_CLASS(vips_foreign_load_pdf_parent_class)->build(object))
@@ -350,7 +350,7 @@ vips_foreign_load_pdf_get_page(VipsForeignLoadPdf *pdf, int page_no)
 	if (pdf->current_page != page_no) {
 		VipsObjectClass *class = VIPS_OBJECT_GET_CLASS(pdf);
 
-		g_mutex_lock(vips_pdfium_mutex);
+		g_mutex_lock(&vips_pdfium_mutex);
 
 		VIPS_FREEF(FPDF_ClosePage, pdf->page);
 		pdf->current_page = -1;
@@ -360,7 +360,7 @@ vips_foreign_load_pdf_get_page(VipsForeignLoadPdf *pdf, int page_no)
 #endif /*DEBUG*/
 
 		if (!(pdf->page = FPDF_LoadPage(pdf->doc, page_no))) {
-			g_mutex_unlock(vips_pdfium_mutex);
+			g_mutex_unlock(&vips_pdfium_mutex);
 			vips_pdfium_error();
 			vips_error(class->nickname,
 				_("unable to load page %d"), page_no);
@@ -368,7 +368,7 @@ vips_foreign_load_pdf_get_page(VipsForeignLoadPdf *pdf, int page_no)
 		}
 		pdf->current_page = page_no;
 
-		g_mutex_unlock(vips_pdfium_mutex);
+		g_mutex_unlock(&vips_pdfium_mutex);
 	}
 
 	return 0;
@@ -412,7 +412,7 @@ vips_foreign_load_pdf_set_image(VipsForeignLoadPdf *pdf, VipsImage *out)
 	vips_image_set_int(out, "pdf-n_pages", pdf->n_pages);
 	vips_image_set_int(out, VIPS_META_N_PAGES, pdf->n_pages);
 
-	g_mutex_lock(vips_pdfium_mutex);
+	g_mutex_lock(&vips_pdfium_mutex);
 
 	for (i = 0; i < n_metadata; i++) {
 		VipsForeignLoadPdfMetadata *metadata =
@@ -436,7 +436,7 @@ vips_foreign_load_pdf_set_image(VipsForeignLoadPdf *pdf, VipsImage *out)
 		}
 	}
 
-	g_mutex_unlock(vips_pdfium_mutex);
+	g_mutex_unlock(&vips_pdfium_mutex);
 
 	/* We need pixels/mm for vips.
 	 */
@@ -463,9 +463,9 @@ vips_foreign_load_pdf_header(VipsForeignLoad *load)
 	printf("vips_foreign_load_pdf_header: %p\n", pdf);
 #endif /*DEBUG*/
 
-	g_mutex_lock(vips_pdfium_mutex);
+	g_mutex_lock(&vips_pdfium_mutex);
 	pdf->n_pages = FPDF_GetPageCount(pdf->doc);
-	g_mutex_unlock(vips_pdfium_mutex);
+	g_mutex_unlock(&vips_pdfium_mutex);
 
 	/* @n == -1 means until the end of the doc.
 	 */
@@ -594,7 +594,7 @@ vips_foreign_load_pdf_generate(VipsRegion *out_region,
 		if (vips_foreign_load_pdf_get_page(pdf, pdf->page_no + i))
 			return -1;
 
-		vips__worker_lock(vips_pdfium_mutex);
+		vips__worker_lock(&vips_pdfium_mutex);
 
 		/* 4 means RGBA.
 		 */
@@ -626,7 +626,7 @@ vips_foreign_load_pdf_generate(VipsRegion *out_region,
 
 		FPDFBitmap_Destroy(bitmap);
 
-		g_mutex_unlock(vips_pdfium_mutex);
+		g_mutex_unlock(&vips_pdfium_mutex);
 
 		top += rect.height;
 		i += 1;
@@ -670,27 +670,12 @@ vips_foreign_load_pdf_load(VipsForeignLoad *load)
 	return 0;
 }
 
-static void *
-vips_foreign_load_pdf_once_init(void *client)
-{
-	/* We must make the mutex on class init (not _build) since we
-	 * can lock even if build is not called.
-	 */
-	vips_pdfium_mutex = vips_g_mutex_new();
-
-	return NULL;
-}
-
 static void
 vips_foreign_load_pdf_class_init(VipsForeignLoadPdfClass *class)
 {
-	static GOnce once = G_ONCE_INIT;
-
 	GObjectClass *gobject_class = G_OBJECT_CLASS(class);
 	VipsObjectClass *object_class = (VipsObjectClass *) class;
 	VipsForeignLoadClass *load_class = (VipsForeignLoadClass *) class;
-
-	VIPS_ONCE(&once, vips_foreign_load_pdf_once_init, NULL);
 
 	gobject_class->dispose = vips_foreign_load_pdf_dispose;
 	gobject_class->set_property = vips_object_set_property;

--- a/libvips/freqfilt/fwfft.c
+++ b/libvips/freqfilt/fwfft.c
@@ -95,23 +95,7 @@ G_DEFINE_TYPE(VipsFwfft, vips_fwfft, VIPS_TYPE_FREQFILT);
 
 /* Everything in fftw3 except execute has to be behind a mutex.
  */
-GMutex *vips__fft_lock = NULL;
-
-static void *
-vips__fft_thread_init(void *data)
-{
-	vips__fft_lock = vips_g_mutex_new();
-
-    return NULL;
-}
-
-void
-vips__fft_init(void)
-{
-	static GOnce once = G_ONCE_INIT;
-
-	VIPS_ONCE(&once, vips__fft_thread_init, NULL);
-}
+GMutex vips__fft_lock;
 
 /* Real to complex forward transform.
  */
@@ -152,23 +136,23 @@ rfwfft1(VipsObject *object, VipsImage *in, VipsImage **out)
 	if (!(half_complex = VIPS_ARRAY(fwfft,
 			  in->Ysize * half_width * 2, double)))
 		return -1;
-	g_mutex_lock(vips__fft_lock);
+	g_mutex_lock(&vips__fft_lock);
 	if (!(plan = fftw_plan_dft_r2c_2d(in->Ysize, in->Xsize,
 			  planner_scratch, (fftw_complex *) half_complex,
 			  0))) {
-		g_mutex_unlock(vips__fft_lock);
+		g_mutex_unlock(&vips__fft_lock);
 		vips_error(class->nickname,
 			"%s", _("unable to create transform plan"));
 		return -1;
 	}
-	g_mutex_unlock(vips__fft_lock);
+	g_mutex_unlock(&vips__fft_lock);
 
 	fftw_execute_dft_r2c(plan,
 		(double *) t[1]->data, (fftw_complex *) half_complex);
 
-	g_mutex_lock(vips__fft_lock);
+	g_mutex_lock(&vips__fft_lock);
 	fftw_destroy_plan(plan);
-	g_mutex_unlock(vips__fft_lock);
+	g_mutex_unlock(&vips__fft_lock);
 
 	/* Write to out as another memory buffer.
 	 */
@@ -271,25 +255,25 @@ cfwfft1(VipsObject *object, VipsImage *in, VipsImage **out)
 
 	/* Make the plan for the transform.
 	 */
-	g_mutex_lock(vips__fft_lock);
+	g_mutex_lock(&vips__fft_lock);
 	if (!(plan = fftw_plan_dft_2d(in->Ysize, in->Xsize,
 			  (fftw_complex *) planner_scratch,
 			  (fftw_complex *) planner_scratch,
 			  FFTW_FORWARD,
 			  0))) {
-		g_mutex_unlock(vips__fft_lock);
+		g_mutex_unlock(&vips__fft_lock);
 		vips_error(class->nickname,
 			"%s", _("unable to create transform plan"));
 		return -1;
 	}
-	g_mutex_unlock(vips__fft_lock);
+	g_mutex_unlock(&vips__fft_lock);
 
 	fftw_execute_dft(plan,
 		(fftw_complex *) t[1]->data, (fftw_complex *) t[1]->data);
 
-	g_mutex_lock(vips__fft_lock);
+	g_mutex_lock(&vips__fft_lock);
 	fftw_destroy_plan(plan);
-	g_mutex_unlock(vips__fft_lock);
+	g_mutex_unlock(&vips__fft_lock);
 
 	/* Write to out as another memory buffer.
 	 */
@@ -331,8 +315,6 @@ vips_fwfft_build(VipsObject *object)
 	VipsImage **t = (VipsImage **) vips_object_local_array(object, 4);
 
 	VipsImage *in;
-
-	vips__fft_init();
 
 	if (VIPS_OBJECT_CLASS(vips_fwfft_parent_class)->build(object))
 		return -1;

--- a/libvips/freqfilt/invfft.c
+++ b/libvips/freqfilt/invfft.c
@@ -113,25 +113,25 @@ cinvfft1(VipsObject *object, VipsImage *in, VipsImage **out)
 	if (!(planner_scratch = VIPS_ARRAY(invfft,
 			  VIPS_IMAGE_N_PELS(in) * 2, double)))
 		return -1;
-	g_mutex_lock(vips__fft_lock);
+	g_mutex_lock(&vips__fft_lock);
 	if (!(plan = fftw_plan_dft_2d(in->Ysize, in->Xsize,
 			  (fftw_complex *) planner_scratch,
 			  (fftw_complex *) planner_scratch,
 			  FFTW_BACKWARD,
 			  0))) {
-		g_mutex_unlock(vips__fft_lock);
+		g_mutex_unlock(&vips__fft_lock);
 		vips_error(class->nickname,
 			"%s", _("unable to create transform plan"));
 		return -1;
 	}
-	g_mutex_unlock(vips__fft_lock);
+	g_mutex_unlock(&vips__fft_lock);
 
 	fftw_execute_dft(plan,
 		(fftw_complex *) (*out)->data, (fftw_complex *) (*out)->data);
 
-	g_mutex_lock(vips__fft_lock);
+	g_mutex_lock(&vips__fft_lock);
 	fftw_destroy_plan(plan);
-	g_mutex_unlock(vips__fft_lock);
+	g_mutex_unlock(&vips__fft_lock);
 
 	(*out)->Type = VIPS_INTERPRETATION_B_W;
 
@@ -194,23 +194,23 @@ rinvfft1(VipsObject *object, VipsImage *in, VipsImage **out)
 	if (!(planner_scratch = VIPS_ARRAY(invfft,
 			  t[1]->Ysize * half_width * 2, double)))
 		return -1;
-	g_mutex_lock(vips__fft_lock);
+	g_mutex_lock(&vips__fft_lock);
 	if (!(plan = fftw_plan_dft_c2r_2d(t[1]->Ysize, t[1]->Xsize,
 			  (fftw_complex *) planner_scratch, (double *) (*out)->data,
 			  0))) {
-		g_mutex_unlock(vips__fft_lock);
+		g_mutex_unlock(&vips__fft_lock);
 		vips_error(class->nickname,
 			"%s", _("unable to create transform plan"));
 		return -1;
 	}
-	g_mutex_unlock(vips__fft_lock);
+	g_mutex_unlock(&vips__fft_lock);
 
 	fftw_execute_dft_c2r(plan,
 		(fftw_complex *) half_complex, (double *) (*out)->data);
 
-	g_mutex_lock(vips__fft_lock);
+	g_mutex_lock(&vips__fft_lock);
 	fftw_destroy_plan(plan);
-	g_mutex_unlock(vips__fft_lock);
+	g_mutex_unlock(&vips__fft_lock);
 
 	return 0;
 }
@@ -223,8 +223,6 @@ vips_invfft_build(VipsObject *object)
 	VipsImage **t = (VipsImage **) vips_object_local_array(object, 4);
 
 	VipsImage *in;
-
-	vips__fft_init();
 
 	if (VIPS_OBJECT_CLASS(vips_invfft_parent_class)->build(object))
 		return -1;

--- a/libvips/freqfilt/pfreqfilt.h
+++ b/libvips/freqfilt/pfreqfilt.h
@@ -37,9 +37,7 @@ extern "C" {
 
 /* All fftw3 calls except execute() need to be locked.
  */
-extern GMutex *vips__fft_lock;
-
-void vips__fft_init(void);
+extern GMutex vips__fft_lock;
 
 #define VIPS_TYPE_FREQFILT (vips_freqfilt_get_type())
 #define VIPS_FREQFILT(obj) \

--- a/libvips/include/vips/internal.h
+++ b/libvips/include/vips/internal.h
@@ -218,7 +218,7 @@ VIPS_API
 int vips__write_header_bytes(VipsImage *im, unsigned char *to);
 int vips__image_meta_copy(VipsImage *dst, const VipsImage *src);
 
-extern GMutex *vips__global_lock;
+extern GMutex vips__global_lock;
 
 int vips_image_written(VipsImage *image);
 void vips_image_preeval(VipsImage *image);

--- a/libvips/include/vips/private.h
+++ b/libvips/include/vips/private.h
@@ -218,8 +218,6 @@ int vips__view_image(struct _VipsImage *image);
 VIPS_API
 int _vips__argument_id;
 
-void vips__meta_init(void);
-
 // autoptr needs typed functions for autofree ... this needs to be in the
 // public API since downstream projects can use our auto defs
 VIPS_API

--- a/libvips/iofuncs/buffer.c
+++ b/libvips/iofuncs/buffer.c
@@ -206,12 +206,12 @@ vips_buffer_free(VipsBuffer *buffer)
 	g_free(buffer);
 
 #ifdef DEBUG
-	g_mutex_lock(vips__global_lock);
+	g_mutex_lock(&vips__global_lock);
 
 	g_assert(g_slist_find(vips__buffer_all, buffer));
 	vips__buffer_all = g_slist_remove(vips__buffer_all, buffer);
 
-	g_mutex_unlock(vips__global_lock);
+	g_mutex_unlock(&vips__global_lock);
 #endif /*DEBUG*/
 
 #ifdef DEBUG_VERBOSE
@@ -234,10 +234,10 @@ buffer_cache_free(VipsBufferCache *cache)
 	GSList *p;
 
 #ifdef DEBUG_CREATE
-	g_mutex_lock(vips__global_lock);
+	g_mutex_lock(&vips__global_lock);
 	vips__buffer_cache_all =
 		g_slist_remove(vips__buffer_cache_all, cache);
-	g_mutex_unlock(vips__global_lock);
+	g_mutex_unlock(&vips__global_lock);
 
 	printf("buffer_cache_free: freeing cache %p on thread %p\n",
 		cache, g_thread_self());
@@ -283,10 +283,10 @@ buffer_cache_new(VipsBufferThread *buffer_thread, VipsImage *im)
 	cache->n_reserve = 0;
 
 #ifdef DEBUG_CREATE
-	g_mutex_lock(vips__global_lock);
+	g_mutex_lock(&vips__global_lock);
 	vips__buffer_cache_all =
 		g_slist_prepend(vips__buffer_cache_all, cache);
-	g_mutex_unlock(vips__global_lock);
+	g_mutex_unlock(&vips__global_lock);
 
 	printf("buffer_cache_new: new cache %p for thread %p on image %p\n",
 		cache, g_thread_self(), im);
@@ -537,10 +537,10 @@ vips_buffer_new(VipsImage *im, VipsRect *area)
 		buffer->bsize = 0;
 
 #ifdef DEBUG
-		g_mutex_lock(vips__global_lock);
+		g_mutex_lock(&vips__global_lock);
 		vips__buffer_all =
 			g_slist_prepend(vips__buffer_all, buffer);
-		g_mutex_unlock(vips__global_lock);
+		g_mutex_unlock(&vips__global_lock);
 #endif /*DEBUG*/
 	}
 

--- a/libvips/iofuncs/error.c
+++ b/libvips/iofuncs/error.c
@@ -144,10 +144,10 @@ static int vips_error_freeze_count = 0;
 void
 vips_error_freeze(void)
 {
-	g_mutex_lock(vips__global_lock);
+	g_mutex_lock(&vips__global_lock);
 	g_assert(vips_error_freeze_count >= 0);
 	vips_error_freeze_count += 1;
-	g_mutex_unlock(vips__global_lock);
+	g_mutex_unlock(&vips__global_lock);
 }
 
 /**
@@ -158,10 +158,10 @@ vips_error_freeze(void)
 void
 vips_error_thaw(void)
 {
-	g_mutex_lock(vips__global_lock);
+	g_mutex_lock(&vips__global_lock);
 	vips_error_freeze_count -= 1;
 	g_assert(vips_error_freeze_count >= 0);
-	g_mutex_unlock(vips__global_lock);
+	g_mutex_unlock(&vips__global_lock);
 }
 
 /**
@@ -179,9 +179,9 @@ vips_error_buffer(void)
 {
 	const char *msg;
 
-	g_mutex_lock(vips__global_lock);
+	g_mutex_lock(&vips__global_lock);
 	msg = vips_buf_all(&vips_error_buf);
-	g_mutex_unlock(vips__global_lock);
+	g_mutex_unlock(&vips__global_lock);
 
 	return msg;
 }
@@ -198,10 +198,10 @@ vips_error_buffer_copy(void)
 {
 	char *msg;
 
-	g_mutex_lock(vips__global_lock);
+	g_mutex_lock(&vips__global_lock);
 	msg = g_strdup(vips_buf_all(&vips_error_buf));
 	vips_buf_rewind(&vips_error_buf);
-	g_mutex_unlock(vips__global_lock);
+	g_mutex_unlock(&vips__global_lock);
 
 	return msg;
 }
@@ -242,7 +242,7 @@ vips_verror(const char *domain, const char *fmt, va_list ap)
 	}
 #endif /*VIPS_DEBUG*/
 
-	g_mutex_lock(vips__global_lock);
+	g_mutex_lock(&vips__global_lock);
 	g_assert(vips_error_freeze_count >= 0);
 	if (!vips_error_freeze_count) {
 		if (domain)
@@ -250,7 +250,7 @@ vips_verror(const char *domain, const char *fmt, va_list ap)
 		vips_buf_vappendf(&vips_error_buf, fmt, ap);
 		vips_buf_appends(&vips_error_buf, "\n");
 	}
-	g_mutex_unlock(vips__global_lock);
+	g_mutex_unlock(&vips__global_lock);
 
 	if (vips__fatal)
 		vips_error_exit("vips__fatal");
@@ -340,9 +340,9 @@ vips_error_g(GError **error)
 
 	/* glib does not expect a trailing '\n' and vips always has one.
 	 */
-	g_mutex_lock(vips__global_lock);
+	g_mutex_lock(&vips__global_lock);
 	vips_buf_removec(&vips_error_buf, '\n');
-	g_mutex_unlock(vips__global_lock);
+	g_mutex_unlock(&vips__global_lock);
 
 	g_set_error(error, vips_domain, -1, "%s", vips_error_buffer());
 	vips_error_clear();
@@ -379,9 +379,9 @@ vips_g_error(GError **error)
 void
 vips_error_clear(void)
 {
-	g_mutex_lock(vips__global_lock);
+	g_mutex_lock(&vips__global_lock);
 	vips_buf_rewind(&vips_error_buf);
-	g_mutex_unlock(vips__global_lock);
+	g_mutex_unlock(&vips__global_lock);
 }
 
 /**

--- a/libvips/iofuncs/gate.c
+++ b/libvips/iofuncs/gate.c
@@ -136,7 +136,7 @@ vips_thread_profile_save_cb(gpointer key, gpointer value, gpointer data)
 static void
 vips_thread_profile_save(VipsThreadProfile *profile)
 {
-	g_mutex_lock(vips__global_lock);
+	g_mutex_lock(&vips__global_lock);
 
 	VIPS_DEBUG_MSG("vips_thread_profile_save: %s\n", profile->name);
 
@@ -144,7 +144,7 @@ vips_thread_profile_save(VipsThreadProfile *profile)
 		vips__thread_fp =
 			vips__file_open_write("vips-profile.txt", TRUE);
 		if (!vips__thread_fp) {
-			g_mutex_unlock(vips__global_lock);
+			g_mutex_unlock(&vips__global_lock);
 			g_warning("unable to create profile log");
 			return;
 		}
@@ -157,7 +157,7 @@ vips_thread_profile_save(VipsThreadProfile *profile)
 		vips_thread_profile_save_cb, vips__thread_fp);
 	vips_thread_profile_save_gate(profile->memory, vips__thread_fp);
 
-	g_mutex_unlock(vips__global_lock);
+	g_mutex_unlock(&vips__global_lock);
 }
 
 static void

--- a/libvips/iofuncs/generate.c
+++ b/libvips/iofuncs/generate.c
@@ -181,7 +181,7 @@ vips__link_break_rev(VipsImage *image_down, VipsImage *image_up, void *b)
 void
 vips__link_break_all(VipsImage *image)
 {
-	g_mutex_lock(vips__global_lock);
+	g_mutex_lock(&vips__global_lock);
 
 	vips_slist_map2(image->upstream,
 		(VipsSListMap2Fn) vips__link_break, image, NULL);
@@ -191,7 +191,7 @@ vips__link_break_all(VipsImage *image)
 	g_assert(!image->upstream);
 	g_assert(!image->downstream);
 
-	g_mutex_unlock(vips__global_lock);
+	g_mutex_unlock(&vips__global_lock);
 }
 
 typedef struct _LinkMap {
@@ -261,7 +261,7 @@ vips__link_map(VipsImage *image, gboolean upstream,
 	 * member. There will be intense confusion if two threads try to do
 	 * this at the same time.
 	 */
-	g_mutex_lock(vips__global_lock);
+	g_mutex_lock(&vips__global_lock);
 
 	serial += 1;
 	map.serial = serial;
@@ -271,7 +271,7 @@ vips__link_map(VipsImage *image, gboolean upstream,
 	for (p = images; p; p = p->next)
 		g_object_ref(p->data);
 
-	g_mutex_unlock(vips__global_lock);
+	g_mutex_unlock(&vips__global_lock);
 
 	result = vips_slist_map2(images, fn, a, b);
 
@@ -330,10 +330,10 @@ vips__demand_hint_array(VipsImage *image,
 
 	/* im depends on all these ims.
 	 */
-	g_mutex_lock(vips__global_lock);
+	g_mutex_lock(&vips__global_lock);
 	for (i = 0; i < len; i++)
 		vips__link_make(in[i], image);
-	g_mutex_unlock(vips__global_lock);
+	g_mutex_unlock(&vips__global_lock);
 
 	/* Set a flag on the image to say we remembered to call this thing.
 	 * vips_image_generate() and friends check this.

--- a/libvips/iofuncs/image.c
+++ b/libvips/iofuncs/image.c
@@ -388,7 +388,7 @@ char *vips__disc_threshold = NULL;
 
 /* Minimise needs a lock.
  */
-static GMutex *vips__minimise_lock = NULL;
+static GMutex vips__minimise_lock;
 
 static guint vips_image_signals[SIG_LAST] = { 0 };
 
@@ -698,7 +698,7 @@ vips_image_sanity(VipsObject *object, VipsBuf *buf)
 
 	/* Must lock around inter-image links.
 	 */
-	g_mutex_lock(vips__global_lock);
+	g_mutex_lock(&vips__global_lock);
 
 	if (vips_slist_map2(image->upstream,
 			(VipsSListMap2Fn) vips_image_sanity_upstream, image, NULL))
@@ -707,7 +707,7 @@ vips_image_sanity(VipsObject *object, VipsBuf *buf)
 			(VipsSListMap2Fn) vips_image_sanity_downstream, image, NULL))
 		vips_buf_appends(buf, "downstream broken\n");
 
-	g_mutex_unlock(vips__global_lock);
+	g_mutex_unlock(&vips__global_lock);
 
 	VIPS_OBJECT_CLASS(vips_image_parent_class)->sanity(object, buf);
 }
@@ -1326,8 +1326,6 @@ vips_image_class_init(VipsImageClass *class)
 		NULL, NULL,
 		g_cclosure_marshal_VOID__VOID,
 		G_TYPE_NONE, 0);
-
-	vips__minimise_lock = vips_g_mutex_new();
 }
 
 static void
@@ -1446,12 +1444,12 @@ vips_image_minimise_all(VipsImage *image)
 	/* Minimisation will modify things like sources, so we can't run it
 	 * from many threads.
 	 */
-	g_mutex_lock(vips__minimise_lock);
+	g_mutex_lock(&vips__minimise_lock);
 
 	(void) vips__link_map(image, TRUE,
 		(VipsSListMap2Fn) vips_image_minimise_all_cb, NULL, NULL);
 
-	g_mutex_unlock(vips__minimise_lock);
+	g_mutex_unlock(&vips__minimise_lock);
 }
 
 /**

--- a/libvips/iofuncs/init.c
+++ b/libvips/iofuncs/init.c
@@ -107,7 +107,7 @@ int vips__fatal = 0;
 /* Use in various small places where we need a mutex and it's not worth
  * making a private one.
  */
-GMutex *vips__global_lock = NULL;
+GMutex vips__global_lock;
 
 /* A debugging timer, zero at library init.
  */
@@ -510,10 +510,6 @@ vips_init(const char *argv0)
 	vips__thread_init();
 	vips__threadpool_init();
 	vips__buffer_init();
-	vips__meta_init();
-
-	if (!vips__global_lock)
-		vips__global_lock = vips_g_mutex_new();
 
 	if (!vips__global_timer)
 		vips__global_timer = g_timer_new();
@@ -749,10 +745,6 @@ vips_shutdown(void)
 	vips__thread_profile_stop();
 	vips__threadpool_shutdown();
 
-	/* Don't free vips__global_lock -- we want to be able to use
-	 * vips_error_buffer() after vips_shutdown(), since vips_leak() can
-	 * call it.
-	 */
 	VIPS_FREE(vips__argv0);
 	VIPS_FREE(vips__prgname);
 	VIPS_FREEF(g_timer_destroy, vips__global_timer);

--- a/libvips/iofuncs/region.c
+++ b/libvips/iofuncs/region.c
@@ -213,9 +213,9 @@ vips_region_finalize(GObject *gobject)
 #endif /*VIPS_DEBUG*/
 
 #ifdef VIPS_DEBUG
-	g_mutex_lock(vips__global_lock);
+	g_mutex_lock(&vips__global_lock);
 	vips__regions_all = g_slist_remove(vips__regions_all, gobject);
-	g_mutex_unlock(vips__global_lock);
+	g_mutex_unlock(&vips__global_lock);
 #endif /*VIPS_DEBUG*/
 
 	G_OBJECT_CLASS(vips_region_parent_class)->finalize(gobject);
@@ -483,11 +483,11 @@ vips_region_init(VipsRegion *region)
 	region->type = VIPS_REGION_NONE;
 
 #ifdef VIPS_DEBUG
-	g_mutex_lock(vips__global_lock);
+	g_mutex_lock(&vips__global_lock);
 	vips__regions_all = g_slist_prepend(vips__regions_all, region);
 	printf("vips_region_init: %d regions in vips\n",
 		g_slist_length(vips__regions_all));
-	g_mutex_unlock(vips__global_lock);
+	g_mutex_unlock(&vips__global_lock);
 #endif /*VIPS_DEBUG*/
 }
 
@@ -2055,13 +2055,13 @@ vips_region_dump_all(void)
 {
 	size_t alive;
 
-	g_mutex_lock(vips__global_lock);
+	g_mutex_lock(&vips__global_lock);
 	alive = 0;
 	printf("%d regions in vips\n", g_slist_length(vips__regions_all));
 	vips_slist_map2(vips__regions_all,
 		(VipsSListMap2Fn) vips_region_dump_all_cb, &alive, NULL);
 	printf("%gMB alive\n", alive / (1024 * 1024.0));
-	g_mutex_unlock(vips__global_lock);
+	g_mutex_unlock(&vips__global_lock);
 }
 #endif /*VIPS_DEBUG*/
 
@@ -2073,12 +2073,12 @@ vips__region_count_pixels(VipsRegion *region, const char *nickname)
 	VipsImagePixels *pixels = g_object_get_qdata(G_OBJECT(image),
 		vips__image_pixels_quark);
 
-	g_mutex_lock(vips__global_lock);
+	g_mutex_lock(&vips__global_lock);
 	if (!pixels->tpels)
 		pixels->tpels = VIPS_IMAGE_N_PELS(image);
 	if (!pixels->nickname)
 		pixels->nickname = nickname;
 	pixels->npels += region->valid.width * region->valid.height;
-	g_mutex_unlock(vips__global_lock);
+	g_mutex_unlock(&vips__global_lock);
 }
 #endif /*DEBUG_LEAK*/

--- a/libvips/iofuncs/type.c
+++ b/libvips/iofuncs/type.c
@@ -186,9 +186,9 @@ vips_area_unref(VipsArea *area)
 #endif /*DEBUG*/
 
 	if (vips__leak) {
-		g_mutex_lock(vips__global_lock);
+		g_mutex_lock(&vips__global_lock);
 		g_assert(g_slist_find(vips_area_all, area));
-		g_mutex_unlock(vips__global_lock);
+		g_mutex_unlock(&vips__global_lock);
 	}
 
 	if (area->count == 0) {
@@ -201,16 +201,16 @@ vips_area_unref(VipsArea *area)
 		g_free(area);
 
 		if (vips__leak) {
-			g_mutex_lock(vips__global_lock);
+			g_mutex_lock(&vips__global_lock);
 			vips_area_all = g_slist_remove(vips_area_all, area);
-			g_mutex_unlock(vips__global_lock);
+			g_mutex_unlock(&vips__global_lock);
 		}
 
 #ifdef DEBUG
-		g_mutex_lock(vips__global_lock);
+		g_mutex_lock(&vips__global_lock);
 		printf("vips_area_unref: free .. total = %d\n",
 			g_slist_length(vips_area_all));
-		g_mutex_unlock(vips__global_lock);
+		g_mutex_unlock(&vips__global_lock);
 #endif /*DEBUG*/
 	}
 	else
@@ -264,17 +264,17 @@ vips_area_new(VipsCallbackFn free_fn, void *data)
 	area->sizeof_type = 0;
 
 	if (vips__leak) {
-		g_mutex_lock(vips__global_lock);
+		g_mutex_lock(&vips__global_lock);
 		vips_area_all = g_slist_prepend(vips_area_all, area);
-		g_mutex_unlock(vips__global_lock);
+		g_mutex_unlock(&vips__global_lock);
 	}
 
 #ifdef DEBUG
-	g_mutex_lock(vips__global_lock);
+	g_mutex_lock(&vips__global_lock);
 	printf("vips_area_new: %p count = %d (%d in total)\n",
 		area, area->count,
 		g_slist_length(vips_area_all));
-	g_mutex_unlock(vips__global_lock);
+	g_mutex_unlock(&vips__global_lock);
 #endif /*DEBUG*/
 
 	return area;

--- a/libvips/iofuncs/window.c
+++ b/libvips/iofuncs/window.c
@@ -93,10 +93,10 @@ vips_window_unmap(VipsWindow *window)
 			return -1;
 
 #ifdef DEBUG_TOTAL
-		g_mutex_lock(vips__global_lock);
+		g_mutex_lock(&vips__global_lock);
 		total_mmap_usage -= window->length;
 		g_assert(total_mmap_usage >= 0);
-		g_mutex_unlock(vips__global_lock);
+		g_mutex_unlock(&vips__global_lock);
 #endif /*DEBUG_TOTAL*/
 
 		window->data = NULL;
@@ -166,7 +166,7 @@ vips_window_unref(VipsWindow *window)
 static void
 trace_mmap_usage(void)
 {
-	g_mutex_lock(vips__global_lock);
+	g_mutex_lock(&vips__global_lock);
 	{
 		static int last_total = 0;
 		int total = total_mmap_usage / (1024 * 1024);
@@ -179,7 +179,7 @@ trace_mmap_usage(void)
 			last_total = total;
 		}
 	}
-	g_mutex_unlock(vips__global_lock);
+	g_mutex_unlock(&vips__global_lock);
 }
 #endif /*DEBUG_TOTAL*/
 
@@ -252,11 +252,11 @@ vips_window_set(VipsWindow *window, int top, int height)
 	vips__read_test &= window->data[0];
 
 #ifdef DEBUG_TOTAL
-	g_mutex_lock(vips__global_lock);
+	g_mutex_lock(&vips__global_lock);
 	total_mmap_usage += window->length;
 	if (total_mmap_usage > max_mmap_usage)
 		max_mmap_usage = total_mmap_usage;
-	g_mutex_unlock(vips__global_lock);
+	g_mutex_unlock(&vips__global_lock);
 	trace_mmap_usage();
 #endif /*DEBUG_TOTAL*/
 

--- a/libvips/morphology/morph.c
+++ b/libvips/morphology/morph.c
@@ -506,9 +506,9 @@ vips_morph_compile_section(VipsMorph *morph, Pass *pass, gboolean first_pass)
 
 	/* Some orcs seem to be unstable with many compilers active at once.
 	 */
-	g_mutex_lock(vips__global_lock);
+	g_mutex_lock(&vips__global_lock);
 	result = orc_program_compile(p);
-	g_mutex_unlock(vips__global_lock);
+	g_mutex_unlock(&vips__global_lock);
 
 	if (!ORC_COMPILE_RESULT_IS_SUCCESSFUL(result))
 		return -1;

--- a/libvips/resample/reducev.cpp
+++ b/libvips/resample/reducev.cpp
@@ -354,9 +354,9 @@ vips_reducev_compile_section(VipsReducev *reducev, Pass *pass, gboolean first)
 
 	/* Some orcs seem to be unstable with many compilers active at once.
 	 */
-	g_mutex_lock(vips__global_lock);
+	g_mutex_lock(&vips__global_lock);
 	result = orc_program_compile(p);
-	g_mutex_unlock(vips__global_lock);
+	g_mutex_unlock(&vips__global_lock);
 
 	if (!ORC_COMPILE_RESULT_IS_SUCCESSFUL(result))
 		return -1;


### PR DESCRIPTION
Mutexes in static storage are initialised to all-zeros, which would avoid the need for explicit calls to `g_mutex_init()` and `g_mutex_clear()`.

Split out from #4249.