### PR TITLE
morph: fix Orc path with large masks

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -18,6 +18,7 @@
 - tiffsave: honor disc threshold during pyramid save [kleisauke]
 - fill_nearest: fix a leak
 - colour: use suggested rendering intent as fallback [kleisauke]
+- morph: fix Orc path with large masks [kleisauke]
 
 10/10/24 8.16.0
 


### PR DESCRIPTION
It looks like we haven't been limiting the maximum number of constants, as we do in `convi`. Regressed since commit b32cb5ec4dce696672218a3aeca9292c08ca23e7, previously this was handled in `vips_vector_full()`.

Resolves: #4363.

Targets the 8.16 branch.