### PR TITLE
Ensure g_warning messages use consistent i18n approach

### DIFF
--- a/libvips/colour/icc_transform.c
+++ b/libvips/colour/icc_transform.c
@@ -616,7 +616,7 @@ vips_icc_load_profile_blob(VipsIcc *icc, VipsBlob *blob,
 
 	data = vips_blob_get(blob, &size);
 	if (!(profile = cmsOpenProfileFromMem(data, size))) {
-		g_warning("%s", _("corrupt profile"));
+		g_warning("corrupt profile");
 		return NULL;
 	}
 
@@ -640,14 +640,14 @@ vips_icc_load_profile_blob(VipsIcc *icc, VipsBlob *blob,
 
 	if (!(info = vips_icc_info(cmsGetColorSpace(profile)))) {
 		VIPS_FREEF(cmsCloseProfile, profile);
-		g_warning("%s", _("unsupported profile"));
+		g_warning("unsupported profile");
 		return NULL;
 	}
 
 	if (image &&
 		!vips_image_is_profile_compatible(image, info->bands)) {
 		VIPS_FREEF(cmsCloseProfile, profile);
-		g_warning("%s", _("profile incompatible with image"));
+		g_warning("profile incompatible with image");
 		return NULL;
 	}
 

--- a/libvips/conversion/copy.c
+++ b/libvips/conversion/copy.c
@@ -178,8 +178,7 @@ vips_copy_build(VipsObject *object)
 		return -1;
 
 	if (copy->swap)
-		g_warning("%s",
-			_("copy swap is deprecated, use byteswap instead"));
+		g_warning("copy swap is deprecated, use byteswap instead");
 
 	if (vips_image_pipelinev(conversion->out,
 			VIPS_DEMAND_STYLE_THINSTRIP, copy->in, NULL))

--- a/libvips/create/text.c
+++ b/libvips/create/text.c
@@ -440,8 +440,7 @@ vips_text_build(VipsObject *object)
 	}
 #else  /*!HAVE_FONTCONFIG*/
 	if (text->fontfile)
-		g_warning("%s",
-			_("ignoring fontfile (no fontconfig support)"));
+		g_warning("ignoring fontfile (no fontconfig support)");
 #endif /*HAVE_FONTCONFIG*/
 
 	/* If our caller set height and not dpi, we adjust dpi until

--- a/libvips/foreign/cgifsave.c
+++ b/libvips/foreign/cgifsave.c
@@ -683,8 +683,7 @@ vips_foreign_save_cgif_write_frame(VipsForeignSaveCgif *cgif)
 #ifdef HAVE_CGIF_FRAME_ATTR_INTERLACED
 		frame_config.attrFlags |= CGIF_FRAME_ATTR_INTERLACED;
 #else  /*!HAVE_CGIF_FRAME_ATTR_INTERLACED*/
-		g_warning("%s: cgif >= v0.3.0 required for interlaced GIF write",
-			class->nickname);
+		g_warning("cgif >= v0.3.0 required for interlaced GIF write");
 #endif /*HAVE_CGIF_FRAME_ATTR_INTERLACED*/
 	}
 

--- a/libvips/foreign/exif.c
+++ b/libvips/foreign/exif.c
@@ -491,7 +491,7 @@ vips_image_resolution_from_exif(VipsImage *image, ExifData *ed)
 		break;
 
 	default:
-		g_warning("%s", _("unknown EXIF resolution unit"));
+		g_warning("unknown EXIF resolution unit");
 		return -1;
 	}
 
@@ -1066,7 +1066,7 @@ vips_exif_resolution_from_image(ExifData *ed, VipsImage *image)
 		break;
 
 	default:
-		g_warning("%s", _("unknown EXIF resolution unit"));
+		g_warning("unknown EXIF resolution unit");
 		return 0;
 	}
 

--- a/libvips/foreign/foreign.c
+++ b/libvips/foreign/foreign.c
@@ -1093,9 +1093,8 @@ vips_foreign_load_build(VipsObject *object)
 
 	if ((flags & VIPS_FOREIGN_PARTIAL) &&
 		(flags & VIPS_FOREIGN_SEQUENTIAL)) {
-		g_warning("%s",
-			_("VIPS_FOREIGN_PARTIAL and VIPS_FOREIGN_SEQUENTIAL "
-			  "both set -- using SEQUENTIAL"));
+		g_warning("VIPS_FOREIGN_PARTIAL and VIPS_FOREIGN_SEQUENTIAL "
+			  "both set -- using SEQUENTIAL");
 		flags ^= VIPS_FOREIGN_PARTIAL;
 	}
 
@@ -1121,9 +1120,8 @@ vips_foreign_load_build(VipsObject *object)
 		return -1;
 
 	if (load->sequential)
-		g_warning("%s",
-			_("ignoring deprecated \"sequential\" mode -- "
-			  "please use \"access\" instead"));
+		g_warning("ignoring deprecated \"sequential\" mode -- "
+			  "please use \"access\" instead");
 
 	g_object_set(object, "out", vips_image_new(), NULL);
 

--- a/libvips/foreign/jpeg2vips.c
+++ b/libvips/foreign/jpeg2vips.c
@@ -654,7 +654,7 @@ read_jpeg_header(ReadJpeg *jpeg, VipsImage *out)
 			break;
 
 		default:
-			g_warning("%s", _("unknown JFIF resolution unit"));
+			g_warning("unknown JFIF resolution unit");
 			break;
 		}
 

--- a/libvips/foreign/jxlload.c
+++ b/libvips/foreign/jxlload.c
@@ -643,7 +643,7 @@ vips_foreign_load_jxl_fix_exif(VipsForeignLoadJxl *jxl)
 		return 0;
 
 	if (jxl->exif_size < 4) {
-		g_warning("%s: invalid data in EXIF box", class->nickname);
+		g_warning("invalid data in EXIF box");
 		return -1;
 	}
 
@@ -651,7 +651,7 @@ vips_foreign_load_jxl_fix_exif(VipsForeignLoadJxl *jxl)
 	 */
 	size_t offset = GUINT32_FROM_BE(*((guint32 *) jxl->exif_data));
 	if (offset > jxl->exif_size - 4) {
-		g_warning("%s: invalid data in EXIF box", class->nickname);
+		g_warning("invalid data in EXIF box");
 		return -1;
 	}
 

--- a/libvips/foreign/magick.c
+++ b/libvips/foreign/magick.c
@@ -654,8 +654,8 @@ magick_optimize_image_layers(Image **images, ExceptionInfo *exception)
 
 	return MagickTrue;
 #else  /*!HAVE_OPTIMIZEPLUSIMAGELAYERS*/
-	g_warning("%s", _("layer optimization is not supported by "
-					  "your version of libMagick"));
+	g_warning("layer optimization is not supported by "
+		  "your version of libMagick");
 
 	return MagickTrue;
 #endif /*HAVE_OPTIMIZEPLUSIMAGELAYERS*/
@@ -670,8 +670,8 @@ magick_optimize_image_transparency(const Image *images,
 
 	return exception->severity == UndefinedException;
 #else  /*!HAVE_OPTIMIZEIMAGETRANSPARENCY*/
-	g_warning("%s", _("transparency optimization is not supported by "
-					  "your version of libMagick"));
+	g_warning("transparency optimization is not supported by "
+		  "your version of libMagick");
 
 	return MagickTrue;
 #endif /*HAVE_OPTIMIZEIMAGETRANSPARENCY*/

--- a/libvips/foreign/ppmsave.c
+++ b/libvips/foreign/ppmsave.c
@@ -335,7 +335,7 @@ vips_foreign_save_ppm_build(VipsObject *object)
 
 	if (ppm->ascii &&
 		image->BandFmt == VIPS_FORMAT_FLOAT) {
-		g_warning("%s", _("float images must be binary -- disabling ascii"));
+		g_warning("float images must be binary -- disabling ascii");
 		ppm->ascii = FALSE;
 	}
 
@@ -344,9 +344,8 @@ vips_foreign_save_ppm_build(VipsObject *object)
 	if (ppm->bitdepth &&
 		(image->Bands != 1 ||
 		 image->BandFmt != VIPS_FORMAT_UCHAR)) {
-		g_warning("%s",
-			_("can only save 1 band uchar images as 1 bit -- "
-			  "disabling 1 bit save"));
+		g_warning("can only save 1 band uchar images as 1 bit -- "
+			  "disabling 1 bit save");
 		ppm->bitdepth = 0;
 	}
 

--- a/libvips/foreign/spngsave.c
+++ b/libvips/foreign/spngsave.c
@@ -431,8 +431,7 @@ vips_foreign_save_spng_write(VipsForeignSaveSpng *spng, VipsImage *in)
 		ihdr.color_type = SPNG_COLOR_TYPE_INDEXED;
 #else
 	if (spng->palette)
-		g_warning("%s",
-			_("ignoring palette (no quantisation support)"));
+		g_warning("ignoring palette (no quantisation support)");
 #endif /*HAVE_QUANTIZATION*/
 
 	ihdr.compression_method = 0;

--- a/libvips/foreign/tiff2vips.c
+++ b/libvips/foreign/tiff2vips.c
@@ -1621,7 +1621,7 @@ rtiff_parse_palette(Rtiff *rtiff, VipsImage *out)
 			read->blue8[i] = read->blue16[i] >> 8;
 		}
 	else {
-		g_warning("%s", _("assuming 8-bit palette"));
+		g_warning("assuming 8-bit palette");
 
 		for (i = 0; i < len; i++) {
 			read->red8[i] = read->red16[i] & 0xff;
@@ -3330,7 +3330,7 @@ rtiff_header_read(Rtiff *rtiff, RtiffHeader *header)
 		for (i = 0; i < extra_samples_count; i++)
 			if (extra_samples_types[i] == EXTRASAMPLE_ASSOCALPHA) {
 				if (header->alpha_band != -1)
-					g_warning("%s", _("more than one alpha -- ignoring"));
+					g_warning("more than one alpha -- ignoring");
 
 				header->alpha_band = header->samples_per_pixel -
 					extra_samples_count + i;

--- a/libvips/foreign/vips2jpeg.c
+++ b/libvips/foreign/vips2jpeg.c
@@ -314,7 +314,7 @@ write_xmp(Write *write, VipsImage *in)
 	 * error with large chunks.
 	 */
 	if (data_length > 60000) {
-		g_warning("%s", _("VipsJpeg: large XMP not saved"));
+		g_warning("large XMP not saved");
 		return 0;
 	}
 
@@ -607,7 +607,7 @@ set_cinfo(struct jpeg_compress_struct *cinfo,
 			cinfo->optimize_coding = TRUE;
 		}
 		else
-			g_warning("%s", _("trellis_quant unsupported"));
+			g_warning("trellis_quant unsupported");
 	}
 
 	/* Apply overshooting to samples with extreme values e.g. 0 & 255
@@ -619,8 +619,7 @@ set_cinfo(struct jpeg_compress_struct *cinfo,
 			jpeg_c_set_bool_param(cinfo,
 				JBOOLEAN_OVERSHOOT_DERINGING, TRUE);
 		else
-			g_warning("%s",
-				_("overshoot_deringing unsupported"));
+			g_warning("overshoot_deringing unsupported");
 	}
 
 	/* Split the spectrum of DCT coefficients into separate scans.
@@ -634,12 +633,10 @@ set_cinfo(struct jpeg_compress_struct *cinfo,
 				jpeg_c_set_bool_param(cinfo,
 					JBOOLEAN_OPTIMIZE_SCANS, TRUE);
 			else
-				g_warning("%s",
-					_("ignoring optimize_scans"));
+				g_warning("ignoring optimize_scans");
 		}
 		else
-			g_warning("%s",
-				_("ignoring optimize_scans for baseline"));
+			g_warning("ignoring optimize_scans for baseline");
 	}
 
 	/* Use predefined quantization table.
@@ -650,21 +647,20 @@ set_cinfo(struct jpeg_compress_struct *cinfo,
 			jpeg_c_set_int_param(cinfo,
 				JINT_BASE_QUANT_TBL_IDX, quant_table);
 		else
-			g_warning("%s",
-				_("setting quant_table unsupported"));
+			g_warning("setting quant_table unsupported");
 	}
 #else
 	/* Using jpeglib.h without extension parameters, warn of ignored
 	 * options.
 	 */
 	if (trellis_quant)
-		g_warning("%s", _("ignoring trellis_quant"));
+		g_warning("ignoring trellis_quant");
 	if (overshoot_deringing)
-		g_warning("%s", _("ignoring overshoot_deringing"));
+		g_warning("ignoring overshoot_deringing");
 	if (optimize_scans)
-		g_warning("%s", _("ignoring optimize_scans"));
+		g_warning("ignoring optimize_scans");
 	if (quant_table > 0)
-		g_warning("%s", _("ignoring quant_table"));
+		g_warning("ignoring quant_table");
 #endif
 
 	/* Set compression quality. Must be called after setting params above.

--- a/libvips/foreign/vips2tiff.c
+++ b/libvips/foreign/vips2tiff.c
@@ -601,7 +601,7 @@ wtiff_embed_iptc(Wtiff *wtiff, TIFF *tif)
 	 * long, not byte.
 	 */
 	if (size & 3) {
-		g_warning("%s", _("rounding up IPTC data length"));
+		g_warning("rounding up IPTC data length");
 		size /= 4;
 		size += 1;
 	}
@@ -1480,8 +1480,7 @@ wtiff_new(VipsImage *input, VipsTarget *target,
 		!(wtiff->bitdepth == 1 ||
 			wtiff->bitdepth == 2 ||
 			wtiff->bitdepth == 4)) {
-		g_warning("%s",
-			_("bitdepth 1, 2 or 4 only -- disabling bitdepth"));
+		g_warning("bitdepth 1, 2 or 4 only -- disabling bitdepth");
 		wtiff->bitdepth = 0;
 	}
 
@@ -1492,16 +1491,14 @@ wtiff_new(VipsImage *input, VipsTarget *target,
 		!(wtiff->ready->Coding == VIPS_CODING_NONE &&
 			wtiff->ready->BandFmt == VIPS_FORMAT_UCHAR &&
 			wtiff->ready->Bands == 1)) {
-		g_warning("%s",
-			("can only set bitdepth for 1-band uchar and "
-			 "3-band float lab -- disabling bitdepth"));
+		g_warning("can only set bitdepth for 1-band uchar and "
+			  "3-band float lab -- disabling bitdepth");
 		wtiff->bitdepth = 0;
 	}
 
 	if (wtiff->bitdepth &&
 		wtiff->compression == COMPRESSION_JPEG) {
-		g_warning("%s",
-			_("can't have <8 bit JPEG -- disabling JPEG"));
+		g_warning("can't have <8 bit JPEG -- disabling JPEG");
 		wtiff->compression = COMPRESSION_NONE;
 	}
 
@@ -1511,9 +1508,8 @@ wtiff_new(VipsImage *input, VipsTarget *target,
 		(wtiff->ready->Coding != VIPS_CODING_NONE ||
 			vips_band_format_iscomplex(wtiff->ready->BandFmt) ||
 			wtiff->ready->Bands > 2)) {
-		g_warning("%s",
-			_("can only save non-complex greyscale images "
-			  "as miniswhite -- disabling miniswhite"));
+		g_warning("can only save non-complex greyscale images "
+			  "as miniswhite -- disabling miniswhite");
 		wtiff->miniswhite = FALSE;
 	}
 

--- a/libvips/foreign/vipspng.c
+++ b/libvips/foreign/vipspng.c
@@ -1149,8 +1149,7 @@ write_vips(Write *write,
 		color_type = PNG_COLOR_TYPE_PALETTE;
 #else
 	if (palette)
-		g_warning("%s",
-			_("ignoring palette (no quantisation support)"));
+		g_warning("ignoring palette (no quantisation support)");
 #endif /*HAVE_QUANTIZATION*/
 
 	interlace_type = interlace ? PNG_INTERLACE_ADAM7 : PNG_INTERLACE_NONE;

--- a/libvips/iofuncs/generate.c
+++ b/libvips/iofuncs/generate.c
@@ -421,7 +421,7 @@ vips_image_pipelinev(VipsImage *image, VipsDemandStyle hint, ...)
 		;
 	va_end(ap);
 	if (i == MAX_IMAGES) {
-		g_warning("%s", _("too many images"));
+		g_warning("too many images");
 
 		/* Make sure we have a sentinel there.
 		 */

--- a/libvips/iofuncs/memory.c
+++ b/libvips/iofuncs/memory.c
@@ -245,9 +245,9 @@ vips_tracked_free(void *s)
 #endif /*DEBUG_VERBOSE_MEM*/
 
 	if (vips_tracked_allocs <= 0)
-		g_warning("%s", _("vips_free: too many frees"));
+		g_warning("vips_free: too many frees");
 	if (vips_tracked_mem < size)
-		g_warning("%s", _("vips_free: too much free"));
+		g_warning("vips_free: too much free");
 
 	vips_tracked_mem -= size;
 	vips_tracked_allocs -= 1;
@@ -282,9 +282,9 @@ vips_tracked_aligned_free(void *s)
 #endif /*DEBUG_VERBOSE*/
 
 	if (vips_tracked_allocs <= 0)
-		g_warning("%s", _("vips_free: too many frees"));
+		g_warning("vips_free: too many frees");
 	if (vips_tracked_mem < size)
-		g_warning("%s", _("vips_free: too much free"));
+		g_warning("vips_free: too much free");
 
 	vips_tracked_mem -= size;
 	vips_tracked_allocs -= 1;

--- a/libvips/mosaicing/global_balance.c
+++ b/libvips/mosaicing/global_balance.c
@@ -1103,7 +1103,7 @@ find_image_stats(VipsImage *mem,
 
 #ifdef DEBUG
 	if (count == 0)
-		g_warning("global_balance %s", _("empty overlap!"));
+		g_warning("global_balance empty overlap");
 #endif /*DEBUG*/
 
 	return t[4];

--- a/po/de.po
+++ b/po/de.po
@@ -1832,14 +1832,6 @@ msgstr "Lesen ergab %ld Warnungen"
 msgid "error reading resolution"
 msgstr "Fehler beim Lesen der Auflösung"
 
-#: libvips/foreign/jpeg2vips.c:510
-msgid "unknown EXIF resolution unit"
-msgstr "unbekannte EXIF-Auflösungseinheit"
-
-#: libvips/foreign/jpeg2vips.c:718
-msgid "unknown JFIF resolution unit"
-msgstr "unbekannte JFIF-Auflösungseinheit"
-
 #: libvips/foreign/fits.c:240
 msgid "dimensions above 3 must be size 1"
 msgstr "Dimensionen größer drei müssen die Größe eins haben"
@@ -1933,10 +1925,6 @@ msgid "can only pyramid LABQ and non-complex images"
 msgstr ""
 "nur LABQ und nicht-komplexe Bilder können pyramidenartig verwendet werden"
 
-#: libvips/foreign/vips2tiff.c:1285
-msgid "can't have 1-bit JPEG -- disabling JPEG"
-msgstr "1-Bit-JPEG nicht möglich – JPEG wird ausgeschaltet"
-
 #: libvips/foreign/vips2tiff.c:1463
 msgid "unsigned 8-bit int, 16-bit int, and 32-bit float only"
 msgstr "nur vorzeichenlose 8-Bit-Ganzzahl und 32-Bit-Fließkommazahl"
@@ -2023,13 +2011,6 @@ msgstr "»%s« ist kein bekanntes Dateiformat"
 #: libvips/foreign/foreign.c:740
 msgid "images do not match"
 msgstr "Bilder passen nicht zusammen"
-
-#: libvips/foreign/foreign.c:826
-msgid ""
-"VIPS_FOREIGN_PARTIAL and VIPS_FOREIGN_SEQUENTIAL both set -- using SEQUENTIAL"
-msgstr ""
-"sowohl VIPS_FOREIGN_PARTIAL als auch VIPS_FOREIGN_SEQUENTIAL setzen – "
-"verwenden Sie SEQUENTIAL"
 
 #: libvips/foreign/foreign.c:894
 msgid "file loaders"
@@ -2234,14 +2215,6 @@ msgstr "»start«-Funktion für Bild »%s« fehlgeschlagen"
 msgid "per-thread state for sink"
 msgstr "Status pro Thread für »sink«"
 
-#: libvips/iofuncs/memory.c:231
-msgid "vips_free: too many frees"
-msgstr "vips_free: zu viele Frees"
-
-#: libvips/iofuncs/memory.c:235
-msgid "vips_free: too much free"
-msgstr "vips_free: zu viel frei"
-
 #: libvips/iofuncs/memory.c:295 libvips/iofuncs/memory.c:298
 #, c-format
 msgid "out of memory --- size == %dMB"
@@ -2301,10 +2274,6 @@ msgstr "Daten für »%s« können nicht gelesen werden, %s"
 #, c-format
 msgid "error reading XML: %s"
 msgstr "Fehler beim Lesen von XML: %s"
-
-#: libvips/iofuncs/generate.c:343 libvips/iofuncs/header.c:611
-msgid "too many images"
-msgstr "zu viele Bilder"
 
 #: libvips/iofuncs/generate.c:606
 msgid "demand hint not set"
@@ -3104,10 +3073,6 @@ msgstr ""
 #: libvips/mosaicing/global_balance.c:734
 msgid "more than one root"
 msgstr "mehr als eine Wurzel"
-
-#: libvips/mosaicing/global_balance.c:1053
-msgid "empty overlap!"
-msgstr "leere Überlappung!"
 
 #: libvips/mosaicing/im_avgdxdy.c:64
 msgid "no points to average"

--- a/po/en_GB.po
+++ b/po/en_GB.po
@@ -1189,10 +1189,6 @@ msgstr ""
 msgid "Background value"
 msgstr ""
 
-#: ../libvips/conversion/copy.c:181
-msgid "copy swap is deprecated, use byteswap instead"
-msgstr ""
-
 #: ../libvips/conversion/copy.c:235
 msgid "must not change pel size"
 msgstr ""
@@ -2638,16 +2634,6 @@ msgstr ""
 msgid "images do not match"
 msgstr ""
 
-#: ../libvips/foreign/foreign.c:880
-msgid ""
-"VIPS_FOREIGN_PARTIAL and VIPS_FOREIGN_SEQUENTIAL both set -- using SEQUENTIAL"
-msgstr ""
-
-#: ../libvips/foreign/foreign.c:900
-msgid ""
-"ignoring deprecated \"sequential\" mode -- please use \"access\" instead"
-msgstr ""
-
 #: ../libvips/foreign/foreign.c:979
 msgid "file loaders"
 msgstr ""
@@ -2728,10 +2714,6 @@ msgstr ""
 #: ../libvips/foreign/ppm.c:621 ../libvips/foreign/ppm.c:638
 #: ../libvips/foreign/ppm.c:672 ../libvips/foreign/ppm.c:686
 msgid "write error"
-msgstr ""
-
-#: ../libvips/foreign/ppm.c:803
-msgid "float images must be binary -- disabling ascii"
 msgstr ""
 
 #: ../libvips/foreign/ppm.c:813 ../libvips/foreign/vips2tiff.c:1001
@@ -3262,38 +3244,6 @@ msgstr ""
 msgid "field \"%s\" is too large for a single JPEG marker, ignoring"
 msgstr ""
 
-#: ../libvips/foreign/vips2jpeg.c:496
-msgid "trellis_quant unsupported"
-msgstr ""
-
-#: ../libvips/foreign/vips2jpeg.c:509
-msgid "overshoot_deringing unsupported"
-msgstr ""
-
-#: ../libvips/foreign/vips2jpeg.c:523 ../libvips/foreign/vips2jpeg.c:550
-msgid "ignoring optimize_scans"
-msgstr ""
-
-#: ../libvips/foreign/vips2jpeg.c:527
-msgid "ignoring optimize_scans for baseline"
-msgstr ""
-
-#: ../libvips/foreign/vips2jpeg.c:539
-msgid "setting quant_table unsupported"
-msgstr ""
-
-#: ../libvips/foreign/vips2jpeg.c:546
-msgid "ignoring trellis_quant"
-msgstr ""
-
-#: ../libvips/foreign/vips2jpeg.c:548
-msgid "ignoring overshoot_deringing"
-msgstr ""
-
-#: ../libvips/foreign/vips2jpeg.c:552
-msgid "ignoring quant_table"
-msgstr ""
-
 #: ../libvips/foreign/ppmload.c:119
 msgid "load ppm from file"
 msgstr ""
@@ -3492,10 +3442,6 @@ msgstr ""
 msgid "unable to init exif"
 msgstr ""
 
-#: ../libvips/foreign/exif.c:413 ../libvips/foreign/exif.c:788
-msgid "unknown EXIF resolution unit"
-msgstr ""
-
 #: ../libvips/foreign/exif.c:918 ../libvips/foreign/exif.c:928
 #: ../libvips/foreign/exif.c:933
 #, c-format
@@ -3640,10 +3586,6 @@ msgstr ""
 #: ../libvips/foreign/jpeg2vips.c:187
 #, c-format
 msgid "read gave %ld warnings"
-msgstr ""
-
-#: ../libvips/foreign/jpeg2vips.c:387
-msgid "unknown JFIF resolution unit"
 msgstr ""
 
 #: ../libvips/foreign/tiffsave.c:172 ../libvips/foreign/tiffsave.c:358
@@ -4152,16 +4094,6 @@ msgstr ""
 
 #: ../libvips/foreign/vips2tiff.c:988
 msgid "can only pyramid LABQ and non-complex images"
-msgstr ""
-
-#: ../libvips/foreign/vips2tiff.c:1009
-msgid "can't have 1-bit JPEG -- disabling JPEG"
-msgstr ""
-
-#: ../libvips/foreign/vips2tiff.c:1020
-msgid ""
-"can only save non-complex greyscale images as miniswhite -- disabling "
-"miniswhite"
 msgstr ""
 
 #: ../libvips/foreign/vips2tiff.c:1043
@@ -4717,10 +4649,6 @@ msgstr ""
 msgid "per-thread state for sinkmemory"
 msgstr ""
 
-#: ../libvips/iofuncs/generate.c:425
-msgid "too many images"
-msgstr ""
-
 #: ../libvips/iofuncs/generate.c:690
 msgid "demand hint not set"
 msgstr ""
@@ -5188,14 +5116,6 @@ msgstr ""
 msgid "unable to form filename"
 msgstr ""
 
-#: ../libvips/iofuncs/memory.c:251
-msgid "vips_free: too many frees"
-msgstr ""
-
-#: ../libvips/iofuncs/memory.c:253
-msgid "vips_free: too much free"
-msgstr ""
-
 #: ../libvips/iofuncs/sinkscreen.c:188
 msgid "per-thread state for render"
 msgstr ""
@@ -5553,10 +5473,6 @@ msgstr ""
 
 #: ../libvips/mosaicing/global_balance.c:741
 msgid "more than one root"
-msgstr ""
-
-#: ../libvips/mosaicing/global_balance.c:1060
-msgid "empty overlap!"
 msgstr ""
 
 #: ../libvips/mosaicing/global_balance.c:1783
@@ -6315,10 +6231,6 @@ msgstr ""
 
 #: ../tools/vipsthumbnail.c:375
 msgid "- thumbnail generator"
-msgstr ""
-
-#: ../tools/vipsthumbnail.c:406
-msgid "auto-rotate disabled: libvips built without exif support"
 msgstr ""
 
 #: ../libvips/resample/reduceh.cpp:457

--- a/po/malkovich.po
+++ b/po/malkovich.po
@@ -386,10 +386,6 @@ msgstr ""
 msgid "can only pyramid LABQ and non-complex images"
 msgstr ""
 
-#: libsrc/conversion/im_vips2tiff.c:1372
-msgid "can't have 1-bit JPEG -- disabling JPEG"
-msgstr ""
-
 #: libsrc/conversion/im_vips2tiff.c:1529
 #, fuzzy
 msgid "unknown coding type"

--- a/tools/vips.c
+++ b/tools/vips.c
@@ -774,8 +774,8 @@ main(int argc, char **argv)
 		}
 #endif /*ENABLE_DEPRECATED*/
 #else  /*!ENABLE_MODULES*/
-		g_warning("%s", _("plugin load disabled: "
-						  "libvips built without modules support"));
+		g_warning("plugin load disabled: "
+			  "libvips built without modules support");
 #endif /*ENABLE_MODULES*/
 	}
 

--- a/tools/vipsthumbnail.c
+++ b/tools/vipsthumbnail.c
@@ -546,9 +546,8 @@ main(int argc, char **argv)
 
 #ifndef HAVE_EXIF
 	if (rotate_image)
-		g_warning("%s",
-			_("auto-rotate disabled: "
-			  "libvips built without exif support"));
+		g_warning("auto-rotate disabled: "
+			  "libvips built without exif support");
 #endif /*!HAVE_EXIF*/
 
 	result = 0;


### PR DESCRIPTION
The recommended approach (a.k.a. "policy") is to not provide translations for warning messages.

I've manually removed only a subset of unused entries from the .po files to keep the diff clean. Once this PR is merged I'll do a follow-up to fully refresh the rest of the translation files e.g. remove all other no longer used entries, update line numbers etc.

Fixes https://github.com/libvips/libvips/issues/3210