### PR TITLE
i18n: refresh translations

### DIFF
--- a/libvips/foreign/foreign.c
+++ b/libvips/foreign/foreign.c
@@ -1094,7 +1094,7 @@ vips_foreign_load_build(VipsObject *object)
 	if ((flags & VIPS_FOREIGN_PARTIAL) &&
 		(flags & VIPS_FOREIGN_SEQUENTIAL)) {
 		g_warning("VIPS_FOREIGN_PARTIAL and VIPS_FOREIGN_SEQUENTIAL "
-			  "both set -- using SEQUENTIAL");
+				  "both set -- using SEQUENTIAL");
 		flags ^= VIPS_FOREIGN_PARTIAL;
 	}
 
@@ -1121,7 +1121,7 @@ vips_foreign_load_build(VipsObject *object)
 
 	if (load->sequential)
 		g_warning("ignoring deprecated \"sequential\" mode -- "
-			  "please use \"access\" instead");
+				  "please use \"access\" instead");
 
 	g_object_set(object, "out", vips_image_new(), NULL);
 

--- a/libvips/foreign/magick.c
+++ b/libvips/foreign/magick.c
@@ -655,7 +655,7 @@ magick_optimize_image_layers(Image **images, ExceptionInfo *exception)
 	return MagickTrue;
 #else  /*!HAVE_OPTIMIZEPLUSIMAGELAYERS*/
 	g_warning("layer optimization is not supported by "
-		  "your version of libMagick");
+			  "your version of libMagick");
 
 	return MagickTrue;
 #endif /*HAVE_OPTIMIZEPLUSIMAGELAYERS*/
@@ -671,7 +671,7 @@ magick_optimize_image_transparency(const Image *images,
 	return exception->severity == UndefinedException;
 #else  /*!HAVE_OPTIMIZEIMAGETRANSPARENCY*/
 	g_warning("transparency optimization is not supported by "
-		  "your version of libMagick");
+			  "your version of libMagick");
 
 	return MagickTrue;
 #endif /*HAVE_OPTIMIZEIMAGETRANSPARENCY*/

--- a/libvips/foreign/ppmsave.c
+++ b/libvips/foreign/ppmsave.c
@@ -345,7 +345,7 @@ vips_foreign_save_ppm_build(VipsObject *object)
 		(image->Bands != 1 ||
 		 image->BandFmt != VIPS_FORMAT_UCHAR)) {
 		g_warning("can only save 1 band uchar images as 1 bit -- "
-			  "disabling 1 bit save");
+				  "disabling 1 bit save");
 		ppm->bitdepth = 0;
 	}
 

--- a/libvips/foreign/vips2tiff.c
+++ b/libvips/foreign/vips2tiff.c
@@ -1492,7 +1492,7 @@ wtiff_new(VipsImage *input, VipsTarget *target,
 			wtiff->ready->BandFmt == VIPS_FORMAT_UCHAR &&
 			wtiff->ready->Bands == 1)) {
 		g_warning("can only set bitdepth for 1-band uchar and "
-			  "3-band float lab -- disabling bitdepth");
+				  "3-band float lab -- disabling bitdepth");
 		wtiff->bitdepth = 0;
 	}
 
@@ -1509,7 +1509,7 @@ wtiff_new(VipsImage *input, VipsTarget *target,
 			vips_band_format_iscomplex(wtiff->ready->BandFmt) ||
 			wtiff->ready->Bands > 2)) {
 		g_warning("can only save non-complex greyscale images "
-			  "as miniswhite -- disabling miniswhite");
+				  "as miniswhite -- disabling miniswhite");
 		wtiff->miniswhite = FALSE;
 	}
 

--- a/po/de.po
+++ b/po/de.po
@@ -7,9 +7,8 @@
 #
 msgid ""
 msgstr ""
-"Project-Id-Version: libvips-doc 7.36.5-1\n"
-"Report-Msgid-Bugs-To: VIPSIP@JISCMAIL.AC.UK\n"
-"POT-Creation-Date: 2012-03-08 21:02+0000\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2025-01-30 14:51+0000\n"
 "PO-Revision-Date: 2014-03-12 21:58+0100\n"
 "Last-Translator: Chris Leick <c.leick@vollbio.de>\n"
 "Language-Team: Debian German <debian-l10n-german@lists.debian.org>\n"
@@ -19,1153 +18,1969 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=n != 1;\n"
 
-#: libvips/arithmetic/abs.c:215
 # http://techpubs.sgi.com/library/tpl/cgi-bin/getdoc.cgi?coll=0650&
 #        db=man&fname=/usr/share/catman/p_man/cat3/il_c/ilAbsImg.z
+#: libvips/arithmetic/abs.c:200
 msgid "absolute value of an image"
 msgstr "absoluter Wert eines Bildes"
 
-#: libvips/arithmetic/statistic.c:147
-msgid "VIPS statistic operations"
-msgstr "statistische VIPS-Transaktionen"
-
-#: libvips/arithmetic/statistic.c:151 libvips/arithmetic/unary.c:87
-#: libvips/conversion/bandmean.c:197 libvips/conversion/cast.c:474
-#: libvips/conversion/tilecache.c:422 libvips/conversion/extract.c:194
-#: libvips/conversion/extract.c:353 libvips/conversion/embed.c:516
-#: libvips/conversion/rot.c:355 libvips/conversion/flip.c:240
-#: libvips/conversion/copy.c:318 libvips/conversion/recomb.c:200
-#: libvips/conversion/replicate.c:196 libvips/conversion/cache.c:106
-#: libvips/conversion/bandjoin.c:171 libvips/foreign/foreign.c:1379
-msgid "Input"
-msgstr "Eingabe"
-
-#: libvips/arithmetic/statistic.c:152 libvips/conversion/cast.c:475
-#: libvips/conversion/tilecache.c:423 libvips/conversion/extract.c:195
-#: libvips/conversion/extract.c:354 libvips/conversion/embed.c:517
-#: libvips/conversion/rot.c:356 libvips/conversion/flip.c:241
-#: libvips/conversion/copy.c:319 libvips/conversion/replicate.c:197
-#: libvips/conversion/cache.c:107
-msgid "Input image"
-msgstr "Eingabebild"
-
-#: libvips/arithmetic/im_point_bilinear.c:74
-msgid "coords outside image"
-msgstr "Koordinaten außerhalb des Bildes"
-
-#. Name
-#: libvips/arithmetic/arith_dispatch.c:298
-msgid "absolute value"
-msgstr "absoluter Wert"
-
-#. Name
-#: libvips/arithmetic/arith_dispatch.c:317 libvips/arithmetic/add.c:186
+#: libvips/arithmetic/add.c:178
 msgid "add two images"
 msgstr "zwei Bilder hinzufügen"
 
-#. Name
-#: libvips/arithmetic/arith_dispatch.c:342
-msgid "average value of image"
-msgstr "Durchschnittswert des Bildes"
-
-#. Name
-#: libvips/arithmetic/arith_dispatch.c:431
-msgid "standard deviation of image"
-msgstr "Standardabweichung des Bildes"
-
-# im_exptra() transforms element x of input to
-# <function>pow</function>(e, x) in output.
-#. Name
-#: libvips/arithmetic/arith_dispatch.c:450
-msgid "10^pel of image"
-msgstr "10^pel des Bildes"
-
-#. Name
-#: libvips/arithmetic/arith_dispatch.c:469
-msgid "e^pel of image"
-msgstr "e^pel des Bildes"
-
-#. Name
-#: libvips/arithmetic/arith_dispatch.c:498
-msgid "x^pel of image"
-msgstr "x^pel des Bildes"
-
-#. Name
-#: libvips/arithmetic/arith_dispatch.c:527
-msgid "[x,y,z]^pel of image"
-msgstr "[x,y,z]^pel des Bildes"
-
-#. Name
-#: libvips/arithmetic/arith_dispatch.c:546 libvips/arithmetic/divide.c:225
-msgid "divide two images"
-msgstr "zwei Bilder teilen"
-
-#. Name
-#: libvips/arithmetic/arith_dispatch.c:565
-msgid "photographic negative"
-msgstr "Fotonegativ"
-
-#. Name
-#: libvips/arithmetic/arith_dispatch.c:596
-msgid "calculate a*in + b = outfile"
-msgstr "Berechnen von a*in + b = Ausgabedatei"
-
-#: libvips/arithmetic/arith_dispatch.c:622
-msgid "vectors not equal length"
-msgstr "Vektoren ungleicher Länge"
-
-#. Name
-#: libvips/arithmetic/arith_dispatch.c:633
-msgid "calculate a*in + b -> out, a and b vectors"
-msgstr "Berechnen von a*in + b -> out, a und b Vektoren"
-
-#. Name
-#: libvips/arithmetic/arith_dispatch.c:652
-msgid "log10 of image"
-msgstr "log10 des Bildes"
-
-#. Name
-#: libvips/arithmetic/arith_dispatch.c:671
-msgid "ln of image"
-msgstr "ln des Bildes"
-
-#. Name
-#: libvips/arithmetic/arith_dispatch.c:690
-msgid "tan of image (angles in degrees)"
-msgstr "Tangens des Bildes (Winkel in Grad)"
-
-#. Name
-#: libvips/arithmetic/arith_dispatch.c:709
-msgid "atan of image (result in degrees)"
-msgstr "Arkustangens des Bildes (Ergebnis in Grad)"
-
-#. Name
-#: libvips/arithmetic/arith_dispatch.c:728
-msgid "cos of image (angles in degrees)"
-msgstr "Kosinus des Bildes (Winkel in Grad)"
-
-#. Name
-#: libvips/arithmetic/arith_dispatch.c:747
-msgid "acos of image (result in degrees)"
-msgstr "Arkuskosinus des Bildes (Ergebnis in Grad)"
-
-# hinter diesem String folgt ein Flag.
-#. Name
-#: libvips/arithmetic/arith_dispatch.c:766
-msgid "round to smallest integer value not less than"
-msgstr "auf kleinsten ganzzahligen Wert runden, nicht weniger als"
-
-# hinter diesem String folgt ein Flag.
-#. Name
-#: libvips/arithmetic/arith_dispatch.c:785
-msgid "round to largest integer value not greater than"
-msgstr "auf größten ganzzahligen Wert runden, nicht größer als"
-
-# hinter diesem String folgt ein Flag.
-#. Name
-#: libvips/arithmetic/arith_dispatch.c:804
-msgid "round to nearest integer value"
-msgstr "auf nächsten ganzzahligen Wert runden"
-
-#. Name
-#: libvips/arithmetic/arith_dispatch.c:823
-msgid "sin of image (angles in degrees)"
-msgstr "Sinus des Bildes (Winkel in Grad)"
-
-#. Name
-#: libvips/arithmetic/arith_dispatch.c:842
-msgid "average image bands"
-msgstr "durchschnittliche Bildbänder"
-
-#. Name
-#: libvips/arithmetic/arith_dispatch.c:861
-msgid "unit vector in direction of value"
-msgstr "Einheitsvektor in Richtung des Wertes"
-
-#. Name
-#: libvips/arithmetic/arith_dispatch.c:880
-msgid "asin of image (result in degrees)"
-msgstr "Arkussinus des Bildes (Ergebnis in Grad)"
-
-#. Name
-#: libvips/arithmetic/arith_dispatch.c:905
-msgid "maximum value of image"
-msgstr "Maximalwert des Bildes"
-
-#. Name
-#: libvips/arithmetic/arith_dispatch.c:940
-msgid "position of maximum value of image"
-msgstr "Position des Maximalwerts des Bildes"
-
-#: libvips/arithmetic/arith_dispatch.c:968
-msgid "position of maximum value of image, averaging in case of draw"
-msgstr ""
-"Position des Maximalwerts des Bildes, durchschnittlich im Fall des Zeichnens"
-
-#: libvips/arithmetic/arith_dispatch.c:1012
-msgid "position and value of n maxima of image"
-msgstr "Position und Wert von n Maxima des Bildes"
-
-#: libvips/arithmetic/arith_dispatch.c:1046
-msgid "position and value of n minima of image"
-msgstr "Position und Wert von n Minima des Bildes"
-
-#. Name
-#: libvips/arithmetic/arith_dispatch.c:1094
-msgid "measure averages of a grid of patches"
-msgstr "Durchschnittsmaße eine Gitters aus Flickstücken"
-
-#. Name
-#: libvips/arithmetic/arith_dispatch.c:1119
-msgid "minimum value of image"
-msgstr "Minimalwert des Bildes"
-
-#. Name
-#: libvips/arithmetic/arith_dispatch.c:1147
-msgid "position of minimum value of image"
-msgstr "Position des Minimalwerts des Bildes"
-
-#. Name
-#: libvips/arithmetic/arith_dispatch.c:1166
-msgid "remainder after integer division"
-msgstr "Rest nach Ganzzahldivision"
-
-#. Name
-#: libvips/arithmetic/arith_dispatch.c:1195
-msgid "remainder after integer division by a constant"
-msgstr "Rest nach Ganzzahldivision durch eine Konstante"
-
-#. Name
-#: libvips/arithmetic/arith_dispatch.c:1224
-msgid "remainder after integer division by a vector of constants"
-msgstr "Rest nach Ganzzahldivision durch einen Vektor von Konstanten"
-
-#. Name
-#: libvips/arithmetic/arith_dispatch.c:1244 libvips/arithmetic/multiply.c:172
-msgid "multiply two images"
-msgstr "zwei Bilder multiplizieren"
-
-#. Name
-#: libvips/arithmetic/arith_dispatch.c:1265
-msgid "pel^x of image"
-msgstr "pel^x des Bildes"
-
-#. Name
-#: libvips/arithmetic/arith_dispatch.c:1286
-msgid "pel^[x,y,z] of image"
-msgstr "pel^[x,y,z] des Bildes"
-
-#. Name
-#: libvips/arithmetic/arith_dispatch.c:1317
-msgid "many image statistics in one pass"
-msgstr "viele Bildstatistiken in einem Durchgang"
-
-#. Name
-#: libvips/arithmetic/arith_dispatch.c:1336 libvips/arithmetic/subtract.c:161
-msgid "subtract two images"
-msgstr "zwei Bilder subtrahieren"
-
-#. Name
-#: libvips/arithmetic/arith_dispatch.c:1384
-msgid "pixelwise linear regression"
-msgstr "bildpunktweise lineare Regression"
-
-#. Name
-#: libvips/arithmetic/arith_dispatch.c:1403
-msgid "phase of cross power spectrum of two complex images"
-msgstr "Phase des Kreuzleistungsspektrums zweier komplexer Bilder"
-
-#: libvips/arithmetic/linear.c:249
-msgid "calculate (a * in + b)"
-msgstr "(a * in + b) berechnen"
-
-#: libvips/arithmetic/linear.c:257
-msgid "a"
-msgstr "a"
-
-#: libvips/arithmetic/linear.c:258
-msgid "Multiply by this"
-msgstr "hiermit multiplizieren"
-
-#: libvips/arithmetic/linear.c:264
-msgid "b"
-msgstr "b"
-
-#: libvips/arithmetic/linear.c:265
-msgid "Add this"
-msgstr "dies hinzufügen"
-
-#: libvips/arithmetic/remainder.c:178
-msgid "remainder after integer division of two images"
-msgstr "Rest nach Ganzzahldivision zweier Bilder"
-
-#: libvips/arithmetic/remainder.c:327
-msgid "remainder after integer division of an image and a constant"
-msgstr "Rest nach Ganzzahldivision eines Bildes und einer Konstante"
-
-#: libvips/arithmetic/im_maxpos_vec.c:121
-#: libvips/arithmetic/im_maxpos_vec.c:186
-msgid "scalar images only"
-msgstr "nur skalare Bilder"
-
-#: libvips/arithmetic/im_maxpos_vec.c:126
-#: libvips/arithmetic/im_maxpos_vec.c:191
-msgid "single band images only"
-msgstr "nur Einzelbandbilder"
-
-#: libvips/arithmetic/im_maxpos_vec.c:131
-#: libvips/arithmetic/im_maxpos_vec.c:196
-msgid "uncoded images only"
-msgstr "nur unkodierte Bilder"
-
-#: libvips/arithmetic/im_maxpos_vec.c:136
-#: libvips/arithmetic/im_maxpos_vec.c:201
-msgid "invalid argument"
-msgstr "ungültiges Argument"
-
-#: libvips/arithmetic/min.c:317
-msgid "find image minimum"
-msgstr "Minimum des Bildes finden"
-
-#: libvips/arithmetic/min.c:325 libvips/arithmetic/arithmetic.c:382
-#: libvips/arithmetic/stats.c:423 libvips/arithmetic/measure.c:202
-#: libvips/arithmetic/max.c:324 libvips/arithmetic/avg.c:218
-#: libvips/arithmetic/deviate.c:219 libvips/conversion/conversion.c:89
-#: libvips/foreign/foreign.c:897
-msgid "Output"
-msgstr "Ausgabe"
-
-#: libvips/arithmetic/min.c:326 libvips/arithmetic/max.c:325
-#: libvips/arithmetic/avg.c:219 libvips/arithmetic/deviate.c:220
-msgid "Output value"
-msgstr "Ausgabewert"
-
-#: libvips/arithmetic/min.c:332 libvips/arithmetic/max.c:331
-#: libvips/conversion/embed.c:522
-msgid "x"
-msgstr "x"
-
-#: libvips/arithmetic/min.c:333
-msgid "Horizontal position of minimum"
-msgstr "horizontale Position des Minimums"
-
-#: libvips/arithmetic/min.c:339 libvips/arithmetic/max.c:338
-#: libvips/conversion/embed.c:529
-msgid "y"
-msgstr "y"
-
-#: libvips/arithmetic/min.c:340
-msgid "Vertical position of minimum"
-msgstr "vertikale Position des Minimums"
-
-#: libvips/arithmetic/boolean.c:209
-msgid "a boolean operation on a pair of images"
-msgstr "eine Wahr-/Falsch-Transaktion für ein Bilderpaar"
-
-#: libvips/arithmetic/boolean.c:217 libvips/arithmetic/boolean.c:519
-#: libvips/arithmetic/math2.c:204 libvips/arithmetic/math2.c:401
-#: libvips/arithmetic/math.c:205 libvips/arithmetic/relational.c:227
-#: libvips/arithmetic/relational.c:560 libvips/arithmetic/complex.c:222
-#: libvips/arithmetic/complex.c:476
-msgid "Operation"
-msgstr "Transaktion"
-
-#: libvips/arithmetic/boolean.c:218 libvips/arithmetic/boolean.c:520
-msgid "boolean to perform"
-msgstr "Boolesch zur Durchführung"
-
-#: libvips/arithmetic/boolean.c:511
-msgid "boolean operations against a constant"
-msgstr "boolesche Transaktionen mit einer Konstante"
-
-#: libvips/arithmetic/arithmetic.c:164
+#: libvips/arithmetic/arithmetic.c:392
 #, c-format
 msgid "not one band or %d bands"
 msgstr "nicht ein Band oder %d Bänder"
 
-#: libvips/arithmetic/arithmetic.c:168 libvips/histograms_lut/im_identity.c:80
-#: libvips/histograms_lut/im_identity.c:143
+#: libvips/arithmetic/arithmetic.c:397 libvips/foreign/spngsave.c:423
 msgid "bad bands"
 msgstr "falsche Bänder"
 
-#: libvips/arithmetic/arithmetic.c:324 libvips/conversion/bandary.c:131
-msgid "too many input images"
-msgstr "zu viele Eingabebilder"
-
-#: libvips/arithmetic/arithmetic.c:378
+#: libvips/arithmetic/arithmetic.c:725
 msgid "arithmetic operations"
 msgstr "arithmetische Transaktionen"
 
-#: libvips/arithmetic/arithmetic.c:383 libvips/conversion/conversion.c:90
-#: libvips/foreign/foreign.c:898
+#: libvips/arithmetic/arithmetic.c:731 libvips/arithmetic/avg.c:235
+#: libvips/arithmetic/deviate.c:237 libvips/arithmetic/hist_find.c:431
+#: libvips/arithmetic/hist_find_indexed.c:475
+#: libvips/arithmetic/hist_find_ndim.c:313 libvips/arithmetic/hough.c:179
+#: libvips/arithmetic/max.c:452 libvips/arithmetic/measure.c:201
+#: libvips/arithmetic/min.c:452 libvips/arithmetic/stats.c:442
+#: libvips/colour/CMYK2XYZ.c:126 libvips/colour/colour.c:415
+#: libvips/colour/colourspace.c:563 libvips/colour/scRGB2BW.c:243
+#: libvips/colour/scRGB2sRGB.c:276 libvips/colour/scRGB2XYZ.c:197
+#: libvips/colour/sRGB2scRGB.c:294 libvips/colour/XYZ2CMYK.c:125
+#: libvips/colour/XYZ2scRGB.c:206 libvips/conversion/conversion.c:346
+#: libvips/conversion/switch.c:202 libvips/convolution/canny.c:448
+#: libvips/convolution/convolution.c:134 libvips/convolution/correlation.c:162
+#: libvips/convolution/edge.c:223 libvips/convolution/gaussblur.c:138
+#: libvips/convolution/sharpen.c:328 libvips/create/create.c:124
+#: libvips/foreign/foreign.c:1215 libvips/freqfilt/freqfilt.c:104
+#: libvips/histogram/case.c:252 libvips/histogram/hist_entropy.c:117
+#: libvips/histogram/hist_equal.c:120 libvips/histogram/hist_local.c:367
+#: libvips/histogram/hist_norm.c:147 libvips/histogram/histogram.c:232
+#: libvips/histogram/hist_plot.c:339 libvips/histogram/maplut.c:750
+#: libvips/histogram/stdif.c:300 libvips/iofuncs/system.c:284
+#: libvips/morphology/morph.c:959 libvips/morphology/rank.c:564
+#: libvips/mosaicing/global_balance.c:1930 libvips/mosaicing/match.c:208
+#: libvips/mosaicing/matrixinvert.c:449 libvips/mosaicing/merge.c:134
+#: libvips/mosaicing/mosaic1.c:510 libvips/mosaicing/mosaic.c:191
+#: libvips/mosaicing/remosaic.c:170 libvips/resample/resample.c:146
+#: libvips/resample/thumbnail.c:968
+msgid "Output"
+msgstr "Ausgabe"
+
+#: libvips/arithmetic/arithmetic.c:732 libvips/arithmetic/hough.c:180
+#: libvips/colour/CMYK2XYZ.c:127 libvips/colour/colour.c:416
+#: libvips/colour/colourspace.c:564 libvips/colour/scRGB2BW.c:244
+#: libvips/colour/scRGB2sRGB.c:277 libvips/colour/scRGB2XYZ.c:198
+#: libvips/colour/sRGB2scRGB.c:295 libvips/colour/XYZ2CMYK.c:126
+#: libvips/colour/XYZ2scRGB.c:207 libvips/conversion/conversion.c:347
+#: libvips/conversion/switch.c:203 libvips/convolution/canny.c:449
+#: libvips/convolution/convolution.c:135 libvips/convolution/correlation.c:163
+#: libvips/convolution/edge.c:224 libvips/convolution/gaussblur.c:139
+#: libvips/convolution/sharpen.c:329 libvips/create/create.c:125
+#: libvips/foreign/foreign.c:1216 libvips/freqfilt/freqfilt.c:105
+#: libvips/histogram/case.c:253 libvips/histogram/hist_equal.c:121
+#: libvips/histogram/hist_local.c:368 libvips/histogram/hist_norm.c:148
+#: libvips/histogram/histogram.c:233 libvips/histogram/hist_plot.c:340
+#: libvips/histogram/maplut.c:751 libvips/histogram/stdif.c:301
+#: libvips/iofuncs/system.c:285 libvips/morphology/morph.c:960
+#: libvips/morphology/rank.c:565 libvips/mosaicing/global_balance.c:1931
+#: libvips/mosaicing/match.c:209 libvips/mosaicing/merge.c:135
+#: libvips/mosaicing/mosaic1.c:511 libvips/mosaicing/mosaic.c:192
+#: libvips/mosaicing/remosaic.c:171 libvips/resample/resample.c:147
+#: libvips/resample/thumbnail.c:969
 msgid "Output image"
 msgstr "Ausgabebild"
 
-#: libvips/arithmetic/stats.c:415 libvips/arithmetic/avg.c:210
-#: libvips/arithmetic/deviate.c:211
+#: libvips/arithmetic/avg.c:227
 msgid "find image average"
 msgstr "Bildmittelwert finden"
 
-#: libvips/arithmetic/stats.c:424 libvips/arithmetic/measure.c:203
-msgid "Output array of statistics"
-msgstr "Ausgabefeld von Statistiken"
+#: libvips/arithmetic/avg.c:236 libvips/arithmetic/deviate.c:238
+#: libvips/arithmetic/max.c:453 libvips/arithmetic/min.c:453
+#: libvips/histogram/hist_entropy.c:118
+msgid "Output value"
+msgstr "Ausgabewert"
 
-#: libvips/arithmetic/math2.c:196
-msgid "pow( left, right)"
-msgstr "pow( links, rechts)"
-
-#: libvips/arithmetic/math2.c:205 libvips/arithmetic/math2.c:402
-#: libvips/arithmetic/math.c:206
-msgid "math to perform"
-msgstr "durchzuführende Berechnung"
-
-#: libvips/arithmetic/math2.c:393
-msgid "pow( @in, @c )"
-msgstr "pow( @in, @c )"
-
-#: libvips/arithmetic/round.c:160
-msgid "perform a round function on an image"
-msgstr "eine Rundungsfunktion für ein Bild ausführen"
-
-#: libvips/arithmetic/round.c:168
-msgid "Round operation"
-msgstr "Rundungstransakktion"
-
-#: libvips/arithmetic/round.c:169
-msgid "rounding operation to perform"
-msgstr "durchzuführende Rundungstransakktion"
-
-#: libvips/arithmetic/measure.c:163
-#, c-format
-msgid "patch %d x %d, band %d: avg = %g, sdev = %g"
-msgstr "Flicken %d x %d, Band %d: Durchschn. = %g, sdev = %g"
-
-#: libvips/arithmetic/measure.c:192
-msgid "measure a set of patches on a colour chart"
-msgstr "messen eines Satzes von Patches auf ein Farbdiagramm"
-
-#: libvips/arithmetic/measure.c:196
-msgid "in"
-msgstr "in"
-
-#: libvips/arithmetic/measure.c:197
-msgid "Image to measure"
-msgstr "zu vermessendes Bild"
-
-#: libvips/arithmetic/measure.c:208 libvips/conversion/replicate.c:202
-msgid "Across"
-msgstr "über"
-
-#: libvips/arithmetic/measure.c:209
-msgid "Number of patches across chart"
-msgstr "Anzahl der Patches über ein Diagramm"
-
-#: libvips/arithmetic/measure.c:215 libvips/conversion/replicate.c:209
-msgid "Down"
-msgstr "hinunter"
-
-#: libvips/arithmetic/measure.c:216
-msgid "Number of patches down chart"
-msgstr "Anzahl der Patches ein Diagramm hinunter"
-
-#: libvips/arithmetic/measure.c:222 libvips/arithmetic/binary.c:95
-#: libvips/conversion/extract.c:200
-msgid "Left"
-msgstr "links"
-
-#: libvips/arithmetic/measure.c:223 libvips/conversion/extract.c:201
-msgid "Left edge of extract area"
-msgstr "linke Kante eines extrahierten Bereichs"
-
-#: libvips/arithmetic/measure.c:229 libvips/conversion/extract.c:207
-msgid "Top"
-msgstr "oben"
-
-#: libvips/arithmetic/measure.c:230 libvips/conversion/extract.c:208
-msgid "Top edge of extract area"
-msgstr "obere Kante eines extrahierten Bereichs"
-
-#: libvips/arithmetic/measure.c:236 libvips/conversion/extract.c:214
-#: libvips/conversion/embed.c:536 libvips/conversion/copy.c:331
-#: libvips/conversion/black.c:128 libvips/foreign/rawload.c:122
-#: libvips/iofuncs/image.c:845
-msgid "Width"
-msgstr "Breite"
-
-#: libvips/arithmetic/measure.c:237 libvips/conversion/extract.c:215
-msgid "Width of extract area"
-msgstr "Breite des extrahierten Bereichs"
-
-#: libvips/arithmetic/measure.c:243 libvips/conversion/extract.c:221
-#: libvips/conversion/embed.c:543 libvips/conversion/copy.c:338
-#: libvips/conversion/black.c:135 libvips/foreign/rawload.c:129
-#: libvips/iofuncs/image.c:852
-msgid "Height"
-msgstr "Höhe"
-
-#: libvips/arithmetic/measure.c:244 libvips/conversion/extract.c:222
-msgid "Height of extract area"
-msgstr "Höhe des extrahierten Bereichs"
-
-#: libvips/arithmetic/math.c:197
-msgid "perform a math function on an image"
-msgstr "eine mathematische Funktion für ein Bild ausführen"
-
-#: libvips/arithmetic/relational.c:219
-msgid "a relational operation on a pair of images"
-msgstr "eine relationale Transaktion für ein Bilderpaar"
-
-#: libvips/arithmetic/relational.c:228 libvips/arithmetic/relational.c:561
-msgid "relational to perform"
-msgstr "relational durchzuführen"
-
-#: libvips/arithmetic/relational.c:552
-msgid "relational operations against a constant"
-msgstr "relationale Transaktion für eine Konstante"
-
-#: libvips/arithmetic/unaryconst.c:201
-msgid "unary operations with a constant"
-msgstr "unäre Transaktionen mit einer Konstante"
-
-#: libvips/arithmetic/unaryconst.c:205
-msgid "c"
-msgstr "c"
-
-#: libvips/arithmetic/unaryconst.c:206
-msgid "Array of constants"
-msgstr "Feld aus Konstanten"
-
-#: libvips/arithmetic/unary.c:80
-msgid "unary operations"
-msgstr "unäre Transaktionen"
-
-#: libvips/arithmetic/unary.c:88 libvips/conversion/bandmean.c:198
-#: libvips/conversion/recomb.c:201
-msgid "Input image argument"
-msgstr "Eingabebildargument"
-
-#: libvips/arithmetic/invert.c:152
-msgid "invert an image"
-msgstr "ein Bild invertieren"
-
-#: libvips/arithmetic/max.c:316
-msgid "find image maximum"
-msgstr "Maximum des Bildes finden"
-
-#: libvips/arithmetic/max.c:332
-msgid "Horizontal position of maximum"
-msgstr "horizontale Position des Maximums"
-
-#: libvips/arithmetic/max.c:339
-msgid "Vertical position of maximum"
-msgstr "vertikale Position des Maximums"
-
-#: libvips/arithmetic/complex.c:215
-msgid "perform a complex operation on an image"
-msgstr "eine komplexe Transaktion mit einem Bild durchführen"
-
-#: libvips/arithmetic/complex.c:223 libvips/arithmetic/complex.c:477
-msgid "complex to perform"
-msgstr "komplex durchzuführen"
-
-#: libvips/arithmetic/complex.c:468
-msgid "get a component from a complex image"
-msgstr "einen Bestandteil eines komplexen Bildes holen"
-
-#: libvips/arithmetic/complex.c:666
-msgid "form a complex image from two real images"
-msgstr "ein komplexes Bild aus zwei echten Bildern erstellen"
-
-#: libvips/arithmetic/binary.c:88
+#: libvips/arithmetic/binary.c:89
 msgid "binary operations"
 msgstr "binäre Transaktionen"
 
-#: libvips/arithmetic/binary.c:96
+#: libvips/arithmetic/binary.c:96 libvips/arithmetic/find_trim.c:216
+#: libvips/arithmetic/measure.c:221 libvips/colour/colour.c:684
+#: libvips/conversion/extract.c:200 libvips/draw/draw_flood.c:593
+#: libvips/draw/draw_rect.c:173 libvips/draw/draw_smudge.c:215
+msgid "Left"
+msgstr "links"
+
+#: libvips/arithmetic/binary.c:97
 msgid "Left-hand image argument"
 msgstr "linksseitiges Bildargument"
 
-#: libvips/arithmetic/binary.c:101
+#: libvips/arithmetic/binary.c:102 libvips/colour/colour.c:690
 msgid "Right"
 msgstr "rechts"
 
-#: libvips/arithmetic/binary.c:102
+#: libvips/arithmetic/binary.c:103
 msgid "Right-hand image argument"
 msgstr "rechtsseitiges Bildargument"
 
-#: libvips/arithmetic/sign.c:151
+#: libvips/arithmetic/boolean.c:269
+#, fuzzy
+msgid "boolean operation on two images"
+msgstr "eine Wahr-/Falsch-Transaktion für ein Bilderpaar"
+
+#: libvips/arithmetic/boolean.c:277 libvips/arithmetic/boolean.c:577
+#: libvips/arithmetic/complex.c:258 libvips/arithmetic/complex.c:538
+#: libvips/arithmetic/complex.c:771 libvips/arithmetic/math2.c:241
+#: libvips/arithmetic/math2.c:471 libvips/arithmetic/math.c:261
+#: libvips/arithmetic/relational.c:246 libvips/arithmetic/relational.c:611
+#: libvips/conversion/bandbool.c:238 tools/vips.c:627
+msgid "Operation"
+msgstr "Transaktion"
+
+#: libvips/arithmetic/boolean.c:278 libvips/arithmetic/boolean.c:578
+#: libvips/conversion/bandbool.c:239
+#, fuzzy
+msgid "Boolean to perform"
+msgstr "Boolesch zur Durchführung"
+
+#: libvips/arithmetic/boolean.c:569
+msgid "boolean operations against a constant"
+msgstr "boolesche Transaktionen mit einer Konstante"
+
+# http://techpubs.sgi.com/library/tpl/cgi-bin/getdoc.cgi?coll=0650&
+#        db=man&fname=/usr/share/catman/p_man/cat3/il_c/ilAbsImg.z
+#: libvips/arithmetic/clamp.c:155
+#, fuzzy
+msgid "clamp values of an image"
+msgstr "absoluter Wert eines Bildes"
+
+#: libvips/arithmetic/clamp.c:162
+#, fuzzy
+msgid "Min"
+msgstr "primär"
+
+#: libvips/arithmetic/clamp.c:163
+#, fuzzy
+msgid "Minimum value"
+msgstr "Minimalwert des Bildes"
+
+#: libvips/arithmetic/clamp.c:169
+msgid "Max"
+msgstr ""
+
+#: libvips/arithmetic/clamp.c:170
+#, fuzzy
+msgid "Maximum value"
+msgstr "Maximalwert des Bildes"
+
+#: libvips/arithmetic/complex.c:251
+msgid "perform a complex operation on an image"
+msgstr "eine komplexe Transaktion mit einem Bild durchführen"
+
+#: libvips/arithmetic/complex.c:259 libvips/arithmetic/complex.c:772
+#, fuzzy
+msgid "Complex to perform"
+msgstr "komplex durchzuführen"
+
+#: libvips/arithmetic/complex.c:531
+#, fuzzy
+msgid "complex binary operations on two images"
+msgstr "eine komplexe Transaktion mit einem Bild durchführen"
+
+#: libvips/arithmetic/complex.c:539
+#, fuzzy
+msgid "Binary complex operation to perform"
+msgstr "durchzuführende Rundungstransakktion"
+
+#: libvips/arithmetic/complex.c:762
+msgid "get a component from a complex image"
+msgstr "einen Bestandteil eines komplexen Bildes holen"
+
+#: libvips/arithmetic/complex.c:978
+msgid "form a complex image from two real images"
+msgstr "ein komplexes Bild aus zwei echten Bildern erstellen"
+
+#: libvips/arithmetic/deviate.c:229
+#, fuzzy
+msgid "find image standard deviation"
+msgstr "Standardabweichung des Bildes"
+
+#: libvips/arithmetic/divide.c:210
+msgid "divide two images"
+msgstr "zwei Bilder teilen"
+
+#: libvips/arithmetic/find_trim.c:183
+msgid "search an image for non-edge areas"
+msgstr ""
+
+#: libvips/arithmetic/find_trim.c:189 libvips/arithmetic/getpoint.c:153
+#: libvips/arithmetic/measure.c:195 libvips/arithmetic/nary.c:87
+#: libvips/arithmetic/statistic.c:167 libvips/arithmetic/unary.c:88
+#: libvips/colour/CMYK2XYZ.c:120 libvips/colour/colour.c:480
+#: libvips/colour/colour.c:573 libvips/colour/colourspace.c:557
+#: libvips/colour/scRGB2BW.c:237 libvips/colour/scRGB2sRGB.c:270
+#: libvips/colour/scRGB2XYZ.c:191 libvips/colour/sRGB2scRGB.c:288
+#: libvips/colour/XYZ2CMYK.c:119 libvips/colour/XYZ2scRGB.c:200
+#: libvips/conversion/addalpha.c:90 libvips/conversion/arrayjoin.c:394
+#: libvips/conversion/autorot.c:207 libvips/conversion/bandbool.c:232
+#: libvips/conversion/bandfold.c:161 libvips/conversion/bandjoin.c:201
+#: libvips/conversion/bandjoin.c:436 libvips/conversion/bandmean.c:212
+#: libvips/conversion/bandrank.c:254 libvips/conversion/bandunfold.c:164
+#: libvips/conversion/byteswap.c:238 libvips/conversion/cache.c:108
+#: libvips/conversion/cast.c:530 libvips/conversion/copy.c:271
+#: libvips/conversion/embed.c:568 libvips/conversion/extract.c:194
+#: libvips/conversion/extract.c:432 libvips/conversion/falsecolour.c:380
+#: libvips/conversion/flatten.c:419 libvips/conversion/flip.c:240
+#: libvips/conversion/gamma.c:142 libvips/conversion/grid.c:199
+#: libvips/conversion/msb.c:247 libvips/conversion/premultiply.c:261
+#: libvips/conversion/recomb.c:224 libvips/conversion/replicate.c:196
+#: libvips/conversion/rot45.c:268 libvips/conversion/rot.c:365
+#: libvips/conversion/scale.c:155 libvips/conversion/sequential.c:243
+#: libvips/conversion/smartcrop.c:433 libvips/conversion/subsample.c:267
+#: libvips/conversion/tilecache.c:398 libvips/conversion/transpose3d.c:167
+#: libvips/conversion/unpremultiply.c:323 libvips/conversion/wrap.c:119
+#: libvips/conversion/zoom.c:373 libvips/convolution/canny.c:442
+#: libvips/convolution/convolution.c:128 libvips/convolution/correlation.c:150
+#: libvips/convolution/edge.c:217 libvips/convolution/gaussblur.c:132
+#: libvips/convolution/sharpen.c:322 libvips/create/buildlut.c:263
+#: libvips/create/invertlut.c:288 libvips/foreign/foreign.c:1894
+#: libvips/freqfilt/freqfilt.c:98 libvips/histogram/hist_entropy.c:111
+#: libvips/histogram/hist_equal.c:114 libvips/histogram/hist_ismonotonic.c:118
+#: libvips/histogram/hist_local.c:361 libvips/histogram/hist_match.c:161
+#: libvips/histogram/hist_norm.c:141 libvips/histogram/hist_plot.c:333
+#: libvips/histogram/hist_unary.c:88 libvips/histogram/maplut.c:744
+#: libvips/histogram/percent.c:109 libvips/histogram/stdif.c:294
+#: libvips/iofuncs/ginputsource.c:274 libvips/iofuncs/sbuf.c:88
+#: libvips/iofuncs/system.c:277 libvips/morphology/morphology.c:121
+#: libvips/mosaicing/global_balance.c:1924 libvips/mosaicing/matrixinvert.c:443
+#: libvips/mosaicing/remosaic.c:164 libvips/resample/resample.c:140
+#: libvips/resample/thumbnail.c:1782
+msgid "Input"
+msgstr "Eingabe"
+
+#: libvips/arithmetic/find_trim.c:190
+#, fuzzy
+msgid "Image to find_trim"
+msgstr "Bilddateiname"
+
+#: libvips/arithmetic/find_trim.c:195 libvips/histogram/percent.c:122
+msgid "Threshold"
+msgstr ""
+
+#: libvips/arithmetic/find_trim.c:196
+msgid "Object threshold"
+msgstr ""
+
+#: libvips/arithmetic/find_trim.c:202 libvips/conversion/arrayjoin.c:415
+#: libvips/conversion/embed.c:595 libvips/conversion/flatten.c:425
+#: libvips/conversion/insert.c:499 libvips/conversion/join.c:270
+#: libvips/foreign/foreign.c:1908 libvips/foreign/pdfiumload.c:723
+#: libvips/foreign/popplerload.c:573 libvips/resample/affine.c:699
+#: libvips/resample/mapim.c:574 libvips/resample/similarity.c:133
+msgid "Background"
+msgstr "Hintergrund"
+
+#: libvips/arithmetic/find_trim.c:203 libvips/conversion/embed.c:596
+#, fuzzy
+msgid "Color for background pixels"
+msgstr "Farbe für neue Bildpunkte"
+
+#: libvips/arithmetic/find_trim.c:209
+msgid "Line art mode"
+msgstr ""
+
+#: libvips/arithmetic/find_trim.c:210
+msgid "Enable line art mode"
+msgstr ""
+
+#: libvips/arithmetic/find_trim.c:217
+#, fuzzy
+msgid "Left edge of image"
+msgstr "linker Rand des Teilbilds im Hauptbild"
+
+#: libvips/arithmetic/find_trim.c:223 libvips/arithmetic/measure.c:228
+#: libvips/conversion/extract.c:207 libvips/draw/draw_flood.c:600
+#: libvips/draw/draw_rect.c:180 libvips/draw/draw_smudge.c:222
+msgid "Top"
+msgstr "oben"
+
+#: libvips/arithmetic/find_trim.c:224 libvips/arithmetic/measure.c:229
+#: libvips/conversion/extract.c:208
+msgid "Top edge of extract area"
+msgstr "obere Kante eines extrahierten Bereichs"
+
+#: libvips/arithmetic/find_trim.c:230 libvips/arithmetic/hough_line.c:147
+#: libvips/arithmetic/measure.c:235 libvips/conversion/copy.c:284
+#: libvips/conversion/embed.c:574 libvips/conversion/extract.c:214
+#: libvips/conversion/smartcrop.c:439 libvips/create/black.c:140
+#: libvips/create/fractsurf.c:104 libvips/create/gaussnoise.c:167
+#: libvips/create/logmat.c:208 libvips/create/perlin.c:294
+#: libvips/create/point.c:141 libvips/create/sdf.c:304
+#: libvips/create/text.c:567 libvips/create/worley.c:307
+#: libvips/create/xyz.c:191 libvips/draw/draw_flood.c:607
+#: libvips/draw/draw_rect.c:187 libvips/draw/draw_smudge.c:229
+#: libvips/foreign/rawload.c:146 libvips/histogram/hist_local.c:373
+#: libvips/histogram/stdif.c:308 libvips/iofuncs/image.c:1102
+#: libvips/morphology/rank.c:570
+msgid "Width"
+msgstr "Breite"
+
+#: libvips/arithmetic/find_trim.c:231 libvips/arithmetic/measure.c:236
+#: libvips/conversion/extract.c:215 libvips/conversion/smartcrop.c:440
+msgid "Width of extract area"
+msgstr "Breite des extrahierten Bereichs"
+
+#: libvips/arithmetic/find_trim.c:237 libvips/arithmetic/hough_line.c:154
+#: libvips/arithmetic/measure.c:242 libvips/conversion/copy.c:291
+#: libvips/conversion/embed.c:581 libvips/conversion/extract.c:221
+#: libvips/conversion/smartcrop.c:446 libvips/create/black.c:147
+#: libvips/create/fractsurf.c:111 libvips/create/gaussnoise.c:174
+#: libvips/create/perlin.c:301 libvips/create/point.c:148
+#: libvips/create/sdf.c:311 libvips/create/text.c:574
+#: libvips/create/worley.c:314 libvips/create/xyz.c:198
+#: libvips/draw/draw_flood.c:614 libvips/draw/draw_rect.c:194
+#: libvips/draw/draw_smudge.c:236 libvips/foreign/rawload.c:153
+#: libvips/histogram/hist_local.c:380 libvips/histogram/stdif.c:315
+#: libvips/iofuncs/image.c:1109 libvips/morphology/rank.c:577
+msgid "Height"
+msgstr "Höhe"
+
+#: libvips/arithmetic/find_trim.c:238 libvips/arithmetic/measure.c:243
+#: libvips/conversion/extract.c:222 libvips/conversion/smartcrop.c:447
+msgid "Height of extract area"
+msgstr "Höhe des extrahierten Bereichs"
+
+#: libvips/arithmetic/getpoint.c:149
+#, fuzzy
+msgid "read a point from an image"
+msgstr "Band aus einem Bild extrahieren"
+
+#: libvips/arithmetic/getpoint.c:154 libvips/arithmetic/statistic.c:168
+#: libvips/arithmetic/unary.c:89 libvips/colour/CMYK2XYZ.c:121
+#: libvips/colour/colour.c:481 libvips/colour/colour.c:574
+#: libvips/colour/colourspace.c:558 libvips/colour/scRGB2BW.c:238
+#: libvips/colour/scRGB2sRGB.c:271 libvips/colour/scRGB2XYZ.c:192
+#: libvips/colour/sRGB2scRGB.c:289 libvips/colour/XYZ2CMYK.c:120
+#: libvips/colour/XYZ2scRGB.c:201 libvips/conversion/addalpha.c:91
+#: libvips/conversion/autorot.c:208 libvips/conversion/bandfold.c:162
+#: libvips/conversion/bandjoin.c:437 libvips/conversion/bandunfold.c:165
+#: libvips/conversion/byteswap.c:239 libvips/conversion/cache.c:109
+#: libvips/conversion/cast.c:531 libvips/conversion/copy.c:272
+#: libvips/conversion/embed.c:569 libvips/conversion/extract.c:195
+#: libvips/conversion/extract.c:433 libvips/conversion/falsecolour.c:381
+#: libvips/conversion/flatten.c:420 libvips/conversion/flip.c:241
+#: libvips/conversion/gamma.c:143 libvips/conversion/grid.c:200
+#: libvips/conversion/msb.c:248 libvips/conversion/premultiply.c:262
+#: libvips/conversion/replicate.c:197 libvips/conversion/rot45.c:269
+#: libvips/conversion/rot.c:366 libvips/conversion/scale.c:156
+#: libvips/conversion/sequential.c:244 libvips/conversion/smartcrop.c:434
+#: libvips/conversion/subsample.c:268 libvips/conversion/tilecache.c:399
+#: libvips/conversion/transpose3d.c:168 libvips/conversion/unpremultiply.c:324
+#: libvips/conversion/wrap.c:120 libvips/conversion/zoom.c:374
+#: libvips/convolution/canny.c:443 libvips/convolution/edge.c:218
+#: libvips/convolution/gaussblur.c:133 libvips/convolution/sharpen.c:323
+#: libvips/freqfilt/freqfilt.c:99 libvips/histogram/hist_equal.c:115
+#: libvips/histogram/hist_local.c:362 libvips/histogram/hist_norm.c:142
+#: libvips/histogram/hist_plot.c:334 libvips/histogram/hist_unary.c:89
+#: libvips/histogram/maplut.c:745 libvips/histogram/percent.c:110
+#: libvips/histogram/stdif.c:295 libvips/mosaicing/global_balance.c:1925
+#: libvips/mosaicing/remosaic.c:165
+msgid "Input image"
+msgstr "Eingabebild"
+
+#: libvips/arithmetic/getpoint.c:159 libvips/arithmetic/max.c:480
+#: libvips/arithmetic/min.c:480
+#, fuzzy
+msgid "Output array"
+msgstr "Ausgabewert"
+
+#: libvips/arithmetic/getpoint.c:160 libvips/arithmetic/max.c:481
+#: libvips/arithmetic/min.c:481
+#, fuzzy
+msgid "Array of output values"
+msgstr "Feld von Eingabebildern"
+
+#: libvips/arithmetic/getpoint.c:166 libvips/arithmetic/max.c:459
+#: libvips/arithmetic/min.c:459 libvips/conversion/composite.cpp:1733
+#: libvips/conversion/embed.c:656 libvips/conversion/wrap.c:125
+#: libvips/draw/draw_flood.c:566 libvips/draw/draw_image.c:275
+#: libvips/draw/draw_mask.c:338
+msgid "x"
+msgstr "x"
+
+#: libvips/arithmetic/getpoint.c:167 libvips/arithmetic/getpoint.c:174
+#, fuzzy
+msgid "Point to read"
+msgstr "keine Punkte zum Mitteln"
+
+#: libvips/arithmetic/getpoint.c:173 libvips/arithmetic/max.c:466
+#: libvips/arithmetic/min.c:466 libvips/conversion/composite.cpp:1740
+#: libvips/conversion/embed.c:663 libvips/conversion/wrap.c:132
+#: libvips/draw/draw_flood.c:573 libvips/draw/draw_image.c:282
+#: libvips/draw/draw_mask.c:345
+msgid "y"
+msgstr "y"
+
+#: libvips/arithmetic/getpoint.c:180
+#, fuzzy
+msgid "unpack_complex"
+msgstr "Maske zu komplex"
+
+#: libvips/arithmetic/getpoint.c:181
+msgid "Complex pixels should be unpacked"
+msgstr ""
+
+#: libvips/arithmetic/hist_find.c:422
+#, fuzzy
+msgid "find image histogram"
+msgstr "Minimum des Bildes finden"
+
+#: libvips/arithmetic/hist_find.c:432
+#: libvips/arithmetic/hist_find_indexed.c:476
+#: libvips/arithmetic/hist_find_ndim.c:314
+#, fuzzy
+msgid "Output histogram"
+msgstr "Ausgabebild"
+
+#: libvips/arithmetic/hist_find.c:437 libvips/conversion/extract.c:438
+#: libvips/conversion/msb.c:253 libvips/histogram/hist_equal.c:126
+#: libvips/histogram/maplut.c:762
+msgid "Band"
+msgstr "Band"
+
+#: libvips/arithmetic/hist_find.c:438
+msgid "Find histogram of band"
+msgstr ""
+
+#: libvips/arithmetic/hist_find_indexed.c:461
+msgid "find indexed image histogram"
+msgstr ""
+
+#: libvips/arithmetic/hist_find_indexed.c:469 libvips/conversion/bandrank.c:261
+#: libvips/histogram/case.c:239 libvips/morphology/rank.c:584
+#: libvips/resample/mapim.c:555
+msgid "Index"
+msgstr ""
+
+#: libvips/arithmetic/hist_find_indexed.c:470 libvips/histogram/case.c:240
+#, fuzzy
+msgid "Index image"
+msgstr "Eingabebild"
+
+#: libvips/arithmetic/hist_find_indexed.c:481 libvips/convolution/compass.c:177
+msgid "Combine"
+msgstr ""
+
+#: libvips/arithmetic/hist_find_indexed.c:482
+msgid "Combine bins like this"
+msgstr ""
+
+#: libvips/arithmetic/hist_find_ndim.c:150
+#, fuzzy
+msgid "image is not 1 - 3 bands"
+msgstr "Bild muss ein oder %d Bänder haben"
+
+#: libvips/arithmetic/hist_find_ndim.c:159
+#, fuzzy, c-format
+msgid "bins out of range [1,%d]"
+msgstr " »bins« außerhalb des Bereichs [1,%d]"
+
+#: libvips/arithmetic/hist_find_ndim.c:304
+#, fuzzy
+msgid "find n-dimensional image histogram"
+msgstr "%d-dimensionale Bilder nicht unterstützt"
+
+#: libvips/arithmetic/hist_find_ndim.c:319
+msgid "Bins"
+msgstr ""
+
+#: libvips/arithmetic/hist_find_ndim.c:320
+#, fuzzy
+msgid "Number of bins in each dimension"
+msgstr "Anzahl der Bänder in einem Bild"
+
+#: libvips/arithmetic/hough.c:170
+msgid "find hough transform"
+msgstr ""
+
+#: libvips/arithmetic/hough_circle.c:115
+msgid "parameters out of range"
+msgstr "Parameter außerhalb des Bereichs"
+
+#: libvips/arithmetic/hough_circle.c:226
+msgid "find hough circle transform"
+msgstr ""
+
+#: libvips/arithmetic/hough_circle.c:233 libvips/foreign/pdfiumload.c:716
+#: libvips/foreign/popplerload.c:566 libvips/foreign/svgload.c:724
+#: libvips/foreign/webpload.c:192 libvips/mosaicing/mosaic.c:274
+#: libvips/resample/similarity.c:200
+msgid "Scale"
+msgstr ""
+
+#: libvips/arithmetic/hough_circle.c:234
+msgid "Scale down dimensions by this factor"
+msgstr ""
+
+#: libvips/arithmetic/hough_circle.c:240
+msgid "Min radius"
+msgstr ""
+
+#: libvips/arithmetic/hough_circle.c:241
+msgid "Smallest radius to search for"
+msgstr ""
+
+#: libvips/arithmetic/hough_circle.c:247
+#, fuzzy
+msgid "Max radius"
+msgstr "Kacheln maximal"
+
+#: libvips/arithmetic/hough_circle.c:248
+msgid "Largest radius to search for"
+msgstr ""
+
+#: libvips/arithmetic/hough_line.c:140
+msgid "find hough line transform"
+msgstr ""
+
+#: libvips/arithmetic/hough_line.c:148
+msgid "Horizontal size of parameter space"
+msgstr ""
+
+#: libvips/arithmetic/hough_line.c:155
+msgid "Vertical size of parameter space"
+msgstr ""
+
+#: libvips/arithmetic/invert.c:178
+msgid "invert an image"
+msgstr "ein Bild invertieren"
+
+#: libvips/arithmetic/linear.c:446
+msgid "calculate (a * in + b)"
+msgstr "(a * in + b) berechnen"
+
+#: libvips/arithmetic/linear.c:454 libvips/create/sdf.c:332
+msgid "a"
+msgstr "a"
+
+#: libvips/arithmetic/linear.c:455
+msgid "Multiply by this"
+msgstr "hiermit multiplizieren"
+
+#: libvips/arithmetic/linear.c:461 libvips/create/sdf.c:339
+msgid "b"
+msgstr "b"
+
+#: libvips/arithmetic/linear.c:462
+msgid "Add this"
+msgstr "dies hinzufügen"
+
+#: libvips/arithmetic/linear.c:468
+msgid "uchar"
+msgstr ""
+
+#: libvips/arithmetic/linear.c:469
+msgid "Output should be uchar"
+msgstr ""
+
+#: libvips/arithmetic/math2.c:233
+#, fuzzy
+msgid "binary math operations"
+msgstr "binäre Transaktionen"
+
+#: libvips/arithmetic/math2.c:242 libvips/arithmetic/math2.c:472
+#: libvips/arithmetic/math.c:262
+#, fuzzy
+msgid "Math to perform"
+msgstr "durchzuführende Berechnung"
+
+#: libvips/arithmetic/math2.c:463
+#, fuzzy
+msgid "binary math operations with a constant"
+msgstr "unäre Transaktionen mit einer Konstante"
+
+#: libvips/arithmetic/math.c:253
+#, fuzzy
+msgid "apply a math operation to an image"
+msgstr "eine komplexe Transaktion mit einem Bild durchführen"
+
+#: libvips/arithmetic/max.c:444
+msgid "find image maximum"
+msgstr "Maximum des Bildes finden"
+
+#: libvips/arithmetic/max.c:460
+msgid "Horizontal position of maximum"
+msgstr "horizontale Position des Maximums"
+
+#: libvips/arithmetic/max.c:467
+msgid "Vertical position of maximum"
+msgstr "vertikale Position des Maximums"
+
+#: libvips/arithmetic/max.c:473 libvips/arithmetic/min.c:473
+#: libvips/create/identity.c:157 libvips/create/invertlut.c:294
+#: libvips/resample/thumbnail.c:988
+msgid "Size"
+msgstr ""
+
+#: libvips/arithmetic/max.c:474
+#, fuzzy
+msgid "Number of maximum values to find"
+msgstr "Position des Maximalwerts des Bildes"
+
+#: libvips/arithmetic/max.c:487 libvips/arithmetic/min.c:487
+msgid "x array"
+msgstr ""
+
+#: libvips/arithmetic/max.c:488 libvips/arithmetic/min.c:488
+#, fuzzy
+msgid "Array of horizontal positions"
+msgstr "Feld aus Konstanten"
+
+#: libvips/arithmetic/max.c:494 libvips/arithmetic/min.c:494
+msgid "y array"
+msgstr ""
+
+#: libvips/arithmetic/max.c:495 libvips/arithmetic/min.c:495
+#, fuzzy
+msgid "Array of vertical positions"
+msgstr "Feld aus Konstanten"
+
+#: libvips/arithmetic/maxpair.c:151
+#, fuzzy
+msgid "maximum of a pair of images"
+msgstr "ein Bilderpaar zusammenführen"
+
+#: libvips/arithmetic/measure.c:164
+#, fuzzy, c-format
+msgid "%s: patch %d x %d, band %d: avg = %g, sdev = %g"
+msgstr "Flicken %d x %d, Band %d: Durchschn. = %g, sdev = %g"
+
+#: libvips/arithmetic/measure.c:191
+#, fuzzy
+msgid "measure a set of patches on a color chart"
+msgstr "messen eines Satzes von Patches auf ein Farbdiagramm"
+
+#: libvips/arithmetic/measure.c:196
+msgid "Image to measure"
+msgstr "zu vermessendes Bild"
+
+#: libvips/arithmetic/measure.c:202 libvips/arithmetic/stats.c:443
+msgid "Output array of statistics"
+msgstr "Ausgabefeld von Statistiken"
+
+#: libvips/arithmetic/measure.c:207 libvips/conversion/arrayjoin.c:401
+#: libvips/conversion/grid.c:212 libvips/conversion/replicate.c:202
+msgid "Across"
+msgstr "über"
+
+#: libvips/arithmetic/measure.c:208
+msgid "Number of patches across chart"
+msgstr "Anzahl der Patches über ein Diagramm"
+
+#: libvips/arithmetic/measure.c:214 libvips/conversion/grid.c:219
+#: libvips/conversion/replicate.c:209
+msgid "Down"
+msgstr "hinunter"
+
+#: libvips/arithmetic/measure.c:215
+msgid "Number of patches down chart"
+msgstr "Anzahl der Patches ein Diagramm hinunter"
+
+#: libvips/arithmetic/measure.c:222 libvips/conversion/extract.c:201
+msgid "Left edge of extract area"
+msgstr "linke Kante eines extrahierten Bereichs"
+
+#: libvips/arithmetic/min.c:444
+msgid "find image minimum"
+msgstr "Minimum des Bildes finden"
+
+#: libvips/arithmetic/min.c:460
+msgid "Horizontal position of minimum"
+msgstr "horizontale Position des Minimums"
+
+#: libvips/arithmetic/min.c:467
+msgid "Vertical position of minimum"
+msgstr "vertikale Position des Minimums"
+
+#: libvips/arithmetic/min.c:474
+#, fuzzy
+msgid "Number of minimum values to find"
+msgstr "Position des Minimalwerts des Bildes"
+
+#: libvips/arithmetic/minpair.c:151
+#, fuzzy
+msgid "minimum of a pair of images"
+msgstr "ein Bilderpaar zusammenführen"
+
+#: libvips/arithmetic/multiply.c:195
+msgid "multiply two images"
+msgstr "zwei Bilder multiplizieren"
+
+#: libvips/arithmetic/nary.c:80
+#, fuzzy
+msgid "nary operations"
+msgstr "unäre Transaktionen"
+
+#: libvips/arithmetic/nary.c:88 libvips/conversion/arrayjoin.c:395
+#: libvips/conversion/bandjoin.c:202 libvips/conversion/bandrank.c:255
+#: libvips/conversion/composite.cpp:1581 libvips/iofuncs/system.c:278
+msgid "Array of input images"
+msgstr "Feld von Eingabebildern"
+
+#: libvips/arithmetic/profile.c:293
+#, fuzzy
+msgid "find image profiles"
+msgstr "Bildmittelwert finden"
+
+#: libvips/arithmetic/profile.c:301 libvips/arithmetic/project.c:332
+msgid "Columns"
+msgstr ""
+
+#: libvips/arithmetic/profile.c:302
+msgid "First non-zero pixel in column"
+msgstr ""
+
+#: libvips/arithmetic/profile.c:307 libvips/arithmetic/project.c:338
+msgid "Rows"
+msgstr ""
+
+#: libvips/arithmetic/profile.c:308
+msgid "First non-zero pixel in row"
+msgstr ""
+
+#: libvips/arithmetic/project.c:324
+#, fuzzy
+msgid "find image projections"
+msgstr "Minimum des Bildes finden"
+
+#: libvips/arithmetic/project.c:333
+msgid "Sums of columns"
+msgstr ""
+
+#: libvips/arithmetic/project.c:339
+msgid "Sums of rows"
+msgstr ""
+
+#: libvips/arithmetic/relational.c:238
+#, fuzzy
+msgid "relational operation on two images"
+msgstr "eine relationale Transaktion für ein Bilderpaar"
+
+#: libvips/arithmetic/relational.c:247 libvips/arithmetic/relational.c:612
+#, fuzzy
+msgid "Relational to perform"
+msgstr "relational durchzuführen"
+
+#: libvips/arithmetic/relational.c:603
+msgid "relational operations against a constant"
+msgstr "relationale Transaktion für eine Konstante"
+
+#: libvips/arithmetic/remainder.c:192
+msgid "remainder after integer division of two images"
+msgstr "Rest nach Ganzzahldivision zweier Bilder"
+
+#: libvips/arithmetic/remainder.c:353
+msgid "remainder after integer division of an image and a constant"
+msgstr "Rest nach Ganzzahldivision eines Bildes und einer Konstante"
+
+#: libvips/arithmetic/round.c:173
+msgid "perform a round function on an image"
+msgstr "eine Rundungsfunktion für ein Bild ausführen"
+
+#: libvips/arithmetic/round.c:181
+msgid "Round operation"
+msgstr "Rundungstransakktion"
+
+#: libvips/arithmetic/round.c:182
+#, fuzzy
+msgid "Rounding operation to perform"
+msgstr "durchzuführende Rundungstransakktion"
+
+#: libvips/arithmetic/sign.c:174
 msgid "unit vector of pixel"
 msgstr "Einheitsvektor von Bildpunkten"
 
-#: libvips/colour/im_rad2float.c:186
-msgid "not a RAD image"
-msgstr "kein RAD-Bild"
+#: libvips/arithmetic/statistic.c:161
+msgid "VIPS statistic operations"
+msgstr "statistische VIPS-Transaktionen"
 
-#: libvips/colour/im_icc_transform.c:202 libvips/colour/im_icc_transform.c:212
-#: libvips/colour/im_icc_transform.c:1000
-#: libvips/colour/im_icc_transform.c:1010
-#, c-format
-msgid "unable to open profile \"%s\""
-msgstr "Profil »%s« kann nicht geöffnet werden"
+#: libvips/arithmetic/stats.c:434
+#, fuzzy
+msgid "find many image stats"
+msgstr "ein Bild umdrehen"
 
-#: libvips/colour/im_icc_transform.c:223
-#: libvips/colour/im_icc_transform.c:1022
-msgid "unable to create profiles"
-msgstr "es können keine Profile erstellt werden"
+#: libvips/arithmetic/subtract.c:174
+msgid "subtract two images"
+msgstr "zwei Bilder subtrahieren"
 
-#: libvips/colour/im_icc_transform.c:242
-#: libvips/colour/im_icc_transform.c:1042
-msgid "unable to read profile"
-msgstr "Profil kann nicht gelesen werden"
+#: libvips/arithmetic/sum.c:149
+#, fuzzy
+msgid "sum an array of images"
+msgstr "ein Bilderpaar zusammenführen"
 
-#: libvips/colour/im_icc_transform.c:363 libvips/colour/im_icc_transform.c:372
-#: libvips/colour/im_icc_transform.c:737
-#: libvips/colour/im_icc_transform.c:1170
-#: libvips/colour/im_icc_transform.c:1179
-#: libvips/colour/im_icc_transform.c:1522
-#, c-format
-msgid ""
-"intent %d (%s) not supported by profile \"%s\"; falling back to default "
-"intent (usually PERCEPTUAL)"
+#: libvips/arithmetic/unary.c:81
+msgid "unary operations"
+msgstr "unäre Transaktionen"
+
+#: libvips/arithmetic/unaryconst.c:138
+msgid "unary operations with a constant"
+msgstr "unäre Transaktionen mit einer Konstante"
+
+#: libvips/arithmetic/unaryconst.c:142
+msgid "c"
+msgstr "c"
+
+#: libvips/arithmetic/unaryconst.c:143
+msgid "Array of constants"
+msgstr "Feld aus Konstanten"
+
+#: libvips/colour/CMYK2XYZ.c:114 libvips/colour/CMYK2XYZ.c:182
+msgid "transform CMYK to XYZ"
 msgstr ""
-"Ziel-%d (%s) nicht von Profil »%s« unterstützt; Rückfall auf Standardabsicht "
-"(normalerweise WAHRNEHMUNG)"
 
-#: libvips/colour/im_icc_transform.c:382
-#: libvips/colour/im_icc_transform.c:1189
-msgid "CMYK input profile needs a 4 band input image"
-msgstr "CMYK-Eingabeprofil benötigt ein Eingabebild mit vier Bändern"
+#: libvips/colour/colour.c:288
+msgid "too many input images"
+msgstr "zu viele Eingabebilder"
 
-#: libvips/colour/im_icc_transform.c:392
-#: libvips/colour/im_icc_transform.c:1199
-msgid "RGB input profile needs a 3 band input image"
-msgstr "RGB-Eingabeprofil benötigt ein Eingabebild mit drei Bändern"
+#: libvips/colour/colour.c:409
+#, fuzzy
+msgid "color operations"
+msgstr "Transaktionen"
 
-#: libvips/colour/im_icc_transform.c:401 libvips/colour/im_icc_transform.c:551
-#: libvips/colour/im_icc_transform.c:1208
-#: libvips/colour/im_icc_transform.c:1340
+#: libvips/colour/colour.c:476
+msgid "color space transformations"
+msgstr ""
+
+#: libvips/colour/colour.c:569
+msgid "change color coding"
+msgstr ""
+
+#: libvips/colour/colour.c:680
+msgid "calculate color difference"
+msgstr ""
+
+#: libvips/colour/colour.c:685
+#, fuzzy
+msgid "Left-hand input image"
+msgstr "zweites Eingabebild"
+
+#: libvips/colour/colour.c:691
+#, fuzzy
+msgid "Right-hand input image"
+msgstr "Haupteingabebild"
+
+#: libvips/colour/colourspace.c:145
+#, fuzzy
+msgid "too few bands for operation"
+msgstr "Rundungstransakktion"
+
+#: libvips/colour/colourspace.c:519
+#, fuzzy, c-format
+msgid "no known route from '%s' to '%s'"
+msgstr "unbekanntes Argument »%s«"
+
+#: libvips/colour/colourspace.c:551
+msgid "convert to a new colorspace"
+msgstr ""
+
+#: libvips/colour/colourspace.c:569
+msgid "Space"
+msgstr ""
+
+#: libvips/colour/colourspace.c:570
+msgid "Destination color space"
+msgstr ""
+
+#: libvips/colour/colourspace.c:576
+msgid "Source space"
+msgstr ""
+
+#: libvips/colour/colourspace.c:577
+#, fuzzy
+msgid "Source color space"
+msgstr "nicht unterstützter Farbraum %d"
+
+#: libvips/colour/dE00.c:236
+msgid "calculate dE00"
+msgstr ""
+
+#: libvips/colour/dE76.c:113
+msgid "calculate dE76"
+msgstr ""
+
+#: libvips/colour/dECMC.c:61
+msgid "calculate dECMC"
+msgstr ""
+
+#: libvips/colour/float2rad.c:206
+msgid "transform float RGB to Radiance coding"
+msgstr ""
+
+#: libvips/colour/HSV2sRGB.c:112
+msgid "transform HSV to sRGB"
+msgstr ""
+
+#: libvips/colour/icc_transform.c:272 libvips/colour/scRGB2BW.c:190
+#: libvips/colour/scRGB2sRGB.c:224
+#, fuzzy
+msgid "depth must be 8 or 16"
+msgstr "»mwidth« muss -1 oder >= 0 sein"
+
+#: libvips/colour/icc_transform.c:284
 #, c-format
 msgid "unimplemented input color space 0x%x"
 msgstr "nicht implementierter Eingabefarbraum 0x%x"
 
-#: libvips/colour/im_icc_transform.c:428 libvips/colour/im_icc_transform.c:767
-#: libvips/colour/im_icc_transform.c:1235
-#: libvips/colour/im_icc_transform.c:1552
+#: libvips/colour/icc_transform.c:360
 #, c-format
 msgid "unimplemented output color space 0x%x"
 msgstr "nicht implementierter Ausgabefarbraum 0x%x"
 
-#: libvips/colour/im_icc_transform.c:444 libvips/colour/im_icc_transform.c:567
-#: libvips/colour/im_icc_transform.c:1251
-#: libvips/colour/im_icc_transform.c:1356
-msgid "uchar or ushort input only"
-msgstr "nur »uchar« oder »ushort«-Eingabe"
-
-#: libvips/colour/im_icc_transform.c:516
-#: libvips/colour/im_icc_transform.c:1305
-#, c-format
-msgid ""
-"intent %d (%s) not supported by profile; falling back to default intent "
-"(usually PERCEPTUAL)"
-msgstr ""
-"Ziel-%d (%s) nicht vom Profil unterstützt; Rückfall auf Standardabsicht "
-"(normalerweise WAHRNEHMUNG)"
-
-#: libvips/colour/im_icc_transform.c:533
-#: libvips/colour/im_icc_transform.c:1322
-msgid "CMYK profile needs a 4 band input image"
-msgstr "CMYK-Profil benötigt ein Eingabebild mit vier Bändern"
-
-#: libvips/colour/im_icc_transform.c:543
-#: libvips/colour/im_icc_transform.c:1332
-msgid "RGB profile needs a 3 band input image"
-msgstr "RGB-Profil benötigt ein Eingabebild mit drei Bändern"
-
-#: libvips/colour/im_icc_transform.c:634
-#: libvips/colour/im_icc_transform.c:1427
-msgid "no embedded profile"
+#: libvips/colour/icc_transform.c:437
+#, fuzzy
+msgid "no device profile"
 msgstr "kein eingebettetes Profil"
 
-#: libvips/colour/im_icc_transform.c:726
-#: libvips/colour/im_icc_transform.c:1511
-msgid "unsupported bit depth"
-msgstr "nicht unterstützte Bit-Tiefe"
+#: libvips/colour/icc_transform.c:612 libvips/colour/icc_transform.c:635
+#: libvips/colour/icc_transform.c:658 libvips/iofuncs/operation.c:442
+msgid "input"
+msgstr "Eingabe"
 
-#: libvips/colour/im_icc_transform.c:815
-#: libvips/colour/im_icc_transform.c:1605
+#: libvips/colour/icc_transform.c:612 libvips/colour/icc_transform.c:635
+#: libvips/colour/icc_transform.c:658 libvips/iofuncs/operation.c:443
+msgid "output"
+msgstr "Ausgabe"
+
+#: libvips/colour/icc_transform.c:631
+#, c-format
+msgid ""
+"fallback to suggested %s intent, as profile does not support %s %s intent"
+msgstr ""
+
+#: libvips/colour/icc_transform.c:656
+#, c-format
+msgid "profile does not support %s %s intent"
+msgstr ""
+
+#: libvips/colour/icc_transform.c:757
+msgid "unable to load or find any compatible input profile"
+msgstr ""
+
+#: libvips/colour/icc_transform.c:775
+msgid "transform using ICC profiles"
+msgstr ""
+
+#: libvips/colour/icc_transform.c:779 libvips/resample/thumbnail.c:1030
+msgid "Intent"
+msgstr ""
+
+#: libvips/colour/icc_transform.c:780 libvips/resample/thumbnail.c:1031
+msgid "Rendering intent"
+msgstr ""
+
+#: libvips/colour/icc_transform.c:786
+msgid "PCS"
+msgstr ""
+
+#: libvips/colour/icc_transform.c:787
+msgid "Set Profile Connection Space"
+msgstr ""
+
+#: libvips/colour/icc_transform.c:793
+msgid "Black point compensation"
+msgstr ""
+
+#: libvips/colour/icc_transform.c:794
+msgid "Enable black point compensation"
+msgstr ""
+
+#: libvips/colour/icc_transform.c:969
+msgid "import from device with ICC profile"
+msgstr ""
+
+#: libvips/colour/icc_transform.c:975 libvips/colour/icc_transform.c:1258
+msgid "Embedded"
+msgstr ""
+
+#: libvips/colour/icc_transform.c:976 libvips/colour/icc_transform.c:1259
+msgid "Use embedded input profile, if available"
+msgstr ""
+
+#: libvips/colour/icc_transform.c:982 libvips/colour/icc_transform.c:1265
+#, fuzzy
+msgid "Input profile"
+msgstr "Profil"
+
+#: libvips/colour/icc_transform.c:983 libvips/colour/icc_transform.c:1266
+#, fuzzy
+msgid "Filename to load input profile from"
+msgstr "Name der Datei, aus der geladen werden soll"
+
+#: libvips/colour/icc_transform.c:1046 libvips/colour/icc_transform.c:1212
+#, fuzzy
+msgid "no output profile"
+msgstr "kein eingebettetes Profil"
+
+#: libvips/colour/icc_transform.c:1141
+msgid "output to device with ICC profile"
+msgstr ""
+
+#: libvips/colour/icc_transform.c:1147 libvips/colour/icc_transform.c:1251
+#, fuzzy
+msgid "Output profile"
+msgstr "Ausgabewert"
+
+#: libvips/colour/icc_transform.c:1148 libvips/colour/icc_transform.c:1252
+#, fuzzy
+msgid "Filename to load output profile from"
+msgstr "Name der Datei, aus der geladen werden soll"
+
+#: libvips/colour/icc_transform.c:1154 libvips/colour/icc_transform.c:1272
+#: libvips/colour/scRGB2BW.c:249 libvips/colour/scRGB2sRGB.c:282
+#: libvips/foreign/dzsave.c:2364 libvips/foreign/tiffsave.c:378
+msgid "Depth"
+msgstr ""
+
+#: libvips/colour/icc_transform.c:1155 libvips/colour/icc_transform.c:1273
+#: libvips/colour/scRGB2BW.c:250 libvips/colour/scRGB2sRGB.c:283
+msgid "Output device space depth in bits"
+msgstr ""
+
+#: libvips/colour/icc_transform.c:1245
+msgid "transform between devices with ICC profiles"
+msgstr ""
+
+#: libvips/colour/icc_transform.c:1321
 msgid "unable to get media white point"
 msgstr "weißer Medienpunkt kann nicht abgefragt werden"
 
-#: libvips/colour/im_icc_transform.c:1672
-msgid "lcms library not linked to this VIPS"
-msgstr "gegen die »lcms«-Bibliothek wird in diesem VIPS nicht verlinkt"
-
-#: libvips/colour/im_icc_transform.c:1682
-#: libvips/colour/im_icc_transform.c:1691
-#: libvips/colour/im_icc_transform.c:1701
-#: libvips/colour/im_icc_transform.c:1710
-msgid "lmcs library not linked to this VIPS"
-msgstr "gegen die »lmcs«-Bibliothek wird in diesem VIPS nicht verlinkt"
-
-#: libvips/colour/disp.c:397
-msgid "out of range [0,255]"
-msgstr "außerhalb des Bereichs [0,255]"
-
-#: libvips/colour/disp.c:423
-msgid "bad display type"
-msgstr "falsche Anzeigetyp"
-
-#: libvips/colour/disp.c:537
-msgid "display unknown"
-msgstr "Anzeige unbekannt"
-
-#: libvips/colour/im_disp2XYZ.c:86
-msgid "input not 3-band uncoded char"
-msgstr "Eingabe ist kein unkodiertes Zeichen mit drei Bändern"
-
-#: libvips/colour/im_XYZ2disp.c:139
-msgid "3-band uncoded float only"
-msgstr "nur unkodierte Fließkommazahlen mit drei Bändern"
-
-#: libvips/colour/im_lab_morph.c:75
-msgid "bad greyscale mask size"
-msgstr "falsche Grauskala-Maskengröße"
-
-#: libvips/colour/im_lab_morph.c:86
-#, c-format
-msgid "bad greyscale mask value, row %d"
-msgstr "falscher Grauskala-Maskenwert, Reihe %d"
-
-#: libvips/conversion/im_gaussnoise.c:124
-msgid "bad parameter"
-msgstr "falscher Parameter"
-
-#: libvips/conversion/bandmean.c:191
-msgid "band-wise average"
-msgstr "bandweiser Durchschnitt"
-
-#: libvips/conversion/cast.c:123
-#, c-format
-msgid "%d underflows and %d overflows detected"
-msgstr "%d Unter- und %d Überläufe entdeckt"
-
-#: libvips/conversion/cast.c:470
-msgid "cast an image"
-msgstr "ein Bild umwandeln"
-
-#: libvips/conversion/cast.c:480 libvips/conversion/copy.c:352
-#: libvips/iofuncs/image.c:866
-msgid "Format"
-msgstr "Format"
-
-#: libvips/conversion/cast.c:481
-msgid "Format to cast to"
-msgstr "Format, in das umgewandelt werden soll"
-
-#: libvips/conversion/ifthenelse.c:395
-msgid "ifthenelse an image"
-msgstr "fallsdannsonst eines Bildes"
-
-#: libvips/conversion/ifthenelse.c:399
-msgid "Condition"
-msgstr "Bedingung"
-
-#: libvips/conversion/ifthenelse.c:400
-msgid "Condition input image"
-msgstr "Bedingung des Eingabebilds"
-
-#: libvips/conversion/ifthenelse.c:405
-msgid "Then image"
-msgstr "dann Bild"
-
-#: libvips/conversion/ifthenelse.c:406
-msgid "Source for TRUE pixels"
-msgstr "Quelle für TRUE-Bildpunkte"
-
-#: libvips/conversion/ifthenelse.c:411
-msgid "Else image"
-msgstr "sonst Bild"
-
-#: libvips/conversion/ifthenelse.c:412
-msgid "Source for FALSE pixels"
-msgstr "Quelle für FALSE-Bildpunkte"
-
-#: libvips/conversion/ifthenelse.c:417
-msgid "blend"
-msgstr "Mischung"
-
-#: libvips/conversion/ifthenelse.c:418
-msgid "Blend smoothly between then and else parts"
-msgstr "nahtlos zwischen »dann«- und »sonst«-Teilen mischen"
-
-#: libvips/conversion/insert.c:349
-msgid "insert an image"
-msgstr "ein Bild einfügen"
-
-#: libvips/conversion/insert.c:353
-msgid "Main"
-msgstr "primär"
-
-#: libvips/conversion/insert.c:354
-msgid "Main input image"
-msgstr "Haupteingabebild"
-
-#: libvips/conversion/insert.c:359
-msgid "Sub-image"
-msgstr "Teilbild"
-
-#: libvips/conversion/insert.c:360
-msgid "Sub-image to insert into main image"
-msgstr "Teilbild, das in das Hauptbild eingefügt werden soll"
-
-#: libvips/conversion/insert.c:365
-msgid "X"
-msgstr "X"
-
-#: libvips/conversion/insert.c:366
-msgid "Left edge of sub in main"
-msgstr "linker Rand des Teilbilds im Hauptbild"
-
-#: libvips/conversion/insert.c:372
-msgid "Y"
-msgstr "Y"
-
-#: libvips/conversion/insert.c:373
-msgid "Top edge of sub in main"
-msgstr "oberer Rand des Teilbilds im Hauptbild"
-
-#: libvips/conversion/insert.c:379 libvips/conversion/join.c:233
-msgid "Expand"
-msgstr "expandieren"
-
-#: libvips/conversion/insert.c:380 libvips/conversion/join.c:234
-msgid "Expand output to hold all of both inputs"
-msgstr "Ausgabe so expandieren, dass sie beide Eingaben vollständig enthält"
-
-#: libvips/conversion/insert.c:386 libvips/conversion/join.c:247
-msgid "Background"
-msgstr "Hintergrund"
-
-#: libvips/conversion/insert.c:387 libvips/conversion/join.c:248
-msgid "Colour for new pixels"
-msgstr "Farbe für neue Bildpunkte"
-
-#: libvips/conversion/tilecache.c:418 libvips/conversion/cache.c:102
-msgid "cache an image"
-msgstr "ein Bild zwischenspeichern"
-
-#: libvips/conversion/tilecache.c:428 libvips/conversion/cache.c:112
-#: libvips/foreign/tiffsave.c:213
-msgid "Tile width"
-msgstr "Kachelbreite"
-
-#: libvips/conversion/tilecache.c:429 libvips/conversion/cache.c:113
-#: libvips/foreign/tiffsave.c:214
-msgid "Tile width in pixels"
-msgstr "Kachelbreite in Bildpunkten"
-
-#: libvips/conversion/tilecache.c:435 libvips/conversion/cache.c:119
-#: libvips/foreign/tiffsave.c:220
-msgid "Tile height"
-msgstr "Kachelhöhe"
-
-#: libvips/conversion/tilecache.c:436 libvips/conversion/cache.c:120
-#: libvips/foreign/tiffsave.c:221
-msgid "Tile height in pixels"
-msgstr "Kachelhöhe in Bildpunkten"
-
-#: libvips/conversion/tilecache.c:442 libvips/conversion/cache.c:126
-msgid "Max tiles"
-msgstr "Kacheln maximal"
-
-#: libvips/conversion/tilecache.c:443 libvips/conversion/cache.c:127
-msgid "Maximum number of tiles to cache"
-msgstr "maximale Anzahl von Kacheln, die zwischengespeichert werden soll"
-
-#: libvips/conversion/tilecache.c:449
-msgid "Strategy"
-msgstr "Strategie"
-
-#: libvips/conversion/tilecache.c:450
-msgid "Expected access pattern"
-msgstr "erwartetes Zugriffsmuster"
-
-#: libvips/conversion/im_text.c:132
-msgid "no text to render"
-msgstr "kein Text zu rendern"
-
-#: libvips/conversion/im_text.c:219
-msgid "invalid markup in text"
-msgstr "ungültige Auszeichnung im Text"
-
-#: libvips/conversion/im_text.c:252
-msgid "pangoft2 support disabled"
-msgstr "Pangoft2-Unterstützung deaktiviert"
-
-#: libvips/conversion/im_zoom.c:331
-msgid "zoom factors should be >= 0"
-msgstr "Zoomfaktoren sollten >=0 sein"
-
-#. Make sure we won't get integer overflow.
-#.
-#: libvips/conversion/im_zoom.c:338
-msgid "zoom factors too large"
-msgstr "Zoomfaktoren zu groß"
-
-#: libvips/conversion/conver_dispatch.c:918
-#: libvips/inplace/inplace_dispatch.c:171
-msgid "vectors not same length"
-msgstr "Vektoren ungleicher Länge"
-
-#: libvips/conversion/extract.c:147
-msgid "bad extract area"
-msgstr "falscher extrahierter Bereich"
-
-#: libvips/conversion/extract.c:190
-msgid "extract an area from an image"
-msgstr "einen Bereich eines Bildes extrahieren"
-
-#: libvips/conversion/extract.c:318
-msgid "bad extract band"
-msgstr "schlecht extrahiertes Band"
-
-#: libvips/conversion/extract.c:347
-msgid "extract band from an image"
-msgstr "Band aus einem Bild extrahieren"
-
-#: libvips/conversion/extract.c:359
-msgid "Band"
-msgstr "Band"
-
-#: libvips/conversion/extract.c:360
-msgid "Band to extract"
-msgstr "zu extrahierendes Band"
-
-#: libvips/conversion/extract.c:366
-msgid "n"
-msgstr "n"
-
-#: libvips/conversion/extract.c:367
-msgid "Number of bands to extract"
-msgstr "Anzahl zu extrahierender Bänder"
-
-#: libvips/conversion/embed.c:430 libvips/iofuncs/image.c:1777
-msgid "bad dimensions"
-msgstr "falsche Abmessungen"
-
-#: libvips/conversion/embed.c:512
-msgid "embed an image in a larger image"
-msgstr "ein Bild in ein größeres Bild einbetten"
-
-#: libvips/conversion/embed.c:523
-msgid "Left edge of input in output"
-msgstr "linker Rand der Eingabe in der Ausgabe"
-
-#: libvips/conversion/embed.c:530
-msgid "Top edge of input in output"
-msgstr "oberer Rand der Eingabe in der Ausgabe"
-
-#: libvips/conversion/embed.c:537 libvips/conversion/copy.c:332
-#: libvips/conversion/black.c:129 libvips/foreign/rawload.c:123
-#: libvips/iofuncs/image.c:846
-msgid "Image width in pixels"
-msgstr "Bildbreite in Bildpunkten"
-
-#: libvips/conversion/embed.c:544 libvips/conversion/copy.c:339
-#: libvips/conversion/black.c:136 libvips/foreign/rawload.c:130
-#: libvips/iofuncs/image.c:853
-msgid "Image height in pixels"
-msgstr "Bildhöhe in Bildpunkten"
-
-#: libvips/conversion/embed.c:550
-msgid "Extend"
-msgstr "vergrößern"
-
-#: libvips/conversion/embed.c:551
-msgid "How to generate the extra pixels"
-msgstr "Wie werden die zusätzlichen Bildpunkte erzeugt?"
-
-#: libvips/conversion/im_grid.c:164
-#: libvips/convolution/im_contrast_surface.c:140 libvips/iofuncs/image.c:710
-#: libvips/iofuncs/sinkscreen.c:1082 libvips/morphology/im_rank.c:342
-msgid "bad parameters"
-msgstr "falsche Parameter"
-
-#: libvips/conversion/im_grid.c:169
-msgid "bad grid geometry"
-msgstr "falsche Gittergeometrie"
-
-#: libvips/conversion/join.c:210
-msgid "join a pair of images"
+#: libvips/colour/icc_transform.c:1416
+#, fuzzy
+msgid "libvips configured without lcms support"
+msgstr "VIPS wurde ohne FFT-Unterstützung konfiguriert"
+
+#: libvips/colour/Lab2LabQ.c:137
+msgid "transform float Lab to LabQ coding"
+msgstr ""
+
+#: libvips/colour/Lab2LabS.c:82
+msgid "transform float Lab to signed short"
+msgstr ""
+
+#: libvips/colour/Lab2LCh.c:132
+msgid "transform Lab to LCh"
+msgstr ""
+
+#: libvips/colour/Lab2XYZ.c:177
+msgid "transform CIELAB to XYZ"
+msgstr ""
+
+#: libvips/colour/Lab2XYZ.c:183 libvips/colour/XYZ2Lab.c:236
+msgid "Temperature"
+msgstr ""
+
+#: libvips/colour/Lab2XYZ.c:184
+msgid "Color temperature"
+msgstr ""
+
+#: libvips/colour/LabQ2Lab.c:125
+msgid "unpack a LabQ image to float Lab"
+msgstr ""
+
+#: libvips/colour/LabQ2LabS.c:104
+msgid "unpack a LabQ image to short Lab"
+msgstr ""
+
+#: libvips/colour/LabQ2sRGB.c:549
+#, fuzzy
+msgid "convert a LabQ image to sRGB"
+msgstr "ein Bild invertieren"
+
+#: libvips/colour/LabS2Lab.c:78
+msgid "transform signed short Lab to float"
+msgstr ""
+
+#: libvips/colour/LabS2LabQ.c:127
+msgid "transform short Lab to LabQ coding"
+msgstr ""
+
+#: libvips/colour/LCh2Lab.c:111
+msgid "transform LCh to Lab"
+msgstr ""
+
+#: libvips/colour/LCh2UCS.c:206 libvips/colour/UCS2LCh.c:273
+msgid "transform LCh to CMC"
+msgstr ""
+
+#: libvips/colour/profile_load.c:123
+#, fuzzy, c-format
+msgid "unable to load profile \"%s\""
+msgstr "Profil »%s« kann nicht geöffnet werden"
+
+# Portable Pixmap
+#: libvips/colour/profile_load.c:147
+#, fuzzy
+msgid "load named ICC profile"
+msgstr "PPM aus Datei laden"
+
+#: libvips/colour/profile_load.c:151
+msgid "Name"
+msgstr ""
+
+#: libvips/colour/profile_load.c:152
+#, fuzzy
+msgid "Profile name"
+msgstr "Dateiname"
+
+#: libvips/colour/profile_load.c:158 libvips/foreign/foreign.c:1922
+#, fuzzy
+msgid "Profile"
+msgstr "Profil"
+
+#: libvips/colour/profile_load.c:159
+#, fuzzy
+msgid "Loaded profile"
+msgstr "kein eingebettetes Profil"
+
+#: libvips/colour/rad2float.c:184
+#, fuzzy
+msgid "unpack Radiance coding to float RGB"
+msgstr "Nur Radiance-Kodierung"
+
+#: libvips/colour/scRGB2BW.c:231
+msgid "convert scRGB to BW"
+msgstr ""
+
+#: libvips/colour/scRGB2sRGB.c:264
+#, fuzzy
+msgid "convert an scRGB image to sRGB"
+msgstr "ein Bild invertieren"
+
+#: libvips/colour/scRGB2XYZ.c:185
+msgid "transform scRGB to XYZ"
+msgstr ""
+
+#: libvips/colour/sRGB2HSV.c:133
+msgid "transform sRGB to HSV"
+msgstr ""
+
+#: libvips/colour/sRGB2scRGB.c:282
+#, fuzzy
+msgid "convert an sRGB image to scRGB"
+msgstr "ein Bild invertieren"
+
+#: libvips/colour/XYZ2CMYK.c:113 libvips/colour/XYZ2CMYK.c:193
+msgid "transform XYZ to CMYK"
+msgstr ""
+
+#: libvips/colour/XYZ2Lab.c:230
+msgid "transform XYZ to Lab"
+msgstr ""
+
+#: libvips/colour/XYZ2Lab.c:237
+msgid "Colour temperature"
+msgstr ""
+
+#: libvips/colour/XYZ2scRGB.c:194
+msgid "transform XYZ to scRGB"
+msgstr ""
+
+#: libvips/colour/XYZ2Yxy.c:98
+msgid "transform XYZ to Yxy"
+msgstr ""
+
+#: libvips/colour/Yxy2XYZ.c:103
+msgid "transform Yxy to XYZ"
+msgstr ""
+
+#: libvips/conversion/addalpha.c:84
+msgid "append an alpha channel"
+msgstr ""
+
+#: libvips/conversion/arrayjoin.c:388
+#, fuzzy
+msgid "join an array of images"
 msgstr "ein Bilderpaar zusammenführen"
 
-#: libvips/conversion/join.c:214
-msgid "in1"
-msgstr "in1"
+#: libvips/conversion/arrayjoin.c:402
+#, fuzzy
+msgid "Number of images across grid"
+msgstr "Anzahl der Patches über ein Diagramm"
 
-#: libvips/conversion/join.c:215
-msgid "First input image"
-msgstr "erstes Eingabebild"
-
-#: libvips/conversion/join.c:220
-msgid "in2"
-msgstr "in2"
-
-#: libvips/conversion/join.c:221
-msgid "Second input image"
-msgstr "zweites Eingabebild"
-
-#: libvips/conversion/join.c:226
-msgid "direction"
-msgstr "Richtung"
-
-#: libvips/conversion/join.c:227
-msgid "Join left-right or up-down"
-msgstr "von links nach rechts oder von oben nach unten zusammenführen"
-
-#: libvips/conversion/join.c:240
+#: libvips/conversion/arrayjoin.c:408 libvips/conversion/join.c:263
 msgid "Shim"
 msgstr "Scheibe"
 
-#: libvips/conversion/join.c:241
+#: libvips/conversion/arrayjoin.c:409 libvips/conversion/join.c:264
 msgid "Pixels between images"
 msgstr "Bildpunkte zwischen Bildern"
 
-#: libvips/conversion/join.c:254
-msgid "Align"
-msgstr "ausrichten"
+#: libvips/conversion/arrayjoin.c:416 libvips/conversion/join.c:271
+msgid "Colour for new pixels"
+msgstr "Farbe für neue Bildpunkte"
 
-#: libvips/conversion/join.c:255
-msgid "Align on the low, centre or high coordinate edge"
+#: libvips/conversion/arrayjoin.c:422
+#, fuzzy
+msgid "Horizontal align"
+msgstr "horizontaler Versatz vom Ursprung"
+
+#: libvips/conversion/arrayjoin.c:423
+#, fuzzy
+msgid "Align on the left, centre or right"
 msgstr "am Rand der unteren, mittleren oder höchsten Koordinate ausrichten"
 
-#: libvips/conversion/rot.c:351
-msgid "rotate an image"
-msgstr "ein Bild drehen"
+#: libvips/conversion/arrayjoin.c:429
+#, fuzzy
+msgid "Vertical align"
+msgstr "vertikaler Versatz vom Ursprung"
 
-#: libvips/conversion/rot.c:361
+#: libvips/conversion/arrayjoin.c:430
+#, fuzzy
+msgid "Align on the top, centre or bottom"
+msgstr "am Rand der unteren, mittleren oder höchsten Koordinate ausrichten"
+
+#: libvips/conversion/arrayjoin.c:436
+#, fuzzy
+msgid "Horizontal spacing"
+msgstr "horizontaler Versatz vom Ursprung"
+
+#: libvips/conversion/arrayjoin.c:437
+#, fuzzy
+msgid "Horizontal spacing between images"
+msgstr "Bildpunkte zwischen Bildern"
+
+#: libvips/conversion/arrayjoin.c:443
+msgid "Vertical spacing"
+msgstr ""
+
+#: libvips/conversion/arrayjoin.c:444
+#, fuzzy
+msgid "Vertical spacing between images"
+msgstr "Bildpunkte zwischen Bildern"
+
+#: libvips/conversion/autorot.c:203
+msgid "autorotate image by exif tag"
+msgstr ""
+
+#: libvips/conversion/autorot.c:213 libvips/conversion/rot45.c:274
+#: libvips/conversion/rot.c:371 libvips/convolution/compass.c:170
+#: libvips/foreign/dzsave.c:2378 libvips/mosaicing/mosaic.c:281
+#: libvips/resample/similarity.c:207 libvips/resample/similarity.c:276
 msgid "Angle"
 msgstr "Winkel"
 
-#: libvips/conversion/rot.c:362
-msgid "Angle to rotate image"
-msgstr "Winkel zum Drehen eines Bildes"
+#: libvips/conversion/autorot.c:214
+msgid "Angle image was rotated by"
+msgstr ""
+
+#: libvips/conversion/autorot.c:220
+msgid "Flip"
+msgstr ""
+
+#: libvips/conversion/autorot.c:221
+msgid "Whether the image was flipped or not"
+msgstr ""
+
+#: libvips/conversion/bandary.c:211 libvips/conversion/bandary.c:280
+#: libvips/conversion/composite.cpp:1299
+msgid "no input images"
+msgstr "keine Eingabebilder"
+
+#: libvips/conversion/bandary.c:257
+msgid "operations on image bands"
+msgstr "Transaktionen für Bänder von Bildern"
+
+#: libvips/conversion/bandbool.c:75
+#, fuzzy, c-format
+msgid "operator %s not supported across image bands"
+msgstr "Transaktionen für Bänder von Bildern"
+
+#: libvips/conversion/bandbool.c:225
+#, fuzzy
+msgid "boolean operation across image bands"
+msgstr "Transaktionen für Bänder von Bildern"
+
+#: libvips/conversion/bandbool.c:233 libvips/conversion/bandmean.c:213
+#: libvips/conversion/recomb.c:225 libvips/convolution/convolution.c:129
+#: libvips/convolution/correlation.c:151 libvips/morphology/morphology.c:122
+#: libvips/resample/resample.c:141 libvips/resample/thumbnail.c:1783
+msgid "Input image argument"
+msgstr "Eingabebildargument"
+
+#: libvips/conversion/bandfold.c:123
+msgid "@factor must be a factor of image width"
+msgstr ""
+
+#: libvips/conversion/bandfold.c:155
+msgid "fold up x axis into bands"
+msgstr ""
+
+#: libvips/conversion/bandfold.c:167 libvips/conversion/bandunfold.c:170
+#: libvips/create/eye.c:108
+#, fuzzy
+msgid "Factor"
+msgstr "Q-Faktor"
+
+#: libvips/conversion/bandfold.c:168
+msgid "Fold by this factor"
+msgstr ""
+
+#: libvips/conversion/bandjoin.c:195
+msgid "bandwise join a set of images"
+msgstr "einen Satz Bilder bandweise zusammenführen"
+
+#: libvips/conversion/bandjoin.c:430
+#, fuzzy
+msgid "append a constant band to an image"
+msgstr "Band aus einem Bild extrahieren"
+
+#: libvips/conversion/bandjoin.c:442
+msgid "Constants"
+msgstr ""
+
+#: libvips/conversion/bandjoin.c:443
+#, fuzzy
+msgid "Array of constants to add"
+msgstr "Feld aus Konstanten"
+
+#: libvips/conversion/bandmean.c:206
+msgid "band-wise average"
+msgstr "bandweiser Durchschnitt"
+
+#: libvips/conversion/bandrank.c:248
+#, fuzzy
+msgid "band-wise rank of a set of images"
+msgstr "einen Satz Bilder bandweise zusammenführen"
+
+#: libvips/conversion/bandrank.c:262
+msgid "Select this band element from sorted list"
+msgstr ""
+
+#: libvips/conversion/bandunfold.c:126
+msgid "@factor must be a factor of image bands"
+msgstr ""
+
+#: libvips/conversion/bandunfold.c:158
+msgid "unfold image bands into x axis"
+msgstr ""
+
+#: libvips/conversion/bandunfold.c:171
+msgid "Unfold by this factor"
+msgstr ""
+
+#: libvips/conversion/byteswap.c:232
+#, fuzzy
+msgid "byteswap an image"
+msgstr "ein Bild drehen"
+
+#: libvips/conversion/cache.c:98 libvips/conversion/tilecache.c:392
+msgid "cache an image"
+msgstr "ein Bild zwischenspeichern"
+
+#: libvips/conversion/cache.c:114 libvips/conversion/tilecache.c:800
+#: libvips/foreign/dzsave.c:2451 libvips/foreign/jp2ksave.c:971
+#: libvips/foreign/tiffsave.c:287
+msgid "Tile width"
+msgstr "Kachelbreite"
+
+#: libvips/conversion/cache.c:115 libvips/conversion/tilecache.c:801
+#: libvips/foreign/dzsave.c:2452 libvips/foreign/jp2ksave.c:972
+#: libvips/foreign/tiffsave.c:288
+msgid "Tile width in pixels"
+msgstr "Kachelbreite in Bildpunkten"
+
+#: libvips/conversion/cache.c:121 libvips/conversion/grid.c:205
+#: libvips/conversion/sequential.c:249 libvips/conversion/tilecache.c:404
+#: libvips/foreign/dzsave.c:2458 libvips/foreign/jp2ksave.c:978
+#: libvips/foreign/tiffsave.c:294
+msgid "Tile height"
+msgstr "Kachelhöhe"
+
+#: libvips/conversion/cache.c:122 libvips/conversion/sequential.c:250
+#: libvips/conversion/tilecache.c:405 libvips/foreign/dzsave.c:2459
+#: libvips/foreign/jp2ksave.c:979 libvips/foreign/tiffsave.c:295
+msgid "Tile height in pixels"
+msgstr "Kachelhöhe in Bildpunkten"
+
+#: libvips/conversion/cache.c:128 libvips/conversion/tilecache.c:807
+msgid "Max tiles"
+msgstr "Kacheln maximal"
+
+#: libvips/conversion/cache.c:129 libvips/conversion/tilecache.c:808
+msgid "Maximum number of tiles to cache"
+msgstr "maximale Anzahl von Kacheln, die zwischengespeichert werden soll"
+
+#: libvips/conversion/cast.c:524
+msgid "cast an image"
+msgstr "ein Bild umwandeln"
+
+#: libvips/conversion/cast.c:536 libvips/conversion/copy.c:305
+#: libvips/foreign/ppmsave.c:506 libvips/foreign/rawload.c:174
+#: libvips/foreign/vips2magick.c:482 libvips/iofuncs/image.c:1123
+msgid "Format"
+msgstr "Format"
+
+#: libvips/conversion/cast.c:537
+msgid "Format to cast to"
+msgstr "Format, in das umgewandelt werden soll"
+
+#: libvips/conversion/cast.c:543
+msgid "Shift"
+msgstr ""
+
+#: libvips/conversion/cast.c:544
+msgid "Shift integer values up and down"
+msgstr ""
+
+#: libvips/conversion/composite.cpp:1304
+#, fuzzy, c-format
+msgid "must be 1 or %d blend modes"
+msgstr "Bild muss ein oder %d Bänder haben"
+
+#: libvips/conversion/composite.cpp:1314
+#, c-format
+msgid "blend mode index %d (%d) invalid"
+msgstr ""
+
+#: libvips/conversion/composite.cpp:1413
+#, fuzzy
+msgid "images do not have same numbers of bands"
+msgstr "Bilder müssen die gleiche Anzahl Bänder haben"
+
+#: libvips/conversion/composite.cpp:1420
+#, fuzzy
+msgid "too many input bands"
+msgstr "zu viele Eingabebilder"
+
+#: libvips/conversion/composite.cpp:1430
+#, fuzzy
+msgid "unsupported compositing space"
+msgstr "nicht unterstützter Farbraum %d"
+
+#: libvips/conversion/composite.cpp:1478
+#, fuzzy
+msgid "blend images together"
+msgstr "falscher Bildtyp"
+
+#: libvips/conversion/composite.cpp:1484
+msgid "Compositing space"
+msgstr ""
+
+#: libvips/conversion/composite.cpp:1485
+msgid "Composite images in this colour space"
+msgstr ""
+
+#: libvips/conversion/composite.cpp:1491 libvips/conversion/smartcrop.c:474
+#: libvips/resample/affine.c:706 libvips/resample/mapim.c:581
+msgid "Premultiplied"
+msgstr ""
+
+#: libvips/conversion/composite.cpp:1492 libvips/resample/affine.c:707
+#: libvips/resample/mapim.c:582
+msgid "Images have premultiplied alpha"
+msgstr ""
+
+#: libvips/conversion/composite.cpp:1540
+#, c-format
+msgid "must be %d x coordinates"
+msgstr ""
+
+#: libvips/conversion/composite.cpp:1548
+#, c-format
+msgid "must be %d y coordinates"
+msgstr ""
+
+#: libvips/conversion/composite.cpp:1574
+msgid "blend an array of images with an array of blend modes"
+msgstr ""
+
+#: libvips/conversion/composite.cpp:1580
+#, fuzzy
+msgid "Inputs"
+msgstr "Eingabe"
+
+#: libvips/conversion/composite.cpp:1587
+#, fuzzy
+msgid "Blend modes"
+msgstr "Öffnen-Modus"
+
+#: libvips/conversion/composite.cpp:1588
+msgid "Array of VipsBlendMode to join with"
+msgstr ""
+
+#: libvips/conversion/composite.cpp:1594
+msgid "x coordinates"
+msgstr ""
+
+#: libvips/conversion/composite.cpp:1595
+#, fuzzy
+msgid "Array of x coordinates to join at"
+msgstr "Feld aus Konstanten"
+
+#: libvips/conversion/composite.cpp:1601
+msgid "y coordinates"
+msgstr ""
+
+#: libvips/conversion/composite.cpp:1602
+#, fuzzy
+msgid "Array of y coordinates to join at"
+msgstr "Feld aus Konstanten"
+
+#: libvips/conversion/composite.cpp:1708
+msgid "blend a pair of images with a blend mode"
+msgstr ""
+
+#: libvips/conversion/composite.cpp:1714
+msgid "Base"
+msgstr ""
+
+#: libvips/conversion/composite.cpp:1715
+#, fuzzy
+msgid "Base image"
+msgstr "sonst Bild"
+
+#: libvips/conversion/composite.cpp:1720
+msgid "Overlay"
+msgstr ""
+
+#: libvips/conversion/composite.cpp:1721
+#, fuzzy
+msgid "Overlay image"
+msgstr "Zeilensprungbild"
+
+#: libvips/conversion/composite.cpp:1726
+#, fuzzy
+msgid "Blend mode"
+msgstr "Öffnen-Modus"
+
+#: libvips/conversion/composite.cpp:1727
+msgid "VipsBlendMode to join with"
+msgstr ""
+
+#: libvips/conversion/composite.cpp:1734
+msgid "x position of overlay"
+msgstr ""
+
+#: libvips/conversion/composite.cpp:1741
+msgid "y position of overlay"
+msgstr ""
+
+#: libvips/conversion/conversion.c:342
+msgid "conversion operations"
+msgstr "Umwandlungstransaktionen"
+
+#: libvips/conversion/copy.c:235
+#, fuzzy
+msgid "must not change pel size"
+msgstr "Bilder passen in der Bildpunktgröße nicht zusammen"
+
+#: libvips/conversion/copy.c:260
+msgid "copy an image"
+msgstr "ein Bild kopieren"
+
+#: libvips/conversion/copy.c:277
+msgid "Swap"
+msgstr "austauschen"
+
+#: libvips/conversion/copy.c:278
+msgid "Swap bytes in image between little and big-endian"
+msgstr "Byte im Bild zwischen Little- und Big-Endian austauschen"
+
+#: libvips/conversion/copy.c:285 libvips/conversion/embed.c:575
+#: libvips/create/black.c:141 libvips/create/fractsurf.c:105
+#: libvips/create/gaussnoise.c:168 libvips/create/perlin.c:295
+#: libvips/create/point.c:142 libvips/create/sdf.c:305
+#: libvips/create/worley.c:308 libvips/create/xyz.c:192
+#: libvips/foreign/rawload.c:147 libvips/iofuncs/image.c:1103
+msgid "Image width in pixels"
+msgstr "Bildbreite in Bildpunkten"
+
+#: libvips/conversion/copy.c:292 libvips/conversion/embed.c:582
+#: libvips/create/black.c:148 libvips/create/fractsurf.c:112
+#: libvips/create/gaussnoise.c:175 libvips/create/perlin.c:302
+#: libvips/create/point.c:149 libvips/create/sdf.c:312
+#: libvips/create/worley.c:315 libvips/create/xyz.c:199
+#: libvips/foreign/rawload.c:154 libvips/iofuncs/image.c:1110
+msgid "Image height in pixels"
+msgstr "Bildhöhe in Bildpunkten"
+
+#: libvips/conversion/copy.c:298 libvips/create/black.c:154
+#: libvips/create/identity.c:143 libvips/foreign/rawload.c:160
+#: libvips/iofuncs/image.c:1116
+msgid "Bands"
+msgstr "Bänder"
+
+#: libvips/conversion/copy.c:299 libvips/create/black.c:155
+#: libvips/foreign/rawload.c:161 libvips/iofuncs/image.c:1117
+msgid "Number of bands in image"
+msgstr "Anzahl der Bänder in einem Bild"
+
+#: libvips/conversion/copy.c:306 libvips/foreign/rawload.c:175
+#: libvips/iofuncs/image.c:1124
+msgid "Pixel format in image"
+msgstr "Bildpunktformat im Bild"
+
+#: libvips/conversion/copy.c:312 libvips/iofuncs/image.c:1130
+msgid "Coding"
+msgstr "Kodierung"
+
+#: libvips/conversion/copy.c:313 libvips/iofuncs/image.c:1131
+msgid "Pixel coding"
+msgstr "Bildpunktkodierung"
+
+#: libvips/conversion/copy.c:319 libvips/foreign/rawload.c:181
+#: libvips/iofuncs/image.c:1137
+msgid "Interpretation"
+msgstr "Interpretation"
+
+#: libvips/conversion/copy.c:320 libvips/foreign/rawload.c:182
+#: libvips/iofuncs/image.c:1138
+msgid "Pixel interpretation"
+msgstr "Bildpunktinterpretation"
+
+#: libvips/conversion/copy.c:326 libvips/foreign/tiffsave.c:329
+#: libvips/iofuncs/image.c:1144
+msgid "Xres"
+msgstr "Xres"
+
+#: libvips/conversion/copy.c:327 libvips/foreign/tiffsave.c:330
+#: libvips/iofuncs/image.c:1145
+msgid "Horizontal resolution in pixels/mm"
+msgstr "horizontale Auflösung in Bildpunkten/mm"
+
+#: libvips/conversion/copy.c:333 libvips/foreign/tiffsave.c:336
+#: libvips/iofuncs/image.c:1151
+msgid "Yres"
+msgstr "Yres"
+
+#: libvips/conversion/copy.c:334 libvips/foreign/tiffsave.c:337
+#: libvips/iofuncs/image.c:1152
+msgid "Vertical resolution in pixels/mm"
+msgstr "vertikale Auflösung in Bildpunkten/mm"
+
+#: libvips/conversion/copy.c:340 libvips/iofuncs/image.c:1158
+msgid "Xoffset"
+msgstr "Xoffset"
+
+#: libvips/conversion/copy.c:341 libvips/iofuncs/image.c:1159
+msgid "Horizontal offset of origin"
+msgstr "horizontaler Versatz vom Ursprung"
+
+#: libvips/conversion/copy.c:347 libvips/iofuncs/image.c:1165
+msgid "Yoffset"
+msgstr "Yoffset"
+
+#: libvips/conversion/copy.c:348 libvips/iofuncs/image.c:1166
+msgid "Vertical offset of origin"
+msgstr "vertikaler Versatz vom Ursprung"
+
+#: libvips/conversion/embed.c:479 libvips/foreign/heifload.c:571
+#: libvips/foreign/svgload.c:502 libvips/iofuncs/image.c:3143
+msgid "bad dimensions"
+msgstr "falsche Abmessungen"
+
+#: libvips/conversion/embed.c:561 libvips/conversion/embed.c:652
+msgid "embed an image in a larger image"
+msgstr "ein Bild in ein größeres Bild einbetten"
+
+#: libvips/conversion/embed.c:588 libvips/resample/affine.c:692
+#: libvips/resample/mapim.c:567
+msgid "Extend"
+msgstr "vergrößern"
+
+#: libvips/conversion/embed.c:589 libvips/resample/affine.c:693
+#: libvips/resample/mapim.c:568
+msgid "How to generate the extra pixels"
+msgstr "Wie werden die zusätzlichen Bildpunkte erzeugt?"
+
+#: libvips/conversion/embed.c:657 libvips/conversion/wrap.c:126
+msgid "Left edge of input in output"
+msgstr "linker Rand der Eingabe in der Ausgabe"
+
+#: libvips/conversion/embed.c:664 libvips/conversion/wrap.c:133
+msgid "Top edge of input in output"
+msgstr "oberer Rand der Eingabe in der Ausgabe"
+
+#: libvips/conversion/embed.c:806
+#, fuzzy
+msgid "place an image within a larger image with a certain gravity"
+msgstr "ein Bild in ein größeres Bild einbetten"
+
+#: libvips/conversion/embed.c:811 libvips/conversion/flip.c:246
+#: libvips/conversion/join.c:249 libvips/morphology/countlines.c:146
+#: libvips/mosaicing/merge.c:140 libvips/mosaicing/mosaic1.c:516
+#: libvips/mosaicing/mosaic.c:197
+msgid "Direction"
+msgstr "Richtung"
+
+#: libvips/conversion/embed.c:812
+msgid "Direction to place image within width/height"
+msgstr ""
+
+#: libvips/conversion/extract.c:150 libvips/conversion/smartcrop.c:341
+msgid "bad extract area"
+msgstr "falscher extrahierter Bereich"
+
+#: libvips/conversion/extract.c:188 libvips/conversion/smartcrop.c:429
+msgid "extract an area from an image"
+msgstr "einen Bereich eines Bildes extrahieren"
+
+#: libvips/conversion/extract.c:398
+msgid "bad extract band"
+msgstr "schlecht extrahiertes Band"
+
+#: libvips/conversion/extract.c:426
+msgid "extract band from an image"
+msgstr "Band aus einem Bild extrahieren"
+
+#: libvips/conversion/extract.c:439
+msgid "Band to extract"
+msgstr "zu extrahierendes Band"
+
+#: libvips/conversion/extract.c:445 libvips/foreign/heifload.c:1090
+#: libvips/foreign/jxlload.c:1139 libvips/foreign/magick6load.c:148
+#: libvips/foreign/magick7load.c:389 libvips/foreign/nsgifload.c:627
+#: libvips/foreign/pdfiumload.c:702 libvips/foreign/popplerload.c:552
+#: libvips/foreign/tiffload.c:203 libvips/foreign/webpload.c:185
+msgid "n"
+msgstr "n"
+
+#: libvips/conversion/extract.c:446
+msgid "Number of bands to extract"
+msgstr "Anzahl zu extrahierender Bänder"
+
+#: libvips/conversion/falsecolour.c:374
+#, fuzzy
+msgid "false-color an image"
+msgstr "ein Bild einfügen"
+
+# http://techpubs.sgi.com/library/tpl/cgi-bin/getdoc.cgi?coll=0650&
+#        db=man&fname=/usr/share/catman/p_man/cat3/il_c/ilAbsImg.z
+#: libvips/conversion/flatten.c:413
+#, fuzzy
+msgid "flatten alpha out of an image"
+msgstr "absoluter Wert eines Bildes"
+
+#: libvips/conversion/flatten.c:426 libvips/foreign/foreign.c:1909
+#: libvips/resample/affine.c:700 libvips/resample/mapim.c:575
+#: libvips/resample/similarity.c:134
+#, fuzzy
+msgid "Background value"
+msgstr "Hintergrund"
+
+#: libvips/conversion/flatten.c:432 libvips/conversion/premultiply.c:267
+#: libvips/conversion/unpremultiply.c:329
+msgid "Maximum alpha"
+msgstr ""
+
+#: libvips/conversion/flatten.c:433 libvips/conversion/premultiply.c:268
+#: libvips/conversion/unpremultiply.c:330
+#, fuzzy
+msgid "Maximum value of alpha channel"
+msgstr "Maximalwert des Bildes"
 
 #: libvips/conversion/flip.c:236
 msgid "flip an image"
 msgstr "ein Bild umdrehen"
 
-#: libvips/conversion/flip.c:246
-msgid "Direction"
-msgstr "Richtung"
-
 #: libvips/conversion/flip.c:247
 msgid "Direction to flip image"
 msgstr "Richtung, nach der das Bild umgedreht werden soll"
 
-#: libvips/conversion/copy.c:314
-msgid "copy an image"
-msgstr "ein Bild kopieren"
+#: libvips/conversion/gamma.c:136
+#, fuzzy
+msgid "gamma an image"
+msgstr "ein Bild umwandeln"
 
-#: libvips/conversion/copy.c:324
-msgid "Swap"
-msgstr "austauschen"
+#: libvips/conversion/gamma.c:148 libvips/conversion/scale.c:168
+msgid "Exponent"
+msgstr ""
 
-#: libvips/conversion/copy.c:325
-msgid "Swap bytes in image between little and big-endian"
-msgstr "Byte im Bild zwischen Little- und Big-Endian austauschen"
+#: libvips/conversion/gamma.c:149
+#, fuzzy
+msgid "Gamma factor"
+msgstr "Q-Faktor"
 
-#: libvips/conversion/copy.c:345 libvips/conversion/black.c:142
-#: libvips/foreign/rawload.c:136 libvips/iofuncs/image.c:859
-msgid "Bands"
-msgstr "Bänder"
+#: libvips/conversion/grid.c:165
+msgid "bad grid geometry"
+msgstr "falsche Gittergeometrie"
 
-#: libvips/conversion/copy.c:346 libvips/conversion/black.c:143
-#: libvips/foreign/rawload.c:137 libvips/iofuncs/image.c:860
-msgid "Number of bands in image"
-msgstr "Anzahl der Bänder in einem Bild"
+#: libvips/conversion/grid.c:195
+#, fuzzy
+msgid "grid an image"
+msgstr "ein Bild umdrehen"
 
-#: libvips/conversion/copy.c:353 libvips/iofuncs/image.c:867
-msgid "Pixel format in image"
-msgstr "Bildpunktformat im Bild"
+#: libvips/conversion/grid.c:206
+msgid "Chop into tiles this high"
+msgstr ""
 
-#: libvips/conversion/copy.c:359 libvips/iofuncs/image.c:873
-msgid "Coding"
-msgstr "Kodierung"
+#: libvips/conversion/grid.c:213
+#, fuzzy
+msgid "Number of tiles across"
+msgstr "Anzahl der Patches über ein Diagramm"
 
-#: libvips/conversion/copy.c:360 libvips/iofuncs/image.c:874
-msgid "Pixel coding"
-msgstr "Bildpunktkodierung"
+#: libvips/conversion/grid.c:220
+#, fuzzy
+msgid "Number of tiles down"
+msgstr "Anzahl der Patches ein Diagramm hinunter"
 
-#: libvips/conversion/copy.c:366 libvips/iofuncs/image.c:880
-msgid "Interpretation"
-msgstr "Interpretation"
+#: libvips/conversion/ifthenelse.c:525
+msgid "ifthenelse an image"
+msgstr "fallsdannsonst eines Bildes"
 
-#: libvips/conversion/copy.c:367 libvips/iofuncs/image.c:881
-msgid "Pixel interpretation"
-msgstr "Bildpunktinterpretation"
+#: libvips/conversion/ifthenelse.c:529
+msgid "Condition"
+msgstr "Bedingung"
 
-#: libvips/conversion/copy.c:373 libvips/foreign/tiffsave.c:249
-#: libvips/iofuncs/image.c:887
-msgid "Xres"
-msgstr "Xres"
+#: libvips/conversion/ifthenelse.c:530
+msgid "Condition input image"
+msgstr "Bedingung des Eingabebilds"
 
-#: libvips/conversion/copy.c:374 libvips/foreign/tiffsave.c:250
-#: libvips/iofuncs/image.c:888
-msgid "Horizontal resolution in pixels/mm"
-msgstr "horizontale Auflösung in Bildpunkten/mm"
+#: libvips/conversion/ifthenelse.c:535
+msgid "Then image"
+msgstr "dann Bild"
 
-#: libvips/conversion/copy.c:380 libvips/foreign/tiffsave.c:256
-#: libvips/iofuncs/image.c:894
-msgid "Yres"
-msgstr "Yres"
+#: libvips/conversion/ifthenelse.c:536
+msgid "Source for TRUE pixels"
+msgstr "Quelle für TRUE-Bildpunkte"
 
-#: libvips/conversion/copy.c:381 libvips/foreign/tiffsave.c:257
-#: libvips/iofuncs/image.c:895
-msgid "Vertical resolution in pixels/mm"
-msgstr "vertikale Auflösung in Bildpunkten/mm"
+#: libvips/conversion/ifthenelse.c:541
+msgid "Else image"
+msgstr "sonst Bild"
 
-#: libvips/conversion/copy.c:387 libvips/iofuncs/image.c:901
-msgid "Xoffset"
-msgstr "Xoffset"
+#: libvips/conversion/ifthenelse.c:542
+msgid "Source for FALSE pixels"
+msgstr "Quelle für FALSE-Bildpunkte"
 
-#: libvips/conversion/copy.c:388 libvips/iofuncs/image.c:902
-msgid "Horizontal offset of origin"
-msgstr "horizontaler Versatz vom Ursprung"
+#: libvips/conversion/ifthenelse.c:547
+#, fuzzy
+msgid "Blend"
+msgstr "Mischung"
 
-#: libvips/conversion/copy.c:394 libvips/iofuncs/image.c:908
-msgid "Yoffset"
-msgstr "Yoffset"
+#: libvips/conversion/ifthenelse.c:548
+msgid "Blend smoothly between then and else parts"
+msgstr "nahtlos zwischen »dann«- und »sonst«-Teilen mischen"
 
-#: libvips/conversion/copy.c:395 libvips/iofuncs/image.c:909
-msgid "Vertical offset of origin"
-msgstr "vertikaler Versatz vom Ursprung"
+#: libvips/conversion/insert.c:460
+msgid "insert image @sub into @main at @x, @y"
+msgstr ""
 
-#: libvips/conversion/bandary.c:127
-msgid "no input images"
-msgstr "keine Eingabebilder"
+#: libvips/conversion/insert.c:466
+msgid "Main"
+msgstr "primär"
 
-#: libvips/conversion/bandary.c:173
-msgid "operations on image bands"
-msgstr "Transaktionen für Bänder von Bildern"
+#: libvips/conversion/insert.c:467
+msgid "Main input image"
+msgstr "Haupteingabebild"
 
-#: libvips/conversion/conversion.c:85
-msgid "conversion operations"
-msgstr "Umwandlungstransaktionen"
+#: libvips/conversion/insert.c:472 libvips/draw/draw_image.c:269
+msgid "Sub-image"
+msgstr "Teilbild"
 
-#: libvips/conversion/recomb.c:160
+#: libvips/conversion/insert.c:473 libvips/draw/draw_image.c:270
+msgid "Sub-image to insert into main image"
+msgstr "Teilbild, das in das Hauptbild eingefügt werden soll"
+
+#: libvips/conversion/insert.c:478
+msgid "X"
+msgstr "X"
+
+#: libvips/conversion/insert.c:479
+msgid "Left edge of sub in main"
+msgstr "linker Rand des Teilbilds im Hauptbild"
+
+#: libvips/conversion/insert.c:485
+msgid "Y"
+msgstr "Y"
+
+#: libvips/conversion/insert.c:486
+msgid "Top edge of sub in main"
+msgstr "oberer Rand des Teilbilds im Hauptbild"
+
+#: libvips/conversion/insert.c:492 libvips/conversion/join.c:256
+msgid "Expand"
+msgstr "expandieren"
+
+#: libvips/conversion/insert.c:493 libvips/conversion/join.c:257
+msgid "Expand output to hold all of both inputs"
+msgstr "Ausgabe so expandieren, dass sie beide Eingaben vollständig enthält"
+
+#: libvips/conversion/insert.c:500
+#, fuzzy
+msgid "Color for new pixels"
+msgstr "Farbe für neue Bildpunkte"
+
+#: libvips/conversion/join.c:231
+msgid "join a pair of images"
+msgstr "ein Bilderpaar zusammenführen"
+
+#: libvips/conversion/join.c:237
+msgid "in1"
+msgstr "in1"
+
+#: libvips/conversion/join.c:238
+msgid "First input image"
+msgstr "erstes Eingabebild"
+
+#: libvips/conversion/join.c:243 libvips/freqfilt/phasecor.c:111
+msgid "in2"
+msgstr "in2"
+
+#: libvips/conversion/join.c:244 libvips/freqfilt/phasecor.c:112
+msgid "Second input image"
+msgstr "zweites Eingabebild"
+
+#: libvips/conversion/join.c:250
+msgid "Join left-right or up-down"
+msgstr "von links nach rechts oder von oben nach unten zusammenführen"
+
+#: libvips/conversion/join.c:277 libvips/create/text.c:581
+msgid "Align"
+msgstr "ausrichten"
+
+#: libvips/conversion/join.c:278
+msgid "Align on the low, centre or high coordinate edge"
+msgstr "am Rand der unteren, mittleren oder höchsten Koordinate ausrichten"
+
+#: libvips/conversion/msb.c:168
+#, fuzzy
+msgid "bad band"
+msgstr "falsche Bänder"
+
+#: libvips/conversion/msb.c:241
+msgid "pick most-significant byte from an image"
+msgstr ""
+
+#: libvips/conversion/msb.c:254
+#, fuzzy
+msgid "Band to msb"
+msgstr "Bänder auf N setzen"
+
+#: libvips/conversion/premultiply.c:255
+#, fuzzy
+msgid "premultiply image alpha"
+msgstr "zwei Bilder multiplizieren"
+
+#: libvips/conversion/recomb.c:183
 msgid "bands in must equal matrix width"
 msgstr "»in«-Bänder müssen die gleiche Breite wie die Matrix haben"
 
-#: libvips/conversion/recomb.c:196
+#: libvips/conversion/recomb.c:218
 msgid "linear recombination with matrix"
 msgstr "lineare Neukombinierung mit der Matrix"
 
-#: libvips/conversion/recomb.c:206
+#: libvips/conversion/recomb.c:230
 msgid "M"
 msgstr "M"
 
-#: libvips/conversion/recomb.c:207
-msgid "matrix of coefficients"
+#: libvips/conversion/recomb.c:231
+#, fuzzy
+msgid "Matrix of coefficients"
 msgstr "Matrix der Koeffizienten"
 
 #: libvips/conversion/replicate.c:192
@@ -1180,1859 +1995,5230 @@ msgstr "horizontal so oft wiederholen"
 msgid "Repeat this many times vertically"
 msgstr "vertikal so oft wiederholen"
 
-#: libvips/conversion/black.c:124
-msgid "make a black image"
-msgstr "ein schwarzes Bild erstellen"
+#: libvips/conversion/rot45.c:264 libvips/conversion/rot.c:361
+msgid "rotate an image"
+msgstr "ein Bild drehen"
 
-#: libvips/conversion/im_msb.c:134 libvips/conversion/im_msb.c:213
-msgid "unknown coding"
-msgstr "unbekannte Kodierung"
+#: libvips/conversion/rot45.c:275 libvips/conversion/rot.c:372
+msgid "Angle to rotate image"
+msgstr "Winkel zum Drehen eines Bildes"
 
-#: libvips/conversion/im_msb.c:169 libvips/resample/im_rightshift_size.c:116
-msgid "bad arguments"
-msgstr "falsche Argumente"
+#: libvips/conversion/scale.c:151
+#, fuzzy
+msgid "scale an image to uchar"
+msgstr "ein Bild zwischenspeichern"
 
-#: libvips/conversion/im_msb.c:183 libvips/conversion/im_msb.c:200
-msgid "image does not have that many bands"
-msgstr "Bild hat nicht so viele Bänder"
+#: libvips/conversion/scale.c:161 libvips/iofuncs/system.c:311
+msgid "Log"
+msgstr ""
 
-#: libvips/conversion/im_system_image.c:76
-#, c-format
-msgid "command failed: \"%s\""
-msgstr "Befehl fehlgeschlagen: »%s«"
+#: libvips/conversion/scale.c:162
+msgid "Log scale"
+msgstr ""
 
-#: libvips/conversion/im_subsample.c:202
-msgid "factors should both be >= 1"
-msgstr "beide Faktoren sollten >=1 sein"
+#: libvips/conversion/scale.c:169
+msgid "Exponent for log scale"
+msgstr ""
 
-#: libvips/conversion/im_subsample.c:221 libvips/resample/im_shrink.c:286
+#: libvips/conversion/sequential.c:239
+msgid "check sequential access"
+msgstr ""
+
+#: libvips/conversion/sequential.c:256
+msgid "Strategy"
+msgstr "Strategie"
+
+#: libvips/conversion/sequential.c:257 libvips/conversion/tilecache.c:412
+msgid "Expected access pattern"
+msgstr "erwartetes Zugriffsmuster"
+
+#: libvips/conversion/sequential.c:263
+msgid "Trace"
+msgstr ""
+
+#: libvips/conversion/sequential.c:264
+msgid "Trace pixel requests"
+msgstr ""
+
+#: libvips/conversion/smartcrop.c:453
+#, fuzzy
+msgid "Interesting"
+msgstr "Interpretation"
+
+#: libvips/conversion/smartcrop.c:454
+msgid "How to measure interestingness"
+msgstr ""
+
+#: libvips/conversion/smartcrop.c:460
+msgid "Attention x"
+msgstr ""
+
+#: libvips/conversion/smartcrop.c:461
+#, fuzzy
+msgid "Horizontal position of attention centre"
+msgstr "horizontale Position des Minimums"
+
+#: libvips/conversion/smartcrop.c:467
+msgid "Attention y"
+msgstr ""
+
+#: libvips/conversion/smartcrop.c:468
+#, fuzzy
+msgid "Vertical position of attention centre"
+msgstr "vertikale Position des Minimums"
+
+#: libvips/conversion/smartcrop.c:475
+msgid "Input image already has premultiplied alpha"
+msgstr ""
+
+#: libvips/conversion/subsample.c:228 libvips/resample/reduceh.cpp:546
+#: libvips/resample/reducev.cpp:1001 libvips/resample/shrinkh.c:316
+#: libvips/resample/shrinkv.c:364
 msgid "image has shrunk to nothing"
 msgstr "Bild ist zu nichts geschrumpft"
 
-#: libvips/conversion/bandjoin.c:165
-msgid "bandwise join a set of images"
-msgstr "einen Satz Bilder bandweise zusammenführen"
+#: libvips/conversion/subsample.c:259
+#, fuzzy
+msgid "subsample an image"
+msgstr "ein Bild zwischenspeichern"
 
-#: libvips/conversion/bandjoin.c:172
-msgid "Array of input images"
-msgstr "Feld von Eingabebildern"
+#: libvips/conversion/subsample.c:273 libvips/conversion/zoom.c:379
+msgid "Xfac"
+msgstr ""
 
-#: libvips/convolution/im_contrast_surface.c:147
-msgid "parameters would result in zero size output image"
-msgstr "Parameter würden zu einem Ausgabebild der Größe Null führen"
+#: libvips/conversion/subsample.c:274
+#, fuzzy
+msgid "Horizontal subsample factor"
+msgstr "horizontaler Versatz vom Ursprung"
 
-#: libvips/convolution/im_aconvsep.c:130 libvips/convolution/im_aconv.c:223
-#: libvips/convolution/im_aconv.c:229 libvips/convolution/im_aconv.c:750
+#: libvips/conversion/subsample.c:280 libvips/conversion/zoom.c:386
+msgid "Yfac"
+msgstr ""
+
+#: libvips/conversion/subsample.c:281
+#, fuzzy
+msgid "Vertical subsample factor"
+msgstr "vertikaler Versatz vom Ursprung"
+
+#: libvips/conversion/subsample.c:287
+msgid "Point"
+msgstr ""
+
+#: libvips/conversion/subsample.c:288
+msgid "Point sample"
+msgstr ""
+
+#: libvips/conversion/switch.c:129
+#, fuzzy
+msgid "bad number of tests"
+msgstr "falsche Achsenanzahl %d"
+
+#: libvips/conversion/switch.c:161
+#, fuzzy
+msgid "test images not 1-band"
+msgstr "Bild muss ein Band haben"
+
+#: libvips/conversion/switch.c:189
+msgid "find the index of the first non-zero pixel in tests"
+msgstr ""
+
+#: libvips/conversion/switch.c:195
+msgid "Tests"
+msgstr ""
+
+#: libvips/conversion/switch.c:196
+#, fuzzy
+msgid "Table of images to test"
+msgstr "Bild in TIFF-Datei speichern"
+
+#: libvips/conversion/tilecache.c:411 libvips/foreign/foreign.c:1235
+msgid "Access"
+msgstr ""
+
+#: libvips/conversion/tilecache.c:418
+msgid "Threaded"
+msgstr ""
+
+#: libvips/conversion/tilecache.c:419
+msgid "Allow threaded access"
+msgstr ""
+
+#: libvips/conversion/tilecache.c:425
+msgid "Persistent"
+msgstr ""
+
+#: libvips/conversion/tilecache.c:426
+msgid "Keep cache between evaluations"
+msgstr ""
+
+#: libvips/conversion/tilecache.c:708
+#, c-format
+msgid "error in tile %d x %d"
+msgstr ""
+
+#: libvips/conversion/tilecache.c:796
+#, fuzzy
+msgid "cache an image as a set of tiles"
+msgstr "ein Bild zwischenspeichern"
+
+#: libvips/conversion/tilecache.c:983
+#, fuzzy
+msgid "cache an image as a set of lines"
+msgstr "ein Bild zwischenspeichern"
+
+#: libvips/conversion/transpose3d.c:135
+msgid "bad page_height"
+msgstr ""
+
+#: libvips/conversion/transpose3d.c:163
+#, fuzzy
+msgid "transpose3d an image"
+msgstr "ein Bild einfügen"
+
+#: libvips/conversion/transpose3d.c:173 libvips/foreign/foreign.c:1915
+#, fuzzy
+msgid "Page height"
+msgstr "Kachelhöhe"
+
+#: libvips/conversion/transpose3d.c:174
+#, fuzzy
+msgid "Height of each input page"
+msgstr "Höhe des extrahierten Bereichs"
+
+#: libvips/conversion/unpremultiply.c:317
+#, fuzzy
+msgid "unpremultiply image alpha"
+msgstr "zwei Bilder multiplizieren"
+
+#: libvips/conversion/unpremultiply.c:336
+#, fuzzy
+msgid "Alpha band"
+msgstr "falsche Bänder"
+
+#: libvips/conversion/unpremultiply.c:337
+msgid "Unpremultiply with this alpha"
+msgstr ""
+
+#: libvips/conversion/wrap.c:115
+msgid "wrap image origin"
+msgstr ""
+
+#: libvips/conversion/zoom.c:328
+msgid "zoom factors too large"
+msgstr "Zoomfaktoren zu groß"
+
+#: libvips/conversion/zoom.c:367
+#, fuzzy
+msgid "zoom an image"
+msgstr "ein Bild kopieren"
+
+#: libvips/conversion/zoom.c:380
+#, fuzzy
+msgid "Horizontal zoom factor"
+msgstr "horizontaler Versatz vom Ursprung"
+
+#: libvips/conversion/zoom.c:387
+#, fuzzy
+msgid "Vertical zoom factor"
+msgstr "vertikaler Versatz vom Ursprung"
+
+#: libvips/convolution/canny.c:436
+msgid "Canny edge detector"
+msgstr ""
+
+#: libvips/convolution/canny.c:454 libvips/convolution/gaussblur.c:144
+#: libvips/convolution/sharpen.c:334 libvips/create/gaussmat.c:185
+#: libvips/create/gaussnoise.c:188
+msgid "Sigma"
+msgstr ""
+
+#: libvips/convolution/canny.c:455 libvips/convolution/gaussblur.c:145
+#: libvips/convolution/sharpen.c:335 libvips/create/gaussmat.c:186
+msgid "Sigma of Gaussian"
+msgstr ""
+
+#: libvips/convolution/canny.c:461 libvips/convolution/compass.c:184
+#: libvips/convolution/conv.c:134 libvips/convolution/convsep.c:130
+#: libvips/convolution/gaussblur.c:158 libvips/create/gaussmat.c:213
+#: libvips/create/logmat.c:229
+#, fuzzy
+msgid "Precision"
+msgstr "Komprimierung"
+
+#: libvips/convolution/canny.c:462 libvips/convolution/compass.c:185
+#: libvips/convolution/conv.c:135 libvips/convolution/convsep.c:131
+#: libvips/convolution/gaussblur.c:159
+msgid "Convolve with this precision"
+msgstr ""
+
+#: libvips/convolution/compass.c:159
+msgid "convolve with rotating mask"
+msgstr ""
+
+#: libvips/convolution/compass.c:163
+msgid "Times"
+msgstr ""
+
+#: libvips/convolution/compass.c:164
+msgid "Rotate and convolve this many times"
+msgstr ""
+
+#: libvips/convolution/compass.c:171
+msgid "Rotate mask by this much between convolutions"
+msgstr ""
+
+#: libvips/convolution/compass.c:178
+msgid "Combine convolution results like this"
+msgstr ""
+
+#: libvips/convolution/compass.c:191 libvips/convolution/conva.c:1323
+#: libvips/convolution/convasep.c:918 libvips/convolution/conv.c:141
+#: libvips/convolution/convsep.c:137
+msgid "Layers"
+msgstr ""
+
+#: libvips/convolution/compass.c:192 libvips/convolution/conva.c:1324
+#: libvips/convolution/convasep.c:919 libvips/convolution/conv.c:142
+#: libvips/convolution/convsep.c:138
+msgid "Use this many layers in approximation"
+msgstr ""
+
+#: libvips/convolution/compass.c:198 libvips/convolution/conva.c:1330
+#: libvips/convolution/conv.c:148 libvips/convolution/convsep.c:144
+msgid "Cluster"
+msgstr ""
+
+#: libvips/convolution/compass.c:199 libvips/convolution/conva.c:1331
+#: libvips/convolution/conv.c:149 libvips/convolution/convsep.c:145
+msgid "Cluster lines closer than this in approximation"
+msgstr ""
+
+#: libvips/convolution/conva.c:236 libvips/convolution/conva.c:242
+#: libvips/convolution/conva.c:760 libvips/convolution/convasep.c:151
 msgid "mask too complex"
 msgstr "Maske zu komplex"
 
-#: libvips/convolution/im_aconvsep.c:798 libvips/convolution/im_conv.c:1038
-#: libvips/convolution/im_conv_f.c:340 libvips/convolution/im_aconv.c:980
-#: libvips/convolution/im_aconv.c:1201 libvips/morphology/morphology.c:721
+#: libvips/convolution/conva.c:997 libvips/convolution/conva.c:1247
+#: libvips/convolution/convasep.c:840
 msgid "image too small for mask"
 msgstr "Bild zu klein für Maske"
 
-#: libvips/convolution/im_conv.c:215
-#, c-format
-msgid "%d overflows and %d underflows detected"
-msgstr "%d Über- und %d Unterläufe entdeckt"
+#: libvips/convolution/conva.c:1319
+msgid "approximate integer convolution"
+msgstr ""
 
-#: libvips/convolution/im_conv.c:1125 libvips/convolution/im_conv_f.c:403
-msgid "expect 1xN or Nx1 input mask"
-msgstr "1xN- oder Nx1-Eingabemaske wird erwartet"
+#: libvips/convolution/convasep.c:914
+msgid "approximate separable integer convolution"
+msgstr ""
 
-# ref und in sind Objekte
-#: libvips/convolution/im_fastcor.c:134 libvips/convolution/im_spcor.c:247
-msgid "ref not smaller than or equal to in"
-msgstr "»ref« nicht kleiner oder gleich »in«"
+#: libvips/convolution/conv.c:130
+#, fuzzy
+msgid "convolution operation"
+msgstr "Umwandlungstransaktionen"
 
-#: libvips/convolution/im_sharpen.c:325 libvips/histograms_lut/im_stdif.c:196
-msgid "parameters out of range"
-msgstr "Parameter außerhalb des Bereichs"
+#: libvips/convolution/convf.c:374
+#, fuzzy
+msgid "float convolution operation"
+msgstr "Umwandlungstransaktionen"
 
-#: libvips/foreign/rawload.c:107
-msgid "load raw data from a file"
-msgstr "Rohdaten aus einer Datei laden"
+#: libvips/convolution/convi.c:1245
+#, fuzzy
+msgid "int convolution operation"
+msgstr "Umwandlungstransaktionen"
 
-#: libvips/foreign/rawload.c:115 libvips/foreign/fitssave.c:128
-#: libvips/foreign/ppmload.c:126 libvips/foreign/radload.c:126
-#: libvips/foreign/openslideload.c:176 libvips/foreign/tiffload.c:142
-#: libvips/foreign/fitsload.c:116 libvips/foreign/vipssave.c:125
-#: libvips/foreign/radsave.c:119 libvips/foreign/openexrload.c:137
-#: libvips/foreign/analyzeload.c:126 libvips/foreign/pngload.c:136
-#: libvips/foreign/tiffsave.c:169 libvips/foreign/vipsload.c:133
-#: libvips/foreign/magickload.c:146 libvips/foreign/matload.c:128
-#: libvips/foreign/jpegload.c:245 libvips/foreign/jpegsave.c:193
-#: libvips/foreign/rawsave.c:166 libvips/foreign/ppmsave.c:118
-#: libvips/foreign/csvsave.c:121 libvips/foreign/csvload.c:132
-#: libvips/foreign/pngsave.c:166 libvips/iofuncs/image.c:915
-msgid "Filename"
-msgstr "Dateiname"
+#: libvips/convolution/convolution.c:119
+#, fuzzy
+msgid "convolution operations"
+msgstr "Umwandlungstransaktionen"
 
-#: libvips/foreign/rawload.c:116 libvips/foreign/ppmload.c:127
-#: libvips/foreign/radload.c:127 libvips/foreign/openslideload.c:177
-#: libvips/foreign/tiffload.c:143 libvips/foreign/fitsload.c:117
-#: libvips/foreign/openexrload.c:138 libvips/foreign/analyzeload.c:127
-#: libvips/foreign/pngload.c:137 libvips/foreign/vipsload.c:134
-#: libvips/foreign/magickload.c:147 libvips/foreign/matload.c:129
-#: libvips/foreign/jpegload.c:246 libvips/foreign/csvload.c:133
-msgid "Filename to load from"
-msgstr "Name der Datei, aus der geladen werden soll"
+#: libvips/convolution/convolution.c:140 libvips/convolution/correlation.c:156
+#: libvips/draw/draw_mask.c:332 libvips/freqfilt/freqmult.c:130
+#: libvips/morphology/labelregions.c:124 libvips/morphology/morph.c:965
+msgid "Mask"
+msgstr ""
 
-#: libvips/foreign/rawload.c:143 libvips/iofuncs/image.c:943
-msgid "Size of header"
-msgstr "Größe der Kopfdaten"
+#: libvips/convolution/convolution.c:141 libvips/morphology/morph.c:966
+#, fuzzy
+msgid "Input matrix image"
+msgstr "Eingabebild"
 
-#: libvips/foreign/rawload.c:144 libvips/iofuncs/image.c:944
-msgid "Offset in bytes from start of file"
-msgstr "Versatz in Byte vom Anfang der Datei"
+#: libvips/convolution/convsep.c:126
+#, fuzzy
+msgid "separable convolution operation"
+msgstr "Umwandlungstransaktionen"
 
-#: libvips/foreign/fitssave.c:119
-# http://de.wikipedia.org/wiki/Flexible_Image_Transport_System
-msgid "save image to fits file"
-msgstr "Bild in FITS-Datei speichern"
+#: libvips/convolution/correlation.c:144
+#, fuzzy
+msgid "correlation operation"
+msgstr "Umwandlungstransaktionen"
 
-#: libvips/foreign/fitssave.c:129 libvips/foreign/vipssave.c:126
-#: libvips/foreign/radsave.c:120 libvips/foreign/tiffsave.c:170
-#: libvips/foreign/jpegsave.c:194 libvips/foreign/rawsave.c:167
-#: libvips/foreign/ppmsave.c:119 libvips/foreign/csvsave.c:122
-#: libvips/foreign/pngsave.c:167
-msgid "Filename to save to"
-msgstr "Name der Datei in die gespeichert werden soll"
+#: libvips/convolution/correlation.c:157
+#, fuzzy
+msgid "Input reference image"
+msgstr "Zeilensprungbild"
 
-#: libvips/foreign/ppmload.c:114
-# Portable Pixmap
-msgid "load ppm from file"
-msgstr "PPM aus Datei laden"
+#: libvips/convolution/edge.c:213
+#, fuzzy
+msgid "Edge detector"
+msgstr "falscher Bild-Deskriptor"
 
-#: libvips/foreign/radload.c:114
-msgid "load a Radiance image from a file"
-msgstr "ein Radiance-Bild aus einer Datei laden"
+#: libvips/convolution/edge.c:258
+msgid "Sobel edge detector"
+msgstr ""
 
-#: libvips/foreign/openslideload.c:159
-msgid "load file with OpenSlide"
-msgstr "Datei mit OpenSlide laden"
+#: libvips/convolution/edge.c:291
+msgid "Scharr edge detector"
+msgstr ""
 
-#: libvips/foreign/openslideload.c:183
-msgid "Level"
-msgstr "Ebene"
+#: libvips/convolution/edge.c:324
+msgid "Prewitt edge detector"
+msgstr ""
 
-#: libvips/foreign/openslideload.c:184
-msgid "Load this level from the file"
-msgstr "diese Ebene aus der Datei laden"
+#: libvips/convolution/fastcor.c:218
+#, fuzzy
+msgid "fast correlation"
+msgstr "Interpretation"
 
-#: libvips/foreign/openslideload.c:190
-msgid "Associated"
-msgstr "dazugehörig"
+#: libvips/convolution/gaussblur.c:126
+msgid "gaussian blur"
+msgstr ""
 
-#: libvips/foreign/openslideload.c:191
-msgid "Load this associated image"
-msgstr "dieses zugehörige Bild laden"
+#: libvips/convolution/gaussblur.c:151 libvips/create/gaussmat.c:192
+msgid "Minimum amplitude"
+msgstr ""
 
-#: libvips/foreign/tiffload.c:130
-msgid "load tiff from file"
-msgstr "TIFF aus Datei laden"
+#: libvips/convolution/gaussblur.c:152 libvips/create/gaussmat.c:193
+#: libvips/create/logmat.c:209
+#, fuzzy
+msgid "Minimum amplitude of Gaussian"
+msgstr "Minimalwert des Bildes"
 
-#: libvips/foreign/tiffload.c:149
-msgid "Page"
-msgstr "Seite"
+#: libvips/convolution/sharpen.c:316
+msgid "unsharp masking for print"
+msgstr ""
 
-#: libvips/foreign/tiffload.c:150
-msgid "Load this page from the file"
-msgstr "diese Seite aus der Datei laden"
+#: libvips/convolution/sharpen.c:341 libvips/draw/draw_line.c:284
+#, fuzzy
+msgid "x1"
+msgstr "x"
 
-#: libvips/foreign/fitsload.c:107
-msgid "load a FITS image"
-msgstr "ein FITS-Bild laden"
+#: libvips/convolution/sharpen.c:342
+msgid "Flat/jaggy threshold"
+msgstr ""
 
-#: libvips/foreign/vipssave.c:114
-msgid "save image to vips file"
-msgstr "Bild in Vips-Datei speichern"
+#: libvips/convolution/sharpen.c:348 libvips/draw/draw_line.c:305
+#, fuzzy
+msgid "y2"
+msgstr "y"
 
-#: libvips/foreign/radsave.c:108
-msgid "save image to Radiance file"
-msgstr "Bild in Radiance-Datei speichern"
+#: libvips/convolution/sharpen.c:349
+msgid "Maximum brightening"
+msgstr ""
 
-#: libvips/foreign/openexrload.c:125
-msgid "load an OpenEXR image"
-msgstr "ein OpenEXR-Bild laden"
+#: libvips/convolution/sharpen.c:355
+#, fuzzy
+msgid "y3"
+msgstr "y"
 
-#: libvips/foreign/analyzeload.c:114
-msgid "load an Analyze6 image"
-msgstr "ein Analyze6-Bild laden"
+#: libvips/convolution/sharpen.c:356
+msgid "Maximum darkening"
+msgstr ""
 
-#: libvips/foreign/pngload.c:124
-msgid "load png from file"
-msgstr "PNG-Datei aus Datei laden"
+#: libvips/convolution/sharpen.c:362
+msgid "m1"
+msgstr ""
 
-#: libvips/foreign/tiffsave.c:159
-msgid "save image to tiff file"
-msgstr "Bild in TIFF-Datei speichern"
+#: libvips/convolution/sharpen.c:363
+msgid "Slope for flat areas"
+msgstr ""
 
-#: libvips/foreign/tiffsave.c:176 libvips/foreign/pngsave.c:103
-msgid "Compression"
-msgstr "Komprimierung"
+#: libvips/convolution/sharpen.c:369
+msgid "m2"
+msgstr ""
 
-#: libvips/foreign/tiffsave.c:177
-msgid "Compression for this file"
-msgstr "Komprimierung für diese Datei"
+#: libvips/convolution/sharpen.c:370
+msgid "Slope for jaggy areas"
+msgstr ""
 
-#: libvips/foreign/tiffsave.c:184 libvips/foreign/jpegsave.c:124
-msgid "Q"
-msgstr "Q"
+#: libvips/convolution/sharpen.c:378 libvips/create/logmat.c:201
+#: libvips/create/mask_butterworth_band.c:136
+#: libvips/create/mask_gaussian_band.c:121 libvips/create/mask_ideal_band.c:112
+#: libvips/create/sdf.c:326 libvips/draw/draw_circle.c:248
+msgid "Radius"
+msgstr ""
 
-#: libvips/foreign/tiffsave.c:185 libvips/foreign/jpegsave.c:125
-msgid "Q factor"
-msgstr "Q-Faktor"
+#: libvips/convolution/sharpen.c:379 libvips/create/logmat.c:202
+msgid "Radius of Gaussian"
+msgstr ""
 
-#: libvips/foreign/tiffsave.c:191
-# http://de.wikipedia.org/wiki/Abhängige_und_unabhängige_Variable
-msgid "predictor"
-msgstr "Prädiktor"
+#: libvips/convolution/spcor.c:317
+msgid "spatial correlation"
+msgstr ""
 
-#: libvips/foreign/tiffsave.c:192
-msgid "Compression prediction"
-msgstr "Prognose der Komprimierung"
+#: libvips/create/black.c:136
+msgid "make a black image"
+msgstr "ein schwarzes Bild erstellen"
 
-#: libvips/foreign/tiffsave.c:199 libvips/foreign/jpegsave.c:131
-msgid "profile"
-msgstr "Profil"
+#: libvips/create/buildlut.c:134
+#, fuzzy, c-format
+msgid "x value row %d not an int"
+msgstr "x-Wert keine Ganzzahl"
 
-#: libvips/foreign/tiffsave.c:200 libvips/foreign/jpegsave.c:132
-msgid "ICC profile to embed"
-msgstr "einzubettendes ICC-Profil"
+#: libvips/create/buildlut.c:149
+msgid "x range too small"
+msgstr "x-Bereich zu klein"
 
-#: libvips/foreign/tiffsave.c:206
-msgid "Tile"
-msgstr "Kachel"
+#: libvips/create/buildlut.c:259 libvips/create/tonelut.c:221
+msgid "build a look-up table"
+msgstr ""
 
-#: libvips/foreign/tiffsave.c:207
-msgid "Write a tiled tiff"
-msgstr "ein gekacheltes TIFF schreiben"
+#: libvips/create/buildlut.c:264 libvips/create/invertlut.c:289
+#, fuzzy
+msgid "Matrix of XY coordinates"
+msgstr "Matrix der Koeffizienten"
 
-#: libvips/foreign/tiffsave.c:227
-msgid "Pyramid"
-msgstr "Pyramide"
+#: libvips/create/create.c:120
+#, fuzzy
+msgid "create operations"
+msgstr "Transaktionen"
 
-#: libvips/foreign/tiffsave.c:228
-msgid "Write a pyramidal tiff"
-msgstr "ein pyramidenförmiges TIFF schreiben"
+#: libvips/create/eye.c:103
+msgid "make an image showing the eye's spatial response"
+msgstr ""
 
-#: libvips/foreign/tiffsave.c:234
-msgid "Squash"
-msgstr "quetschen"
+#: libvips/create/eye.c:109
+msgid "Maximum spatial frequency"
+msgstr ""
 
-#: libvips/foreign/tiffsave.c:235
-msgid "Squash images down to 1 bit"
-msgstr "Bilder auf ein Bit zusammenquetschen"
+#: libvips/create/fractsurf.c:100
+#, fuzzy
+msgid "make a fractal surface"
+msgstr "ein schwarzes Bild erstellen"
 
-#: libvips/foreign/tiffsave.c:241 libvips/foreign/tiffsave.c:242
-msgid "Resolution unit"
-msgstr "Einheit der Auflösung"
+#: libvips/create/fractsurf.c:118 libvips/create/fractsurf.c:119
+#: libvips/create/mask_fractal.c:93 libvips/create/mask_fractal.c:94
+#, fuzzy
+msgid "Fractal dimension"
+msgstr "falsche Abmessungen"
 
-#: libvips/foreign/tiffsave.c:263
-# http://de.wikipedia.org/wiki/Liste_von_Dateinamenserweiterungen/T
-msgid "Bigtiff"
-msgstr "BigTIFF"
+#: libvips/create/gaussmat.c:129 libvips/create/logmat.c:147
+#, fuzzy
+msgid "mask too large"
+msgstr "Maske zu komplex"
 
-#: libvips/foreign/tiffsave.c:264
-msgid "Write a bigtiff image"
-msgstr "ein BigTIFF-Bild schreiben"
+#: libvips/create/gaussmat.c:181
+#, fuzzy
+msgid "make a gaussian image"
+msgstr "ein schwarzes Bild erstellen"
 
-#: libvips/foreign/csv.c:183
-#, c-format
-msgid "error parsing number, line %d, column %d"
-msgstr "Fehler beim Auswerten von Nummer, Zeile %d, Spalte %d"
+#: libvips/create/gaussmat.c:199 libvips/create/logmat.c:215
+#, fuzzy
+msgid "Separable"
+msgstr "Trenner"
 
-#: libvips/foreign/csv.c:237
-msgid "end of file while skipping start"
-msgstr "Dateiende während des Überspringens des Startes"
+#: libvips/create/gaussmat.c:200 libvips/create/logmat.c:216
+msgid "Generate separable Gaussian"
+msgstr ""
 
-#: libvips/foreign/csv.c:246 libvips/iofuncs/util.c:1072
-#: libvips/iofuncs/util.c:1078
-msgid "unable to seek"
-msgstr "kann nicht gesucht werden"
+#: libvips/create/gaussmat.c:206 libvips/create/logmat.c:222
+#, fuzzy
+msgid "Integer"
+msgstr "Zeilensprung"
 
-#: libvips/foreign/csv.c:257
-msgid "empty line"
+#: libvips/create/gaussmat.c:207 libvips/create/logmat.c:223
+#, fuzzy
+msgid "Generate integer Gaussian"
+msgstr "Rest nach Ganzzahldivision"
+
+#: libvips/create/gaussmat.c:214 libvips/create/logmat.c:230
+msgid "Generate with this precision"
+msgstr ""
+
+#: libvips/create/gaussnoise.c:159
+#, fuzzy
+msgid "make a gaussnoise image"
+msgstr "ein schwarzes Bild erstellen"
+
+#: libvips/create/gaussnoise.c:181 libvips/histogram/stdif.c:329
+msgid "Mean"
+msgstr ""
+
+#: libvips/create/gaussnoise.c:182
+#, fuzzy
+msgid "Mean of pixels in generated image"
+msgstr "keine Bildpunktdaten in angehängtem Bild"
+
+#: libvips/create/gaussnoise.c:189
+#, fuzzy
+msgid "Standard deviation of pixels in generated image"
+msgstr "Standardabweichung des Bildes"
+
+#: libvips/create/gaussnoise.c:195 libvips/create/perlin.c:322
+#: libvips/create/worley.c:328
+msgid "Seed"
+msgstr ""
+
+#: libvips/create/gaussnoise.c:196 libvips/create/perlin.c:323
+#: libvips/create/worley.c:329
+#, fuzzy
+msgid "Random number seed"
+msgstr "falsche Achsenanzahl %d"
+
+#: libvips/create/grey.c:89
+#, fuzzy
+msgid "make a grey ramp image"
+msgstr "ein schwarzes Bild erstellen"
+
+#: libvips/create/identity.c:139
+msgid "make a 1D image where pixel values are indexes"
+msgstr ""
+
+#: libvips/create/identity.c:144
+#, fuzzy
+msgid "Number of bands in LUT"
+msgstr "Anzahl der Bänder in einem Bild"
+
+#: libvips/create/identity.c:150
+msgid "Ushort"
+msgstr ""
+
+#: libvips/create/identity.c:151
+msgid "Create a 16-bit LUT"
+msgstr ""
+
+#: libvips/create/identity.c:158
+msgid "Size of 16-bit LUT"
+msgstr ""
+
+#: libvips/create/invertlut.c:124
+msgid "bad input matrix"
+msgstr "falsche Eingabematrix"
+
+#: libvips/create/invertlut.c:129
+msgid "bad size"
+msgstr "falsche Größe"
+
+#: libvips/create/invertlut.c:149
+#, fuzzy, c-format
+msgid "element (%d, %d) is %g, outside range [0,1]"
+msgstr "Element außerhalb des Bereichs [0,1]"
+
+#: libvips/create/invertlut.c:284
+msgid "build an inverted look-up table"
+msgstr ""
+
+#: libvips/create/invertlut.c:295
+msgid "LUT size to generate"
+msgstr ""
+
+#: libvips/create/logmat.c:197
+#, fuzzy
+msgid "make a Laplacian of Gaussian image"
+msgstr "ein schwarzes Bild erstellen"
+
+#: libvips/create/mask_butterworth_band.c:110
+msgid "make a butterworth_band filter"
+msgstr ""
+
+#: libvips/create/mask_butterworth_band.c:115
+#: libvips/create/mask_butterworth.c:91
+msgid "Order"
+msgstr ""
+
+#: libvips/create/mask_butterworth_band.c:116
+#: libvips/create/mask_butterworth.c:92
+msgid "Filter order"
+msgstr ""
+
+#: libvips/create/mask_butterworth_band.c:122
+#: libvips/create/mask_butterworth_band.c:123
+#: libvips/create/mask_gaussian_band.c:107
+#: libvips/create/mask_gaussian_band.c:108 libvips/create/mask_ideal_band.c:98
+#: libvips/create/mask_ideal_band.c:99
+msgid "Frequency cutoff x"
+msgstr ""
+
+#: libvips/create/mask_butterworth_band.c:129
+#: libvips/create/mask_butterworth_band.c:130
+#: libvips/create/mask_gaussian_band.c:114
+#: libvips/create/mask_gaussian_band.c:115 libvips/create/mask_ideal_band.c:105
+#: libvips/create/mask_ideal_band.c:106
+msgid "Frequency cutoff y"
+msgstr ""
+
+#: libvips/create/mask_butterworth_band.c:137
+#: libvips/create/mask_gaussian_band.c:122 libvips/create/mask_ideal_band.c:113
+msgid "Radius of circle"
+msgstr ""
+
+#: libvips/create/mask_butterworth_band.c:143
+#: libvips/create/mask_butterworth_band.c:144
+#: libvips/create/mask_butterworth.c:105 libvips/create/mask_butterworth.c:106
+#: libvips/create/mask_gaussian_band.c:128
+#: libvips/create/mask_gaussian_band.c:129 libvips/create/mask_gaussian.c:93
+#: libvips/create/mask_gaussian.c:94
+msgid "Amplitude cutoff"
+msgstr ""
+
+#: libvips/create/mask_butterworth.c:86
+msgid "make a butterworth filter"
+msgstr ""
+
+#: libvips/create/mask_butterworth.c:98 libvips/create/mask_butterworth.c:99
+#: libvips/create/mask_gaussian.c:86 libvips/create/mask_gaussian.c:87
+#: libvips/create/mask_ideal.c:84 libvips/create/mask_ideal.c:85
+msgid "Frequency cutoff"
+msgstr ""
+
+#: libvips/create/mask_butterworth_ring.c:101
+msgid "make a butterworth ring filter"
+msgstr ""
+
+#: libvips/create/mask_butterworth_ring.c:106
+#: libvips/create/mask_butterworth_ring.c:107
+#: libvips/create/mask_gaussian_ring.c:101
+#: libvips/create/mask_gaussian_ring.c:102 libvips/create/mask_ideal_ring.c:98
+#: libvips/create/mask_ideal_ring.c:99
+#, fuzzy
+msgid "Ringwidth"
+msgstr "Kachelbreite"
+
+#: libvips/create/mask.c:114
+msgid "base class for frequency filters"
+msgstr ""
+
+#: libvips/create/mask.c:122
+msgid "Optical"
+msgstr ""
+
+#: libvips/create/mask.c:123
+msgid "Rotate quadrants to optical space"
+msgstr ""
+
+#: libvips/create/mask.c:129
+msgid "Reject"
+msgstr ""
+
+#: libvips/create/mask.c:130
+msgid "Invert the sense of the filter"
+msgstr ""
+
+#: libvips/create/mask.c:136
+msgid "Nodc"
+msgstr ""
+
+#: libvips/create/mask.c:137
+msgid "Remove DC component"
+msgstr ""
+
+#: libvips/create/mask_fractal.c:88
+msgid "make fractal filter"
+msgstr ""
+
+#: libvips/create/mask_gaussian_band.c:102 libvips/create/mask_gaussian.c:81
+msgid "make a gaussian filter"
+msgstr ""
+
+#: libvips/create/mask_gaussian_ring.c:96
+msgid "make a gaussian ring filter"
+msgstr ""
+
+#: libvips/create/mask_ideal_band.c:93
+msgid "make an ideal band filter"
+msgstr ""
+
+#: libvips/create/mask_ideal.c:79
+msgid "make an ideal filter"
+msgstr ""
+
+#: libvips/create/mask_ideal_ring.c:93
+msgid "make an ideal ring filter"
+msgstr ""
+
+#: libvips/create/perlin.c:290
+#, fuzzy
+msgid "make a perlin noise image"
+msgstr "ein schwarzes Bild erstellen"
+
+#: libvips/create/perlin.c:308 libvips/create/worley.c:321
+msgid "Cell size"
+msgstr ""
+
+#: libvips/create/perlin.c:309
+msgid "Size of Perlin cells"
+msgstr ""
+
+#: libvips/create/perlin.c:315 libvips/create/point.c:155
+msgid "Uchar"
+msgstr ""
+
+#: libvips/create/perlin.c:316 libvips/create/point.c:156
+#, fuzzy
+msgid "Output an unsigned char image"
+msgstr "kein »uchar«-Bild mit einem Band"
+
+#: libvips/create/point.c:132
+#, fuzzy
+msgid "make a point image"
+msgstr "ein schwarzes Bild erstellen"
+
+#: libvips/create/sdf.c:178
+msgid "circle needs a, r to be set"
+msgstr ""
+
+#: libvips/create/sdf.c:183
+msgid "rounded-box needs 2 values for a"
+msgstr ""
+
+#: libvips/create/sdf.c:196
+msgid "box needs a, b to be set"
+msgstr ""
+
+#: libvips/create/sdf.c:202
+msgid "box needs 2 values for a, b"
+msgstr ""
+
+#: libvips/create/sdf.c:216
+msgid "rounded-box needs a, b to be set"
+msgstr ""
+
+#: libvips/create/sdf.c:222
+msgid "rounded-box needs 2 values for a, b"
+msgstr ""
+
+#: libvips/create/sdf.c:227
+msgid "rounded-box needs 4 values for corners"
+msgstr ""
+
+#: libvips/create/sdf.c:242
+msgid "line needs sx, sy to be set"
+msgstr ""
+
+#: libvips/create/sdf.c:248
+msgid "line needs 2 values for a, b"
+msgstr ""
+
+#: libvips/create/sdf.c:259
+#, fuzzy, c-format
+msgid "unknown SDF %d"
+msgstr "unbekannte Kodierung"
+
+#: libvips/create/sdf.c:300
+#, fuzzy
+msgid "create an SDF image"
+msgstr "ein Bild drehen"
+
+#: libvips/create/sdf.c:318
+msgid "Shape"
+msgstr ""
+
+#: libvips/create/sdf.c:319
+msgid "SDF shape to create"
+msgstr ""
+
+#: libvips/create/sdf.c:325
+msgid "r"
+msgstr ""
+
+#: libvips/create/sdf.c:333
+msgid "Point a"
+msgstr ""
+
+#: libvips/create/sdf.c:340
+msgid "Point b"
+msgstr ""
+
+#: libvips/create/sdf.c:346
+msgid "corners"
+msgstr ""
+
+#: libvips/create/sdf.c:347
+msgid "Corner radii"
+msgstr ""
+
+#: libvips/create/sines.c:122
+msgid "make a 2D sine wave"
+msgstr ""
+
+#: libvips/create/sines.c:128
+msgid "hfreq"
+msgstr ""
+
+#: libvips/create/sines.c:129
+#, fuzzy
+msgid "Horizontal spatial frequency"
+msgstr "horizontaler Versatz vom Ursprung"
+
+#: libvips/create/sines.c:135
+msgid "vfreq"
+msgstr ""
+
+#: libvips/create/sines.c:136
+msgid "Vertical spatial frequency"
+msgstr ""
+
+#: libvips/create/text.c:406
+msgid "invalid markup in text"
+msgstr "ungültige Auszeichnung im Text"
+
+#: libvips/create/text.c:428
+#, fuzzy, c-format
+msgid "unable to load fontfile \"%s\""
+msgstr "Profil »%s« kann nicht geöffnet werden"
+
+#: libvips/create/text.c:467
+msgid "no text to render"
+msgstr "kein Text zu rendern"
+
+#: libvips/create/text.c:549
+#, fuzzy
+msgid "make a text image"
+msgstr "ein schwarzes Bild erstellen"
+
+#: libvips/create/text.c:553
+msgid "Text"
+msgstr ""
+
+#: libvips/create/text.c:554
+#, fuzzy
+msgid "Text to render"
+msgstr "kein Text zu rendern"
+
+#: libvips/create/text.c:560
+msgid "Font"
+msgstr ""
+
+#: libvips/create/text.c:561
+#, fuzzy
+msgid "Font to render with"
+msgstr "kein Text zu rendern"
+
+#: libvips/create/text.c:568
+#, fuzzy
+msgid "Maximum image width in pixels"
+msgstr "Bildbreite in Bildpunkten"
+
+#: libvips/create/text.c:575
+#, fuzzy
+msgid "Maximum image height in pixels"
+msgstr "Bildhöhe in Bildpunkten"
+
+#: libvips/create/text.c:582
+#, fuzzy
+msgid "Align on the low, centre or high edge"
+msgstr "am Rand der unteren, mittleren oder höchsten Koordinate ausrichten"
+
+#: libvips/create/text.c:588
+msgid "Justify"
+msgstr ""
+
+#: libvips/create/text.c:589
+#, fuzzy
+msgid "Justify lines"
 msgstr "leere Zeile"
 
-#: libvips/foreign/csv.c:301
-#, c-format
-msgid "unexpected EOF, line %d col %d"
-msgstr "unerwartetes Dateiende, Zeile %d, Spalte %d"
+#: libvips/create/text.c:595 libvips/foreign/pdfiumload.c:709
+#: libvips/foreign/popplerload.c:559 libvips/foreign/svgload.c:717
+msgid "DPI"
+msgstr ""
 
-#: libvips/foreign/csv.c:307
-#, c-format
-msgid "unexpected EOL, line %d col %d"
-msgstr "unerwartetes Zeilenende, Zeile %d, Spalte %d"
+#: libvips/create/text.c:596 libvips/foreign/pdfiumload.c:710
+#: libvips/foreign/popplerload.c:560
+#, fuzzy
+msgid "DPI to render at"
+msgstr "kein Text zu rendern"
 
-#: libvips/foreign/vipsload.c:121
-msgid "load vips from file"
-msgstr "Vips aus einer Datei laden"
+#: libvips/create/text.c:602
+msgid "Autofit DPI"
+msgstr ""
 
-#: libvips/foreign/magickload.c:131
-msgid "load file with ImageMagick"
-msgstr "Datei mit ImageMagick laden"
+#: libvips/create/text.c:603
+msgid "DPI selected by autofit"
+msgstr ""
 
-#: libvips/foreign/matload.c:116
-# http://www.dateiendung.com/format/mat
-msgid "load mat from file"
-msgstr "Mat aus Datei laden"
+#: libvips/create/text.c:609
+msgid "Spacing"
+msgstr ""
 
-#: libvips/foreign/jpegload.c:118
-#, c-format
-msgid "bad shrink factor %d"
-msgstr "falscher Schrumpffaktor %d"
+#: libvips/create/text.c:610
+msgid "Line spacing"
+msgstr ""
 
-#: libvips/foreign/jpegload.c:140
-msgid "load jpeg"
-msgstr "JPEG laden"
+#: libvips/create/text.c:616
+#, fuzzy
+msgid "Font file"
+msgstr "Profil"
 
-#: libvips/foreign/jpegload.c:146
-msgid "Shrink"
-msgstr "verkleinern"
+#: libvips/create/text.c:617
+#, fuzzy
+msgid "Load this font file"
+msgstr "diese Seite aus der Datei laden"
 
-#: libvips/foreign/jpegload.c:147
-msgid "Shrink factor on load"
-msgstr "falscher Verkleinerungsfaktor %d"
+#: libvips/create/text.c:623
+msgid "RGBA"
+msgstr ""
 
-#: libvips/foreign/jpegload.c:153
-msgid "Fail"
-msgstr "scheitern"
+#: libvips/create/text.c:624
+msgid "Enable RGBA output"
+msgstr ""
 
-#: libvips/foreign/jpegload.c:154
-msgid "Fail on first warning"
-msgstr "scheitert bei erster Warnung"
+#: libvips/create/text.c:630
+msgid "Wrap"
+msgstr ""
 
-#: libvips/foreign/jpegload.c:234
-msgid "load jpeg from file"
-msgstr "JPEG aus Datei laden"
+#: libvips/create/text.c:631
+msgid "Wrap lines on word or character boundaries"
+msgstr ""
 
-#: libvips/foreign/jpegload.c:309
-msgid "load jpeg from buffer"
-msgstr "JPEG aus Puffer laden"
+#: libvips/create/tonelut.c:225
+msgid "In-max"
+msgstr ""
 
-#: libvips/foreign/jpegload.c:315 libvips/foreign/jpegsave.c:260
-#: libvips/foreign/pngsave.c:228
-msgid "Buffer"
-msgstr "Puffer"
+#: libvips/create/tonelut.c:226
+msgid "Size of LUT to build"
+msgstr ""
 
-#: libvips/foreign/jpegload.c:316
-msgid "Buffer to load from"
-msgstr "Puffer, aus dem geladen werden soll"
+#: libvips/create/tonelut.c:232
+msgid "Out-max"
+msgstr ""
 
-#: libvips/foreign/openslide2vips.c:134
-msgid "invalid associated image name"
-msgstr "ungültiger zugehöriger Bildname"
+#: libvips/create/tonelut.c:233
+#, fuzzy
+msgid "Maximum value in output LUT"
+msgstr "Maximalwert des Bildes"
 
-#: libvips/foreign/openslide2vips.c:159
-msgid "failure opening slide"
-msgstr "Fehler beim Öffnen des Dias"
+#: libvips/create/tonelut.c:239
+msgid "Black point"
+msgstr ""
 
-#: libvips/foreign/openslide2vips.c:166
-msgid "invalid slide level"
-msgstr "ungültige Diastufe"
+#: libvips/create/tonelut.c:240
+#, fuzzy
+msgid "Lowest value in output"
+msgstr "linker Rand der Eingabe in der Ausgabe"
 
-#: libvips/foreign/openslide2vips.c:202
-#, c-format
-msgid "getting dimensions: %s"
+#: libvips/create/tonelut.c:246
+msgid "White point"
+msgstr ""
+
+#: libvips/create/tonelut.c:247
+msgid "Highest value in output"
+msgstr ""
+
+#: libvips/create/tonelut.c:253
+msgid "Shadow point"
+msgstr ""
+
+#: libvips/create/tonelut.c:254
+msgid "Position of shadow"
+msgstr ""
+
+#: libvips/create/tonelut.c:260
+msgid "Mid-tone point"
+msgstr ""
+
+#: libvips/create/tonelut.c:261
+msgid "Position of mid-tones"
+msgstr ""
+
+#: libvips/create/tonelut.c:267
+msgid "Highlight point"
+msgstr ""
+
+#: libvips/create/tonelut.c:268
+msgid "Position of highlights"
+msgstr ""
+
+#: libvips/create/tonelut.c:274
+msgid "Shadow adjust"
+msgstr ""
+
+#: libvips/create/tonelut.c:275
+msgid "Adjust shadows by this much"
+msgstr ""
+
+#: libvips/create/tonelut.c:281
+msgid "Mid-tone adjust"
+msgstr ""
+
+#: libvips/create/tonelut.c:282
+msgid "Adjust mid-tones by this much"
+msgstr ""
+
+#: libvips/create/tonelut.c:288
+msgid "Highlight adjust"
+msgstr ""
+
+#: libvips/create/tonelut.c:289
+msgid "Adjust highlights by this much"
+msgstr ""
+
+#: libvips/create/worley.c:303
+#, fuzzy
+msgid "make a worley noise image"
+msgstr "ein schwarzes Bild erstellen"
+
+#: libvips/create/worley.c:322
+msgid "Size of Worley cells"
+msgstr ""
+
+#: libvips/create/xyz.c:139
+#, fuzzy
+msgid "lower dimensions not set"
 msgstr "Abfragen der Abmessungen: %s"
 
-#: libvips/foreign/openslide2vips.c:209
-msgid "image dimensions overflow int"
-msgstr "Überlaufganzzahl der Bildabmessungen"
+#: libvips/create/xyz.c:156 libvips/foreign/heifsave.c:682
+#: libvips/foreign/webpsave.c:734
+#, fuzzy
+msgid "image too large"
+msgstr "Bild zu schmal"
 
-#: libvips/foreign/openslide2vips.c:274
-#, c-format
-msgid "reading region: %s"
-msgstr "Region wird gelesen: %s"
+#: libvips/create/xyz.c:187
+msgid "make an image where pixel values are coordinates"
+msgstr ""
 
-#: libvips/foreign/openslide2vips.c:348
-#, c-format
-msgid "reading associated image: %s"
-msgstr "zugehöriges Bild wird gelesen: %s"
+#: libvips/create/xyz.c:205
+#, fuzzy
+msgid "csize"
+msgstr "falsche Größe"
+
+#: libvips/create/xyz.c:206
+msgid "Size of third dimension"
+msgstr ""
+
+#: libvips/create/xyz.c:212
+#, fuzzy
+msgid "dsize"
+msgstr "falsche Größe"
+
+#: libvips/create/xyz.c:213
+msgid "Size of fourth dimension"
+msgstr ""
+
+#: libvips/create/xyz.c:219
+#, fuzzy
+msgid "esize"
+msgstr "falsche Größe"
+
+#: libvips/create/xyz.c:220
+msgid "Size of fifth dimension"
+msgstr ""
+
+#: libvips/create/zone.c:90
+msgid "make a zone plate"
+msgstr ""
+
+#: libvips/draw/draw.c:131
+#, fuzzy
+msgid "draw operations"
+msgstr "Transaktionen"
+
+#: libvips/draw/draw.c:138
+#, fuzzy
+msgid "Image"
+msgstr "Eingabebild"
+
+#: libvips/draw/draw.c:139
+#, fuzzy
+msgid "Image to draw on"
+msgstr "zu speicherndes Bild"
+
+#: libvips/draw/draw_circle.c:230
+#, fuzzy
+msgid "draw a circle on an image"
+msgstr "einen Bereich eines Bildes extrahieren"
+
+#: libvips/draw/draw_circle.c:234
+#, fuzzy
+msgid "cx"
+msgstr "x"
+
+#: libvips/draw/draw_circle.c:235 libvips/draw/draw_circle.c:242
+msgid "Centre of draw_circle"
+msgstr ""
+
+#: libvips/draw/draw_circle.c:241
+#, fuzzy
+msgid "cy"
+msgstr "y"
+
+#: libvips/draw/draw_circle.c:249
+#, fuzzy
+msgid "Radius in pixels"
+msgstr "Bildbreite in Bildpunkten"
+
+#: libvips/draw/draw_circle.c:255 libvips/draw/draw_rect.c:201
+msgid "Fill"
+msgstr ""
+
+#: libvips/draw/draw_circle.c:256 libvips/draw/draw_rect.c:202
+msgid "Draw a solid object"
+msgstr ""
+
+#: libvips/draw/draw_flood.c:562
+msgid "flood-fill an area"
+msgstr ""
+
+#: libvips/draw/draw_flood.c:567 libvips/draw/draw_flood.c:574
+msgid "DrawFlood start point"
+msgstr ""
+
+#: libvips/draw/draw_flood.c:580
+msgid "Test"
+msgstr ""
+
+#: libvips/draw/draw_flood.c:581
+#, fuzzy
+msgid "Test pixels in this image"
+msgstr "keine Bildpunktdaten in angehängtem Bild"
+
+#: libvips/draw/draw_flood.c:586
+msgid "Equal"
+msgstr ""
+
+#: libvips/draw/draw_flood.c:587
+msgid "DrawFlood while equal to edge"
+msgstr ""
+
+#: libvips/draw/draw_flood.c:594
+#, fuzzy
+msgid "Left edge of modified area"
+msgstr "linke Kante eines extrahierten Bereichs"
+
+#: libvips/draw/draw_flood.c:601
+#, fuzzy
+msgid "Top edge of modified area"
+msgstr "obere Kante eines extrahierten Bereichs"
+
+#: libvips/draw/draw_flood.c:608
+#, fuzzy
+msgid "Width of modified area"
+msgstr "Breite des extrahierten Bereichs"
+
+#: libvips/draw/draw_flood.c:615
+#, fuzzy
+msgid "Height of modified area"
+msgstr "Höhe des extrahierten Bereichs"
+
+#: libvips/draw/draw_image.c:265
+#, fuzzy
+msgid "paint an image into another image"
+msgstr "ein Bild in ein größeres Bild einbetten"
+
+#: libvips/draw/draw_image.c:276 libvips/draw/draw_image.c:283
+#, fuzzy
+msgid "Draw image here"
+msgstr "- Bild-Kopfzeilen ausgeben"
+
+#: libvips/draw/draw_image.c:289 libvips/iofuncs/image.c:1179
+msgid "Mode"
+msgstr "Modus"
+
+#: libvips/draw/draw_image.c:290
+msgid "Combining mode"
+msgstr ""
+
+#: libvips/draw/drawink.c:86
+#, fuzzy
+msgid "draw with ink operations"
+msgstr "arithmetische Transaktionen"
+
+#: libvips/draw/drawink.c:90
+msgid "Ink"
+msgstr ""
+
+#: libvips/draw/drawink.c:91
+#, fuzzy
+msgid "Color for pixels"
+msgstr "Farbe für neue Bildpunkte"
+
+#: libvips/draw/draw_line.c:280
+#, fuzzy
+msgid "draw a line on an image"
+msgstr "eine mathematische Funktion für ein Bild ausführen"
+
+#: libvips/draw/draw_line.c:285 libvips/draw/draw_line.c:292
+msgid "Start of draw_line"
+msgstr ""
+
+#: libvips/draw/draw_line.c:291
+#, fuzzy
+msgid "y1"
+msgstr "y"
+
+#: libvips/draw/draw_line.c:298
+#, fuzzy
+msgid "x2"
+msgstr "x"
+
+#: libvips/draw/draw_line.c:299 libvips/draw/draw_line.c:306
+msgid "End of draw_line"
+msgstr ""
+
+#: libvips/draw/draw_mask.c:328
+#, fuzzy
+msgid "draw a mask on an image"
+msgstr "einen Bereich eines Bildes extrahieren"
+
+#: libvips/draw/draw_mask.c:333
+msgid "Mask of pixels to draw"
+msgstr ""
+
+#: libvips/draw/draw_mask.c:339 libvips/draw/draw_mask.c:346
+msgid "Draw mask here"
+msgstr ""
+
+#: libvips/draw/draw_rect.c:169
+#, fuzzy
+msgid "paint a rectangle on an image"
+msgstr "einen Bereich eines Bildes extrahieren"
+
+#: libvips/draw/draw_rect.c:174 libvips/draw/draw_rect.c:181
+#: libvips/draw/draw_rect.c:188 libvips/draw/draw_rect.c:195
+#: libvips/draw/draw_smudge.c:216 libvips/draw/draw_smudge.c:223
+#: libvips/draw/draw_smudge.c:230 libvips/draw/draw_smudge.c:237
+#, fuzzy
+msgid "Rect to fill"
+msgstr "Ziel zu klein"
+
+# http://techpubs.sgi.com/library/tpl/cgi-bin/getdoc.cgi?coll=0650&
+#        db=man&fname=/usr/share/catman/p_man/cat3/il_c/ilAbsImg.z
+#: libvips/draw/draw_smudge.c:211
+#, fuzzy
+msgid "blur a rectangle on an image"
+msgstr "absoluter Wert eines Bildes"
 
 #: libvips/foreign/analyze2vips.c:308
 msgid "header file size incorrect"
 msgstr "Kopfdatendateigröße nicht korrekt"
 
-#: libvips/foreign/analyze2vips.c:353
+#: libvips/foreign/analyze2vips.c:352
 msgid "header size incorrect"
 msgstr "Kopfdatengröße nicht korrekt"
 
-#: libvips/foreign/analyze2vips.c:371
+#: libvips/foreign/analyze2vips.c:370 libvips/foreign/niftiload.c:399
 #, c-format
 msgid "%d-dimensional images not supported"
 msgstr "%d-dimensionale Bilder nicht unterstützt"
 
-#: libvips/foreign/analyze2vips.c:424
+#: libvips/foreign/analyze2vips.c:423 libvips/foreign/niftiload.c:442
 #, c-format
 msgid "datatype %d not supported"
 msgstr "Datentyp %d nicht unterstützt"
 
-#: libvips/foreign/tiff2vips.c:262 libvips/foreign/tiff2vips.c:285
-#: libvips/foreign/tiff2vips.c:303
-#, c-format
-msgid "required field %d missing"
-msgstr "benötigtes Feld %d fehlt"
+#: libvips/foreign/analyzeload.c:120
+msgid "load an Analyze6 image"
+msgstr "ein Analyze6-Bild laden"
 
-#: libvips/foreign/tiff2vips.c:266
-#, c-format
-msgid "required field %d=%d, not %d"
-msgstr "benötigtes Feld %d=%d, nicht %d"
+#: libvips/foreign/analyzeload.c:141 libvips/foreign/cgifsave.c:1058
+#: libvips/foreign/csvload.c:590 libvips/foreign/csvsave.c:274
+#: libvips/foreign/dzsave.c:2597 libvips/foreign/fitsload.c:259
+#: libvips/foreign/fitssave.c:143 libvips/foreign/heifload.c:1271
+#: libvips/foreign/heifsave.c:897 libvips/foreign/jp2kload.c:1309
+#: libvips/foreign/jp2ksave.c:1063 libvips/foreign/jpegload.c:354
+#: libvips/foreign/jpegsave.c:361 libvips/foreign/jxlload.c:1218
+#: libvips/foreign/jxlsave.c:897 libvips/foreign/magick6load.c:238
+#: libvips/foreign/magick7load.c:851 libvips/foreign/matload.c:138
+#: libvips/foreign/matrixload.c:374 libvips/foreign/matrixsave.c:228
+#: libvips/foreign/niftiload.c:713 libvips/foreign/niftisave.c:441
+#: libvips/foreign/nsgifload.c:765 libvips/foreign/openexrload.c:149
+#: libvips/foreign/openslideload.c:1152 libvips/foreign/pdfiumload.c:812
+#: libvips/foreign/pngload.c:318 libvips/foreign/pngsave.c:378
+#: libvips/foreign/popplerload.c:689 libvips/foreign/ppmload.c:829
+#: libvips/foreign/ppmsave.c:592 libvips/foreign/radload.c:281
+#: libvips/foreign/radsave.c:154 libvips/foreign/rawload.c:139
+#: libvips/foreign/rawsave.c:196 libvips/foreign/spngload.c:835
+#: libvips/foreign/spngsave.c:858 libvips/foreign/svgload.c:929
+#: libvips/foreign/tiffload.c:382 libvips/foreign/tiffsave.c:527
+#: libvips/foreign/vips2magick.c:578 libvips/foreign/vipsload.c:236
+#: libvips/foreign/vipssave.c:197 libvips/foreign/webpload.c:346
+#: libvips/foreign/webpsave.c:1038 libvips/iofuncs/connection.c:133
+#: libvips/iofuncs/image.c:1172 libvips/resample/thumbnail.c:1198
+msgid "Filename"
+msgstr "Dateiname"
 
-#: libvips/foreign/tiff2vips.c:650
-#, c-format
-msgid "%d bits per sample palette image not supported"
-msgstr "%d Bit pro Musterfarbpalettenbild nicht unterstützt"
+#: libvips/foreign/analyzeload.c:142 libvips/foreign/csvload.c:591
+#: libvips/foreign/fitsload.c:260 libvips/foreign/heifload.c:1272
+#: libvips/foreign/jp2kload.c:1310 libvips/foreign/jpegload.c:355
+#: libvips/foreign/jxlload.c:1219 libvips/foreign/magick6load.c:239
+#: libvips/foreign/magick7load.c:852 libvips/foreign/matload.c:139
+#: libvips/foreign/matrixload.c:375 libvips/foreign/niftiload.c:714
+#: libvips/foreign/nsgifload.c:766 libvips/foreign/openexrload.c:150
+#: libvips/foreign/openslideload.c:1153 libvips/foreign/pdfiumload.c:813
+#: libvips/foreign/pngload.c:319 libvips/foreign/popplerload.c:690
+#: libvips/foreign/ppmload.c:830 libvips/foreign/radload.c:282
+#: libvips/foreign/rawload.c:140 libvips/foreign/spngload.c:836
+#: libvips/foreign/svgload.c:930 libvips/foreign/tiffload.c:383
+#: libvips/foreign/vipsload.c:237 libvips/foreign/webpload.c:347
+msgid "Filename to load from"
+msgstr "Name der Datei, aus der geladen werden soll"
 
-#: libvips/foreign/tiff2vips.c:659
-msgid "bad colormap"
-msgstr "falsche Farbzusammenstellung"
+#: libvips/foreign/archive.c:138
+#, fuzzy
+msgid "unable to create archive"
+msgstr "es können keine Profile erstellt werden"
 
-#: libvips/foreign/tiff2vips.c:716 libvips/foreign/tiff2vips.c:747
-msgid "3 or 4 bands RGB TIFF only"
-msgstr "nur RGB-TIFF mit drei oder vier Bändern"
+#: libvips/foreign/archive.c:146
+#, fuzzy
+msgid "unable to set zip format"
+msgstr "Dateistatus kann nicht abgefragt werden"
 
-#: libvips/foreign/tiff2vips.c:818
-msgid "4 or 5 bands CMYK TIFF only"
-msgstr "nur CMYK-TIFF mit vier oder fünf Bändern"
+#: libvips/foreign/archive.c:163
+#, fuzzy
+msgid "unable to set compression"
+msgstr "»%s« kann nicht gesetzt werden"
 
-#: libvips/foreign/tiff2vips.c:869
-msgid "unknown resolution unit"
-msgstr "unbekannte Auflösungseinheit"
+#: libvips/foreign/archive.c:175
+#, fuzzy
+msgid "unable to set padding"
+msgstr "»%s« kann nicht gesetzt werden"
 
-#: libvips/foreign/tiff2vips.c:874
-#, c-format
-msgid ""
-"no resolution information for TIFF image \"%s\" -- defaulting to 1 pixel per "
-"mm"
-msgstr ""
-"Keine Auflösungsinformationen für TIFF-Bild »%s« – Standard auf 1 Bildpunkt "
-"pro mm"
-
-#: libvips/foreign/tiff2vips.c:946
-#, c-format
-msgid "unsupported sample format %d for lab image"
-msgstr "nicht unterstütztes Musterformat %d für LAB-Bild"
-
-#: libvips/foreign/tiff2vips.c:956
-#, c-format
-msgid "unsupported depth %d for LAB image"
-msgstr "nicht unterstützte Tiefe %d für LAB-Bild"
-
-#: libvips/foreign/tiff2vips.c:995
-#, c-format
-msgid "unsupported sample format %d for greyscale image"
-msgstr "nicht unterstütztes Musterformat %d für Graustufenbild"
-
-#: libvips/foreign/tiff2vips.c:1004
-#, c-format
-msgid "unsupported depth %d for greyscale image"
-msgstr "nicht unterstützte Tiefe %d für Graustufenbild"
-
-#: libvips/foreign/tiff2vips.c:1052
-#, c-format
-msgid "unsupported sample format %d for rgb image"
-msgstr "nicht unterstütztes Musterformat %d für RGB-Bild"
-
-#: libvips/foreign/tiff2vips.c:1061
-#, c-format
-msgid "unsupported depth %d for RGB image"
-msgstr "nicht unterstützte Tiefe %d für RGB-Bild"
-
-#: libvips/foreign/tiff2vips.c:1075
-#, c-format
-msgid "unknown photometric interpretation %d"
-msgstr "unbekannte fotometrische Deutung %d"
-
-#: libvips/foreign/tiff2vips.c:1331 libvips/foreign/radiance.c:959
-msgid "read error"
-msgstr "Lesefehler"
-
-#: libvips/foreign/tiff2vips.c:1444
-#, c-format
-msgid "bad page number %d"
-msgstr "falsche Seitennummer %d"
-
-#: libvips/foreign/tiff2vips.c:1465 libvips/foreign/vips2tiff.c:286
-#, c-format
-msgid "unable to open \"%s\" for input"
+#: libvips/foreign/archive.c:184 libvips/iofuncs/target.c:129
+#, fuzzy
+msgid "unable to open for write"
 msgstr "»%s« kann nicht zur Eingabe geöffnet werden"
 
-#: libvips/foreign/tiff2vips.c:1520 libvips/foreign/tiff2vips.c:1550
-#, c-format
-msgid "TIFF file does not contain page %d"
-msgstr "TIFF-Datei enthält nicht Seite %d"
+#: libvips/foreign/archive.c:205 libvips/iofuncs/util.c:1097
+#, fuzzy, c-format
+msgid "unable to create directory \"%s\", %s"
+msgstr "Daten für »%s« können nicht gelesen werden, %s"
 
-#: libvips/foreign/jpegsave.c:118
-msgid "save jpeg"
-msgstr "JPEG speichern"
+#: libvips/foreign/archive.c:240
+#, fuzzy
+msgid "unable to create entry"
+msgstr "Thread kann nicht erstellt werden"
 
-#: libvips/foreign/jpegsave.c:187
-msgid "save image to jpeg file"
-msgstr "Bild in JPEG-Datei speichern"
+#: libvips/foreign/archive.c:256
+#, fuzzy
+msgid "unable to write header"
+msgstr "Thread kann nicht erstellt werden"
 
-#: libvips/foreign/jpegsave.c:256
-msgid "save image to jpeg buffer"
-msgstr "Bild in den JPEG-Puffer speichern"
+#: libvips/foreign/archive.c:265
+#, fuzzy
+msgid "unable to write data"
+msgstr "Daten können nicht gelesen werden"
 
-#: libvips/foreign/jpegsave.c:261 libvips/foreign/pngsave.c:229
+#: libvips/foreign/cgifsave.c:407 libvips/foreign/cgifsave.c:833
+#: libvips/foreign/quantise.c:403 libvips/foreign/quantise.c:423
+msgid "quantisation failed"
+msgstr ""
+
+#: libvips/foreign/cgifsave.c:587
+#, fuzzy
+msgid "dither failed"
+msgstr "Schreiben fehlgeschlagen"
+
+#: libvips/foreign/cgifsave.c:772
+#, fuzzy
+msgid "frame too large"
+msgstr "Zoomfaktoren zu groß"
+
+#: libvips/foreign/cgifsave.c:811
+#, fuzzy
+msgid "gif-palette too large"
+msgstr "Zoomfaktoren zu groß"
+
+#: libvips/foreign/cgifsave.c:884
+#, fuzzy
+msgid "save as gif"
+msgstr "Bild als ASCII speichern"
+
+#: libvips/foreign/cgifsave.c:893 libvips/foreign/pngsave.c:247
+#: libvips/foreign/spngsave.c:725
+msgid "Dithering"
+msgstr ""
+
+#: libvips/foreign/cgifsave.c:894 libvips/foreign/pngsave.c:248
+#: libvips/foreign/spngsave.c:726
+msgid "Amount of dithering"
+msgstr ""
+
+#: libvips/foreign/cgifsave.c:900 libvips/foreign/heifsave.c:803
+#: libvips/foreign/jxlsave.c:824 libvips/foreign/pngsave.c:261
+#: libvips/foreign/spngsave.c:739 libvips/foreign/webpsave.c:890
+msgid "Effort"
+msgstr ""
+
+#: libvips/foreign/cgifsave.c:901
+msgid "Quantisation effort"
+msgstr ""
+
+#: libvips/foreign/cgifsave.c:907 libvips/foreign/heifsave.c:781
+#: libvips/foreign/pngsave.c:254 libvips/foreign/ppmsave.c:521
+#: libvips/foreign/spngsave.c:732 libvips/foreign/tiffsave.c:315
+#: libvips/foreign/vips2magick.c:510
+msgid "Bit depth"
+msgstr ""
+
+#: libvips/foreign/cgifsave.c:908 libvips/foreign/heifsave.c:782
+#: libvips/foreign/vips2magick.c:511
+#, fuzzy
+msgid "Number of bits per pixel"
+msgstr "Anzahl der Bänder in einem Bild"
+
+#: libvips/foreign/cgifsave.c:914
+#, fuzzy
+msgid "Maximum inter-frame error"
+msgstr "interner Fehler"
+
+#: libvips/foreign/cgifsave.c:915
+msgid "Maximum inter-frame error for transparency"
+msgstr ""
+
+#: libvips/foreign/cgifsave.c:921
+msgid "Reuse palette"
+msgstr ""
+
+#: libvips/foreign/cgifsave.c:922
+msgid "Reuse palette from input"
+msgstr ""
+
+#: libvips/foreign/cgifsave.c:928
+#, fuzzy
+msgid "Maximum inter-palette error"
+msgstr "interner Fehler"
+
+#: libvips/foreign/cgifsave.c:929
+msgid "Maximum inter-palette error for palette reusage"
+msgstr ""
+
+#: libvips/foreign/cgifsave.c:935
+#, fuzzy
+msgid "Interlaced"
+msgstr "Zeilensprung"
+
+#: libvips/foreign/cgifsave.c:936
+msgid "Generate an interlaced (progressive) GIF"
+msgstr ""
+
+#: libvips/foreign/cgifsave.c:945
+msgid "Reoptimise palettes"
+msgstr ""
+
+#: libvips/foreign/cgifsave.c:946
+msgid "Reoptimise colour palettes"
+msgstr ""
+
+#: libvips/foreign/cgifsave.c:952
+#, fuzzy
+msgid "Keep duplicate frames"
+msgstr "ein Bild nachmachen"
+
+#: libvips/foreign/cgifsave.c:953
+msgid "Keep duplicate frames in the output instead of combining them"
+msgstr ""
+
+#: libvips/foreign/cgifsave.c:1010 libvips/foreign/csvsave.c:325
+#: libvips/foreign/dzsave.c:2537 libvips/foreign/heifsave.c:1020
+#: libvips/foreign/jp2ksave.c:1182 libvips/foreign/jpegsave.c:292
+#: libvips/foreign/jxlsave.c:1016 libvips/foreign/matrixsave.c:281
+#: libvips/foreign/pngsave.c:326 libvips/foreign/ppmsave.c:648
+#: libvips/foreign/radsave.c:207 libvips/foreign/rawsave.c:252
+#: libvips/foreign/spngsave.c:805 libvips/foreign/tiffsave.c:474
+#: libvips/foreign/vipssave.c:253 libvips/foreign/webpsave.c:987
+#: libvips/iofuncs/target.c:283
+msgid "Target"
+msgstr ""
+
+#: libvips/foreign/cgifsave.c:1011 libvips/foreign/csvsave.c:326
+#: libvips/foreign/dzsave.c:2538 libvips/foreign/heifsave.c:1021
+#: libvips/foreign/jp2ksave.c:1183 libvips/foreign/jpegsave.c:293
+#: libvips/foreign/jxlsave.c:1017 libvips/foreign/matrixsave.c:282
+#: libvips/foreign/pngsave.c:327 libvips/foreign/ppmsave.c:649
+#: libvips/foreign/radsave.c:208 libvips/foreign/rawsave.c:253
+#: libvips/foreign/spngsave.c:806 libvips/foreign/tiffsave.c:475
+#: libvips/foreign/vipssave.c:254 libvips/foreign/webpsave.c:988
+#, fuzzy
+msgid "Target to save to"
+msgstr "zu speicherndes Bild"
+
+#: libvips/foreign/cgifsave.c:1059 libvips/foreign/csvsave.c:275
+#: libvips/foreign/dzsave.c:2598 libvips/foreign/fitssave.c:144
+#: libvips/foreign/heifsave.c:898 libvips/foreign/jp2ksave.c:1064
+#: libvips/foreign/jpegsave.c:362 libvips/foreign/jxlsave.c:898
+#: libvips/foreign/matrixsave.c:229 libvips/foreign/niftisave.c:442
+#: libvips/foreign/pngsave.c:379 libvips/foreign/ppmsave.c:593
+#: libvips/foreign/radsave.c:155 libvips/foreign/rawsave.c:197
+#: libvips/foreign/spngsave.c:859 libvips/foreign/tiffsave.c:528
+#: libvips/foreign/vips2magick.c:579 libvips/foreign/vipssave.c:198
+#: libvips/foreign/webpsave.c:1039
+msgid "Filename to save to"
+msgstr "Name der Datei in die gespeichert werden soll"
+
+#: libvips/foreign/cgifsave.c:1117 libvips/foreign/dzsave.c:2656
+#: libvips/foreign/heifload.c:1340 libvips/foreign/heifsave.c:962
+#: libvips/foreign/jp2kload.c:1385 libvips/foreign/jp2ksave.c:1126
+#: libvips/foreign/jpegload.c:430 libvips/foreign/jpegsave.c:439
+#: libvips/foreign/jxlload.c:1293 libvips/foreign/jxlsave.c:960
+#: libvips/foreign/magick6load.c:313 libvips/foreign/magick7load.c:932
+#: libvips/foreign/nsgifload.c:843 libvips/foreign/pdfiumload.c:872
+#: libvips/foreign/pngload.c:394 libvips/foreign/pngsave.c:437
+#: libvips/foreign/popplerload.c:749 libvips/foreign/radload.c:356
+#: libvips/foreign/radsave.c:273 libvips/foreign/rawsave.c:314
+#: libvips/foreign/spngload.c:911 libvips/foreign/spngsave.c:918
+#: libvips/foreign/svgload.c:997 libvips/foreign/tiffload.c:460
+#: libvips/foreign/tiffsave.c:588 libvips/foreign/vips2magick.c:650
+#: libvips/foreign/webpload.c:424 libvips/foreign/webpsave.c:1096
+#: libvips/resample/thumbnail.c:1445
+msgid "Buffer"
+msgstr "Puffer"
+
+#: libvips/foreign/cgifsave.c:1118 libvips/foreign/dzsave.c:2657
+#: libvips/foreign/heifsave.c:963 libvips/foreign/jp2ksave.c:1127
+#: libvips/foreign/jpegsave.c:440 libvips/foreign/jxlsave.c:961
+#: libvips/foreign/pngsave.c:438 libvips/foreign/radsave.c:274
+#: libvips/foreign/rawsave.c:315 libvips/foreign/spngsave.c:919
+#: libvips/foreign/tiffsave.c:589 libvips/foreign/vips2magick.c:651
+#: libvips/foreign/webpsave.c:1097
 msgid "Buffer to save to"
 msgstr "Puffer, in den gespeichert werden soll"
 
-#: libvips/foreign/jpegsave.c:303
-msgid "error writing output"
-msgstr "Fehler beim Schreiben der Ausgabe"
+#: libvips/foreign/csvload.c:301
+#, fuzzy, c-format
+msgid "bad number, line %d, column %d"
+msgstr "Fehler beim Auswerten von Nummer, Zeile %d, Spalte %d"
 
-#: libvips/foreign/jpegsave.c:319
-# http://de.wikipedia.org/wiki/MIME#image
-msgid "save image to jpeg mime"
-msgstr "Bild in JPEG-MIME speichern"
+#: libvips/foreign/csvload.c:341 libvips/foreign/csvload.c:402
+#: libvips/foreign/csvload.c:434
+#, fuzzy
+msgid "unexpected end of file"
+msgstr "Unerwartetes Ende der Zeichenkette"
 
-#: libvips/foreign/rawsave.c:159
-# http://de.wikipedia.org/wiki/Rohdatenformat_(Fotografie)
-msgid "save image to raw file"
-msgstr "Bild in Rohdatenformatdatei speichern"
+#: libvips/foreign/csvload.c:440
+#, c-format
+msgid "line %d has only %d columns"
+msgstr ""
 
-#: libvips/foreign/rawsave.c:266
-msgid "write raw image to file descriptor"
-msgstr "Rohdatenbild in Datei-Deskriptor schreiben"
+#: libvips/foreign/csvload.c:479
+#, fuzzy
+msgid "load csv"
+msgstr "CSV aus Datei laden"
 
-#: libvips/foreign/rawsave.c:273
-msgid "File descriptor"
-msgstr "Datei-Deskriptor"
+#: libvips/foreign/csvload.c:492
+msgid "Skip"
+msgstr "überspringen"
 
-#: libvips/foreign/rawsave.c:274
-msgid "File descriptor to write to"
-msgstr "Datei-Deskriptor, in den geschrieben werden soll"
+#: libvips/foreign/csvload.c:493
+msgid "Skip this many lines at the start of the file"
+msgstr "so viele Zeilen ab dem Dateianfang überspringen"
 
-#: libvips/foreign/ppmsave.c:109
+#: libvips/foreign/csvload.c:499
+msgid "Lines"
+msgstr "Zeilen"
+
+#: libvips/foreign/csvload.c:500
+msgid "Read this many lines from the file"
+msgstr "so viele Zeilen aus der Datei lesen"
+
+#: libvips/foreign/csvload.c:506
+msgid "Whitespace"
+msgstr "Leerraum"
+
+#: libvips/foreign/csvload.c:507
+msgid "Set of whitespace characters"
+msgstr "Satz von Leerraumzeichen"
+
+#: libvips/foreign/csvload.c:513 libvips/foreign/csvsave.c:223
+msgid "Separator"
+msgstr "Trenner"
+
+#: libvips/foreign/csvload.c:514
+msgid "Set of separator characters"
+msgstr "Satz von Trennzeichen"
+
+#: libvips/foreign/csvload.c:661 libvips/foreign/fitsload.c:338
+#: libvips/foreign/heifload.c:1414 libvips/foreign/jp2kload.c:1448
+#: libvips/foreign/jpegload.c:278 libvips/foreign/jxlload.c:1357
+#: libvips/foreign/matrixload.c:462 libvips/foreign/niftiload.c:792
+#: libvips/foreign/nsgifload.c:909 libvips/foreign/openslideload.c:1230
+#: libvips/foreign/pdfiumload.c:932 libvips/foreign/pngload.c:242
+#: libvips/foreign/popplerload.c:809 libvips/foreign/ppmload.c:890
+#: libvips/foreign/radload.c:205 libvips/foreign/spngload.c:757
+#: libvips/foreign/svgload.c:836 libvips/foreign/tiffload.c:302
+#: libvips/foreign/vipsload.c:312 libvips/foreign/webpload.c:266
+#: libvips/resample/thumbnail.c:1658
+msgid "Source"
+msgstr ""
+
+#: libvips/foreign/csvload.c:662 libvips/foreign/fitsload.c:339
+#: libvips/foreign/heifload.c:1415 libvips/foreign/jp2kload.c:1449
+#: libvips/foreign/jpegload.c:279 libvips/foreign/jxlload.c:1358
+#: libvips/foreign/matrixload.c:463 libvips/foreign/niftiload.c:793
+#: libvips/foreign/nsgifload.c:910 libvips/foreign/openslideload.c:1231
+#: libvips/foreign/pdfiumload.c:933 libvips/foreign/pngload.c:243
+#: libvips/foreign/popplerload.c:810 libvips/foreign/ppmload.c:891
+#: libvips/foreign/radload.c:206 libvips/foreign/spngload.c:758
+#: libvips/foreign/svgload.c:837 libvips/foreign/tiffload.c:303
+#: libvips/foreign/vipsload.c:313 libvips/foreign/webpload.c:267
+#: libvips/iofuncs/sbuf.c:89 libvips/resample/thumbnail.c:1659
+#, fuzzy
+msgid "Source to load from"
+msgstr "Puffer, aus dem geladen werden soll"
+
+#: libvips/foreign/csvsave.c:215
+#, fuzzy
+msgid "save image to csv"
+msgstr "Bild in CSV-Datei speichern"
+
+#: libvips/foreign/csvsave.c:224
+msgid "Separator characters"
+msgstr "Trennzeichen"
+
+#: libvips/foreign/dzsave.c:2008
+#, fuzzy
+msgid "overlap too large"
+msgstr "Überlappen zu schmal"
+
 # http://de.wikipedia.org/wiki/Portable_Pixmap
-msgid "save image to ppm file"
+#: libvips/foreign/dzsave.c:2319
+#, fuzzy
+msgid "save image to deep zoom format"
 msgstr "Bild in PPM-Datei speichern"
 
-#: libvips/foreign/ppmsave.c:125
-msgid "ASCII"
-msgstr "ASCII"
+#: libvips/foreign/dzsave.c:2329 libvips/foreign/dzsave.c:2330
+#, fuzzy
+msgid "Image name"
+msgstr "Bilddateiname"
 
-#: libvips/foreign/ppmsave.c:126
-msgid "save as ascii"
-msgstr "Bild als ASCII speichern"
+#: libvips/foreign/dzsave.c:2336
+msgid "Layout"
+msgstr ""
 
-#: libvips/foreign/vips2jpeg.c:132
-#, c-format
-msgid "%s"
-msgstr "%s"
+#: libvips/foreign/dzsave.c:2337
+msgid "Directory layout"
+msgstr ""
 
-#: libvips/foreign/vips2jpeg.c:363
-msgid "error setting JPEG resolution"
-msgstr "Fehler beim Setzen der JPEG-Auflösung"
+#: libvips/foreign/dzsave.c:2343
+msgid "Suffix"
+msgstr ""
 
-#: libvips/foreign/vips2jpeg.c:510
+#: libvips/foreign/dzsave.c:2344
+msgid "Filename suffix for tiles"
+msgstr ""
+
+#: libvips/foreign/dzsave.c:2350
+#, fuzzy
+msgid "Overlap"
+msgstr "kein Überlappen"
+
+#: libvips/foreign/dzsave.c:2351
+#, fuzzy
+msgid "Tile overlap in pixels"
+msgstr "Kachelhöhe in Bildpunkten"
+
+#: libvips/foreign/dzsave.c:2357
+#, fuzzy
+msgid "Tile size"
+msgstr "Kachelbreite"
+
+#: libvips/foreign/dzsave.c:2358
+#, fuzzy
+msgid "Tile size in pixels"
+msgstr "Kachelbreite in Bildpunkten"
+
+#: libvips/foreign/dzsave.c:2365 libvips/foreign/tiffsave.c:379
+#, fuzzy
+msgid "Pyramid depth"
+msgstr "Pyramide"
+
+#: libvips/foreign/dzsave.c:2371
+msgid "Center"
+msgstr ""
+
+#: libvips/foreign/dzsave.c:2372
+#, fuzzy
+msgid "Center image in tile"
+msgstr "Bild in PNG-Datei speichern"
+
+#: libvips/foreign/dzsave.c:2379
+msgid "Rotate image during save"
+msgstr ""
+
+#: libvips/foreign/dzsave.c:2385
+msgid "Container"
+msgstr ""
+
+#: libvips/foreign/dzsave.c:2386
+msgid "Pyramid container type"
+msgstr ""
+
+#: libvips/foreign/dzsave.c:2392 libvips/foreign/heifsave.c:795
+#: libvips/foreign/pngsave.c:211 libvips/foreign/spngsave.c:689
+#: libvips/foreign/tiffsave.c:257
+msgid "Compression"
+msgstr "Komprimierung"
+
+#: libvips/foreign/dzsave.c:2393
+msgid "ZIP deflate compression level"
+msgstr ""
+
+#: libvips/foreign/dzsave.c:2399 libvips/foreign/tiffsave.c:357
+msgid "Region shrink"
+msgstr ""
+
+#: libvips/foreign/dzsave.c:2400 libvips/foreign/tiffsave.c:358
+msgid "Method to shrink regions"
+msgstr ""
+
+#: libvips/foreign/dzsave.c:2406
+msgid "Skip blanks"
+msgstr ""
+
+#: libvips/foreign/dzsave.c:2407
+msgid "Skip tiles which are nearly equal to the background"
+msgstr ""
+
+#: libvips/foreign/dzsave.c:2413
+msgid "id"
+msgstr ""
+
+#: libvips/foreign/dzsave.c:2414
+msgid "Resource ID"
+msgstr ""
+
+#: libvips/foreign/dzsave.c:2420 libvips/foreign/heifsave.c:774
+#: libvips/foreign/jp2ksave.c:1000 libvips/foreign/jpegsave.c:164
+#: libvips/foreign/jxlsave.c:838 libvips/foreign/tiffsave.c:265
+#: libvips/foreign/webpsave.c:826
+msgid "Q"
+msgstr "Q"
+
+#: libvips/foreign/dzsave.c:2421 libvips/foreign/heifsave.c:775
+#: libvips/foreign/jp2ksave.c:1001 libvips/foreign/jpegsave.c:165
+#: libvips/foreign/tiffsave.c:266 libvips/foreign/webpsave.c:827
+msgid "Q factor"
+msgstr "Q-Faktor"
+
+#: libvips/foreign/dzsave.c:2430
+msgid "No strip"
+msgstr ""
+
+#: libvips/foreign/dzsave.c:2431
+msgid "Don't strip tile metadata"
+msgstr ""
+
+#: libvips/foreign/dzsave.c:2437
+#, fuzzy
+msgid "Base name"
+msgstr "Bilddateiname"
+
+#: libvips/foreign/dzsave.c:2438
+#, fuzzy
+msgid "Base name to save to"
+msgstr "Name der Datei in die gespeichert werden soll"
+
+#: libvips/foreign/dzsave.c:2444
+#, fuzzy
+msgid "Directory name"
+msgstr "Richtung"
+
+#: libvips/foreign/dzsave.c:2445
+#, fuzzy
+msgid "Directory name to save to"
+msgstr "Name der Datei in die gespeichert werden soll"
+
+#: libvips/foreign/dzsave.c:2465 libvips/foreign/tiffsave.c:350
+#, fuzzy
+msgid "Properties"
+msgstr "Transaktionen"
+
+#: libvips/foreign/dzsave.c:2466
+msgid "Write a properties file to the output directory"
+msgstr ""
+
+# http://de.wikipedia.org/wiki/Portable_Pixmap
+#: libvips/foreign/dzsave.c:2533
+#, fuzzy
+msgid "save image to deepzoom target"
+msgstr "Bild in PPM-Datei speichern"
+
+# http://de.wikipedia.org/wiki/Portable_Pixmap
+#: libvips/foreign/dzsave.c:2593
+#, fuzzy
+msgid "save image to deepzoom file"
+msgstr "Bild in PPM-Datei speichern"
+
+#: libvips/foreign/dzsave.c:2652
+#, fuzzy
+msgid "save image to dz buffer"
+msgstr "Bild in den PNG-Puffer speichern"
+
+#: libvips/foreign/exif.c:199
+#, fuzzy
+msgid "exif too small"
+msgstr "Ziel zu klein"
+
+#: libvips/foreign/exif.c:203
+#, fuzzy
+msgid "exif too large"
+msgstr "Fenster zu groß"
+
+#: libvips/foreign/exif.c:208
+#, fuzzy
+msgid "unable to init exif"
+msgstr "kann nicht gekürzt werden"
+
+#: libvips/foreign/exif.c:1260 libvips/foreign/exif.c:1270
+#: libvips/foreign/exif.c:1279 libvips/foreign/exif.c:1319
+#, fuzzy, c-format
+msgid "bad exif meta \"%s\""
+msgstr "falscher Modus »%s«"
+
+#: libvips/foreign/exif.c:1496
 msgid "error saving EXIF"
 msgstr "Fehler beim Speichern von EXIF"
 
-#: libvips/foreign/openexr2vips.c:115
-#, c-format
-msgid "EXR error: %s"
-msgstr "EXR-Fehler: %s"
-
-#: libvips/foreign/magick2vips.c:215
-#, c-format
-msgid "unsupported image type %d"
-msgstr "nicht unterstützter Bildtyp %d"
-
-#: libvips/foreign/magick2vips.c:275
-#, c-format
-msgid "unsupported bit depth %d"
-msgstr "nicht unterstützte Bit-Tiefe %d"
-
-#: libvips/foreign/magick2vips.c:307
-#, c-format
-msgid "unsupported colorspace %d"
-msgstr "nicht unterstützter Farbraum %d"
-
-#: libvips/foreign/magick2vips.c:622
-msgid "unable to read pixels"
-msgstr "Bildpunkte können nicht gelesen werden"
-
-#: libvips/foreign/magick2vips.c:658
-#, c-format
-msgid ""
-"unable to read file \"%s\"\n"
-"libMagick error: %s %s"
-msgstr ""
-"Datei »%s« kann nicht gelesen werden\n"
-"libMagick-Fehler: %s %s"
-
-#: libvips/foreign/magick2vips.c:692
-#, c-format
-msgid ""
-"unable to ping file \"%s\"\n"
-"libMagick error: %s %s"
-msgstr ""
-"Datei »%s« kann nicht angepingt werden\n"
-"libMagick-Fehler: %s %s"
-
-#: libvips/foreign/magick2vips.c:703
-msgid "bad image size"
-msgstr "falsche Bildgröße"
-
-#: libvips/foreign/vipspng.c:230
-msgid "unsupported color type"
-msgstr "nicht unterstützter Farbtyp"
-
-#: libvips/foreign/vipspng.c:570
-msgid "compress should be in [0,9]"
-msgstr "Komprimierung sollte in [0,9] liegen"
-
-#: libvips/foreign/vipspng.c:650
-#, c-format
-msgid "unable to write \"%s\""
-msgstr "»%s« kann nicht geschrieben werden"
-
-#: libvips/foreign/vipspng.c:749
-msgid "unable to write to buffer"
-msgstr "In den Puffer kann nicht geschrieben werden."
-
-#: libvips/foreign/matlab.c:106 libvips/foreign/fits.c:178
-#: libvips/iofuncs/vips.c:143 libvips/mosaicing/global_balance.c:1181
-#: libvips/mosaicing/global_balance.c:1516
+#: libvips/foreign/fits.c:184 libvips/foreign/matlab.c:113
+#: libvips/iofuncs/vips.c:159 libvips/mosaicing/global_balance.c:1240
+#: libvips/mosaicing/global_balance.c:1690
 #, c-format
 msgid "unable to open \"%s\""
 msgstr "»%s« kann nicht geöffnet werden"
 
-#: libvips/foreign/matlab.c:114
-#, c-format
-msgid "no matrix variables in \"%s\""
-msgstr "keine Matrixvariablen in »%s«"
+#: libvips/foreign/fits.c:237
+msgid "no HDU found with naxes > 0"
+msgstr ""
 
-#: libvips/foreign/matlab.c:175
-#, c-format
-msgid "unsupported rank %d\n"
-msgstr "nicht unterstützte Rangstufe %d\n"
-
-#: libvips/foreign/matlab.c:188
-#, c-format
-msgid "unsupported class type %d\n"
-msgstr "nicht unterstützter Klassentyp %d\n"
-
-#: libvips/foreign/matlab.c:236
-msgid "Mat_VarReadDataAll failed"
-msgstr "»Mat_VarReadDataAll« fehlgeschlagen"
-
-#: libvips/foreign/jpeg2vips.c:167
-#, c-format
-msgid "read gave %ld warnings"
-msgstr "Lesen ergab %ld Warnungen"
-
-#: libvips/foreign/jpeg2vips.c:489
-msgid "error reading resolution"
-msgstr "Fehler beim Lesen der Auflösung"
-
-#: libvips/foreign/fits.c:240
+#: libvips/foreign/fits.c:275
 msgid "dimensions above 3 must be size 1"
 msgstr "Dimensionen größer drei müssen die Größe eins haben"
 
-#: libvips/foreign/fits.c:256
+#: libvips/foreign/fits.c:290
 #, c-format
 msgid "bad number of axis %d"
 msgstr "falsche Achsenanzahl %d"
 
-#: libvips/foreign/fits.c:272
+#: libvips/foreign/fits.c:301
 #, c-format
 msgid "unsupported bitpix %d\n"
 msgstr "nicht unterstützte »bitpix« %d\n"
 
-#: libvips/foreign/fits.c:576 libvips/iofuncs/vips.c:171
+#: libvips/foreign/fits.c:586 libvips/iofuncs/vips.c:222
 #, c-format
 msgid "unable to write to \"%s\""
 msgstr "auf »%s« kann nicht geschrieben werden"
 
-#: libvips/foreign/fits.c:637
+#: libvips/foreign/fits.c:729
 #, c-format
 msgid "unsupported BandFmt %d\n"
 msgstr "nicht unterstütztes BandFmt %d\n"
 
-#: libvips/foreign/csvsave.c:112
-msgid "save image to csv file"
-msgstr "Bild in CSV-Datei speichern"
-
-#: libvips/foreign/csvsave.c:128 libvips/foreign/csvload.c:160
-msgid "Separator"
-msgstr "Trenner"
-
-#: libvips/foreign/csvsave.c:129
-msgid "Separator characters"
-msgstr "Trennzeichen"
-
-#: libvips/foreign/ppm.c:109
-msgid "bad int"
-msgstr "falsche Ganzzahl"
-
-#: libvips/foreign/ppm.c:121
-msgid "bad float"
-msgstr "falsche Fließkommazahl"
-
-#: libvips/foreign/ppm.c:172
-msgid "bad magic number"
-msgstr "falsche magische Zahl"
-
-#: libvips/foreign/ppm.c:222
-msgid "not whitespace before start of binary data"
-msgstr "kein Leerraum vor dem Start der binären Daten"
-
-#: libvips/foreign/ppm.c:599 libvips/foreign/ppm.c:611
-msgid "write error ... disc full?"
-msgstr "Schreibfehler … Platte voll?"
-
-#: libvips/foreign/ppm.c:716
-msgid "binary >8 bit images must be float"
-msgstr "binäre Bilder >8 Bit müssen aus Fließkommazahlen bestehen"
-
-#: libvips/foreign/vips2tiff.c:270
-#, c-format
-msgid "unable to open \"%s\" for output"
-msgstr "»%s« kann nicht zur Ausgabe geöffnet werden"
-
-#: libvips/foreign/vips2tiff.c:692
-msgid "layer buffer exhausted -- try making TIFF output tiles smaller"
+#: libvips/foreign/fitsload.c:101 libvips/foreign/niftiload.c:130
+#: libvips/foreign/openslideload.c:916
+msgid "no filename available"
 msgstr ""
-"Ebenenpuffer aufgebraucht – versuchen Sie die TIFF-Ausgabekacheln zu "
-"verkleinern"
 
-#: libvips/foreign/vips2tiff.c:922
-msgid "TIFF write tile failed"
-msgstr "Schreiben des TIFF-Bildes fehlgeschlagen"
+#: libvips/foreign/fitsload.c:183
+#, fuzzy
+msgid "FITS loader base class"
+msgstr "Basisklasse"
 
-#: libvips/foreign/vips2tiff.c:998
-msgid "internal error #9876345"
-msgstr "interner Fehler #9876345"
+#: libvips/foreign/fitsload.c:251
+msgid "load a FITS image"
+msgstr "ein FITS-Bild laden"
 
-#: libvips/foreign/vips2tiff.c:1251
-msgid "tile size not a multiple of 16"
-msgstr "Bildgröße kein Vielfaches von 16"
+#: libvips/foreign/fitsload.c:329
+#, fuzzy
+msgid "load FITS from a source"
+msgstr "ein FITS-Bild laden"
 
-#: libvips/foreign/vips2tiff.c:1257
-msgid "can't have strip pyramid -- enabling tiling"
-msgstr ""
-"nicht ummantelte Pyramide nicht möglich – Zerteilung wird eingeschaltet"
+# http://de.wikipedia.org/wiki/Flexible_Image_Transport_System
+#: libvips/foreign/fitssave.c:129
+msgid "save image to fits file"
+msgstr "Bild in FITS-Datei speichern"
 
-#: libvips/foreign/vips2tiff.c:1268
-msgid "can only pyramid LABQ and non-complex images"
-msgstr ""
-"nur LABQ und nicht-komplexe Bilder können pyramidenartig verwendet werden"
-
-#: libvips/foreign/vips2tiff.c:1463
-msgid "unsigned 8-bit int, 16-bit int, and 32-bit float only"
-msgstr "nur vorzeichenlose 8-Bit-Ganzzahl und 32-Bit-Fließkommazahl"
-
-#: libvips/foreign/vips2tiff.c:1470
-msgid "1 to 5 bands only"
-msgstr "nur 1 bis 5 Bänder"
-
-#: libvips/foreign/radiance.c:885
-# http://radsite.lbl.gov/radiance/refer/Notes/picture_format.html
-msgid "error reading radiance header"
-msgstr "Fehler beim Lesen der Radiance-Kopfzeilen"
-
-#: libvips/foreign/csvload.c:121
-msgid "load csv from file"
-msgstr "CSV aus Datei laden"
-
-#: libvips/foreign/csvload.c:139
-msgid "Skip"
-msgstr "überspringen"
-
-#: libvips/foreign/csvload.c:140
-msgid "Skip this many lines at the start of the file"
-msgstr "so viele Zeilen ab dem Dateianfang überspringen"
-
-#: libvips/foreign/csvload.c:146
-msgid "Lines"
-msgstr "Zeilen"
-
-#: libvips/foreign/csvload.c:147
-msgid "Read this many lines from the file"
-msgstr "so viele Zeilen aus der Datei lesen"
-
-#: libvips/foreign/csvload.c:153
-msgid "Whitespace"
-msgstr "Leerraum"
-
-#: libvips/foreign/csvload.c:154
-msgid "Set of whitespace characters"
-msgstr "Satz von Leerraumzeichen"
-
-#: libvips/foreign/csvload.c:161
-msgid "Set of separator characters"
-msgstr "Satz von Trennzeichen"
-
-#: libvips/foreign/pngsave.c:95
-msgid "save png"
-msgstr "PNG speichern"
-
-#: libvips/foreign/pngsave.c:104
-msgid "Compression factor"
-msgstr "Komprimierungsfaktor"
-
-#: libvips/foreign/pngsave.c:110
-msgid "Interlace"
-msgstr "Zeilensprung"
-
-#: libvips/foreign/pngsave.c:111
-msgid "Interlace image"
-msgstr "Zeilensprungbild"
-
-#: libvips/foreign/pngsave.c:162
-msgid "save image to png file"
-msgstr "Bild in PNG-Datei speichern"
-
-#: libvips/foreign/pngsave.c:224
-msgid "save image to png buffer"
-msgstr "Bild in den PNG-Puffer speichern"
-
-#: libvips/foreign/foreign.c:384
+#: libvips/foreign/foreign.c:408
 msgid "load and save image files"
 msgstr "Bilddateien laden und speichern"
 
-#: libvips/foreign/foreign.c:525 libvips/mosaicing/im_remosaic.c:76
-#, c-format
-msgid "file \"%s\" not found"
+#: libvips/foreign/foreign.c:607
+#, fuzzy, c-format
+msgid "file \"%s\" does not exist"
 msgstr "Datei »%s« nicht gefunden"
 
-#: libvips/foreign/foreign.c:534 libvips/foreign/foreign.c:1022
+#: libvips/foreign/foreign.c:612
+#, c-format
+msgid "\"%s\" is a directory"
+msgstr ""
+
+#: libvips/foreign/foreign.c:621 libvips/foreign/foreign.c:2003
 #, c-format
 msgid "\"%s\" is not a known file format"
 msgstr "»%s« ist kein bekanntes Dateiformat"
 
-#: libvips/foreign/foreign.c:740
-msgid "images do not match"
-msgstr "Bilder passen nicht zusammen"
+#: libvips/foreign/foreign.c:708
+#, fuzzy
+msgid "buffer is not in a known format"
+msgstr "»%s« ist kein bekanntes Dateiformat"
 
-#: libvips/foreign/foreign.c:894
-msgid "file loaders"
+#: libvips/foreign/foreign.c:769
+#, fuzzy
+msgid "source is not in a known format"
+msgstr "»%s« ist kein bekanntes Dateiformat"
+
+#: libvips/foreign/foreign.c:979
+#, fuzzy
+msgid "images do not match between header and load"
+msgstr "Bilder passen in der Bildpunktgröße nicht zusammen"
+
+#: libvips/foreign/foreign.c:1210
+#, fuzzy
+msgid "loaders"
 msgstr "Dateilader"
 
-#: libvips/foreign/foreign.c:903
+#: libvips/foreign/foreign.c:1221
 msgid "Flags"
 msgstr "Schalter"
 
-#: libvips/foreign/foreign.c:904
+#: libvips/foreign/foreign.c:1222
 msgid "Flags for this file"
 msgstr "Schalter für diese Datei"
 
-#: libvips/foreign/foreign.c:910
-msgid "Disc"
-msgstr "Platte"
+#: libvips/foreign/foreign.c:1228 libvips/iofuncs/target.c:294
+msgid "Memory"
+msgstr ""
 
-#: libvips/foreign/foreign.c:911
-msgid "Open to disc"
-msgstr "offen zur Platte"
+#: libvips/foreign/foreign.c:1229
+msgid "Force open via memory"
+msgstr ""
 
-#: libvips/foreign/foreign.c:917
+#: libvips/foreign/foreign.c:1236
+#, fuzzy
+msgid "Required access pattern for this file"
+msgstr "Komprimierung für diese Datei"
+
+#: libvips/foreign/foreign.c:1242 libvips/resample/thumbnail.c:1037
+#, fuzzy
+msgid "Fail on"
+msgstr "scheitern"
+
+#: libvips/foreign/foreign.c:1243 libvips/resample/thumbnail.c:1038
+msgid "Error level to fail on"
+msgstr ""
+
+#: libvips/foreign/foreign.c:1249
+msgid "Revalidate"
+msgstr ""
+
+#: libvips/foreign/foreign.c:1250
+msgid "Don't use a cached result for this operation"
+msgstr ""
+
+#: libvips/foreign/foreign.c:1256
 msgid "Sequential"
 msgstr "sequenziell"
 
-#: libvips/foreign/foreign.c:918
+#: libvips/foreign/foreign.c:1257
 msgid "Sequential read only"
 msgstr "sequenziell nur mit Lesezugriff"
 
-#: libvips/foreign/foreign.c:1370
-msgid "file savers"
+#: libvips/foreign/foreign.c:1263
+msgid "Fail"
+msgstr "scheitern"
+
+#: libvips/foreign/foreign.c:1264
+msgid "Fail on first warning"
+msgstr "scheitert bei erster Warnung"
+
+#: libvips/foreign/foreign.c:1270
+msgid "Disc"
+msgstr "Platte"
+
+#: libvips/foreign/foreign.c:1271
+msgid "Open to disc"
+msgstr "offen zur Platte"
+
+#: libvips/foreign/foreign.c:1871
+#, fuzzy
+msgid "savers"
 msgstr "Dateispeicherer"
 
-#: libvips/foreign/foreign.c:1380
+#: libvips/foreign/foreign.c:1895
 msgid "Image to save"
 msgstr "zu speicherndes Bild"
 
-#: libvips/freq_filt/im_freq_mask.c:108
-msgid "mask sizes power of 2 only"
-msgstr "Maskengröße nur Potenzen von 2"
+#: libvips/foreign/foreign.c:1900
+msgid "Keep"
+msgstr ""
 
-#: libvips/freq_filt/im_freq_mask.c:155
-msgid "unimplemented mask type"
-msgstr "nicht implementierter Maskentyp"
+#: libvips/foreign/foreign.c:1901
+msgid "Which metadata to retain"
+msgstr ""
 
-#: libvips/freq_filt/fmaskcir.c:158 libvips/freq_filt/fmaskcir.c:303
-#: libvips/freq_filt/fmaskcir.c:394 libvips/freq_filt/fmaskcir.c:476
-#: libvips/freq_filt/fmaskcir.c:556
-msgid "bad sizes"
-msgstr "falsche Größen"
+#: libvips/foreign/foreign.c:1916
+msgid "Set page height for multipage save"
+msgstr ""
 
-#: libvips/freq_filt/fmaskcir.c:172 libvips/freq_filt/fmaskcir.c:228
-#: libvips/freq_filt/fmaskcir.c:242 libvips/freq_filt/fmaskcir.c:317
-#: libvips/freq_filt/fmaskcir.c:321 libvips/freq_filt/fmaskcir.c:408
-#: libvips/freq_filt/fmaskcir.c:412 libvips/freq_filt/fmaskcir.c:570
-#: libvips/freq_filt/fmaskcir.c:574 libvips/freq_filt/fmask4th.c:120
-#: libvips/freq_filt/fmask4th.c:129 libvips/freq_filt/fmask4th.c:163
-#: libvips/freq_filt/fmask4th.c:172 libvips/freq_filt/fmask4th.c:205
-#: libvips/freq_filt/fmask4th.c:214 libvips/freq_filt/fmask4th.c:252
-#: libvips/freq_filt/fmask4th.c:261 libvips/freq_filt/fmask4th.c:292
-#: libvips/freq_filt/fmask4th.c:301 libvips/freq_filt/fmask4th.c:333
-#: libvips/freq_filt/fmask4th.c:342 libvips/freq_filt/fmask4th.c:373
-#: libvips/freq_filt/fmask4th.c:387 libvips/freq_filt/fmask4th.c:423
-#: libvips/freq_filt/fmask4th.c:437 libvips/freq_filt/fmask4th.c:473
-#: libvips/freq_filt/fmask4th.c:487 libvips/freq_filt/fmask4th.c:527
-#: libvips/freq_filt/fmask4th.c:541 libvips/freq_filt/fmask4th.c:578
-#: libvips/freq_filt/fmask4th.c:592 libvips/freq_filt/fmask4th.c:629
-#: libvips/freq_filt/fmask4th.c:643 libvips/freq_filt/fmask4th.c:697
-msgid "bad args"
-msgstr "falsche Argumente"
+#: libvips/foreign/foreign.c:1923
+#, fuzzy
+msgid "Filename of ICC profile to embed"
+msgstr "einzubettendes ICC-Profil"
 
-#: libvips/freq_filt/fmaskcir.c:490
-msgid "bad args (f)"
-msgstr "falsche Argumente (f)"
+#: libvips/foreign/foreign.c:1929
+msgid "Strip"
+msgstr ""
 
-#: libvips/freq_filt/fmaskcir.c:494
-msgid "bad args (ac)"
-msgstr "falsche Argumente (ac)"
+#: libvips/foreign/foreign.c:1930
+#, fuzzy
+msgid "Strip all metadata from image"
+msgstr "einen Bereich eines Bildes extrahieren"
 
-#: libvips/freq_filt/fmaskcir.c:655 libvips/freq_filt/fmask4th.c:791
-msgid "unimplemented mask"
+#: libvips/foreign/foreign.c:2158
+#, fuzzy, c-format
+msgid "\"%s\" is not a known target format"
+msgstr "»%s« ist kein bekanntes Dateiformat"
+
+#: libvips/foreign/foreign.c:2216
+#, fuzzy, c-format
+msgid "\"%s\" is not a known buffer format"
+msgstr "»%s« ist kein bekanntes Dateiformat"
+
+#: libvips/foreign/heifload.c:820 libvips/foreign/jxlload.c:753
+#: libvips/foreign/nsgifload.c:448 libvips/foreign/webp2vips.c:501
+#, fuzzy
+msgid "bad page number"
+msgstr "falsche Seitennummer %d"
+
+#: libvips/foreign/heifload.c:872
+msgid "undefined bits per pixel"
+msgstr ""
+
+#: libvips/foreign/heifload.c:884
+msgid "not all pages are the same size"
+msgstr ""
+
+#: libvips/foreign/heifload.c:983
+#, fuzzy
+msgid "bad image dimensions on decode"
+msgstr "Überlaufganzzahl der Bildabmessungen"
+
+#: libvips/foreign/heifload.c:990
+#, fuzzy
+msgid "unable to get image data"
+msgstr "Dateistatus kann nicht abgefragt werden"
+
+#: libvips/foreign/heifload.c:1075
+#, fuzzy
+msgid "load a HEIF image"
+msgstr "ein FITS-Bild laden"
+
+#: libvips/foreign/heifload.c:1083 libvips/foreign/jp2kload.c:1229
+#: libvips/foreign/jxlload.c:1132 libvips/foreign/magick6load.c:141
+#: libvips/foreign/magick7load.c:382 libvips/foreign/nsgifload.c:620
+#: libvips/foreign/pdfiumload.c:695 libvips/foreign/popplerload.c:545
+#: libvips/foreign/tiffload.c:196 libvips/foreign/webpload.c:178
+msgid "Page"
+msgstr "Seite"
+
+#: libvips/foreign/heifload.c:1084 libvips/foreign/jxlload.c:1133
+#: libvips/foreign/magick6load.c:142 libvips/foreign/magick7load.c:383
+#: libvips/foreign/nsgifload.c:621 libvips/foreign/pdfiumload.c:696
+#: libvips/foreign/popplerload.c:546 libvips/foreign/tiffload.c:197
+#: libvips/foreign/webpload.c:179
+#, fuzzy
+msgid "First page to load"
+msgstr "Name der Datei, aus der geladen werden soll"
+
+#: libvips/foreign/heifload.c:1091 libvips/foreign/jxlload.c:1140
+#: libvips/foreign/magick6load.c:149 libvips/foreign/magick7load.c:390
+#: libvips/foreign/nsgifload.c:628 libvips/foreign/pdfiumload.c:703
+#: libvips/foreign/popplerload.c:553 libvips/foreign/tiffload.c:204
+#: libvips/foreign/webpload.c:186
+#, fuzzy
+msgid "Number of pages to load, -1 for all"
+msgstr "Anzahl der Patches ein Diagramm hinunter"
+
+#: libvips/foreign/heifload.c:1097
+msgid "Thumbnail"
+msgstr ""
+
+#: libvips/foreign/heifload.c:1098
+#, fuzzy
+msgid "Fetch thumbnail image"
+msgstr "Miniaturansicht auf GRÖẞE setzen"
+
+#: libvips/foreign/heifload.c:1104 libvips/foreign/jpegload.c:198
+#: libvips/foreign/tiffload.c:210
+msgid "Autorotate"
+msgstr ""
+
+#: libvips/foreign/heifload.c:1105 libvips/foreign/jpegload.c:199
+msgid "Rotate image using exif orientation"
+msgstr ""
+
+#: libvips/foreign/heifload.c:1112 libvips/foreign/jpegload.c:206
+#: libvips/foreign/pngload.c:171 libvips/foreign/spngload.c:678
+#: libvips/foreign/svgload.c:732 libvips/foreign/tiffload.c:225
+msgid "Unlimited"
+msgstr ""
+
+#: libvips/foreign/heifload.c:1113 libvips/foreign/jpegload.c:207
+#: libvips/foreign/pngload.c:172 libvips/foreign/spngload.c:679
+#: libvips/foreign/tiffload.c:226
+msgid "Remove all denial of service limits"
+msgstr ""
+
+#: libvips/foreign/heifload.c:1341 libvips/foreign/jp2kload.c:1386
+#: libvips/foreign/jpegload.c:431 libvips/foreign/jxlload.c:1294
+#: libvips/foreign/magick6load.c:314 libvips/foreign/magick7load.c:933
+#: libvips/foreign/nsgifload.c:844 libvips/foreign/pdfiumload.c:873
+#: libvips/foreign/pngload.c:395 libvips/foreign/popplerload.c:750
+#: libvips/foreign/radload.c:357 libvips/foreign/spngload.c:912
+#: libvips/foreign/svgload.c:998 libvips/foreign/tiffload.c:461
+#: libvips/foreign/webpload.c:425 libvips/resample/thumbnail.c:1446
+msgid "Buffer to load from"
+msgstr "Puffer, aus dem geladen werden soll"
+
+#: libvips/foreign/heifsave.c:441
+#, fuzzy
+msgid "unimplemented format conversion"
 msgstr "nicht implementierte Maske"
 
-#: libvips/freq_filt/im_fractsurf.c:72
-msgid "dimension should be in (2,3)"
-msgstr "Dimension sollte in (2,3) liegen"
+#: libvips/foreign/heifsave.c:550
+#, fuzzy, c-format
+msgid "%d-bit colour depth not supported"
+msgstr "%d-dimensionale Bilder nicht unterstützt"
 
-#: libvips/freq_filt/im_invfft.c:105 libvips/freq_filt/im_invfftr.c:124
-#: libvips/freq_filt/im_fwfft.c:125 libvips/freq_filt/im_fwfft.c:241
+#: libvips/foreign/heifsave.c:583
+#, fuzzy
+msgid "Unsupported compression"
+msgstr "nicht unterstützter Farbtyp"
+
+#: libvips/foreign/heifsave.c:767
+#, fuzzy
+msgid "save image in HEIF format"
+msgstr "Bild in den PNG-Puffer speichern"
+
+#: libvips/foreign/heifsave.c:788 libvips/foreign/jp2ksave.c:985
+#: libvips/foreign/jxlsave.c:831 libvips/foreign/tiffsave.c:371
+#: libvips/foreign/webpsave.c:833
+msgid "Lossless"
+msgstr ""
+
+#: libvips/foreign/heifsave.c:789 libvips/foreign/jp2ksave.c:986
+#: libvips/foreign/jxlsave.c:832 libvips/foreign/webpsave.c:834
+msgid "Enable lossless compression"
+msgstr ""
+
+#: libvips/foreign/heifsave.c:796
+#, fuzzy
+msgid "Compression format"
+msgstr "Komprimierungsfaktor"
+
+#: libvips/foreign/heifsave.c:804 libvips/foreign/heifsave.c:819
+msgid "CPU effort"
+msgstr ""
+
+#: libvips/foreign/heifsave.c:810 libvips/foreign/jp2ksave.c:992
+#: libvips/foreign/jpegsave.c:220
+#, fuzzy
+msgid "Subsample mode"
+msgstr "Öffnen-Modus"
+
+#: libvips/foreign/heifsave.c:811 libvips/foreign/jp2ksave.c:993
+#: libvips/foreign/jpegsave.c:221
+msgid "Select chroma subsample operation mode"
+msgstr ""
+
+#: libvips/foreign/heifsave.c:818
+msgid "Speed"
+msgstr ""
+
+#: libvips/foreign/heifsave.c:825
+msgid "Encoder"
+msgstr ""
+
+#: libvips/foreign/heifsave.c:826
+msgid "Select encoder to use"
+msgstr ""
+
+#: libvips/foreign/heifsave.c:1047
+#, fuzzy
+msgid "save image in AVIF format"
+msgstr "Bild in den PNG-Puffer speichern"
+
+#: libvips/foreign/jp2kload.c:235
+#, fuzzy
+msgid "unable to create jp2k stream"
+msgstr "Thread kann nicht erstellt werden"
+
+#: libvips/foreign/jp2kload.c:548
+#, fuzzy, c-format
+msgid "unsupported colourspace %d"
+msgstr "nicht unterstützter Farbraum %d"
+
+#: libvips/foreign/jp2kload.c:597
+#, fuzzy
+msgid "too many image bands"
+msgstr "zu viele Argumente"
+
+#: libvips/foreign/jp2kload.c:601
+#, fuzzy
+msgid "no image components"
+msgstr "keine Bilddaten"
+
+#: libvips/foreign/jp2kload.c:618
+msgid "components differ in geometry"
+msgstr ""
+
+#: libvips/foreign/jp2kload.c:625
+msgid "components differ in precision"
+msgstr ""
+
+#: libvips/foreign/jp2kload.c:996 libvips/foreign/jp2kload.c:1093
+#, fuzzy
+msgid "decoded image does not match container"
+msgstr "»ink«-Bild passt nicht in das Bild"
+
+#: libvips/foreign/jp2kload.c:1217
+#, fuzzy
+msgid "load JPEG2000 image"
+msgstr "ein FITS-Bild laden"
+
+#: libvips/foreign/jp2kload.c:1230
+#, fuzzy
+msgid "Load this page from the image"
+msgstr "diese Seite aus der Datei laden"
+
+#: libvips/foreign/jp2kload.c:1600 libvips/foreign/jp2ksave.c:1434
+#, fuzzy
+msgid "libvips built without JPEG2000 support"
+msgstr "VIPS wurde ohne FFT-Unterstützung konfiguriert"
+
+#: libvips/foreign/jp2ksave.c:818
+#, fuzzy
+msgid "not an integer format"
+msgstr "»%s« ist kein bekanntes Dateiformat"
+
+#: libvips/foreign/jp2ksave.c:963
+msgid "save image in JPEG2000 format"
+msgstr ""
+
+#: libvips/foreign/jpeg2vips.c:415
+#, c-format
+msgid "read gave %ld warnings"
+msgstr "Lesen ergab %ld Warnungen"
+
+#: libvips/foreign/jpeg2vips.c:886 libvips/foreign/spngload.c:529
+#: libvips/foreign/vipspng.c:723
+#, c-format
+msgid "out of order read at line %d"
+msgstr ""
+
+#: libvips/foreign/jpegload.c:116
+#, c-format
+msgid "bad shrink factor %d"
+msgstr "falscher Schrumpffaktor %d"
+
+#: libvips/foreign/jpegload.c:177
+msgid "load jpeg"
+msgstr "JPEG laden"
+
+#: libvips/foreign/jpegload.c:191 libvips/foreign/webpload.c:199
+msgid "Shrink"
+msgstr "verkleinern"
+
+#: libvips/foreign/jpegload.c:192 libvips/foreign/webpload.c:200
+msgid "Shrink factor on load"
+msgstr "falscher Verkleinerungsfaktor %d"
+
+#: libvips/foreign/jpegload.c:270
+#, fuzzy
+msgid "load image from jpeg source"
+msgstr "Bild in den JPEG-Puffer speichern"
+
+#: libvips/foreign/jpegload.c:346
+msgid "load jpeg from file"
+msgstr "JPEG aus Datei laden"
+
+#: libvips/foreign/jpegload.c:424
+msgid "load jpeg from buffer"
+msgstr "JPEG aus Puffer laden"
+
+#: libvips/foreign/jpegsave.c:153
+msgid "save jpeg"
+msgstr "JPEG speichern"
+
+#: libvips/foreign/jpegsave.c:171
+#, fuzzy
+msgid "Optimize coding"
+msgstr "Bildpunktkodierung"
+
+#: libvips/foreign/jpegsave.c:172
+msgid "Compute optimal Huffman coding tables"
+msgstr ""
+
+#: libvips/foreign/jpegsave.c:178 libvips/foreign/pngsave.c:218
+#: libvips/foreign/spngsave.c:696
+msgid "Interlace"
+msgstr "Zeilensprung"
+
+#: libvips/foreign/jpegsave.c:179
+msgid "Generate an interlaced (progressive) jpeg"
+msgstr ""
+
+#: libvips/foreign/jpegsave.c:185
+msgid "No subsample"
+msgstr ""
+
+#: libvips/foreign/jpegsave.c:186
+msgid "Disable chroma subsample"
+msgstr ""
+
+#: libvips/foreign/jpegsave.c:192
+msgid "Trellis quantisation"
+msgstr ""
+
+#: libvips/foreign/jpegsave.c:193
+msgid "Apply trellis quantisation to each 8x8 block"
+msgstr ""
+
+#: libvips/foreign/jpegsave.c:199
+msgid "Overshoot de-ringing"
+msgstr ""
+
+#: libvips/foreign/jpegsave.c:200
+msgid "Apply overshooting to samples with extreme values"
+msgstr ""
+
+#: libvips/foreign/jpegsave.c:206
+msgid "Optimize scans"
+msgstr ""
+
+#: libvips/foreign/jpegsave.c:207
+msgid "Split spectrum of DCT coefficients into separate scans"
+msgstr ""
+
+#: libvips/foreign/jpegsave.c:213
+msgid "Quantization table"
+msgstr ""
+
+#: libvips/foreign/jpegsave.c:214
+msgid "Use predefined quantization table with given index"
+msgstr ""
+
+#: libvips/foreign/jpegsave.c:228
+msgid "Restart interval"
+msgstr ""
+
+#: libvips/foreign/jpegsave.c:229
+msgid "Add restart markers every specified number of mcu"
+msgstr ""
+
+#: libvips/foreign/jpegsave.c:288
+#, fuzzy
+msgid "save image to jpeg target"
+msgstr "Bild in JPEG-Datei speichern"
+
+#: libvips/foreign/jpegsave.c:357
+msgid "save image to jpeg file"
+msgstr "Bild in JPEG-Datei speichern"
+
+#: libvips/foreign/jpegsave.c:435
+msgid "save image to jpeg buffer"
+msgstr "Bild in den JPEG-Puffer speichern"
+
+# http://de.wikipedia.org/wiki/MIME#image
+#: libvips/foreign/jpegsave.c:511
+msgid "save image to jpeg mime"
+msgstr "Bild in JPEG-MIME speichern"
+
+#: libvips/foreign/jxlload.c:251 libvips/foreign/jxlsave.c:433
+#: libvips/iofuncs/dbuf.c:81 libvips/iofuncs/util.c:684
+msgid "out of memory"
+msgstr "Hauptspeicher reicht nicht aus"
+
+#: libvips/foreign/jxlload.c:576
+#, fuzzy
+msgid "bad buffer size"
+msgstr "falsche Größe"
+
+#: libvips/foreign/jxlload.c:602 libvips/foreign/webp2vips.c:724
+msgid "not enough frames"
+msgstr ""
+
+#: libvips/foreign/jxlload.c:683 libvips/foreign/radiance.c:704
+#, fuzzy
+msgid "image size out of bounds"
+msgstr "Bild muss ein Band haben"
+
+#: libvips/foreign/jxlload.c:1119
+#, fuzzy
+msgid "load JPEG-XL image"
+msgstr "ein OpenEXR-Bild laden"
+
+#: libvips/foreign/jxlsave.c:748 libvips/foreign/webpsave.c:744
+#, c-format
+msgid "failed to allocate %zu bytes"
+msgstr ""
+
+#: libvips/foreign/jxlsave.c:796
+msgid "save image in JPEG-XL format"
+msgstr ""
+
+#: libvips/foreign/jxlsave.c:810
+msgid "Tier"
+msgstr ""
+
+#: libvips/foreign/jxlsave.c:811
+msgid "Decode speed tier"
+msgstr ""
+
+#: libvips/foreign/jxlsave.c:817 libvips/morphology/nearest.c:315
+msgid "Distance"
+msgstr ""
+
+#: libvips/foreign/jxlsave.c:818
+msgid "Target butteraugli distance"
+msgstr ""
+
+#: libvips/foreign/jxlsave.c:825
+msgid "Encoding effort"
+msgstr ""
+
+#: libvips/foreign/jxlsave.c:839
+#, fuzzy
+msgid "Quality factor"
+msgstr "Q-Faktor"
+
+#: libvips/foreign/magick2vips.c:305
+#, c-format
+msgid "unsupported image type %d"
+msgstr "nicht unterstützter Bildtyp %d"
+
+#: libvips/foreign/magick2vips.c:354 libvips/foreign/magick7load.c:471
+#, c-format
+msgid "bad image dimensions %d x %d pixels, %d bands"
+msgstr ""
+
+#: libvips/foreign/magick2vips.c:384
+#, c-format
+msgid "unsupported bit depth %d"
+msgstr "nicht unterstützte Bit-Tiefe %d"
+
+#: libvips/foreign/magick2vips.c:791 libvips/foreign/webp2vips.c:638
+msgid "unable to read pixels"
+msgstr "Bildpunkte können nicht gelesen werden"
+
+#: libvips/foreign/magick2vips.c:823 libvips/foreign/magick2vips.c:861
+#, fuzzy, c-format
+msgid "unable to read file \"%s\""
+msgstr "Profil kann nicht gelesen werden"
+
+#: libvips/foreign/magick2vips.c:870 libvips/foreign/magick2vips.c:949
+msgid "bad image size"
+msgstr "falsche Bildgröße"
+
+#: libvips/foreign/magick2vips.c:902
+#, fuzzy
+msgid "unable to read buffer"
+msgstr "In den Puffer kann nicht geschrieben werden."
+
+#: libvips/foreign/magick2vips.c:940
+#, fuzzy
+msgid "unable to ping blob"
+msgstr "»%s« kann nicht geöffnet werden"
+
+#: libvips/foreign/magick6load.c:113
+#, fuzzy
+msgid "load with ImageMagick"
+msgstr "Datei mit ImageMagick laden"
+
+#: libvips/foreign/magick6load.c:134 libvips/foreign/magick7load.c:375
+msgid "Density"
+msgstr ""
+
+#: libvips/foreign/magick6load.c:135 libvips/foreign/magick7load.c:376
+msgid "Canvas resolution for rendering vector formats like SVG"
+msgstr ""
+
+#: libvips/foreign/magick6load.c:155 libvips/foreign/magick7load.c:396
+msgid "All frames"
+msgstr ""
+
+#: libvips/foreign/magick6load.c:156 libvips/foreign/magick7load.c:397
+#, fuzzy
+msgid "Read all frames from an image"
+msgstr "einen Bereich eines Bildes extrahieren"
+
+#: libvips/foreign/magick6load.c:231
+msgid "load file with ImageMagick"
+msgstr "Datei mit ImageMagick laden"
+
+#: libvips/foreign/magick6load.c:306
+#, fuzzy
+msgid "load buffer with ImageMagick"
+msgstr "Datei mit ImageMagick laden"
+
+#: libvips/foreign/magick7load.c:353
+#, fuzzy
+msgid "load with ImageMagick7"
+msgstr "Datei mit ImageMagick laden"
+
+#: libvips/foreign/magick7load.c:414
+#, c-format
+msgid "Magick: %s %s"
+msgstr ""
+
+#: libvips/foreign/magick7load.c:491
+#, fuzzy, c-format
+msgid "unsupported bit depth %zd"
+msgstr "nicht unterstützte Bit-Tiefe %d"
+
+#: libvips/foreign/magick7load.c:845
+#, fuzzy
+msgid "load file with ImageMagick7"
+msgstr "Datei mit ImageMagick laden"
+
+#: libvips/foreign/magick7load.c:926
+#, fuzzy
+msgid "load buffer with ImageMagick7"
+msgstr "Datei mit ImageMagick laden"
+
+#: libvips/foreign/magick.c:804
+#, fuzzy, c-format
+msgid "libMagick error: %s %s"
+msgstr ""
+"Datei »%s« kann nicht gelesen werden\n"
+"libMagick-Fehler: %s %s"
+
+#: libvips/foreign/magick.c:807
+#, fuzzy, c-format
+msgid "libMagick error: %s"
+msgstr "EXR-Fehler: %s"
+
+#: libvips/foreign/magick.c:810
+msgid "libMagick error:"
+msgstr ""
+
+#: libvips/foreign/matlab.c:121
+#, c-format
+msgid "no matrix variables in \"%s\""
+msgstr "keine Matrixvariablen in »%s«"
+
+#: libvips/foreign/matlab.c:203
+#, c-format
+msgid "unsupported rank %d\n"
+msgstr "nicht unterstützte Rangstufe %d\n"
+
+#: libvips/foreign/matlab.c:211
+#, c-format
+msgid "unsupported class type %d\n"
+msgstr "nicht unterstützter Klassentyp %d\n"
+
+#: libvips/foreign/matlab.c:265
+msgid "Mat_VarReadDataAll failed"
+msgstr "»Mat_VarReadDataAll« fehlgeschlagen"
+
+# http://www.dateiendung.com/format/mat
+#: libvips/foreign/matload.c:122
+msgid "load mat from file"
+msgstr "Mat aus Datei laden"
+
+#: libvips/foreign/matrixload.c:128 libvips/foreign/matrixload.c:242
+#, fuzzy, c-format
+msgid "bad number \"%s\""
+msgstr "falscher Modus »%s«"
+
+#: libvips/foreign/matrixload.c:137
+msgid "no width / height"
+msgstr ""
+
+#: libvips/foreign/matrixload.c:143
+msgid "width / height not int"
+msgstr ""
+
+#: libvips/foreign/matrixload.c:156
+#, fuzzy
+msgid "width / height out of range"
+msgstr "Parameter außerhalb des Bereichs"
+
+#: libvips/foreign/matrixload.c:160
+msgid "zero scale"
+msgstr ""
+
+#: libvips/foreign/matrixload.c:251
+#, c-format
+msgid "line %d too short"
+msgstr ""
+
+# http://www.dateiendung.com/format/mat
+#: libvips/foreign/matrixload.c:273
+#, fuzzy
+msgid "load matrix"
+msgstr "Mat aus Datei laden"
+
+# http://de.wikipedia.org/wiki/Rohdatenformat_(Fotografie)
+#: libvips/foreign/matrixsave.c:175
+#, fuzzy
+msgid "save image to matrix"
+msgstr "Bild in Rohdatenformatdatei speichern"
+
+#: libvips/foreign/matrixsave.c:323
+#, fuzzy
+msgid "print matrix"
+msgstr "falsche Eingabematrix"
+
+#: libvips/foreign/niftiload.c:406
+#, fuzzy
+msgid "invalid dimension"
+msgstr "falsche Abmessungen"
+
+#: libvips/foreign/niftiload.c:417
+#, fuzzy
+msgid "invalid resolution"
+msgstr "ungültiges Argument"
+
+#: libvips/foreign/niftiload.c:431 libvips/foreign/niftiload.c:435
+#: libvips/foreign/niftisave.c:309
+#, fuzzy
+msgid "dimension overflow"
+msgstr "Überlaufganzzahl der Bildabmessungen"
+
+#: libvips/foreign/niftiload.c:536
+#, fuzzy
+msgid "unable to read NIFTI header"
+msgstr "Kopfdaten für »%s« können nicht gelesen werden"
+
+#: libvips/foreign/niftiload.c:564
+#, fuzzy
+msgid "unable to load NIFTI file"
+msgstr "Profil kann nicht gelesen werden"
+
+#: libvips/foreign/niftiload.c:594
+#, fuzzy
+msgid "load a NIFTI image"
+msgstr "ein FITS-Bild laden"
+
+#: libvips/foreign/niftiload.c:705
+msgid "load NIfTI volume"
+msgstr ""
+
+#: libvips/foreign/niftiload.c:783
+msgid "load NIfTI volumes"
+msgstr ""
+
+#: libvips/foreign/niftisave.c:115 libvips/foreign/niftisave.c:322
+#, fuzzy
+msgid "unsupported libvips image type"
+msgstr "nicht unterstützter Bildtyp %d"
+
+#: libvips/foreign/niftisave.c:122
+#, fuzzy
+msgid "8-bit colour images only"
+msgstr "nur skalare Bilder"
+
+#: libvips/foreign/niftisave.c:132
+#, fuzzy
+msgid "3 or 4 band colour images only"
+msgstr "nur RGB-TIFF mit drei oder vier Bändern"
+
+#: libvips/foreign/niftisave.c:251
+msgid "bad nifti-ext- field name"
+msgstr ""
+
+#: libvips/foreign/niftisave.c:260
+#, fuzzy
+msgid "unable to attach nifti ext"
+msgstr "Dateistatus kann nicht abgefragt werden"
+
+#: libvips/foreign/niftisave.c:315 libvips/foreign/nsgifload.c:644
+#: libvips/foreign/webp2vips.c:550
+#, fuzzy
+msgid "bad image dimensions"
+msgstr "falsche Abmessungen"
+
+#: libvips/foreign/niftisave.c:375
+#, fuzzy
+msgid "unable to set nifti filename"
+msgstr "Dateistatus kann nicht abgefragt werden"
+
+# http://de.wikipedia.org/wiki/Flexible_Image_Transport_System
+#: libvips/foreign/niftisave.c:427
+#, fuzzy
+msgid "save image to nifti file"
+msgstr "Bild in FITS-Datei speichern"
+
+#: libvips/foreign/nsgifload.c:420
+msgid "no frames in GIF"
+msgstr ""
+
+#: libvips/foreign/nsgifload.c:463
+#, fuzzy
+msgid "bad frame"
+msgstr "falscher Parameter"
+
+#: libvips/foreign/nsgifload.c:607 libvips/foreign/nsgifload.c:757
+#: libvips/foreign/nsgifload.c:837
+msgid "load GIF with libnsgif"
+msgstr ""
+
+#: libvips/foreign/nsgifload.c:901
+#, fuzzy
+msgid "load gif from source"
+msgstr "TIFF aus Datei laden"
+
+#: libvips/foreign/openexr2vips.c:123
+#, c-format
+msgid "EXR error: %s"
+msgstr "EXR-Fehler: %s"
+
+#: libvips/foreign/openexrload.c:129
+msgid "load an OpenEXR image"
+msgstr "ein OpenEXR-Bild laden"
+
+#: libvips/foreign/openslideload.c:207
+msgid "invalid associated image name"
+msgstr "ungültiger zugehöriger Bildname"
+
+#: libvips/foreign/openslideload.c:252
+msgid "specify only one of level and associated image"
+msgstr ""
+
+#: libvips/foreign/openslideload.c:259
+msgid "specify only one of attach_assicated and associated image"
+msgstr ""
+
+#: libvips/foreign/openslideload.c:376 libvips/foreign/openslideload.c:491
+#: libvips/foreign/openslideload.c:652
+#, fuzzy, c-format
+msgid "opening slide: %s"
+msgstr "Fehler beim Öffnen des Dias"
+
+#: libvips/foreign/openslideload.c:398
+#, c-format
+msgid "reading associated image: %s"
+msgstr "zugehöriges Bild wird gelesen: %s"
+
+#: libvips/foreign/openslideload.c:485
+#, fuzzy
+msgid "unsupported slide format"
+msgstr "nicht unterstützte Bit-Tiefe"
+
+#: libvips/foreign/openslideload.c:498
+msgid "invalid slide level"
+msgstr "ungültige Diastufe"
+
+#: libvips/foreign/openslideload.c:590
+#, c-format
+msgid "getting dimensions: %s"
+msgstr "Abfragen der Abmessungen: %s"
+
+#: libvips/foreign/openslideload.c:597
+msgid "image dimensions overflow int"
+msgstr "Überlaufganzzahl der Bildabmessungen"
+
+#: libvips/foreign/openslideload.c:753
+#, c-format
+msgid "reading region: %s"
+msgstr "Region wird gelesen: %s"
+
+#: libvips/foreign/openslideload.c:1017
+msgid "load OpenSlide base class"
+msgstr ""
+
+#: libvips/foreign/openslideload.c:1046 libvips/foreign/tiffsave.c:364
+msgid "Level"
+msgstr "Ebene"
+
+#: libvips/foreign/openslideload.c:1047
+msgid "Load this level from the file"
+msgstr "diese Ebene aus der Datei laden"
+
+#: libvips/foreign/openslideload.c:1053
+msgid "Autocrop"
+msgstr ""
+
+#: libvips/foreign/openslideload.c:1054
+#, fuzzy
+msgid "Crop to image bounds"
+msgstr "Transaktionen für Bänder von Bildern"
+
+#: libvips/foreign/openslideload.c:1060
+msgid "Associated"
+msgstr "dazugehörig"
+
+#: libvips/foreign/openslideload.c:1061
+msgid "Load this associated image"
+msgstr "dieses zugehörige Bild laden"
+
+#: libvips/foreign/openslideload.c:1067
+#, fuzzy
+msgid "Attach associated"
+msgstr "dazugehörig"
+
+#: libvips/foreign/openslideload.c:1068
+#, fuzzy
+msgid "Attach all associated images"
+msgstr "dieses zugehörige Bild laden"
+
+#: libvips/foreign/openslideload.c:1074
+#, fuzzy
+msgid "RGB"
+msgstr "GB"
+
+#: libvips/foreign/openslideload.c:1075
+msgid "Output RGB (not RGBA)"
+msgstr ""
+
+#: libvips/foreign/openslideload.c:1144
+msgid "load file with OpenSlide"
+msgstr "Datei mit OpenSlide laden"
+
+#: libvips/foreign/openslideload.c:1223
+#, fuzzy
+msgid "load source with OpenSlide"
+msgstr "Datei mit OpenSlide laden"
+
+#: libvips/foreign/pdfiumload.c:196
+#, fuzzy
+msgid "unknown error"
+msgstr "Unix-Fehler"
+
+#: libvips/foreign/pdfiumload.c:291
+#, c-format
+msgid "%s: too large for pdfium"
+msgstr ""
+
+#: libvips/foreign/pdfiumload.c:307
+#, fuzzy, c-format
+msgid "%s: unable to load"
+msgstr "»fd« kann nicht geschlossen werden"
+
+#: libvips/foreign/pdfiumload.c:318
+#, c-format
+msgid "%s: unable to initialize form fill environment"
+msgstr ""
+
+#: libvips/foreign/pdfiumload.c:366 libvips/foreign/popplerload.c:239
+#, fuzzy, c-format
+msgid "unable to load page %d"
+msgstr "»fd« kann nicht geschlossen werden"
+
+#: libvips/foreign/pdfiumload.c:478 libvips/foreign/popplerload.c:333
+#, fuzzy
+msgid "pages out of range"
+msgstr "Parameter außerhalb des Bereichs"
+
+#: libvips/foreign/pdfiumload.c:513
+#, fuzzy
+msgid "page size out of range"
+msgstr "Parameter außerhalb des Bereichs"
+
+#: libvips/foreign/pdfiumload.c:685
+msgid "load PDF with PDFium"
+msgstr ""
+
+#: libvips/foreign/pdfiumload.c:717 libvips/foreign/popplerload.c:567
+#: libvips/foreign/webpload.c:193
+msgid "Factor to scale by"
+msgstr ""
+
+#: libvips/foreign/pdfiumload.c:724 libvips/foreign/popplerload.c:574
+#, fuzzy
+msgid "Background colour"
+msgstr "Hintergrund"
+
+#: libvips/foreign/pdfiumload.c:730 libvips/foreign/popplerload.c:580
+msgid "Password"
+msgstr ""
+
+#: libvips/foreign/pdfiumload.c:731 libvips/foreign/popplerload.c:581
+msgid "Password to decrypt with"
+msgstr ""
+
+# Portable Pixmap
+#: libvips/foreign/pdfiumload.c:803 libvips/foreign/popplerload.c:680
+#, fuzzy
+msgid "load PDF from file"
+msgstr "PPM aus Datei laden"
+
+#: libvips/foreign/pdfiumload.c:866 libvips/foreign/popplerload.c:743
+#, fuzzy
+msgid "load PDF from buffer"
+msgstr "JPEG aus Puffer laden"
+
+#: libvips/foreign/pdfiumload.c:924 libvips/foreign/popplerload.c:801
+#, fuzzy
+msgid "load PDF from source"
+msgstr "JPEG aus Puffer laden"
+
+#: libvips/foreign/pngload.c:157 libvips/foreign/spngload.c:664
+#, fuzzy
+msgid "load png base class"
+msgstr "Basisklasse"
+
+#: libvips/foreign/pngload.c:234 libvips/foreign/spngload.c:749
+#, fuzzy
+msgid "load png from source"
+msgstr "PNG-Datei aus Datei laden"
+
+#: libvips/foreign/pngload.c:310 libvips/foreign/spngload.c:827
+msgid "load png from file"
+msgstr "PNG-Datei aus Datei laden"
+
+#: libvips/foreign/pngload.c:388 libvips/foreign/spngload.c:905
+#, fuzzy
+msgid "load png from buffer"
+msgstr "JPEG aus Puffer laden"
+
+#: libvips/foreign/pngsave.c:202
+msgid "save png"
+msgstr "PNG speichern"
+
+#: libvips/foreign/pngsave.c:212 libvips/foreign/spngsave.c:690
+msgid "Compression factor"
+msgstr "Komprimierungsfaktor"
+
+#: libvips/foreign/pngsave.c:219 libvips/foreign/spngsave.c:697
+msgid "Interlace image"
+msgstr "Zeilensprungbild"
+
+#: libvips/foreign/pngsave.c:225 libvips/foreign/spngsave.c:703
+msgid "Filter"
+msgstr ""
+
+#: libvips/foreign/pngsave.c:226
+msgid "libpng row filter flag(s)"
+msgstr ""
+
+#: libvips/foreign/pngsave.c:233 libvips/foreign/spngsave.c:711
+msgid "Palette"
+msgstr ""
+
+#: libvips/foreign/pngsave.c:234 libvips/foreign/spngsave.c:712
+msgid "Quantise to 8bpp palette"
+msgstr ""
+
+#: libvips/foreign/pngsave.c:240 libvips/foreign/spngsave.c:718
+#: libvips/foreign/vips2magick.c:489
+msgid "Quality"
+msgstr ""
+
+#: libvips/foreign/pngsave.c:241 libvips/foreign/spngsave.c:719
+msgid "Quantisation quality"
+msgstr ""
+
+#: libvips/foreign/pngsave.c:255 libvips/foreign/spngsave.c:733
+msgid "Write as a 1, 2, 4, 8 or 16 bit image"
+msgstr ""
+
+#: libvips/foreign/pngsave.c:262 libvips/foreign/spngsave.c:740
+msgid "Quantisation CPU effort"
+msgstr ""
+
+#: libvips/foreign/pngsave.c:268 libvips/foreign/spngsave.c:746
+msgid "Colours"
+msgstr ""
+
+#: libvips/foreign/pngsave.c:269 libvips/foreign/spngsave.c:747
+#, fuzzy
+msgid "Max number of palette colours"
+msgstr "maximale Anzahl von Kacheln, die zwischengespeichert werden soll"
+
+# http://de.wikipedia.org/wiki/Rohdatenformat_(Fotografie)
+#: libvips/foreign/pngsave.c:322 libvips/foreign/spngsave.c:801
+#, fuzzy
+msgid "save image to target as PNG"
+msgstr "Bild in Rohdatenformatdatei speichern"
+
+#: libvips/foreign/pngsave.c:374
+msgid "save image to png file"
+msgstr "Bild in PNG-Datei speichern"
+
+#: libvips/foreign/pngsave.c:433
+msgid "save image to png buffer"
+msgstr "Bild in den PNG-Puffer speichern"
+
+#: libvips/foreign/popplerload.c:531
+msgid "load PDF with libpoppler"
+msgstr ""
+
+#: libvips/foreign/ppmload.c:264
+msgid "bad magic number"
+msgstr "falsche magische Zahl"
+
+#: libvips/foreign/ppmload.c:521
+#, fuzzy
+msgid "file truncated"
+msgstr "Datei wurde gekürzt"
+
+#: libvips/foreign/ppmload.c:746
+#, fuzzy
+msgid "load ppm base class"
+msgstr "Basisklasse"
+
+# Portable Pixmap
+#: libvips/foreign/ppmload.c:823
+msgid "load ppm from file"
+msgstr "PPM aus Datei laden"
+
+#: libvips/foreign/ppmsave.c:321
+#, fuzzy
+msgid "too few bands for format"
+msgstr "unbekanntes Bandformat %d"
+
+# http://de.wikipedia.org/wiki/Portable_Pixmap
+#: libvips/foreign/ppmsave.c:499
+#, fuzzy
+msgid "save to ppm"
+msgstr "Bild in PPM-Datei speichern"
+
+#: libvips/foreign/ppmsave.c:507 libvips/foreign/vips2magick.c:483
+#, fuzzy
+msgid "Format to save in"
+msgstr "Format, in das umgewandelt werden soll"
+
+#: libvips/foreign/ppmsave.c:514
+msgid "ASCII"
+msgstr "ASCII"
+
+#: libvips/foreign/ppmsave.c:515
+#, fuzzy
+msgid "Save as ascii"
+msgstr "Bild als ASCII speichern"
+
+#: libvips/foreign/ppmsave.c:522
+msgid "Set to 1 to write as a 1 bit image"
+msgstr ""
+
+#: libvips/foreign/ppmsave.c:528 libvips/foreign/tiffsave.c:406
+msgid "Squash"
+msgstr "quetschen"
+
+#: libvips/foreign/ppmsave.c:529
+msgid "Save as one bit"
+msgstr ""
+
+# http://de.wikipedia.org/wiki/Portable_Pixmap
+#: libvips/foreign/ppmsave.c:586
+msgid "save image to ppm file"
+msgstr "Bild in PPM-Datei speichern"
+
+# http://de.wikipedia.org/wiki/Portable_Pixmap
+#: libvips/foreign/ppmsave.c:675
+#, fuzzy
+msgid "save image in pbm format"
+msgstr "Bild in PPM-Datei speichern"
+
+#: libvips/foreign/ppmsave.c:707
+#, fuzzy
+msgid "save image in pgm format"
+msgstr "Bild in den PNG-Puffer speichern"
+
+# http://de.wikipedia.org/wiki/Portable_Pixmap
+#: libvips/foreign/ppmsave.c:739
+#, fuzzy
+msgid "save image in pfm format"
+msgstr "Bild in PPM-Datei speichern"
+
+#: libvips/foreign/ppmsave.c:771
+#, fuzzy
+msgid "save image in pnm format"
+msgstr "Bild in den PNG-Puffer speichern"
+
+#: libvips/foreign/quantise.c:469
+msgid "libvips not built with quantisation support"
+msgstr ""
+
+#: libvips/foreign/radiance.c:438
+msgid "scanline length mismatch"
+msgstr ""
+
+#: libvips/foreign/radiance.c:455
+msgid "overrun"
+msgstr ""
+
+# http://radsite.lbl.gov/radiance/refer/Notes/picture_format.html
+#: libvips/foreign/radiance.c:687
+msgid "error reading radiance header"
+msgstr "Fehler beim Lesen der Radiance-Kopfzeilen"
+
+#: libvips/foreign/radiance.c:774
+#, fuzzy, c-format
+msgid "read error line %d"
+msgstr "Lesefehler"
+
+#: libvips/foreign/radload.c:125
+#, fuzzy
+msgid "load rad base class"
+msgstr "Basisklasse"
+
+# http://www.dateiendung.com/format/mat
+#: libvips/foreign/radload.c:197
+#, fuzzy
+msgid "load rad from source"
+msgstr "Mat aus Datei laden"
+
+#: libvips/foreign/radload.c:273
+msgid "load a Radiance image from a file"
+msgstr "ein Radiance-Bild aus einer Datei laden"
+
+#: libvips/foreign/radload.c:350
+#, fuzzy
+msgid "load rad from buffer"
+msgstr "JPEG aus Puffer laden"
+
+#: libvips/foreign/radsave.c:92
+#, fuzzy
+msgid "save Radiance"
+msgstr "Bild in Radiance-Datei speichern"
+
+#: libvips/foreign/radsave.c:150
+msgid "save image to Radiance file"
+msgstr "Bild in Radiance-Datei speichern"
+
+#: libvips/foreign/radsave.c:203
+#, fuzzy
+msgid "save image to Radiance target"
+msgstr "Bild in Radiance-Datei speichern"
+
+#: libvips/foreign/radsave.c:269
+#, fuzzy
+msgid "save image to Radiance buffer"
+msgstr "Bild in Radiance-Datei speichern"
+
+#: libvips/foreign/rawload.c:131
+msgid "load raw data from a file"
+msgstr "Rohdaten aus einer Datei laden"
+
+#: libvips/foreign/rawload.c:167 libvips/iofuncs/image.c:1200
+msgid "Size of header"
+msgstr "Größe der Kopfdaten"
+
+#: libvips/foreign/rawload.c:168 libvips/iofuncs/image.c:1201
+msgid "Offset in bytes from start of file"
+msgstr "Versatz in Byte vom Anfang der Datei"
+
+# http://de.wikipedia.org/wiki/Rohdatenformat_(Fotografie)
+#: libvips/foreign/rawsave.c:138
+#, fuzzy
+msgid "save image to raw"
+msgstr "Bild in Rohdatenformatdatei speichern"
+
+# http://de.wikipedia.org/wiki/Rohdatenformat_(Fotografie)
+#: libvips/foreign/rawsave.c:190
+msgid "save image to raw file"
+msgstr "Bild in Rohdatenformatdatei speichern"
+
+#: libvips/foreign/rawsave.c:246
+#, fuzzy
+msgid "write raw image to target"
+msgstr "Rohdatenbild in Datei-Deskriptor schreiben"
+
+#: libvips/foreign/rawsave.c:308
+#, fuzzy
+msgid "write raw image to buffer"
+msgstr "Rohdatenbild in Datei-Deskriptor schreiben"
+
+#: libvips/foreign/spngload.c:252 libvips/foreign/vipspng.c:582
+#, c-format
+msgid "%d text chunks, only %d text chunks will be loaded"
+msgstr ""
+
+#: libvips/foreign/spngload.c:403
+#, fuzzy
+msgid "unknown color type"
+msgstr "unbekannter Kodierungstyp"
+
+#: libvips/foreign/spngload.c:562
+#, fuzzy
+msgid "libspng read error"
+msgstr "Lesefehler"
+
+#: libvips/foreign/spngsave.c:164 libvips/foreign/vipspng.c:1013
+#, fuzzy
+msgid "bad png comment key"
+msgstr "falsche Gittergeometrie"
+
+#: libvips/foreign/spngsave.c:680
+#, fuzzy
+msgid "save spng"
+msgstr "PNG speichern"
+
+#: libvips/foreign/spngsave.c:704
+msgid "libspng row filter flag(s)"
+msgstr ""
+
+# http://de.wikipedia.org/wiki/Rohdatenformat_(Fotografie)
+#: libvips/foreign/spngsave.c:854
+#, fuzzy
+msgid "save image to file as PNG"
+msgstr "Bild in Rohdatenformatdatei speichern"
+
+#: libvips/foreign/spngsave.c:914
+#, fuzzy
+msgid "save image to buffer as PNG"
+msgstr "Bild in den PNG-Puffer speichern"
+
+#: libvips/foreign/svgload.c:626 libvips/foreign/svgload.c:644
+msgid "SVG rendering failed"
+msgstr ""
+
+#: libvips/foreign/svgload.c:700
+msgid "load SVG with rsvg"
+msgstr ""
+
+#: libvips/foreign/svgload.c:718
+msgid "Render at this DPI"
+msgstr ""
+
+#: libvips/foreign/svgload.c:725
+msgid "Scale output by this factor"
+msgstr ""
+
+#: libvips/foreign/svgload.c:733
+msgid "Allow SVG of any size"
+msgstr ""
+
+#: libvips/foreign/svgload.c:827
+#, fuzzy
+msgid "load svg from source"
+msgstr "CSV aus Datei laden"
+
+#: libvips/foreign/tiff2vips.c:480 libvips/foreign/tiff2vips.c:498
+#, c-format
+msgid "required field %d missing"
+msgstr "benötigtes Feld %d fehlt"
+
+#: libvips/foreign/tiff2vips.c:540
+msgid "unknown resolution unit"
+msgstr "unbekannte Auflösungseinheit"
+
+#: libvips/foreign/tiff2vips.c:680
+#, c-format
+msgid "bad page number %d"
+msgstr "falsche Seitennummer %d"
+
+#: libvips/foreign/tiff2vips.c:690
+#, fuzzy, c-format
+msgid "bad number of pages %d"
+msgstr "falsche Achsenanzahl %d"
+
+#: libvips/foreign/tiff2vips.c:718 libvips/foreign/tiff2vips.c:760
+#: libvips/iofuncs/source.c:812
+msgid "read error"
+msgstr "Lesefehler"
+
+#: libvips/foreign/tiff2vips.c:802
+#, fuzzy, c-format
+msgid "TIFF does not contain page %d"
+msgstr "TIFF-Datei enthält nicht Seite %d"
+
+#: libvips/foreign/tiff2vips.c:812
+msgid "no SUBIFD tag"
+msgstr ""
+
+#: libvips/foreign/tiff2vips.c:818
+#, c-format
+msgid "subifd %d out of range, only 0-%d available"
+msgstr ""
+
+#: libvips/foreign/tiff2vips.c:826
+msgid "subdirectory unreadable"
+msgstr ""
+
+#: libvips/foreign/tiff2vips.c:867
+#, fuzzy, c-format
+msgid "not %d bands"
+msgstr "nicht ein Band oder %d Bänder"
+
+#: libvips/foreign/tiff2vips.c:880
+#, c-format
+msgid "not at least %d samples per pixel"
+msgstr ""
+
+#: libvips/foreign/tiff2vips.c:895
+msgid "samples_per_pixel not a whole number of bytes"
+msgstr ""
+
+#: libvips/foreign/tiff2vips.c:908
+#, fuzzy, c-format
+msgid "not photometric interpretation %d"
+msgstr "unbekannte fotometrische Deutung %d"
+
+#: libvips/foreign/tiff2vips.c:920
+#, c-format
+msgid "not %d bits per sample"
+msgstr ""
+
+#: libvips/foreign/tiff2vips.c:936
+#, c-format
+msgid "%d bits per sample palette image not supported"
+msgstr "%d Bit pro Musterfarbpalettenbild nicht unterstützt"
+
+#: libvips/foreign/tiff2vips.c:995
+#, fuzzy
+msgid "unsupported tiff image type\n"
+msgstr "nicht unterstützter Bildtyp %d"
+
+#: libvips/foreign/tiff2vips.c:1603
+msgid "bad colormap"
+msgstr "falsche Farbzusammenstellung"
+
+#: libvips/foreign/tiff2vips.c:2330
+#, c-format
+msgid "decompress error tile %d x %d"
+msgstr ""
+
+#: libvips/foreign/tiff2vips.c:2608
+#, fuzzy
+msgid "tiled separate planes not supported"
+msgstr "Datentyp %d nicht unterstützt"
+
+#: libvips/foreign/tiff2vips.c:2627 libvips/foreign/tiff2vips.c:2910
+#: libvips/foreign/tiff2vips.c:3034
+#, fuzzy
+msgid "unsupported tiff image type"
+msgstr "nicht unterstützter Bildtyp %d"
+
+#: libvips/foreign/tiff2vips.c:2761
+#, c-format
+msgid "out of order read -- at line %d, but line %d requested"
+msgstr ""
+
+#: libvips/foreign/tiff2vips.c:3070
+#, fuzzy
+msgid "subsampled images not supported"
+msgstr "%d-dimensionale Bilder nicht unterstützt"
+
+#: libvips/foreign/tiff2vips.c:3082
+msgid "not SGI-compressed LOGLUV"
+msgstr ""
+
+#: libvips/foreign/tiff2vips.c:3099
+#, fuzzy
+msgid "width/height out of range"
+msgstr "Parameter außerhalb des Bereichs"
+
+#: libvips/foreign/tiff2vips.c:3108
+#, fuzzy
+msgid "samples out of range"
+msgstr "Parameter außerhalb des Bereichs"
+
+#: libvips/foreign/tiff2vips.c:3194 libvips/foreign/tiff2vips.c:3222
+#, fuzzy
+msgid "tile size out of range"
+msgstr "Parameter außerhalb des Bereichs"
+
+#: libvips/foreign/tiff2vips.c:3414
+#, c-format
+msgid "page %d differs from page %d"
+msgstr ""
+
+#: libvips/foreign/tiff.c:207 libvips/foreign/tiff.c:222
+#, fuzzy
+msgid "unable to open source for input"
+msgstr "»%s« kann nicht zur Eingabe geöffnet werden"
+
+#: libvips/foreign/tiff.c:330 libvips/foreign/tiff.c:345
+#, fuzzy
+msgid "unable to open target for output"
+msgstr "»%s« kann nicht zur Ausgabe geöffnet werden"
+
+#: libvips/foreign/tiffload.c:183
+#, fuzzy
+msgid "load tiff"
+msgstr "TIFF aus Datei laden"
+
+#: libvips/foreign/tiffload.c:211
+msgid "Rotate image using orientation tag"
+msgstr ""
+
+#: libvips/foreign/tiffload.c:217
+msgid "subifd"
+msgstr ""
+
+#: libvips/foreign/tiffload.c:218
+msgid "Subifd index"
+msgstr ""
+
+#: libvips/foreign/tiffload.c:294
+#, fuzzy
+msgid "load tiff from source"
+msgstr "TIFF aus Datei laden"
+
+#: libvips/foreign/tiffload.c:374
+msgid "load tiff from file"
+msgstr "TIFF aus Datei laden"
+
+#: libvips/foreign/tiffload.c:454
+#, fuzzy
+msgid "load tiff from buffer"
+msgstr "TIFF aus Datei laden"
+
+#: libvips/foreign/tiffsave.c:248
+#, fuzzy
+msgid "save image as tiff"
+msgstr "Bild in TIFF-Datei speichern"
+
+#: libvips/foreign/tiffsave.c:258
+msgid "Compression for this file"
+msgstr "Komprimierung für diese Datei"
+
+# http://de.wikipedia.org/wiki/Abhängige_und_unabhängige_Variable
+#: libvips/foreign/tiffsave.c:272
+#, fuzzy
+msgid "Predictor"
+msgstr "Prädiktor"
+
+#: libvips/foreign/tiffsave.c:273
+msgid "Compression prediction"
+msgstr "Prognose der Komprimierung"
+
+#: libvips/foreign/tiffsave.c:280
+msgid "Tile"
+msgstr "Kachel"
+
+#: libvips/foreign/tiffsave.c:281
+msgid "Write a tiled tiff"
+msgstr "ein gekacheltes TIFF schreiben"
+
+#: libvips/foreign/tiffsave.c:301
+msgid "Pyramid"
+msgstr "Pyramide"
+
+#: libvips/foreign/tiffsave.c:302
+msgid "Write a pyramidal tiff"
+msgstr "ein pyramidenförmiges TIFF schreiben"
+
+#: libvips/foreign/tiffsave.c:308
+msgid "Miniswhite"
+msgstr ""
+
+#: libvips/foreign/tiffsave.c:309
+msgid "Use 0 for white in 1-bit images"
+msgstr ""
+
+#: libvips/foreign/tiffsave.c:316
+#, fuzzy
+msgid "Write as a 1, 2, 4 or 8 bit image"
+msgstr "ein BigTIFF-Bild schreiben"
+
+#: libvips/foreign/tiffsave.c:322 libvips/foreign/tiffsave.c:323
+msgid "Resolution unit"
+msgstr "Einheit der Auflösung"
+
+# http://de.wikipedia.org/wiki/Liste_von_Dateinamenserweiterungen/T
+#: libvips/foreign/tiffsave.c:343
+msgid "Bigtiff"
+msgstr "BigTIFF"
+
+#: libvips/foreign/tiffsave.c:344
+msgid "Write a bigtiff image"
+msgstr "ein BigTIFF-Bild schreiben"
+
+#: libvips/foreign/tiffsave.c:351
+msgid "Write a properties document to IMAGEDESCRIPTION"
+msgstr ""
+
+#: libvips/foreign/tiffsave.c:365
+msgid "Deflate (1-9, default 6) or ZSTD (1-22, default 9) compression level"
+msgstr ""
+
+#: libvips/foreign/tiffsave.c:372
+#, fuzzy
+msgid "Enable WEBP lossless mode"
+msgstr "»fd« kann nicht geschlossen werden"
+
+#: libvips/foreign/tiffsave.c:385
+msgid "Sub-IFD"
+msgstr ""
+
+#: libvips/foreign/tiffsave.c:386
+msgid "Save pyr layers as sub-IFDs"
+msgstr ""
+
+#: libvips/foreign/tiffsave.c:392
+msgid "Premultiply"
+msgstr ""
+
+#: libvips/foreign/tiffsave.c:393
+msgid "Save with premultiplied alpha"
+msgstr ""
+
+#: libvips/foreign/tiffsave.c:399
+msgid "RGB JPEG"
+msgstr ""
+
+#: libvips/foreign/tiffsave.c:400
+msgid "Output RGB JPEG rather than YCbCr"
+msgstr ""
+
+#: libvips/foreign/tiffsave.c:407
+msgid "Squash images down to 1 bit"
+msgstr "Bilder auf ein Bit zusammenquetschen"
+
+#: libvips/foreign/tiffsave.c:470
+#, fuzzy
+msgid "save image to tiff target"
+msgstr "Bild in TIFF-Datei speichern"
+
+#: libvips/foreign/tiffsave.c:523
+msgid "save image to tiff file"
+msgstr "Bild in TIFF-Datei speichern"
+
+#: libvips/foreign/tiffsave.c:584
+#, fuzzy
+msgid "save image to tiff buffer"
+msgstr "Bild in TIFF-Datei speichern"
+
+#: libvips/foreign/vips2jpeg.c:176
+#, c-format
+msgid "%s"
+msgstr "%s"
+
+#: libvips/foreign/vips2jpeg.c:273
+#, c-format
+msgid "field \"%s\" is too large for a single JPEG marker, ignoring"
+msgstr ""
+
+#: libvips/foreign/vips2jpeg.c:1059
+#, fuzzy
+msgid "libvips built without JPEG support"
+msgstr "VIPS wurde ohne FFT-Unterstützung konfiguriert"
+
+#: libvips/foreign/vips2magick.c:319
+#, fuzzy
+msgid "unsupported image format"
+msgstr "nicht unterstützter Bildtyp %d"
+
+#: libvips/foreign/vips2magick.c:349
+#, fuzzy
+msgid "unsupported number of image bands"
+msgstr "nicht unterstützter Bildtyp %d"
+
+#: libvips/foreign/vips2magick.c:464
+#, fuzzy
+msgid "save with ImageMagick"
+msgstr "Datei mit ImageMagick laden"
+
+#: libvips/foreign/vips2magick.c:490
+#, fuzzy
+msgid "Quality to use"
+msgstr "kann nicht gesucht werden"
+
+#: libvips/foreign/vips2magick.c:496
+msgid "Optimize_gif_frames"
+msgstr ""
+
+#: libvips/foreign/vips2magick.c:497
+msgid "Apply GIF frames optimization"
+msgstr ""
+
+#: libvips/foreign/vips2magick.c:503
+msgid "Optimize_gif_transparency"
+msgstr ""
+
+#: libvips/foreign/vips2magick.c:504
+msgid "Apply GIF transparency optimization"
+msgstr ""
+
+#: libvips/foreign/vips2magick.c:574
+#, fuzzy
+msgid "save file with ImageMagick"
+msgstr "Datei mit ImageMagick laden"
+
+#: libvips/foreign/vips2magick.c:646
+#, fuzzy
+msgid "save image to magick buffer"
+msgstr "Bild in den PNG-Puffer speichern"
+
+#: libvips/foreign/vips2magick.c:677
+#, fuzzy
+msgid "save bmp image with ImageMagick"
+msgstr "Datei mit ImageMagick laden"
+
+#: libvips/foreign/vips2magick.c:710
+#, fuzzy
+msgid "save bmp image to magick buffer"
+msgstr "Bild in den PNG-Puffer speichern"
+
+#: libvips/foreign/vips2magick.c:743
+#, fuzzy
+msgid "save gif image with ImageMagick"
+msgstr "Datei mit ImageMagick laden"
+
+#: libvips/foreign/vips2magick.c:776
+#, fuzzy
+msgid "save gif image to magick buffer"
+msgstr "Bild in den PNG-Puffer speichern"
+
+#: libvips/foreign/vips2tiff.c:1449
+msgid "can only pyramid LABQ and non-complex images"
+msgstr ""
+"nur LABQ und nicht-komplexe Bilder können pyramidenartig verwendet werden"
+
+#: libvips/foreign/vips2tiff.c:1472
+msgid "tile size not a multiple of 16"
+msgstr "Bildgröße kein Vielfaches von 16"
+
+#: libvips/foreign/vips2tiff.c:1830 libvips/foreign/vips2tiff.c:2019
+msgid "TIFF write tile failed"
+msgstr "Schreiben des TIFF-Bildes fehlgeschlagen"
+
+#: libvips/foreign/vipsload.c:126
+msgid "no filename associated with source"
+msgstr ""
+
+#: libvips/foreign/vipsload.c:157
+#, fuzzy
+msgid "load vips base class"
+msgstr "Basisklasse"
+
+#: libvips/foreign/vipsload.c:228
+msgid "load vips from file"
+msgstr "Vips aus einer Datei laden"
+
+#: libvips/foreign/vipsload.c:303
+#, fuzzy
+msgid "load vips from source"
+msgstr "Vips aus einer Datei laden"
+
+#: libvips/foreign/vipspng.c:450
+msgid "unsupported color type"
+msgstr "nicht unterstützter Farbtyp"
+
+#: libvips/foreign/vipspng.c:564
+#, fuzzy
+msgid "unable to read PNG header"
+msgstr "Kopfdaten für »%s« können nicht gelesen werden"
+
+#: libvips/foreign/vipspng.c:756
+#, fuzzy
+msgid "libpng read error"
+msgstr "Lesefehler"
+
+#: libvips/foreign/vipspng.c:1113
+msgid "compress should be in [0,9]"
+msgstr "Komprimierung sollte in [0,9] liegen"
+
+#: libvips/foreign/vipspng.c:1141
+#, c-format
+msgid "can't save %d band image as png"
+msgstr ""
+
+#: libvips/foreign/vipspng.c:1349
+#, fuzzy, c-format
+msgid "unable to write to target %s"
+msgstr "auf »%s« kann nicht geschrieben werden"
+
+#: libvips/foreign/vipssave.c:114
+#, fuzzy
+msgid "no filename associated with target"
+msgstr "dieses zugehörige Bild laden"
+
+#: libvips/foreign/vipssave.c:141
+#, fuzzy
+msgid "save vips base class"
+msgstr "Basisklasse"
+
+#: libvips/foreign/vipssave.c:193
+#, fuzzy
+msgid "save image to file in vips format"
+msgstr "Bild in Vips-Datei speichern"
+
+#: libvips/foreign/vipssave.c:249
+#, fuzzy
+msgid "save image to target in vips format"
+msgstr "Bild in Vips-Datei speichern"
+
+#: libvips/foreign/webp2vips.c:407
+#, fuzzy
+msgid "unable to parse image"
+msgstr "es kann nicht zu einem %s-Bild ausgegeben werden"
+
+#: libvips/foreign/webp2vips.c:595
+#, fuzzy
+msgid "unable to loop through frames"
+msgstr "es kann nicht zu einem %s-Bild ausgegeben werden"
+
+#: libvips/foreign/webpload.c:164
+#, fuzzy
+msgid "load webp"
+msgstr "JPEG laden"
+
+# Portable Pixmap
+#: libvips/foreign/webpload.c:258
+#, fuzzy
+msgid "load webp from source"
+msgstr "PPM aus Datei laden"
+
+# Portable Pixmap
+#: libvips/foreign/webpload.c:338
+#, fuzzy
+msgid "load webp from file"
+msgstr "PPM aus Datei laden"
+
+#: libvips/foreign/webpload.c:418
+#, fuzzy
+msgid "load webp from buffer"
+msgstr "JPEG aus Puffer laden"
+
+#: libvips/foreign/webpsave.c:248
+#, fuzzy
+msgid "picture version error"
+msgstr "Version ausgeben"
+
+#: libvips/foreign/webpsave.c:290
+msgid "picture memory error"
+msgstr ""
+
+#: libvips/foreign/webpsave.c:315
+#, fuzzy
+msgid "anim add error"
+msgstr "Lesefehler"
+
+#: libvips/foreign/webpsave.c:332
+#, fuzzy
+msgid "unable to encode"
+msgstr "kann nicht gesucht werden"
+
+#: libvips/foreign/webpsave.c:428
+#, fuzzy
+msgid "chunk add error"
+msgstr "Lesefehler"
+
+#: libvips/foreign/webpsave.c:534 libvips/foreign/webpsave.c:575
+#, fuzzy
+msgid "mux error"
+msgstr "Unix-Fehler"
+
+#: libvips/foreign/webpsave.c:595 libvips/foreign/webpsave.c:605
+#: libvips/foreign/webpsave.c:644
+#, fuzzy
+msgid "config version error"
+msgstr "Umwandlungstransaktionen"
+
+#: libvips/foreign/webpsave.c:625
+msgid "invalid configuration"
+msgstr ""
+
+#: libvips/foreign/webpsave.c:655
+#, fuzzy
+msgid "unable to init animation"
+msgstr "kann nicht gekürzt werden"
+
+#: libvips/foreign/webpsave.c:698
+#, fuzzy
+msgid "anim close error"
+msgstr "XML-Fehler beim Speichern"
+
+#: libvips/foreign/webpsave.c:703
+#, fuzzy
+msgid "anim build error"
+msgstr "Lesefehler"
+
+#: libvips/foreign/webpsave.c:711 libvips/mosaicing/lrmerge.c:309
+#: libvips/mosaicing/tbmerge.c:187 libvips/mosaicing/tbmerge.c:262
+#: libvips/mosaicing/tbmerge.c:594
+msgid "internal error"
+msgstr "interner Fehler"
+
+#: libvips/foreign/webpsave.c:817
+#, fuzzy
+msgid "save as WebP"
+msgstr "Bild als ASCII speichern"
+
+#: libvips/foreign/webpsave.c:840
+msgid "Preset"
+msgstr ""
+
+#: libvips/foreign/webpsave.c:841
+msgid "Preset for lossy compression"
+msgstr ""
+
+#: libvips/foreign/webpsave.c:848
+msgid "Smart subsampling"
+msgstr ""
+
+#: libvips/foreign/webpsave.c:849
+msgid "Enable high quality chroma subsampling"
+msgstr ""
+
+#: libvips/foreign/webpsave.c:855
+msgid "Near lossless"
+msgstr ""
+
+#: libvips/foreign/webpsave.c:856
+msgid "Enable preprocessing in lossless mode (uses Q)"
+msgstr ""
+
+#: libvips/foreign/webpsave.c:862
+msgid "Alpha quality"
+msgstr ""
+
+#: libvips/foreign/webpsave.c:863
+msgid "Change alpha plane fidelity for lossy compression"
+msgstr ""
+
+#: libvips/foreign/webpsave.c:869
+msgid "Minimise size"
+msgstr ""
+
+#: libvips/foreign/webpsave.c:870
+msgid "Optimise for minimum size"
+msgstr ""
+
+#: libvips/foreign/webpsave.c:876
+msgid "Minimum keyframe spacing"
+msgstr ""
+
+#: libvips/foreign/webpsave.c:877
+#, fuzzy
+msgid "Minimum number of frames between key frames"
+msgstr "maximale Anzahl von Kacheln, die zwischengespeichert werden soll"
+
+#: libvips/foreign/webpsave.c:883
+msgid "Maximum keyframe spacing"
+msgstr ""
+
+#: libvips/foreign/webpsave.c:884
+#, fuzzy
+msgid "Maximum number of frames between key frames"
+msgstr "maximale Anzahl von Kacheln, die zwischengespeichert werden soll"
+
+#: libvips/foreign/webpsave.c:891 libvips/foreign/webpsave.c:912
+msgid "Level of CPU effort to reduce file size"
+msgstr ""
+
+#: libvips/foreign/webpsave.c:897
+#, fuzzy
+msgid "Target size"
+msgstr "falsche Bildgröße"
+
+#: libvips/foreign/webpsave.c:898
+msgid "Desired target size in bytes"
+msgstr ""
+
+#: libvips/foreign/webpsave.c:904
+msgid "Passes"
+msgstr ""
+
+#: libvips/foreign/webpsave.c:905
+msgid "Number of entropy-analysis passes (in [1..10])"
+msgstr ""
+
+#: libvips/foreign/webpsave.c:911
+msgid "Reduction effort"
+msgstr ""
+
+#: libvips/foreign/webpsave.c:918
+#, fuzzy
+msgid "Mixed encoding"
+msgstr "Bildpunktkodierung"
+
+#: libvips/foreign/webpsave.c:919
+msgid "Allow mixed encoding (might reduce file size)"
+msgstr ""
+
+#: libvips/foreign/webpsave.c:925
+msgid "Smart deblocking"
+msgstr ""
+
+#: libvips/foreign/webpsave.c:926
+msgid "Enable auto-adjusting of the deblocking filter"
+msgstr ""
+
+# http://de.wikipedia.org/wiki/MIME#image
+#: libvips/foreign/webpsave.c:1156
+#, fuzzy
+msgid "save image to webp mime"
+msgstr "Bild in JPEG-MIME speichern"
+
+#: libvips/freqfilt/freqfilt.c:94
+#, fuzzy
+msgid "frequency-domain filter operations"
+msgstr "unäre Transaktionen"
+
+#: libvips/freqfilt/freqmult.c:126
+msgid "frequency-domain filtering"
+msgstr ""
+
+#: libvips/freqfilt/freqmult.c:131
+#, fuzzy
+msgid "Input mask image"
+msgstr "Eingabebild"
+
+#: libvips/freqfilt/fwfft.c:145 libvips/freqfilt/fwfft.c:266
+#: libvips/freqfilt/invfft.c:124 libvips/freqfilt/invfft.c:203
 msgid "unable to create transform plan"
 msgstr "Umwandlungsplan kann nicht erstellt werden"
 
-#: libvips/freq_filt/im_invfft.c:130 libvips/freq_filt/im_invfftr.c:145
-#: libvips/freq_filt/im_fwfft.c:301
-msgid "vips configured without FFT support"
-msgstr "VIPS wurde ohne FFT-Unterstützung konfiguriert"
+#: libvips/freqfilt/fwfft.c:351
+msgid "forward FFT"
+msgstr ""
 
-#: libvips/histograms_lut/im_stdif.c:186
-#: libvips/histograms_lut/im_lhisteq.c:159
+#: libvips/freqfilt/invfft.c:263
+msgid "inverse FFT"
+msgstr ""
+
+#: libvips/freqfilt/invfft.c:267
+msgid "Real"
+msgstr ""
+
+#: libvips/freqfilt/invfft.c:268
+msgid "Output only the real part of the transform"
+msgstr ""
+
+#: libvips/freqfilt/phasecor.c:107
+msgid "calculate phase correlation"
+msgstr ""
+
+#: libvips/freqfilt/spectrum.c:100
+msgid "make displayable power spectrum"
+msgstr ""
+
+#: libvips/histogram/case.c:164
+#, fuzzy
+msgid "bad number of cases"
+msgstr "falsche Achsenanzahl %d"
+
+#: libvips/histogram/case.c:169
+#, fuzzy
+msgid "index image not 1-band"
+msgstr "»ink«-Bild nicht 1x1 Bildpunkte"
+
+#: libvips/histogram/case.c:233
+msgid "use pixel values to pick cases from an array of images"
+msgstr ""
+
+#: libvips/histogram/case.c:245
+msgid "Cases"
+msgstr ""
+
+#: libvips/histogram/case.c:246
+#, fuzzy
+msgid "Array of case images"
+msgstr "Feld von Eingabebildern"
+
+#: libvips/histogram/hist_cum.c:158
+msgid "form cumulative histogram"
+msgstr ""
+
+#: libvips/histogram/hist_entropy.c:107
+msgid "estimate image entropy"
+msgstr ""
+
+#: libvips/histogram/hist_entropy.c:112
+#: libvips/histogram/hist_ismonotonic.c:119
+#, fuzzy
+msgid "Input histogram image"
+msgstr "Eingabebild"
+
+#: libvips/histogram/hist_equal.c:110
+msgid "histogram equalisation"
+msgstr ""
+
+#: libvips/histogram/hist_equal.c:127
+msgid "Equalise with this band"
+msgstr ""
+
+#: libvips/histogram/hist_ismonotonic.c:114
+msgid "test for monotonicity"
+msgstr ""
+
+#: libvips/histogram/hist_ismonotonic.c:124
+msgid "Monotonic"
+msgstr ""
+
+#: libvips/histogram/hist_ismonotonic.c:125
+msgid "true if in is monotonic"
+msgstr ""
+
+#: libvips/histogram/hist_local.c:304 libvips/histogram/stdif.c:236
+#: libvips/morphology/rank.c:491
 msgid "window too large"
 msgstr "Fenster zu groß"
 
-#: libvips/histograms_lut/im_stdif.c:191
-#: libvips/histograms_lut/im_lhisteq.c:164
-msgid "window too small"
-msgstr "Fenster zu klein"
+#: libvips/histogram/hist_local.c:355
+msgid "local histogram equalisation"
+msgstr ""
 
-#: libvips/histograms_lut/im_histnD.c:227
-#, c-format
-msgid " bins out of range [1,%d]"
-msgstr " »bins« außerhalb des Bereichs [1,%d]"
+#: libvips/histogram/hist_local.c:374 libvips/histogram/stdif.c:309
+#: libvips/morphology/rank.c:571
+#, fuzzy
+msgid "Window width in pixels"
+msgstr "Kachelbreite in Bildpunkten"
 
-#: libvips/histograms_lut/im_identity.c:139 libvips/other/im_grey.c:101
-#: libvips/other/im_make_xy.c:95
-msgid "bad size"
-msgstr "falsche Größe"
+#: libvips/histogram/hist_local.c:381 libvips/histogram/stdif.c:316
+#: libvips/morphology/rank.c:578
+#, fuzzy
+msgid "Window height in pixels"
+msgstr "Kachelhöhe in Bildpunkten"
 
-#: libvips/histograms_lut/im_buildlut.c:120
-msgid "x value not an int"
-msgstr "x-Wert keine Ganzzahl"
+#: libvips/histogram/hist_local.c:387
+#, fuzzy
+msgid "Max slope"
+msgstr "Kacheln maximal"
 
-#: libvips/histograms_lut/im_buildlut.c:133
-msgid "x range too small"
-msgstr "x-Bereich zu klein"
+#: libvips/histogram/hist_local.c:388
+msgid "Maximum slope (CLAHE)"
+msgstr ""
 
-#: libvips/histograms_lut/im_buildlut.c:278
-msgid "bad input matrix size"
-msgstr "falsche Eingabematrix-Größe"
+#: libvips/histogram/hist_match.c:154
+msgid "match two histograms"
+msgstr ""
 
-#: libvips/histograms_lut/tone.c:194
-msgid "bad in_max, out_max parameters"
-msgstr "falsche »in_max«-, »out_max«-Parameter"
+#: libvips/histogram/hist_match.c:162
+#, fuzzy
+msgid "Input histogram"
+msgstr "Eingabebild"
 
-#: libvips/histograms_lut/tone.c:199
-msgid "bad Lb, Lw parameters"
-msgstr "falsche »Lb«-, »Lw«-Parameter"
+#: libvips/histogram/hist_match.c:167 libvips/mosaicing/match.c:196
+#: libvips/mosaicing/merge.c:122 libvips/mosaicing/mosaic1.c:498
+#: libvips/mosaicing/mosaic.c:179
+msgid "Reference"
+msgstr ""
 
-#: libvips/histograms_lut/tone.c:204
-msgid "Ps not in range [0.0,1.0]"
-msgstr "»Ps« nicht im Bereich [0.0,1.0]"
+#: libvips/histogram/hist_match.c:168
+msgid "Reference histogram"
+msgstr ""
 
-#: libvips/histograms_lut/tone.c:209
-msgid "Pm not in range [0.0,1.0]"
-msgstr "»Pm« nicht im Bereich [0.0,1.0]"
+#: libvips/histogram/hist_norm.c:137
+msgid "normalise histogram"
+msgstr ""
 
-#: libvips/histograms_lut/tone.c:214
-msgid "Ph not in range [0.0,1.0]"
-msgstr "»Ph« nicht im Bereich [0.0,1.0]"
+#: libvips/histogram/histogram.c:223
+#, fuzzy
+msgid "histogram operations"
+msgstr "binäre Transaktionen"
 
-#: libvips/histograms_lut/tone.c:219
-msgid "S not in range [-30,+30]"
-msgstr "»S« nicht im Bereich [-30,+30]"
+#: libvips/histogram/hist_plot.c:329
+msgid "plot histogram"
+msgstr ""
 
-#: libvips/histograms_lut/tone.c:224
-msgid "M not in range [-30,+30]"
-msgstr "»M« nicht im Bereich [-30,+30]"
+#: libvips/histogram/hist_unary.c:84
+#, fuzzy
+msgid "hist_unary operations"
+msgstr "unäre Transaktionen"
 
-#: libvips/histograms_lut/tone.c:229
-msgid "H not in range [-30,+30]"
-msgstr "»H« nicht im Bereich [-30,+30]"
-
-#: libvips/histograms_lut/im_invertlut.c:132
-msgid "element out of range [0,1]"
-msgstr "Element außerhalb des Bereichs [0,1]"
-
-#: libvips/histograms_lut/im_invertlut.c:287
-msgid "bad input matrix"
-msgstr "falsche Eingabematrix"
-
-#: libvips/histograms_lut/im_invertlut.c:292
-msgid "bad lut_size"
-msgstr "falsche »lut_size«"
-
-#: libvips/histograms_lut/im_maplut.c:97
+#: libvips/histogram/maplut.c:110
 #, c-format
 msgid "%d overflows detected"
 msgstr "%d Überläufe entdeckt"
 
-#: libvips/inplace/im_draw_line.c:389
-msgid "mask image not 1 band 8 bit uncoded"
-msgstr "Maskenbild nicht 8-Bit-kodiert mit einem Band"
-
-#: libvips/inplace/im_draw_line.c:395
-msgid "ink image does not match in image"
-msgstr "»ink«-Bild passt nicht in das Bild"
-
-#: libvips/inplace/im_draw_line.c:399
-msgid "ink image not 1x1 pixels"
-msgstr "»ink«-Bild nicht 1x1 Bildpunkte"
-
-#: libvips/iofuncs/sink.c:105
-#, c-format
-msgid "stop function failed for image \"%s\""
-msgstr "»stop«-Funktion für Bild »%s« fehlgeschlagen"
-
-#: libvips/iofuncs/sink.c:142
-#, c-format
-msgid "start function failed for image \"%s\""
-msgstr "»start«-Funktion für Bild »%s« fehlgeschlagen"
-
-#: libvips/iofuncs/sink.c:175
-msgid "per-thread state for sink"
-msgstr "Status pro Thread für »sink«"
-
-#: libvips/iofuncs/memory.c:295 libvips/iofuncs/memory.c:298
-#, c-format
-msgid "out of memory --- size == %dMB"
-msgstr "Hauptspeicher reicht nicht aus – Größe == %dMB"
-
-#: libvips/iofuncs/vips.c:286
-#, c-format
-msgid "\"%s\" is not a VIPS image"
-msgstr "»%s« ist kein VIPS-Bild"
-
-#: libvips/iofuncs/vips.c:374
-msgid "unable to read history"
-msgstr "Verlauf kann nicht gelesen werden"
-
-#: libvips/iofuncs/vips.c:407
-msgid "more than a 10 megabytes of XML? sufferin' succotash!"
-msgstr "mehr als 10 Megabyte XML? Leidende Succotash!"
-
-#: libvips/iofuncs/vips.c:455
-msgid "incorrect namespace in XML"
-msgstr "falscher Namensraum in XML"
-
-#: libvips/iofuncs/vips.c:579
-msgid "error transforming from save format"
-msgstr "Fehler beim Umwandeln vom gespeicherten Format"
-
-#: libvips/iofuncs/vips.c:680
-#, c-format
-msgid "unable to set property \"%s\" to value \"%s\"."
-msgstr "Eigenschaft »%s« kann nicht auf Wert »%s« gesetzt werden."
-
-#: libvips/iofuncs/vips.c:728
-msgid "error transforming to save format"
-msgstr "Fehler beim Umwandeln in das zu speichernde Format"
-
-#: libvips/iofuncs/vips.c:776 libvips/iofuncs/vips.c:973
-#: libvips/iofuncs/window.c:237
-msgid "file has been truncated"
-msgstr "Datei wurde gekürzt"
-
-#: libvips/iofuncs/vips.c:890 libvips/iofuncs/vips.c:899
-#: libvips/iofuncs/vips.c:922
-msgid "xml save error"
-msgstr "XML-Fehler beim Speichern"
-
-#: libvips/iofuncs/vips.c:959
-#, c-format
-msgid "unable to read header for \"%s\""
-msgstr "Kopfdaten für »%s« können nicht gelesen werden"
-
-#: libvips/iofuncs/vips.c:972 libvips/iofuncs/window.c:236
-#, c-format
-msgid "unable to read data for \"%s\", %s"
-msgstr "Daten für »%s« können nicht gelesen werden, %s"
-
-#: libvips/iofuncs/vips.c:984
-#, c-format
-msgid "error reading XML: %s"
-msgstr "Fehler beim Lesen von XML: %s"
-
-#: libvips/iofuncs/generate.c:606
-msgid "demand hint not set"
-msgstr "Hinweisanfrage nicht gesetzt"
-
-#: libvips/iofuncs/generate.c:625 libvips/iofuncs/generate.c:650
-msgid "generate() called twice"
-msgstr "generate() zweimal aufgerufen"
-
-#: libvips/iofuncs/generate.c:682 libvips/iofuncs/image.c:1873
-#, c-format
-msgid "unable to output to a %s image"
-msgstr "es kann nicht zu einem %s-Bild ausgegeben werden"
-
-#: libvips/iofuncs/region.c:212
-#, c-format
-msgid "start function failed for image %s"
-msgstr "Startfunktion für Bild %s fehlgeschlagen"
-
-#: libvips/iofuncs/region.c:528 libvips/iofuncs/region.c:598
-#: libvips/iofuncs/region.c:745 libvips/iofuncs/region.c:1241
-msgid "valid clipped to nothing"
-msgstr "gültig an nichts angeklammert"
-
-#: libvips/iofuncs/region.c:642
-msgid "bad image type"
-msgstr "falscher Bildtyp"
-
-#: libvips/iofuncs/region.c:687
-msgid "no pixel data on attached image"
-msgstr "keine Bildpunktdaten in angehängtem Bild"
-
-#: libvips/iofuncs/region.c:693
-msgid "images do not match in pixel size"
-msgstr "Bilder passen in der Bildpunktgröße nicht zusammen"
-
-#: libvips/iofuncs/region.c:726 libvips/iofuncs/region.c:1223
-msgid "dest too small"
-msgstr "Ziel zu klein"
-
-#: libvips/iofuncs/region.c:813
-msgid "bad position"
-msgstr "falsche Position"
-
-#: libvips/iofuncs/region.c:1102 libvips/iofuncs/region.c:1294
-#, c-format
-msgid "unable to input from a %s image"
-msgstr "Eingabe von einem %s-Bild nicht möglich"
-
-#: libvips/iofuncs/region.c:1126
-msgid "incomplete header"
-msgstr "unvollständige Kopfzeilen"
-
-#: libvips/iofuncs/region.c:1197
-msgid "inappropriate region type"
-msgstr "Ungeeigneter Regionstyp"
-
-#: libvips/iofuncs/init.c:366
-msgid "evaluate with N concurrent threads"
-msgstr "mit N gleichzeitigen Threads auswerten"
-
-#: libvips/iofuncs/init.c:369
-msgid "set tile width to N (DEBUG)"
-msgstr "Bildbreite auf N setzen (DEBUG)"
-
-#: libvips/iofuncs/init.c:372
-msgid "set tile height to N (DEBUG)"
-msgstr "Bildhöhe auf N setzen (DEBUG)"
-
-#: libvips/iofuncs/init.c:375
-msgid "set thinstrip height to N (DEBUG)"
-msgstr "»thinstrip«-Höhe auf N setzen (DEBUG)"
-
-#: libvips/iofuncs/init.c:378
-msgid "set fatstrip height to N (DEBUG)"
-msgstr "»fatstrip«-Höhe auf N setzen (DEBUG)"
-
-#: libvips/iofuncs/init.c:381
-msgid "show progress feedback"
-msgstr "Fortschrittsrückmeldung anzeigen"
-
-#: libvips/iofuncs/init.c:384
-msgid "leak-check on exit"
-msgstr "Lückenprüfung beim Beenden"
-
-#: libvips/iofuncs/init.c:387
-msgid "images larger than N are decompressed to disc"
-msgstr "Bilder, die größer als N sind, werden auf die Platte dekomprimiert"
-
-#: libvips/iofuncs/init.c:390
-msgid "disable vectorised versions of operations"
-msgstr "vektorgesteuerte Versionen von Transaktionen deaktivieren"
-
-#: libvips/iofuncs/init.c:393
-msgid "cache at most N operations"
-msgstr "höchstens N Transaktionen zwischenspeichern"
-
-#: libvips/iofuncs/init.c:396
-msgid "cache at most N bytes in memory"
-msgstr "höchstens N Byte zwischenspeichern"
-
-#: libvips/iofuncs/init.c:399
-msgid "allow at most N open files"
-msgstr "höchstens N offene Dateien erlauben"
-
-#: libvips/iofuncs/init.c:402
-msgid "trace operation cache"
-msgstr "Transaktionszwischenspeicher aufzeichnen"
-
-#: libvips/iofuncs/init.c:405
-msgid "dump operation cache on exit"
-msgstr "Transaktionszwischenspeicher beim Beenden ausgeben"
-
-#: libvips/iofuncs/init.c:428
-msgid "VIPS Options"
-msgstr "VIPS-Optionen"
-
-#: libvips/iofuncs/init.c:428
-msgid "Show VIPS options"
-msgstr "VIPS-Optionen anzeigen"
-
-#: libvips/iofuncs/image.c:293
-msgid "unable to close fd"
-msgstr "»fd« kann nicht geschlossen werden"
-
-#: libvips/iofuncs/image.c:373
-#, c-format
-msgid "%dx%d %s, %d band, %s"
-msgid_plural "%dx%d %s, %d bands, %s"
-msgstr[0] "%dx%d %s, %d Band, %s"
-msgstr[1] "%dx%d %s, %d Bänder, %s"
-
-#: libvips/iofuncs/image.c:403
-#, c-format
-msgid " %s, %d band, %s"
-msgid_plural " %s, %d bands, %s"
-msgstr[0] " %s, %d band, %s"
-msgstr[1] " %s, %d Bänder, %s"
-
-#: libvips/iofuncs/image.c:529
-#, c-format
-msgid "%s %s: %d threads, %d x %d tiles, groups of %d scanlines"
-msgstr "%s %s: %d Threads, %d x %d Kacheln, Gruppen von %d Scan-Zeilen"
-
-#: libvips/iofuncs/image.c:542
-#, c-format
-msgid "%s %s: %d%% complete"
-msgstr "%s %s: %d%% komplett"
-
-#. Spaces at end help to erase the %complete message we overwrite.
-#.
-#: libvips/iofuncs/image.c:559
-#, c-format
-msgid "%s %s: done in %ds          \n"
-msgstr "%s %s: Erledigt in %ds      \n"
-
-#: libvips/iofuncs/image.c:738
-#, c-format
-msgid "unable to open \"%s\", file too short"
-msgstr "»%s« kann nicht geöffnet werden, Datei zu klein"
-
-#: libvips/iofuncs/image.c:748
-#, c-format
-msgid "%s is longer than expected"
-msgstr "%s ist länger als erwartet"
-
-#: libvips/iofuncs/image.c:765
-#, c-format
-msgid "bad mode \"%s\""
-msgstr "falscher Modus »%s«"
-
-#: libvips/iofuncs/image.c:820
-msgid "image class"
-msgstr "Bildklasse"
-
-#: libvips/iofuncs/image.c:916
-msgid "Image filename"
-msgstr "Bilddateiname"
-
-#: libvips/iofuncs/image.c:922
-msgid "Mode"
-msgstr "Modus"
-
-#: libvips/iofuncs/image.c:923
-msgid "Open mode"
-msgstr "Öffnen-Modus"
-
-#: libvips/iofuncs/image.c:929
-msgid "Kill"
-msgstr "töten"
-
-#: libvips/iofuncs/image.c:930
-msgid "Block evaluation on this image"
-msgstr "Blockauswertung dieses Bildes"
-
-#: libvips/iofuncs/image.c:936
-msgid "Demand style"
-msgstr "Nachfragestil"
-
-#: libvips/iofuncs/image.c:937
-msgid "Preferred demand style for this image"
-msgstr "für dieses Bild bevorzugter Nachfragestil"
-
-#: libvips/iofuncs/image.c:950
-msgid "Foreign buffer"
-msgstr "Fremdpuffer"
-
-#: libvips/iofuncs/image.c:951
-msgid "Pointer to foreign pixels"
-msgstr "Puffer für fremde Bildpunkte"
-
-#: libvips/iofuncs/image.c:1215
-#, c-format
-msgid "killed for image \"%s\""
-msgstr "für Bild »%s« abgeschossen"
-
-#: libvips/iofuncs/image.c:1815
-msgid "bad image descriptor"
-msgstr "falscher Bild-Deskriptor"
-
-#: libvips/iofuncs/image.c:1917
-#, c-format
-msgid "auto-rewind for %s failed"
-msgstr "automatischer Rücklauf für %s fehlgeschlagen"
-
-#: libvips/iofuncs/image.c:1973 libvips/iofuncs/image.c:2168
-#: libvips/iofuncs/image.c:2185
-msgid "no image data"
-msgstr "keine Bilddaten"
-
-#: libvips/iofuncs/image.c:2041 libvips/iofuncs/image.c:2208
-msgid "image not readable"
-msgstr "Bild nicht lesbar"
-
-#: libvips/iofuncs/image.c:2062 libvips/iofuncs/image.c:2238
-#: libvips/iofuncs/image.c:2247
-msgid "image already written"
-msgstr "Bild bereits geschrieben"
-
-#: libvips/iofuncs/image.c:2086 libvips/iofuncs/image.c:2259
-msgid "image not writeable"
-msgstr "Bild nicht schreibbar"
-
-#: libvips/iofuncs/image.c:2132
-msgid "bad file type"
-msgstr "falscher Dateityp"
-
-#: libvips/iofuncs/sinkscreen.c:185
-msgid "per-thread state for render"
-msgstr "Status pro Thread für »render«"
-
-#: libvips/iofuncs/sinkscreen.c:537 libvips/iofuncs/sinkdisc.c:236
-#: libvips/iofuncs/threadpool.c:606
-msgid "unable to create thread"
-msgstr "Thread kann nicht erstellt werden"
-
-#: libvips/iofuncs/mapfile.c:130 libvips/iofuncs/mapfile.c:297
-msgid "unable to CreateFileMapping"
-msgstr "»CreateFileMapping« nicht möglich"
-
-#: libvips/iofuncs/mapfile.c:138 libvips/iofuncs/mapfile.c:309
-msgid "unable to MapViewOfFile"
-msgstr "»MapViewOfFile« nicht möglich"
-
-#: libvips/iofuncs/mapfile.c:178
-msgid "unable to mmap"
-msgstr "»mmap« nicht möglich"
-
-#: libvips/iofuncs/mapfile.c:179
-#, c-format
-msgid ""
-"map failed (%s), running very low on system resources, expect a crash soon"
+#: libvips/histogram/maplut.c:738
+msgid "map an image though a lut"
 msgstr ""
-"»map« fehlgeschlagen (%s), die Systemressourcen werden knapp, ein Absturz "
-"steht bevor"
 
-#: libvips/iofuncs/mapfile.c:196 libvips/iofuncs/mapfile.c:303
-msgid "unable to UnmapViewOfFile"
-msgstr "»UnmapViewOfFile« nicht möglich"
+#: libvips/histogram/maplut.c:756
+msgid "LUT"
+msgstr ""
 
-#: libvips/iofuncs/mapfile.c:202
-msgid "unable to munmap file"
-msgstr "»munmap« der Datei nicht möglich"
+#: libvips/histogram/maplut.c:757
+#, fuzzy
+msgid "Look-up table image"
+msgstr "ein Bild kopieren"
 
-#: libvips/iofuncs/mapfile.c:224
-msgid "file is less than 64 bytes"
-msgstr "Datei ist weniger als 64 Byte groß"
+#: libvips/histogram/maplut.c:763
+msgid "Apply one-band lut to this band of in"
+msgstr ""
 
-#: libvips/iofuncs/mapfile.c:229 libvips/iofuncs/mapfile.c:263
-msgid "unable to get file status"
-msgstr "Dateistatus kann nicht abgefragt werden"
+#: libvips/histogram/percent.c:105
+msgid "find threshold for percent of pixels"
+msgstr ""
 
-#: libvips/iofuncs/mapfile.c:235
-msgid "not a regular file"
-msgstr "keine reguläre Datei"
+#: libvips/histogram/percent.c:115
+msgid "Percent"
+msgstr ""
 
-#: libvips/iofuncs/mapfile.c:269
-msgid "unable to read data"
-msgstr "Daten können nicht gelesen werden"
+#: libvips/histogram/percent.c:116
+#, fuzzy
+msgid "Percent of pixels"
+msgstr "Einheitsvektor von Bildpunkten"
 
-#: libvips/iofuncs/mapfile.c:329
-#, c-format
-msgid "unable to mmap: \"%s\" - %s"
-msgstr "»mmap« nicht möglich: \"%s\" - %s"
+#: libvips/histogram/percent.c:123
+msgid "Threshold above which lie percent of pixels"
+msgstr ""
 
-#: libvips/iofuncs/mapfile.c:339
-#, c-format
-msgid "unable to mmap \"%s\" to same address"
-msgstr "»mmap %s« zur gleichen Adresse nicht möglich"
-
-#: libvips/iofuncs/base64.c:170
-msgid "too little data"
-msgstr "zu wenige Daten"
-
-#: libvips/iofuncs/object.c:148
-#, c-format
-msgid "parameter %s not set"
-msgstr "Parameter %s nicht gesetzt"
-
-#: libvips/iofuncs/object.c:505
-#, c-format
-msgid "no property named `%s'"
-msgstr "keine Eigenschaft namens »%s«"
-
-#: libvips/iofuncs/object.c:513
-#, c-format
-msgid "no vips argument named `%s'"
-msgstr "kein VIPS-Argument namens »%s«"
-
-#: libvips/iofuncs/object.c:520
-#, c-format
-msgid "argument `%s' has no instance"
-msgstr "Argument »%s« hat keine Instanz"
-
-#: libvips/iofuncs/object.c:1248 libvips/iofuncs/operation.c:287
-#: libvips/resample/interpolate.c:615
-#, c-format
-msgid "class \"%s\" not found"
-msgstr "Klasse »%s« nicht gefunden"
-
-#: libvips/iofuncs/object.c:1297
-msgid "base class"
-msgstr "Basisklasse"
-
-#: libvips/iofuncs/object.c:1311
-msgid "Nickname"
-msgstr "Nickname"
-
-#: libvips/iofuncs/object.c:1312
-msgid "Class nickname"
-msgstr "Klassen-Nickname"
-
-#: libvips/iofuncs/object.c:1318
-msgid "Description"
-msgstr "Beschreibung"
-
-#: libvips/iofuncs/object.c:1319
-msgid "Class description"
-msgstr "Klassenbeschreibung"
-
-#: libvips/iofuncs/object.c:1509
-#, c-format
-msgid "enum '%s' has no member '%s'"
-msgstr "Aufzählung »%s« hat keinen Bestandteil »%s«"
-
-#: libvips/iofuncs/object.c:1769
-#, c-format
-msgid "unable to set '%s'"
-msgstr "»%s« kann nicht gesetzt werden"
-
-#: libvips/iofuncs/object.c:1777
-msgid "not , or ) after parameter"
-msgstr "kein »,« oder »)« nach Parameter"
-
-#: libvips/iofuncs/object.c:1784
-msgid "extra tokens after ')'"
-msgstr "keine zusätzlichen Token nach »)«"
-
-#. File length unit.
-#.
-#: libvips/iofuncs/buf.c:520
-msgid "bytes"
-msgstr "Byte"
-
-#. Kilo byte unit.
-#.
-#: libvips/iofuncs/buf.c:524
-msgid "KB"
-msgstr "KB"
-
-#. Mega byte unit.
-#.
-#: libvips/iofuncs/buf.c:528
-msgid "MB"
-msgstr "MB"
-
-#. Giga byte unit.
-#.
-#: libvips/iofuncs/buf.c:532
-msgid "GB"
-msgstr "GB"
-
-#. Tera byte unit.
-#.
-#: libvips/iofuncs/buf.c:536
-msgid "TB"
-msgstr "TB"
-
-#: libvips/iofuncs/util.c:639
-msgid "unable to get file stats"
-msgstr "Dateistatus kann nicht abgefragt werden"
-
-#: libvips/iofuncs/util.c:656 libvips/iofuncs/sinkdisc.c:262
-msgid "write failed"
-msgstr "Schreiben fehlgeschlagen"
-
-#: libvips/iofuncs/util.c:720
-#, c-format
-msgid "unable to open file \"%s\" for reading"
-msgstr "Datei »%s« kann nicht zum Lesen geöffnet werden"
-
-#: libvips/iofuncs/util.c:742
-#, c-format
-msgid "unable to open file \"%s\" for writing"
-msgstr "Datei »%s« kann nicht zum Schreiben geöffnet werden"
-
-#: libvips/iofuncs/util.c:767
-#, c-format
-msgid "\"%s\" too long"
-msgstr "»%s« zu lang"
-
-#: libvips/iofuncs/util.c:784
-msgid "out of memory"
-msgstr "Hauptspeicher reicht nicht aus"
-
-#: libvips/iofuncs/util.c:810
-#, c-format
-msgid "error reading from file \"%s\""
-msgstr "Fehler beim Lesen von Datei »%s«"
-
-#: libvips/iofuncs/util.c:857
-#, c-format
-msgid "write error (%zd out of %zd blocks written) ... disc full?"
-msgstr "Schreibfehler (%zd aus %zd Blöcken geschrieben) … Platte voll?"
-
-#: libvips/iofuncs/util.c:1106 libvips/iofuncs/util.c:1113
-msgid "unable to truncate"
-msgstr "kann nicht gekürzt werden"
-
-#: libvips/iofuncs/util.c:1297
-msgid "unexpected end of string"
-msgstr "Unerwartetes Ende der Zeichenkette"
-
-#: libvips/iofuncs/util.c:1315
-#, c-format
-msgid "expected %s, saw %s"
-msgstr "%s erwartet, %s gesehen"
-
-#: libvips/iofuncs/util.c:1485
-#, c-format
-msgid "unable to make temporary file %s"
-msgstr "temporäre Datei %s kann nicht erstellt werden"
-
-#: libvips/iofuncs/operation.c:97
-msgid "input"
-msgstr "Eingabe"
-
-#: libvips/iofuncs/operation.c:97
-msgid "output"
-msgstr "Ausgabe"
-
-#: libvips/iofuncs/operation.c:246
-msgid "operations"
-msgstr "Transaktionen"
-
-#: libvips/iofuncs/operation.c:273
-msgid "usage:"
-msgstr "Aufruf:"
-
-#: libvips/iofuncs/operation.c:699
-#, c-format
-msgid "unknown argument '%s'"
-msgstr "unbekanntes Argument »%s«"
-
-#: libvips/iofuncs/operation.c:810
-msgid "too few arguments"
-msgstr "zu wenige Argumente"
-
-#: libvips/iofuncs/operation.c:931
-msgid "too many arguments"
+#: libvips/histogram/stdif.c:240
+#, fuzzy
+msgid "too many bands"
 msgstr "zu viele Argumente"
 
-#: libvips/iofuncs/header.c:210
+#: libvips/histogram/stdif.c:290
+msgid "statistical difference"
+msgstr ""
+
+#: libvips/histogram/stdif.c:322
+#, fuzzy
+msgid "Mean weight"
+msgstr "Kachelhöhe"
+
+#: libvips/histogram/stdif.c:323
+#, fuzzy
+msgid "Weight of new mean"
+msgstr "Höhe des extrahierten Bereichs"
+
+#: libvips/histogram/stdif.c:330
+msgid "New mean"
+msgstr ""
+
+#: libvips/histogram/stdif.c:336
+msgid "Deviation weight"
+msgstr ""
+
+#: libvips/histogram/stdif.c:337
+msgid "Weight of new deviation"
+msgstr ""
+
+#: libvips/histogram/stdif.c:343
+#, fuzzy
+msgid "Deviation"
+msgstr "Beschreibung"
+
+#: libvips/histogram/stdif.c:344
+msgid "New deviation"
+msgstr ""
+
+#: libvips/iofuncs/buf.c:609
 #, c-format
-msgid "unknown band format %d"
-msgstr "unbekanntes Bandformat %d"
+msgid "%zd bytes of binary data"
+msgstr ""
 
-#: libvips/iofuncs/header.c:781
-#, c-format
-msgid "field \"%s\" not found"
-msgstr "Feld »%s« nicht gefunden"
+#: libvips/iofuncs/connection.c:126
+#, fuzzy
+msgid "Descriptor"
+msgstr "Beschreibung"
 
-#: libvips/iofuncs/header.c:949
-#, c-format
-msgid "field \"%s\" is of type %s, not %s"
-msgstr "Feld »%s« ist vom Typ %s, nicht %s"
+#: libvips/iofuncs/connection.c:127
+#, fuzzy
+msgid "File descriptor for read or write"
+msgstr "Datei-Deskriptor, in den geschrieben werden soll"
 
-#: libvips/iofuncs/sinkmemory.c:108
-msgid "per-thread state for sinkmemory"
-msgstr "Status pro Thread für »sinkmemory«"
+#: libvips/iofuncs/connection.c:134
+#, fuzzy
+msgid "Name of file to open"
+msgstr "falscher Dateityp"
 
-#: libvips/iofuncs/sinkdisc.c:121
-msgid "per-thread state for sinkdisc"
-msgstr "Status pro Thread für »sinkdisc«"
+#: libvips/iofuncs/error.c:296
+#, fuzzy
+msgid "system error"
+msgstr "Lesefehler"
 
-#: libvips/iofuncs/error.c:210
-msgid "windows error"
-msgstr "Windows-Fehler"
-
-#: libvips/iofuncs/error.c:219
-msgid "unix error"
-msgstr "Unix-Fehler"
-
-#: libvips/iofuncs/error.c:304 libvips/iofuncs/error.c:305
-#: libvips/iofuncs/error.c:354 libvips/iofuncs/error.c:355
-#, c-format
-msgid "%s: "
-msgstr "%s: "
-
-#: libvips/iofuncs/error.c:304
-msgid "vips diagnostic"
-msgstr "Vips-Diagnose"
-
-#: libvips/iofuncs/error.c:354
-msgid "vips warning"
-msgstr "Vips-Warnung"
-
-#: libvips/iofuncs/error.c:438
+#: libvips/iofuncs/error.c:443
 msgid "image must be uncoded"
 msgstr "Bild muss unkodiert sein"
 
-#: libvips/iofuncs/error.c:466
-msgid "image coding must be NONE or LABQ"
+#: libvips/iofuncs/error.c:471
+#, fuzzy
+msgid "image coding must be 'none' or 'labq'"
 msgstr "Bildkodierung muss NONE oder LABQ sein"
 
-#: libvips/iofuncs/error.c:494
+#: libvips/iofuncs/error.c:499
 msgid "unknown image coding"
 msgstr "unbekannte Bildkodierung"
 
-#: libvips/iofuncs/error.c:520
-msgid "Radiance coding only"
-msgstr "Nur Radiance-Kodierung"
-
-#: libvips/iofuncs/error.c:546
-msgid "LABQ coding only"
+#: libvips/iofuncs/error.c:524
+#, fuzzy, c-format
+msgid "coding '%s' only"
 msgstr "Nur LABQ-Kodierung"
 
-#: libvips/iofuncs/error.c:570
+#: libvips/iofuncs/error.c:549
 msgid "image must one band"
 msgstr "Bild muss ein Band haben"
 
-#: libvips/iofuncs/error.c:595
+#: libvips/iofuncs/error.c:574
 #, c-format
 msgid "image must have %d bands"
 msgstr "Bild muss %d Bänder haben"
 
-#: libvips/iofuncs/error.c:620
+#: libvips/iofuncs/error.c:599
 msgid "image must have one or three bands"
 msgstr "Bild muss ein oder drei Bänder haben"
 
-#: libvips/iofuncs/error.c:648
+#: libvips/iofuncs/error.c:625
+#, fuzzy, c-format
+msgid "image must have at least %d bands"
+msgstr "Bild muss %d Bänder haben"
+
+#: libvips/iofuncs/error.c:653
 msgid "images must have the same number of bands, or one must be single-band"
 msgstr ""
 "Bilder müssen die gleiche Anzahl Bänder haben oder eines muss ein Band haben"
 
-#: libvips/iofuncs/error.c:675
+#: libvips/iofuncs/error.c:680
 #, c-format
 msgid "image must have 1 or %d bands"
 msgstr "Bild muss ein oder %d Bänder haben"
 
-#: libvips/iofuncs/error.c:699
+#: libvips/iofuncs/error.c:704
 msgid "image must be non-complex"
 msgstr "Bild muss nicht-komplex sein"
 
-#: libvips/iofuncs/error.c:723
+#: libvips/iofuncs/error.c:728
 msgid "image must be complex"
 msgstr "Bild muss komplex sein"
 
-#: libvips/iofuncs/error.c:749
+#: libvips/iofuncs/error.c:755
+#, fuzzy
+msgid "image must be two-band or complex"
+msgstr "Bild muss nicht-komplex sein"
+
+#: libvips/iofuncs/error.c:781
 #, c-format
 msgid "image must be %s"
 msgstr "Bild muss %s sein"
 
-#: libvips/iofuncs/error.c:774
+#: libvips/iofuncs/error.c:806
 msgid "image must be integer"
 msgstr "Bild muss ganzzahlig sein"
 
-#: libvips/iofuncs/error.c:799
+#: libvips/iofuncs/error.c:831
 msgid "image must be unsigned integer"
 msgstr "Bild muss aus vorzeichenlosen Ganzzahlen bestehen"
 
-#: libvips/iofuncs/error.c:827
+#: libvips/iofuncs/error.c:859
 msgid "image must be 8- or 16-bit integer, signed or unsigned"
 msgstr ""
 "Bild muss aus 8- oder 16-Bit Ganzzahlen mit oder ohne Vorzeichen bestehen"
 
-#: libvips/iofuncs/error.c:854
+#: libvips/iofuncs/error.c:885
 msgid "image must be 8- or 16-bit unsigned integer"
 msgstr "Bild muss aus 8- oder 16-Bit vorzeichenlosen Ganzzahlen bestehen"
 
-#: libvips/iofuncs/error.c:880
+#: libvips/iofuncs/error.c:911
 msgid "image must be 8- or 16-bit unsigned integer, or float"
 msgstr ""
 "Bild muss aus 8- oder 16-Bit vorzeichenlosen Ganzzahlen oder "
 "Fließkommazahlen bestehen"
 
-#: libvips/iofuncs/error.c:908
+#: libvips/iofuncs/error.c:938
 msgid "image must be unsigned int or float"
 msgstr ""
 "Bild muss aus 8- oder 16-Bit vorzeichenlosen Ganz- oder Fließkommazahlen "
 "bestehen"
 
-#: libvips/iofuncs/error.c:933
+#: libvips/iofuncs/error.c:964
 msgid "images must match in size"
 msgstr "Bilder müssen in der Größe passen"
 
-#: libvips/iofuncs/error.c:959
+#: libvips/iofuncs/error.c:990
+#, fuzzy
+msgid "images must be odd and square"
+msgstr "Bild muss %d Bänder haben"
+
+#: libvips/iofuncs/error.c:1016
 msgid "images must have the same number of bands"
 msgstr "Bilder müssen die gleiche Anzahl Bänder haben"
 
-#: libvips/iofuncs/error.c:1013
+#: libvips/iofuncs/error.c:1070
 msgid "images must have the same band format"
 msgstr "Bilder müssen das gleiche Bandformat haben"
 
-#: libvips/iofuncs/error.c:1039
+#: libvips/iofuncs/error.c:1096
 msgid "images must have the same coding"
 msgstr "Bilder müssen die gleiche Kodierung haben"
 
-#: libvips/iofuncs/error.c:1064
+#: libvips/iofuncs/error.c:1119
+#, fuzzy, c-format
+msgid "vector must have %d elements"
+msgstr "Vektor muss 1 oder %d Elemente haben"
+
+#: libvips/iofuncs/error.c:1155
+#, fuzzy
+msgid "vector must have 1 element"
+msgstr "Vektor muss 1 oder %d Elemente haben"
+
+#: libvips/iofuncs/error.c:1158
 #, c-format
 msgid "vector must have 1 or %d elements"
 msgstr "Vektor muss 1 oder %d Elemente haben"
 
-#: libvips/iofuncs/error.c:1089
+#: libvips/iofuncs/error.c:1183
 msgid "histograms must have width or height 1"
 msgstr "Histogramme müssen eine Breite oder Höhe von eins haben"
 
-#: libvips/iofuncs/error.c:1094
+#: libvips/iofuncs/error.c:1188
 msgid "histograms must have not have more than 65536 elements"
 msgstr "Histogramm dürfen nicht mehr als 65536 Elemente haben"
 
-#: libvips/iofuncs/error.c:1123 libvips/iofuncs/error.c:1151
-msgid "nonsense mask parameters"
-msgstr "unsinnige Maskenparameter"
+#: libvips/iofuncs/error.c:1224
+#, fuzzy
+msgid "matrix image too large"
+msgstr "Zoomfaktoren zu groß"
 
-#: libvips/iofuncs/error.c:1176
-msgid "mask must be 1D"
-msgstr "Maske muss 1D sein"
+#: libvips/iofuncs/error.c:1229
+#, fuzzy
+msgid "matrix image must have one band"
+msgstr "Bild muss %d Bänder haben"
 
-#: libvips/iofuncs/threadpool.c:217
+#: libvips/iofuncs/error.c:1263
+#, fuzzy
+msgid "separable matrix images must have width or height 1"
+msgstr "Histogramme müssen eine Breite oder Höhe von eins haben"
+
+#: libvips/iofuncs/error.c:1289
+#, fuzzy
+msgid "precision must be int or float"
+msgstr ""
+"Bild muss aus 8- oder 16-Bit vorzeichenlosen Ganz- oder Fließkommazahlen "
+"bestehen"
+
+#: libvips/iofuncs/generate.c:696
+msgid "demand hint not set"
+msgstr "Hinweisanfrage nicht gesetzt"
+
+#: libvips/iofuncs/generate.c:715 libvips/iofuncs/generate.c:743
+msgid "generate() called twice"
+msgstr "generate() zweimal aufgerufen"
+
+#: libvips/iofuncs/generate.c:784 libvips/iofuncs/image.c:3235
+#, c-format
+msgid "unable to output to a %s image"
+msgstr "es kann nicht zu einem %s-Bild ausgegeben werden"
+
+#: libvips/iofuncs/ginputsource.c:164 libvips/iofuncs/ginputsource.c:229
+#, c-format
+msgid "Error while seeking: %s"
+msgstr ""
+
+#: libvips/iofuncs/ginputsource.c:185
+msgid "Cannot truncate VipsGInputStream"
+msgstr ""
+
+#: libvips/iofuncs/ginputsource.c:206
+#, fuzzy, c-format
+msgid "Error while reading: %s"
+msgstr "Fehler beim Lesen von XML: %s"
+
+#: libvips/iofuncs/ginputsource.c:275
+msgid "Stream to wrap"
+msgstr ""
+
+#: libvips/iofuncs/header.c:1380
+#, c-format
+msgid "field \"%s\" not found"
+msgstr "Feld »%s« nicht gefunden"
+
+#: libvips/iofuncs/header.c:1614
+#, c-format
+msgid "field \"%s\" is of type %s, not %s"
+msgstr "Feld »%s« ist vom Typ %s, nicht %s"
+
+#: libvips/iofuncs/header.c:1888
+#, fuzzy, c-format
+msgid "field \"%s\" is of type %s, not VipsRefString"
+msgstr "Feld »%s« ist vom Typ %s, nicht %s"
+
+#: libvips/iofuncs/image.c:539
+msgid "unable to close fd"
+msgstr "»fd« kann nicht geschlossen werden"
+
+#: libvips/iofuncs/image.c:762
+#, fuzzy, c-format
+msgid "%s %s: %d x %d pixels, %d threads, %d x %d tiles, %d lines in buffer"
+msgstr "%s %s: %d Threads, %d x %d Kacheln, Gruppen von %d Scan-Zeilen"
+
+#: libvips/iofuncs/image.c:775
+#, c-format
+msgid "%s %s: %d%% complete"
+msgstr "%s %s: %d%% komplett"
+
+#: libvips/iofuncs/image.c:794
+#, fuzzy, c-format
+msgid "%s %s: done in %.3gs          \n"
+msgstr "%s %s: Erledigt in %ds      \n"
+
+#: libvips/iofuncs/image.c:976
+#, c-format
+msgid "unable to open \"%s\", file too short"
+msgstr "»%s« kann nicht geöffnet werden, Datei zu klein"
+
+#: libvips/iofuncs/image.c:985
+#, c-format
+msgid "%s is longer than expected"
+msgstr "%s ist länger als erwartet"
+
+#: libvips/iofuncs/image.c:1003
+#, c-format
+msgid "bad mode \"%s\""
+msgstr "falscher Modus »%s«"
+
+#: libvips/iofuncs/image.c:1075
+msgid "image class"
+msgstr "Bildklasse"
+
+#: libvips/iofuncs/image.c:1173
+msgid "Image filename"
+msgstr "Bilddateiname"
+
+#: libvips/iofuncs/image.c:1180
+msgid "Open mode"
+msgstr "Öffnen-Modus"
+
+#: libvips/iofuncs/image.c:1186
+msgid "Kill"
+msgstr "töten"
+
+#: libvips/iofuncs/image.c:1187
+msgid "Block evaluation on this image"
+msgstr "Blockauswertung dieses Bildes"
+
+#: libvips/iofuncs/image.c:1193
+msgid "Demand style"
+msgstr "Nachfragestil"
+
+#: libvips/iofuncs/image.c:1194
+msgid "Preferred demand style for this image"
+msgstr "für dieses Bild bevorzugter Nachfragestil"
+
+#: libvips/iofuncs/image.c:1207
+msgid "Foreign buffer"
+msgstr "Fremdpuffer"
+
+#: libvips/iofuncs/image.c:1208
+msgid "Pointer to foreign pixels"
+msgstr "Puffer für fremde Bildpunkte"
+
+#: libvips/iofuncs/image.c:1660
+#, c-format
+msgid "killed for image \"%s\""
+msgstr "für Bild »%s« abgeschossen"
+
+#: libvips/iofuncs/image.c:2069
+msgid "memory area too small --- should be %"
+msgstr ""
+
+#: libvips/iofuncs/image.c:2258
+#, fuzzy
+msgid "unable to load source"
+msgstr "Verlauf kann nicht gelesen werden"
+
+#: libvips/iofuncs/image.c:2369
+#, c-format
+msgid "bad array length --- should be %d, you passed %d"
+msgstr ""
+
+#: libvips/iofuncs/image.c:2886 libvips/iofuncs/image.c:2888
+#: libvips/iofuncs/memory.c:336 libvips/iofuncs/memory.c:338
+#: libvips/iofuncs/memory.c:409 libvips/iofuncs/memory.c:411
+#, c-format
+msgid "out of memory --- size == %dMB"
+msgstr "Hauptspeicher reicht nicht aus – Größe == %dMB"
+
+#: libvips/iofuncs/image.c:3179
+msgid "bad image descriptor"
+msgstr "falscher Bild-Deskriptor"
+
+#: libvips/iofuncs/image.c:3298
+#, c-format
+msgid "auto-rewind for %s failed"
+msgstr "automatischer Rücklauf für %s fehlgeschlagen"
+
+#: libvips/iofuncs/image.c:3372 libvips/iofuncs/image.c:3502
+#: libvips/iofuncs/image.c:3679
+msgid "image not readable"
+msgstr "Bild nicht lesbar"
+
+#: libvips/iofuncs/image.c:3417 libvips/iofuncs/image.c:3643
+msgid "no image data"
+msgstr "keine Bilddaten"
+
+#: libvips/iofuncs/image.c:3523 libvips/iofuncs/image.c:3709
+#: libvips/iofuncs/image.c:3718
+msgid "image already written"
+msgstr "Bild bereits geschrieben"
+
+#: libvips/iofuncs/image.c:3547 libvips/iofuncs/image.c:3730
+msgid "image not writeable"
+msgstr "Bild nicht schreibbar"
+
+#: libvips/iofuncs/image.c:3602
+msgid "bad file type"
+msgstr "falscher Dateityp"
+
+#: libvips/iofuncs/init.c:316 tools/vips.c:772
+#, fuzzy, c-format
+msgid "unable to load \"%s\" -- %s"
+msgstr "»mmap« nicht möglich: \"%s\" - %s"
+
+#: libvips/iofuncs/init.c:1270
+#, fuzzy
+msgid "flag not in [0, 5]"
+msgstr "Schalter nicht -1 oder 1"
+
+#: libvips/iofuncs/mapfile.c:189 libvips/iofuncs/mapfile.c:355
+msgid "unable to CreateFileMapping"
+msgstr "»CreateFileMapping« nicht möglich"
+
+#: libvips/iofuncs/mapfile.c:196 libvips/iofuncs/mapfile.c:367
+msgid "unable to MapViewOfFile"
+msgstr "»MapViewOfFile« nicht möglich"
+
+#: libvips/iofuncs/mapfile.c:235
+msgid "unable to mmap"
+msgstr "»mmap« nicht möglich"
+
+#: libvips/iofuncs/mapfile.c:250 libvips/iofuncs/mapfile.c:361
+msgid "unable to UnmapViewOfFile"
+msgstr "»UnmapViewOfFile« nicht möglich"
+
+#: libvips/iofuncs/mapfile.c:256
+msgid "unable to munmap file"
+msgstr "»munmap« der Datei nicht möglich"
+
+#: libvips/iofuncs/mapfile.c:278
+msgid "file is less than 64 bytes"
+msgstr "Datei ist weniger als 64 Byte groß"
+
+#: libvips/iofuncs/mapfile.c:283 libvips/iofuncs/mapfile.c:317
+msgid "unable to get file status"
+msgstr "Dateistatus kann nicht abgefragt werden"
+
+#: libvips/iofuncs/mapfile.c:289
+msgid "not a regular file"
+msgstr "keine reguläre Datei"
+
+#: libvips/iofuncs/mapfile.c:323
+msgid "unable to read data"
+msgstr "Daten können nicht gelesen werden"
+
+#: libvips/iofuncs/mapfile.c:387
+#, c-format
+msgid "unable to mmap: \"%s\" - %s"
+msgstr "»mmap« nicht möglich: \"%s\" - %s"
+
+#: libvips/iofuncs/mapfile.c:398
+#, c-format
+msgid "unable to mmap \"%s\" to same address"
+msgstr "»mmap %s« zur gleichen Adresse nicht möglich"
+
+#: libvips/iofuncs/object.c:346
+#, c-format
+msgid "parameter %s not set"
+msgstr "Parameter %s nicht gesetzt"
+
+#: libvips/iofuncs/object.c:781
+#, c-format
+msgid "no property named `%s'"
+msgstr "keine Eigenschaft namens »%s«"
+
+#: libvips/iofuncs/object.c:787
+#, c-format
+msgid "no vips argument named `%s'"
+msgstr "kein VIPS-Argument namens »%s«"
+
+#: libvips/iofuncs/object.c:793
+#, c-format
+msgid "argument `%s' has no instance"
+msgstr "Argument »%s« hat keine Instanz"
+
+#: libvips/iofuncs/object.c:1533 libvips/iofuncs/operation.c:749
+#: libvips/resample/interpolate.c:659
+#, c-format
+msgid "class \"%s\" not found"
+msgstr "Klasse »%s« nicht gefunden"
+
+#: libvips/iofuncs/object.c:1584
+msgid "base class"
+msgstr "Basisklasse"
+
+#: libvips/iofuncs/object.c:1598
+msgid "Nickname"
+msgstr "Nickname"
+
+#: libvips/iofuncs/object.c:1599
+msgid "Class nickname"
+msgstr "Klassen-Nickname"
+
+#: libvips/iofuncs/object.c:1605
+msgid "Description"
+msgstr "Beschreibung"
+
+#: libvips/iofuncs/object.c:1606
+msgid "Class description"
+msgstr "Klassenbeschreibung"
+
+#: libvips/iofuncs/object.c:1844
+#, c-format
+msgid "no value supplied for argument '%s'"
+msgstr ""
+
+#: libvips/iofuncs/object.c:1847
+#, c-format
+msgid "no value supplied for argument '%s' ('%s')"
+msgstr ""
+
+#: libvips/iofuncs/object.c:2039 libvips/iofuncs/object.c:2058
+#, fuzzy, c-format
+msgid "'%s' is not an integer"
+msgstr "»%s« ist keine positive Ganzzahl"
+
+#: libvips/iofuncs/object.c:2481
+#, fuzzy, c-format
+msgid "expected string or ), saw %s"
+msgstr "%s erwartet, %s gesehen"
+
+#: libvips/iofuncs/object.c:2524
+#, c-format
+msgid "unable to set '%s'"
+msgstr "»%s« kann nicht gesetzt werden"
+
+#: libvips/iofuncs/object.c:2537
+msgid "not , or ) after parameter"
+msgstr "kein »,« oder »)« nach Parameter"
+
+#: libvips/iofuncs/object.c:2544
+msgid "extra tokens after ')'"
+msgstr "keine zusätzlichen Token nach »)«"
+
+#: libvips/iofuncs/operation.c:235
+#, c-format
+msgid "%d pixels calculated"
+msgstr ""
+
+#: libvips/iofuncs/operation.c:343
+msgid "default enum"
+msgstr ""
+
+#: libvips/iofuncs/operation.c:347
+msgid "allowed enums"
+msgstr ""
+
+#: libvips/iofuncs/operation.c:375
+msgid "default flags"
+msgstr ""
+
+#: libvips/iofuncs/operation.c:380
+msgid "allowed flags"
+msgstr ""
+
+#: libvips/iofuncs/operation.c:396 libvips/iofuncs/operation.c:404
+#: libvips/iofuncs/operation.c:416
+msgid "default"
+msgstr ""
+
+#: libvips/iofuncs/operation.c:407 libvips/iofuncs/operation.c:419
+#, fuzzy
+msgid "min"
+msgstr "in"
+
+#: libvips/iofuncs/operation.c:409 libvips/iofuncs/operation.c:421
+msgid "max"
+msgstr ""
+
+#: libvips/iofuncs/operation.c:618
+#, fuzzy
+msgid "operation is blocked"
+msgstr "Transaktionen"
+
+#: libvips/iofuncs/operation.c:664
+msgid "operations"
+msgstr "Transaktionen"
+
+#: libvips/iofuncs/operation.c:755
+#, fuzzy, c-format
+msgid "\"%s\" is not an instantiable class"
+msgstr "»%s« ist kein bekanntes Dateiformat"
+
+#: libvips/iofuncs/operation.c:1225
+#, c-format
+msgid "unknown argument '%s'"
+msgstr "unbekanntes Argument »%s«"
+
+#: libvips/iofuncs/operation.c:1350
+msgid "too few arguments"
+msgstr "zu wenige Argumente"
+
+#: libvips/iofuncs/operation.c:1469
+msgid "too many arguments"
+msgstr "zu viele Argumente"
+
+#: libvips/iofuncs/region.c:565 libvips/iofuncs/region.c:635
+#: libvips/iofuncs/region.c:777 libvips/iofuncs/region.c:1848
+msgid "valid clipped to nothing"
+msgstr "gültig an nichts angeklammert"
+
+#: libvips/iofuncs/region.c:675
+msgid "bad image type"
+msgstr "falscher Bildtyp"
+
+#: libvips/iofuncs/region.c:719
+msgid "no pixel data on attached image"
+msgstr "keine Bildpunktdaten in angehängtem Bild"
+
+#: libvips/iofuncs/region.c:725
+msgid "images do not match in pixel size"
+msgstr "Bilder passen in der Bildpunktgröße nicht zusammen"
+
+#: libvips/iofuncs/region.c:758 libvips/iofuncs/region.c:1830
+msgid "dest too small"
+msgstr "Ziel zu klein"
+
+#: libvips/iofuncs/region.c:847
+msgid "bad position"
+msgstr "falsche Position"
+
+#: libvips/iofuncs/region.c:1628
+#, fuzzy
+msgid "stop requested"
+msgstr "Fehler abgefragt"
+
+#: libvips/iofuncs/region.c:1711 libvips/iofuncs/region.c:1901
+#, c-format
+msgid "unable to input from a %s image"
+msgstr "Eingabe von einem %s-Bild nicht möglich"
+
+#: libvips/iofuncs/region.c:1735
+msgid "incomplete header"
+msgstr "unvollständige Kopfzeilen"
+
+#: libvips/iofuncs/region.c:1804
+msgid "inappropriate region type"
+msgstr "Ungeeigneter Regionstyp"
+
+#: libvips/iofuncs/sbuf.c:85
+msgid "buffered source"
+msgstr ""
+
+#: libvips/iofuncs/sbuf.c:280
+#, fuzzy
+msgid "end of file"
+msgstr "ln des Bildes"
+
+#: libvips/iofuncs/sink.c:262
+#, c-format
+msgid "stop function failed for image \"%s\""
+msgstr "»stop«-Funktion für Bild »%s« fehlgeschlagen"
+
+#: libvips/iofuncs/sink.c:299
+#, c-format
+msgid "start function failed for image \"%s\""
+msgstr "»start«-Funktion für Bild »%s« fehlgeschlagen"
+
+#: libvips/iofuncs/sink.c:331
+msgid "per-thread state for sink"
+msgstr "Status pro Thread für »sink«"
+
+#: libvips/iofuncs/sinkdisc.c:108 libvips/iofuncs/util.c:477
+msgid "write failed"
+msgstr "Schreiben fehlgeschlagen"
+
+#: libvips/iofuncs/sinkdisc.c:137
+msgid "per-thread state for sinkdisc"
+msgstr "Status pro Thread für »sinkdisc«"
+
+#: libvips/iofuncs/sinkmemory.c:109
+msgid "per-thread state for sinkmemory"
+msgstr "Status pro Thread für »sinkmemory«"
+
+#: libvips/iofuncs/sinkscreen.c:196
+msgid "per-thread state for render"
+msgstr "Status pro Thread für »render«"
+
+#: libvips/iofuncs/sinkscreen.c:1122
+msgid "bad parameters"
+msgstr "falsche Parameter"
+
+#: libvips/iofuncs/source.c:281 libvips/iofuncs/target.c:114
+#, fuzzy
+msgid "don't set 'filename' and 'descriptor'"
+msgstr "kein Datei-Deskriptor"
+
+#: libvips/iofuncs/source.c:358
+msgid "input source"
+msgstr ""
+
+#: libvips/iofuncs/source.c:366 libvips/iofuncs/target.c:304
+msgid "Blob"
+msgstr ""
+
+#: libvips/iofuncs/source.c:367
+#, fuzzy
+msgid "Blob to load from"
+msgstr "Puffer, aus dem geladen werden soll"
+
+#: libvips/iofuncs/source.c:512
+#, fuzzy
+msgid "unimplemented target"
+msgstr "nicht implementierte Maske"
+
+#: libvips/iofuncs/source.c:649
+#, fuzzy
+msgid "unable to open for read"
+msgstr "Datei »%s« kann nicht zum Lesen geöffnet werden"
+
+#: libvips/iofuncs/source.c:890
+#, fuzzy
+msgid "pipe too long"
+msgstr "»%s« zu lang"
+
+#: libvips/iofuncs/source.c:1165 libvips/iofuncs/source.c:1190
+#: libvips/iofuncs/target.c:206
+msgid "bad 'whence'"
+msgstr ""
+
+#: libvips/iofuncs/source.c:1211
+#, fuzzy
+msgid "bad seek to %"
+msgstr "falscher Schrumpffaktor %d"
+
+#: libvips/iofuncs/sourcecustom.c:173
+msgid "Custom source"
+msgstr ""
+
+#: libvips/iofuncs/sourceginput.c:219
+msgid "GInputStream source"
+msgstr ""
+
+#: libvips/iofuncs/sourceginput.c:227
+msgid "Stream"
+msgstr ""
+
+#: libvips/iofuncs/sourceginput.c:228
+#, fuzzy
+msgid "GInputStream to read from"
+msgstr "Name der Datei, aus der geladen werden soll"
+
+#: libvips/iofuncs/system.c:185
+#, fuzzy
+msgid "unable to substitute input filename"
+msgstr "»munmap« der Datei nicht möglich"
+
+#: libvips/iofuncs/system.c:191
+#, fuzzy
+msgid "unable to substitute output filename"
+msgstr "es kann nicht zu einem %s-Bild ausgegeben werden"
+
+#: libvips/iofuncs/system.c:226
+#, fuzzy, c-format
+msgid "command \"%s\" failed"
+msgstr "Befehl fehlgeschlagen: »%s«"
+
+#: libvips/iofuncs/system.c:234
+#, c-format
+msgid "stderr output: %s"
+msgstr ""
+
+#: libvips/iofuncs/system.c:269
+msgid "run an external command"
+msgstr ""
+
+#: libvips/iofuncs/system.c:290
+msgid "Command"
+msgstr ""
+
+#: libvips/iofuncs/system.c:291
+msgid "Command to run"
+msgstr ""
+
+#: libvips/iofuncs/system.c:297
+#, fuzzy
+msgid "Input format"
+msgstr "Eingabebild"
+
+#: libvips/iofuncs/system.c:298
+#, fuzzy
+msgid "Format for input filename"
+msgstr "erstes Eingabebild"
+
+#: libvips/iofuncs/system.c:304
+#, fuzzy
+msgid "Output format"
+msgstr "Ausgabebild"
+
+#: libvips/iofuncs/system.c:305
+msgid "Format for output filename"
+msgstr ""
+
+#: libvips/iofuncs/system.c:312
+msgid "Command log"
+msgstr ""
+
+#: libvips/iofuncs/target.c:295
+#, fuzzy
+msgid "File descriptor should output to memory"
+msgstr "Datei-Deskriptor, in den geschrieben werden soll"
+
+#: libvips/iofuncs/target.c:305
+#, fuzzy
+msgid "Blob to save to"
+msgstr "Puffer, in den gespeichert werden soll"
+
+#: libvips/iofuncs/target.c:474
+#, fuzzy
+msgid "write error"
+msgstr "Lesefehler"
+
+#: libvips/iofuncs/targetcustom.c:235
+msgid "Custom target"
+msgstr ""
+
+#: libvips/iofuncs/thread.c:179
+msgid "unable to create thread"
+msgstr "Thread kann nicht erstellt werden"
+
+#: libvips/iofuncs/thread.c:214 libvips/iofuncs/thread.c:243
 #, c-format
 msgid "threads clipped to %d"
 msgstr "Threads an %d angeheftet"
 
-#: libvips/iofuncs/threadpool.c:281
+#: libvips/iofuncs/threadpool.c:193
 msgid "per-thread state for vipsthreadpool"
 msgstr "Status pro Thread für »vipsthreadpool«"
 
-#: libvips/morphology/im_profile.c:104
-msgid "dir not 0 or 1"
-msgstr "»dir« nicht 0 oder 1"
+#: libvips/iofuncs/type.c:958
+#, fuzzy, c-format
+msgid "unable to convert \"%s\" to int"
+msgstr "»%s« kann nicht zur Eingabe geöffnet werden"
 
-#: libvips/morphology/morphology.c:311
+#: libvips/iofuncs/util.c:455
+msgid "unable to get file stats"
+msgstr "Dateistatus kann nicht abgefragt werden"
+
+#: libvips/iofuncs/util.c:619
 #, c-format
-msgid "bad mask element (%d should be 0, 128 or 255)"
+msgid "unable to open file \"%s\" for reading"
+msgstr "Datei »%s« kann nicht zum Lesen geöffnet werden"
+
+#: libvips/iofuncs/util.c:641
+#, c-format
+msgid "unable to open file \"%s\" for writing"
+msgstr "Datei »%s« kann nicht zum Schreiben geöffnet werden"
+
+#: libvips/iofuncs/util.c:662
+#, c-format
+msgid "\"%s\" too long"
+msgstr "»%s« zu lang"
+
+#: libvips/iofuncs/util.c:710
+#, c-format
+msgid "error reading from file \"%s\""
+msgstr "Fehler beim Lesen von Datei »%s«"
+
+#: libvips/iofuncs/util.c:756
+#, fuzzy, c-format
+msgid "write error (%zd out of %zd blocks written)"
+msgstr "Schreibfehler (%zd aus %zd Blöcken geschrieben) … Platte voll?"
+
+#: libvips/iofuncs/util.c:1003
+msgid "unable to seek"
+msgstr "kann nicht gesucht werden"
+
+#: libvips/iofuncs/util.c:1028 libvips/iofuncs/util.c:1035
+msgid "unable to truncate"
+msgstr "kann nicht gekürzt werden"
+
+#: libvips/iofuncs/util.c:1121
+#, fuzzy, c-format
+msgid "unable to remove directory \"%s\", %s"
+msgstr "Daten für »%s« können nicht gelesen werden, %s"
+
+#: libvips/iofuncs/util.c:1138
+#, fuzzy, c-format
+msgid "unable to rename file \"%s\" as \"%s\", %s"
+msgstr ""
+"Datei »%s« kann nicht gelesen werden\n"
+"libMagick-Fehler: %s %s"
+
+#: libvips/iofuncs/util.c:1267
+msgid "unexpected end of string"
+msgstr "Unerwartetes Ende der Zeichenkette"
+
+#: libvips/iofuncs/util.c:1285 libvips/iofuncs/util.c:1355
+#, c-format
+msgid "expected %s, saw %s"
+msgstr "%s erwartet, %s gesehen"
+
+#: libvips/iofuncs/util.c:1664
+msgid "no such enum type"
+msgstr ""
+
+#: libvips/iofuncs/util.c:1682
+#, fuzzy, c-format
+msgid "enum '%s' has no member '%s', should be one of: %s"
+msgstr "Aufzählung »%s« hat keinen Bestandteil »%s«"
+
+#: libvips/iofuncs/util.c:1701
+msgid "no such flag type"
+msgstr ""
+
+#: libvips/iofuncs/util.c:1720
+#, fuzzy, c-format
+msgid "flags '%s' has no member '%s'"
+msgstr "Aufzählung »%s« hat keinen Bestandteil »%s«"
+
+#: libvips/iofuncs/vips.c:338
+#, c-format
+msgid "\"%s\" is not a VIPS image"
+msgstr "»%s« ist kein VIPS-Bild"
+
+#: libvips/iofuncs/vips.c:395
+msgid "unknown coding"
+msgstr "unbekannte Kodierung"
+
+#: libvips/iofuncs/vips.c:405
+msgid "malformed LABQ image"
+msgstr ""
+
+#: libvips/iofuncs/vips.c:414
+#, fuzzy
+msgid "malformed RAD image"
+msgstr "kein RAD-Bild"
+
+#: libvips/iofuncs/vips.c:485
+msgid "unable to read history"
+msgstr "Verlauf kann nicht gelesen werden"
+
+#: libvips/iofuncs/vips.c:518
+#, fuzzy
+msgid "more than 100 megabytes of XML? sufferin' succotash!"
+msgstr "mehr als 10 Megabyte XML? Leidende Succotash!"
+
+#: libvips/iofuncs/vips.c:552
+#, fuzzy
+msgid "unable to allocate read buffer"
+msgstr "In den Puffer kann nicht geschrieben werden."
+
+#: libvips/iofuncs/vips.c:558
+msgid "read error while fetching XML"
+msgstr ""
+
+#: libvips/iofuncs/vips.c:570
+#, fuzzy
+msgid "XML parse error"
+msgstr "Lesefehler"
+
+#: libvips/iofuncs/vips.c:635
+msgid "incorrect namespace in XML"
+msgstr "falscher Namensraum in XML"
+
+#: libvips/iofuncs/vips.c:683
+msgid "error transforming from save format"
+msgstr "Fehler beim Umwandeln vom gespeicherten Format"
+
+#: libvips/iofuncs/vips.c:784 libvips/iofuncs/vips.c:1056
+#: libvips/iofuncs/window.c:232
+msgid "file has been truncated"
+msgstr "Datei wurde gekürzt"
+
+#: libvips/iofuncs/vips.c:836 libvips/iofuncs/vips.c:927
+msgid "error transforming to save format"
+msgstr "Fehler beim Umwandeln in das zu speichernde Format"
+
+#: libvips/iofuncs/vips.c:1041
+#, c-format
+msgid "unable to read header for \"%s\""
+msgstr "Kopfdaten für »%s« können nicht gelesen werden"
+
+#: libvips/iofuncs/vips.c:1055 libvips/iofuncs/window.c:231
+#, c-format
+msgid "unable to read data for \"%s\", %s"
+msgstr "Daten für »%s« können nicht gelesen werden, %s"
+
+# http://radsite.lbl.gov/radiance/refer/Notes/picture_format.html
+#: libvips/iofuncs/vips.c:1067
+#, fuzzy, c-format
+msgid "error reading vips image metadata: %s"
+msgstr "Fehler beim Lesen der Radiance-Kopfzeilen"
+
+# http://techpubs.sgi.com/library/tpl/cgi-bin/getdoc.cgi?coll=0650&
+#        db=man&fname=/usr/share/catman/p_man/cat3/il_c/ilAbsImg.z
+#: libvips/morphology/countlines.c:135
+#, fuzzy
+msgid "count lines in an image"
+msgstr "absoluter Wert eines Bildes"
+
+#: libvips/morphology/countlines.c:139
+#, fuzzy
+msgid "Nolines"
+msgstr "Zeilen"
+
+#: libvips/morphology/countlines.c:140
+#, fuzzy
+msgid "Number of lines"
+msgstr "Anzahl der Bänder in einem Bild"
+
+#: libvips/morphology/countlines.c:147
+#, fuzzy
+msgid "Countlines left-right or up-down"
+msgstr "von links nach rechts oder von oben nach unten zusammenführen"
+
+#: libvips/morphology/labelregions.c:120
+#, fuzzy
+msgid "label regions in an image"
+msgstr "Anzahl der Bänder in einem Bild"
+
+#: libvips/morphology/labelregions.c:125
+msgid "Mask of region labels"
+msgstr ""
+
+#: libvips/morphology/labelregions.c:130
+msgid "Segments"
+msgstr ""
+
+#: libvips/morphology/labelregions.c:131
+msgid "Number of discrete contiguous regions"
+msgstr ""
+
+#: libvips/morphology/morph.c:885
+#, fuzzy, c-format
+msgid "bad mask element (%f should be 0, 128 or 255)"
 msgstr "falsches Maskenelement (%d sollte 0, 128 oder 255 sein)"
 
-#: libvips/morphology/im_zerox.c:141
-msgid "flag not -1 or 1"
-msgstr "Schalter nicht -1 oder 1"
+#: libvips/morphology/morph.c:955
+#, fuzzy
+msgid "morphology operation"
+msgstr "unäre Transaktionen"
 
-#: libvips/morphology/im_zerox.c:145
-msgid "image too narrow"
-msgstr "Bild zu schmal"
+#: libvips/morphology/morph.c:971
+msgid "Morphology"
+msgstr ""
 
-#: libvips/morphology/im_cntlines.c:81
-msgid "flag should be 0 (horizontal) or 1 (vertical)"
-msgstr "Schalter sollte 0 (horizontal) oder 1 (vertikal) sein"
+#: libvips/morphology/morph.c:972
+#, fuzzy
+msgid "Morphological operation to perform"
+msgstr "durchzuführende Rundungstransakktion"
 
-#: libvips/morphology/im_rank.c:365
-msgid "image too small for window"
-msgstr "Bild zu klein für Fenster"
+#: libvips/morphology/morphology.c:115
+#, fuzzy
+msgid "morphological operations"
+msgstr "arithmetische Transaktionen"
 
-#: libvips/morphology/im_rank_image.c:303
-msgid "zero input images!"
-msgstr "null Eingabebilder"
+#: libvips/morphology/nearest.c:305
+msgid "fill image zeros with nearest non-zero pixel"
+msgstr ""
 
-#: libvips/morphology/im_rank_image.c:308
-#, c-format
-msgid "index should be in range 0 - %d"
-msgstr "Index sollte im Bereich 0 - %d liegen"
+#: libvips/morphology/nearest.c:309
+#, fuzzy
+msgid "Out"
+msgstr "Ausgabe"
 
-#: libvips/mosaicing/im_lrmerge.c:213 libvips/mosaicing/im_lrmerge.c:262
-#: libvips/mosaicing/im_lrmerge.c:603 libvips/mosaicing/im_tbmerge.c:163
-#: libvips/mosaicing/im_tbmerge.c:217 libvips/mosaicing/im_tbmerge.c:535
-msgid "internal error"
-msgstr "interner Fehler"
+#: libvips/morphology/nearest.c:310
+msgid "Value of nearest non-zero pixel"
+msgstr ""
 
-#: libvips/mosaicing/im_lrmerge.c:703
-msgid "mwidth must be -1 or >= 0"
-msgstr "»mwidth« muss -1 oder >= 0 sein"
+#: libvips/morphology/nearest.c:316
+msgid "Distance to nearest non-zero pixel"
+msgstr ""
 
-#: libvips/mosaicing/im_lrmerge.c:732
-msgid "no overlap"
-msgstr "kein Überlappen"
+#: libvips/morphology/rank.c:496
+#, fuzzy
+msgid "index out of range"
+msgstr " »bins« außerhalb des Bereichs [1,%d]"
 
-#: libvips/mosaicing/im_lrmerge.c:803 libvips/mosaicing/im_tbmerge.c:634
-#: libvips/resample/im_affine.c:469
-msgid "unknown coding type"
-msgstr "unbekannter Kodierungstyp"
+#: libvips/morphology/rank.c:560
+msgid "rank filter"
+msgstr ""
 
-#: libvips/mosaicing/im_lrmerge.c:820 libvips/mosaicing/im_tbmerge.c:652
-msgid "too much overlap"
-msgstr "zu viel Überlappung"
+#: libvips/morphology/rank.c:585
+msgid "Select pixel at index"
+msgstr ""
 
-#: libvips/mosaicing/im_remosaic.c:104
-#, c-format
-msgid "substitute image \"%s\" is not the same size as \"%s\""
-msgstr "Bild zum Ersetzen »%s« hat nicht die gleiche Größe wie »%s«"
-
-#: libvips/mosaicing/im_tbmosaic.c:89 libvips/mosaicing/im_lrmosaic.c:113
-msgid "bad area parameters"
-msgstr "falsche Bereichsparameter"
-
-#: libvips/mosaicing/im_tbmosaic.c:110 libvips/mosaicing/im_lrmosaic.c:134
-msgid "overlap too small for search"
-msgstr "Überlappen zu klein für Suche"
-
-#: libvips/mosaicing/im_tbmosaic.c:143 libvips/mosaicing/im_lrmosaic.c:167
-msgid "unknown Coding type"
-msgstr "unbekannter Kodierungstyp"
-
-#: libvips/mosaicing/im_chkpair.c:200
+#: libvips/mosaicing/chkpair.c:200
 msgid "inputs incompatible"
 msgstr "Eingaben inkompatibel"
 
-#: libvips/mosaicing/im_chkpair.c:204 libvips/mosaicing/im_tbcalcon.c:102
+#: libvips/mosaicing/chkpair.c:204 libvips/mosaicing/im_tbcalcon.c:105
 msgid "help!"
 msgstr "Hilfe!"
 
-#: libvips/mosaicing/im_tbcalcon.c:116
-msgid "overlap too small"
-msgstr "Überlappen zu schmal"
-
-#: libvips/mosaicing/global_balance.c:145
+#: libvips/mosaicing/global_balance.c:151
 msgid "no matching '>'"
 msgstr "kein passendes »>«"
 
-#: libvips/mosaicing/global_balance.c:154
+#: libvips/mosaicing/global_balance.c:160
 msgid "too many items"
 msgstr "zu viele Elemente"
 
@@ -3040,29 +7226,29 @@ msgstr "zu viele Elemente"
 # so there is a doubling up of this node. If this is a leaf, then we have the
 # same leaf twice (which, in fact, we can cope with); if this is a node, we
 # have circularity.
-#: libvips/mosaicing/global_balance.c:448
+#: libvips/mosaicing/global_balance.c:463
 msgid "circularity detected"
 msgstr "Zirkularität entdeckt"
 
-#: libvips/mosaicing/global_balance.c:482
-#: libvips/mosaicing/global_balance.c:538
+#: libvips/mosaicing/global_balance.c:497
+#: libvips/mosaicing/global_balance.c:557
 #, c-format
 msgid "image \"%s\" used twice as output"
 msgstr "Bild »%s« zweimal als Ausgabe benutzt"
 
-#: libvips/mosaicing/global_balance.c:587
+#: libvips/mosaicing/global_balance.c:606
 msgid "bad number of args in join line"
 msgstr "falsche Anzahl von Argumenten in »join«-Zeile"
 
-#: libvips/mosaicing/global_balance.c:629
+#: libvips/mosaicing/global_balance.c:648
 msgid "bad number of args in join1 line"
 msgstr "falsche Anzahl von Argumenten in »join1«-Zeile"
 
-#: libvips/mosaicing/global_balance.c:665
+#: libvips/mosaicing/global_balance.c:684
 msgid "bad number of args in copy line"
 msgstr "falsche Anzahl von Argumenten in »copy«-Zeile"
 
-#: libvips/mosaicing/global_balance.c:723
+#: libvips/mosaicing/global_balance.c:742
 msgid ""
 "mosaic root not found in desc file\n"
 "is this really a mosaiced image?"
@@ -3070,392 +7256,1558 @@ msgstr ""
 "Mosaik-Wurzel nicht in Beschreibungsdatei gefunden\n"
 "ist das wirklich ein Bild?"
 
-#: libvips/mosaicing/global_balance.c:734
+#: libvips/mosaicing/global_balance.c:753
 msgid "more than one root"
 msgstr "mehr als eine Wurzel"
 
-#: libvips/mosaicing/im_avgdxdy.c:64
+#: libvips/mosaicing/global_balance.c:1525
+msgid "bad sizes"
+msgstr "falsche Größen"
+
+#: libvips/mosaicing/global_balance.c:1920
+#, fuzzy
+msgid "global balance an image mosaic"
+msgstr "ein Radiance-Bild aus einer Datei laden"
+
+#: libvips/mosaicing/global_balance.c:1936
+msgid "Gamma"
+msgstr ""
+
+#: libvips/mosaicing/global_balance.c:1937
+#, fuzzy
+msgid "Image gamma"
+msgstr "Bilddateiname"
+
+#: libvips/mosaicing/global_balance.c:1943
+#, fuzzy
+msgid "Int output"
+msgstr "Ausgabe"
+
+#: libvips/mosaicing/global_balance.c:1944
+#, fuzzy
+msgid "Integer output"
+msgstr "detaillierte Ausgabe"
+
+#: libvips/mosaicing/im_avgdxdy.c:65
 msgid "no points to average"
 msgstr "keine Punkte zum Mitteln"
 
-#: libvips/mosaicing/im_lrcalcon.c:203
+#: libvips/mosaicing/im_clinear.c:138
+#, fuzzy
+msgid "vips_invmat failed"
+msgstr "»im_invmat« fehlgeschlagen"
+
+#: libvips/mosaicing/im_lrcalcon.c:206
 msgid "overlap too small for your search size"
 msgstr "Überlappen zu schmal für Ihre Suchgröße"
 
-#: libvips/mosaicing/im_lrcalcon.c:242
+#: libvips/mosaicing/im_lrcalcon.c:245
 #, c-format
 msgid "found %d tie-points, need at least %d"
 msgstr "es wurden %d Verbindungspunkte gefunden, mindestens %d sind nötig"
 
-#: libvips/mosaicing/im_lrcalcon.c:287
+#: libvips/mosaicing/im_lrcalcon.c:290
 msgid "not 1-band uchar image"
 msgstr "kein »uchar«-Bild mit einem Band"
 
-#: libvips/mosaicing/im_clinear.c:136
-msgid "im_invmat failed"
-msgstr "»im_invmat« fehlgeschlagen"
+#: libvips/mosaicing/im_tbcalcon.c:119
+msgid "overlap too small"
+msgstr "Überlappen zu schmal"
 
-#: libvips/other/im_zone.c:80
-msgid "size must be even and positive"
-msgstr "Größe muss gerade und positiv sein"
+#: libvips/mosaicing/lrmerge.c:786
+msgid "mwidth must be -1 or >= 0"
+msgstr "»mwidth« muss -1 oder >= 0 sein"
 
-#: libvips/other/im_sines.c:88
-msgid "wrong sizes"
-msgstr "falsche Größen"
+#: libvips/mosaicing/lrmerge.c:818
+msgid "no overlap"
+msgstr "kein Überlappen"
 
-#: libvips/other/im_sines.c:101
-msgid "calloc failed"
-msgstr "»calloc« fehlgeschlagen"
+#: libvips/mosaicing/lrmerge.c:888 libvips/mosaicing/tbmerge.c:693
+msgid "unknown coding type"
+msgstr "unbekannter Kodierungstyp"
 
-#: libvips/other/im_eye.c:83
-msgid "factor should be in [1,0)"
-msgstr "Faktor sollte in [0,1) liegen"
+#: libvips/mosaicing/lrmerge.c:906 libvips/mosaicing/tbmerge.c:711
+msgid "too much overlap"
+msgstr "zu viel Überlappung"
 
-#: libvips/resample/im_affine.c:410
+#: libvips/mosaicing/lrmosaic.c:122 libvips/mosaicing/tbmosaic.c:93
+msgid "bad area parameters"
+msgstr "falsche Bereichsparameter"
+
+#: libvips/mosaicing/lrmosaic.c:143 libvips/mosaicing/tbmosaic.c:114
+msgid "overlap too small for search"
+msgstr "Überlappen zu klein für Suche"
+
+#: libvips/mosaicing/lrmosaic.c:171 libvips/mosaicing/tbmosaic.c:142
+msgid "unknown Coding type"
+msgstr "unbekannter Kodierungstyp"
+
+#: libvips/mosaicing/match.c:192
+#, fuzzy
+msgid "first-order match of two images"
+msgstr "zwei Bilder subtrahieren"
+
+#: libvips/mosaicing/match.c:197 libvips/mosaicing/merge.c:123
+#: libvips/mosaicing/mosaic1.c:499 libvips/mosaicing/mosaic.c:180
+#, fuzzy
+msgid "Reference image"
+msgstr "Zeilensprungbild"
+
+#: libvips/mosaicing/match.c:202 libvips/mosaicing/merge.c:128
+#: libvips/mosaicing/mosaic1.c:504 libvips/mosaicing/mosaic.c:185
+msgid "Secondary"
+msgstr ""
+
+#: libvips/mosaicing/match.c:203 libvips/mosaicing/merge.c:129
+#: libvips/mosaicing/mosaic1.c:505 libvips/mosaicing/mosaic.c:186
+#, fuzzy
+msgid "Secondary image"
+msgstr "zweites Eingabebild"
+
+#: libvips/mosaicing/match.c:214 libvips/mosaicing/mosaic1.c:523
+msgid "xr1"
+msgstr ""
+
+#: libvips/mosaicing/match.c:215 libvips/mosaicing/match.c:222
+#: libvips/mosaicing/mosaic1.c:524 libvips/mosaicing/mosaic1.c:531
+msgid "Position of first reference tie-point"
+msgstr ""
+
+#: libvips/mosaicing/match.c:221 libvips/mosaicing/mosaic1.c:530
+msgid "yr1"
+msgstr ""
+
+#: libvips/mosaicing/match.c:228 libvips/mosaicing/mosaic1.c:537
+msgid "xs1"
+msgstr ""
+
+#: libvips/mosaicing/match.c:229 libvips/mosaicing/match.c:236
+#: libvips/mosaicing/mosaic1.c:538 libvips/mosaicing/mosaic1.c:545
+msgid "Position of first secondary tie-point"
+msgstr ""
+
+#: libvips/mosaicing/match.c:235 libvips/mosaicing/mosaic1.c:544
+msgid "ys1"
+msgstr ""
+
+#: libvips/mosaicing/match.c:242 libvips/mosaicing/mosaic1.c:551
+msgid "xr2"
+msgstr ""
+
+#: libvips/mosaicing/match.c:243 libvips/mosaicing/match.c:250
+#: libvips/mosaicing/mosaic1.c:552 libvips/mosaicing/mosaic1.c:559
+msgid "Position of second reference tie-point"
+msgstr ""
+
+#: libvips/mosaicing/match.c:249 libvips/mosaicing/mosaic1.c:558
+msgid "yr2"
+msgstr ""
+
+#: libvips/mosaicing/match.c:256 libvips/mosaicing/mosaic1.c:565
+msgid "xs2"
+msgstr ""
+
+#: libvips/mosaicing/match.c:257 libvips/mosaicing/match.c:264
+#: libvips/mosaicing/mosaic1.c:566 libvips/mosaicing/mosaic1.c:573
+msgid "Position of second secondary tie-point"
+msgstr ""
+
+#: libvips/mosaicing/match.c:263 libvips/mosaicing/mosaic1.c:572
+msgid "ys2"
+msgstr ""
+
+#: libvips/mosaicing/match.c:270 libvips/mosaicing/mosaic1.c:579
+#: libvips/mosaicing/mosaic.c:232
+#, fuzzy
+msgid "hwindow"
+msgstr "Windows-Fehler"
+
+#: libvips/mosaicing/match.c:271 libvips/mosaicing/mosaic1.c:580
+#: libvips/mosaicing/mosaic.c:233
+msgid "Half window size"
+msgstr ""
+
+#: libvips/mosaicing/match.c:277 libvips/mosaicing/mosaic1.c:586
+#: libvips/mosaicing/mosaic.c:239
+msgid "harea"
+msgstr ""
+
+#: libvips/mosaicing/match.c:278 libvips/mosaicing/mosaic1.c:587
+#: libvips/mosaicing/mosaic.c:240
+#, fuzzy
+msgid "Half area size"
+msgstr "falsche Bildgröße"
+
+#: libvips/mosaicing/match.c:284 libvips/mosaicing/mosaic1.c:593
+msgid "Search"
+msgstr ""
+
+#: libvips/mosaicing/match.c:285 libvips/mosaicing/mosaic1.c:594
+msgid "Search to improve tie-points"
+msgstr ""
+
+#: libvips/mosaicing/match.c:291 libvips/mosaicing/mosaic1.c:600
+#: libvips/resample/affine.c:651 libvips/resample/mapim.c:561
+#: libvips/resample/quadratic.c:351 libvips/resample/resize.c:376
+#: libvips/resample/similarity.c:127
+#, fuzzy
+msgid "Interpolate"
+msgstr "Zeilensprung"
+
+#: libvips/mosaicing/match.c:292 libvips/mosaicing/mosaic1.c:601
+#: libvips/resample/affine.c:652 libvips/resample/mapim.c:562
+#: libvips/resample/resize.c:377 libvips/resample/similarity.c:128
+msgid "Interpolate pixels with this"
+msgstr ""
+
+#: libvips/mosaicing/matrixinvert.c:312 libvips/mosaicing/matrixinvert.c:328
+#: libvips/mosaicing/matrixinvert.c:353 libvips/resample/transform.c:60
+msgid "singular or near-singular matrix"
+msgstr ""
+
+#: libvips/mosaicing/matrixinvert.c:406
+msgid "non-square matrix"
+msgstr ""
+
+#: libvips/mosaicing/matrixinvert.c:439
+#, fuzzy
+msgid "invert an matrix"
+msgstr "ein Bild invertieren"
+
+#: libvips/mosaicing/matrixinvert.c:444
+msgid "An square matrix"
+msgstr ""
+
+#: libvips/mosaicing/matrixinvert.c:450
+#, fuzzy
+msgid "Output matrix"
+msgstr "Ausgabebild"
+
+#: libvips/mosaicing/merge.c:116
+#, fuzzy
+msgid "merge two images"
+msgstr "zwei Bilder hinzufügen"
+
+#: libvips/mosaicing/merge.c:141
+#, fuzzy
+msgid "Horizontal or vertical merge"
+msgstr "horizontaler Versatz vom Ursprung"
+
+#: libvips/mosaicing/merge.c:147
+#, fuzzy
+msgid "dx"
+msgstr "x"
+
+#: libvips/mosaicing/merge.c:148
+msgid "Horizontal displacement from sec to ref"
+msgstr ""
+
+#: libvips/mosaicing/merge.c:154
+#, fuzzy
+msgid "dy"
+msgstr "y"
+
+#: libvips/mosaicing/merge.c:155
+msgid "Vertical displacement from sec to ref"
+msgstr ""
+
+#: libvips/mosaicing/merge.c:161 libvips/mosaicing/mosaic1.c:606
+#: libvips/mosaicing/mosaic.c:246
+#, fuzzy
+msgid "Max blend"
+msgstr "Mischung"
+
+#: libvips/mosaicing/merge.c:162 libvips/mosaicing/mosaic1.c:607
+#: libvips/mosaicing/mosaic.c:247
+#, fuzzy
+msgid "Maximum blend size"
+msgstr "Maximalwert des Bildes"
+
+#: libvips/mosaicing/mosaic1.c:494
+#, fuzzy
+msgid "first-order mosaic of two images"
+msgstr "zwei Bilder subtrahieren"
+
+#: libvips/mosaicing/mosaic1.c:517 libvips/mosaicing/mosaic.c:198
+#, fuzzy
+msgid "Horizontal or vertical mosaic"
+msgstr "horizontale Position des Maximums"
+
+#: libvips/mosaicing/mosaic1.c:613 libvips/mosaicing/mosaic.c:253
+#, fuzzy
+msgid "Search band"
+msgstr "falsche Bänder"
+
+#: libvips/mosaicing/mosaic1.c:614 libvips/mosaicing/mosaic.c:254
+msgid "Band to search for features on"
+msgstr ""
+
+#: libvips/mosaicing/mosaic.c:175
+#, fuzzy
+msgid "mosaic two images"
+msgstr "zwei Bilder subtrahieren"
+
+#: libvips/mosaicing/mosaic.c:204
+msgid "xref"
+msgstr ""
+
+#: libvips/mosaicing/mosaic.c:205 libvips/mosaicing/mosaic.c:212
+msgid "Position of reference tie-point"
+msgstr ""
+
+#: libvips/mosaicing/mosaic.c:211
+msgid "yref"
+msgstr ""
+
+#: libvips/mosaicing/mosaic.c:218
+msgid "xsec"
+msgstr ""
+
+#: libvips/mosaicing/mosaic.c:219 libvips/mosaicing/mosaic.c:226
+msgid "Position of secondary tie-point"
+msgstr ""
+
+#: libvips/mosaicing/mosaic.c:225
+msgid "ysec"
+msgstr ""
+
+#: libvips/mosaicing/mosaic.c:260 libvips/mosaicing/mosaic.c:267
+msgid "Integer offset"
+msgstr ""
+
+#: libvips/mosaicing/mosaic.c:261 libvips/mosaicing/mosaic.c:268
+msgid "Detected integer offset"
+msgstr ""
+
+#: libvips/mosaicing/mosaic.c:275
+msgid "Detected scale"
+msgstr ""
+
+#: libvips/mosaicing/mosaic.c:282
+msgid "Detected rotation"
+msgstr ""
+
+#: libvips/mosaicing/mosaic.c:288 libvips/mosaicing/mosaic.c:295
+msgid "First-order displacement"
+msgstr ""
+
+#: libvips/mosaicing/mosaic.c:289 libvips/mosaicing/mosaic.c:296
+msgid "Detected first-order displacement"
+msgstr ""
+
+#: libvips/mosaicing/remosaic.c:89
+#, c-format
+msgid "file \"%s\" not found"
+msgstr "Datei »%s« nicht gefunden"
+
+#: libvips/mosaicing/remosaic.c:117
+#, c-format
+msgid "substitute image \"%s\" is not the same size as \"%s\""
+msgstr "Bild zum Ersetzen »%s« hat nicht die gleiche Größe wie »%s«"
+
+#: libvips/mosaicing/remosaic.c:160
+#, fuzzy
+msgid "rebuild an mosaiced image"
+msgstr "Bilddateien laden und speichern"
+
+#: libvips/mosaicing/remosaic.c:176
+msgid "old_str"
+msgstr ""
+
+#: libvips/mosaicing/remosaic.c:177
+msgid "Search for this string"
+msgstr ""
+
+#: libvips/mosaicing/remosaic.c:183
+msgid "new_str"
+msgstr ""
+
+#: libvips/mosaicing/remosaic.c:184
+msgid "And swap for this string"
+msgstr ""
+
+#: libvips/resample/affine.c:516
 msgid "output coordinates out of range"
 msgstr "Ausgabekoordinaten außerhalb des Bereichs"
 
-#: libvips/resample/im_shrink.c:346
-msgid "shrink factors should be >= 1"
-msgstr "Schrumpffaktoren sollten >=1 sein"
+#: libvips/resample/affine.c:640
+#, fuzzy
+msgid "affine transform of an image"
+msgstr "Band aus einem Bild extrahieren"
 
-#: libvips/resample/interpolate.c:180
+#: libvips/resample/affine.c:644
+msgid "Matrix"
+msgstr ""
+
+#: libvips/resample/affine.c:645
+msgid "Transformation matrix"
+msgstr ""
+
+#: libvips/resample/affine.c:657
+#, fuzzy
+msgid "Output rect"
+msgstr "Ausgabe"
+
+#: libvips/resample/affine.c:658
+msgid "Area of output to generate"
+msgstr ""
+
+#: libvips/resample/affine.c:664 libvips/resample/affine.c:671
+#: libvips/resample/similarity.c:140 libvips/resample/similarity.c:147
+#, fuzzy
+msgid "Output offset"
+msgstr "Ausgabewert"
+
+#: libvips/resample/affine.c:665 libvips/resample/similarity.c:141
+msgid "Horizontal output displacement"
+msgstr ""
+
+#: libvips/resample/affine.c:672 libvips/resample/similarity.c:148
+msgid "Vertical output displacement"
+msgstr ""
+
+#: libvips/resample/affine.c:678 libvips/resample/affine.c:685
+#: libvips/resample/resize.c:360 libvips/resample/resize.c:367
+#: libvips/resample/similarity.c:154 libvips/resample/similarity.c:161
+#, fuzzy
+msgid "Input offset"
+msgstr "Xoffset"
+
+#: libvips/resample/affine.c:679 libvips/resample/resize.c:361
+#: libvips/resample/similarity.c:155
+msgid "Horizontal input displacement"
+msgstr ""
+
+#: libvips/resample/affine.c:686 libvips/resample/resize.c:368
+#: libvips/resample/similarity.c:162
+msgid "Vertical input displacement"
+msgstr ""
+
+#: libvips/resample/bicubic.cpp:629
+#, fuzzy
+msgid "bicubic interpolation (Catmull-Rom)"
+msgstr "doppelt kubische Interpolation (Catmull-Rom)"
+
+#: libvips/resample/interpolate.c:185
 msgid "VIPS interpolators"
 msgstr "VIPS-Interpolatoren"
 
 #: libvips/resample/interpolate.c:361
-msgid "Nearest-neighbour interpolation"
+#, fuzzy
+msgid "nearest-neighbour interpolation"
 msgstr "Nächste-Nachbar-Interpolation"
 
-#: libvips/resample/interpolate.c:532
-msgid "Bilinear interpolation"
+#: libvips/resample/interpolate.c:579
+#, fuzzy
+msgid "bilinear interpolation"
 msgstr "Bilineare Interpolation"
 
-#: libvips/resample/im_rightshift_size.c:120
-msgid "shift by zero: falling back to im_copy"
-msgstr "verschieben um Null: Rückfall auf »im_copy«"
+#: libvips/resample/lbb.cpp:872
+#, fuzzy
+msgid "reduced halo bicubic"
+msgstr "doppelt kubische Halo-Reduzierung"
 
-#: libvips/resample/im_rightshift_size.c:124
-msgid "would result in zero size output image"
-msgstr "würde in einem Ausgabebild der Größe Null resultieren"
+#: libvips/resample/mapim.c:551
+#, fuzzy
+msgid "resample with a map image"
+msgstr "ein Bild nachmachen"
 
-#: libvips/resample/im_rightshift_size.c:132
-msgid "image and band_fmt must match in sign"
-msgstr "Bild und Band-Fmt müssen im Kennzeichen zusammenpassen"
-
-#: libvips/video/im_video_test.c:51
-msgid "error requested"
-msgstr "Fehler abgefragt"
-
-#: libvips/video/im_video_v4l1.c:241
-msgid "no file descriptor"
-msgstr "kein Datei-Deskriptor"
-
-#: libvips/video/im_video_v4l1.c:246
-#, c-format
-msgid "ioctl(0x%x) failed: %s"
-msgstr "ioctl(0x%x) fehlgeschlagen: %s"
-
-#: libvips/video/im_video_v4l1.c:295
-#, c-format
-msgid "cannot open video device \"%s\""
-msgstr "Videogerät »%s« kann nicht geöffnet werden"
-
-#: libvips/video/im_video_v4l1.c:303
-msgid "cannot get video capability"
-msgstr "Videofähigkeit kann nicht abgefragt werden"
-
-#: libvips/video/im_video_v4l1.c:312
-msgid "card cannot capture to memory"
-msgstr "Karte kann nicht in Speicher digitalisiert werden"
-
-#: libvips/video/im_video_v4l1.c:458
-msgid "unable to map memory"
-msgstr "Speicher kann nicht abgebildet werden"
-
-#: libvips/video/im_video_v4l1.c:470
-#, c-format
-msgid "channel not between 0 and %d"
-msgstr "Kanal nicht zwischen 0 und %d"
-
-#: libvips/video/im_video_v4l1.c:698
-msgid "compiled without im_video_v4l1 support"
-msgstr "ohne »im_video_v4l1«-Unterstützung kompiliert"
-
-#: tools/edvips.c:82
-msgid "tag file as big or little-endian"
-msgstr "Kennzeichendatei als Big- oder Little-Endian"
-
-#: tools/edvips.c:84
-msgid "set width to N pixels"
-msgstr "Breite auf N Bildpunkte setzen"
-
-#: tools/edvips.c:86
-msgid "set height to N pixels"
-msgstr "Höhe auf N Bildpunkte setzen"
-
-#: tools/edvips.c:88
-msgid "set Bands to N"
-msgstr "Bänder auf N setzen"
-
-#: tools/edvips.c:90
-msgid "set BandFmt to F (eg. uchar, float)"
-msgstr "»BandFmt« auf F setzen (z.B. uchar, float)"
-
-#: tools/edvips.c:92
-msgid "set interpretation to I (eg. xyz)"
-msgstr "Interpretation aif I setzen (z.B. xyz)"
-
-#: tools/edvips.c:94
-msgid "set Coding to C (eg. labq)"
-msgstr "Kodierung auf C setzen (z.B. labq)"
-
-#: tools/edvips.c:96
-msgid "set Xres to R pixels/mm"
-msgstr "»Xres« auf R Bildpunkte/mm setzen"
-
-#: tools/edvips.c:98
-msgid "set Yres to R pixels/mm"
-msgstr "»Yres« auf R Bildpunkte/mm setzen"
-
-#: tools/edvips.c:100
-msgid "set Xoffset to N pixels"
-msgstr "»Xoffset« auf N Bildpunkte setzen"
-
-#: tools/edvips.c:102
-msgid "set Yoffset to N pixels"
-msgstr "»Yoffset« auf N Bildpunkte setzen"
-
-#: tools/edvips.c:104
-msgid "replace extension block with stdin"
-msgstr "Erweiterungsblock mit STDIN ersetzen"
-
-#: tools/edvips.c:106
-msgid "set Xsize to N (deprecated, use width)"
-msgstr "»Xsize« auf N setzen (missbilligt, benutzen Sie »width«)"
-
-#: tools/edvips.c:108
-msgid "set Ysize to N (deprecated, use height)"
-msgstr "»Ysize« auf N setzen (missbilligt, benutzen Sie »height«)"
-
-#: tools/edvips.c:110
-msgid "set Type to T (deprecated, use interpretation)"
-msgstr "Typ auf N setzen (missbilligt, benutzen Sie »interpretation«"
-
-#: tools/edvips.c:121
-#, c-format
-msgid "'%s' is not a positive integer"
-msgstr "»%s« ist keine positive Ganzzahl"
-
-#: tools/edvips.c:133
-msgid "unable to start VIPS"
-msgstr "VIPS kann nicht gestartet werden"
-
-#: tools/edvips.c:138
-msgid "vipsfile - edit vipsfile header"
-msgstr "»vipsfile« - »vipsfile«-Kopfzeilen bearbeiten"
-
-#: tools/edvips.c:150
-#, c-format
-msgid "usage: %s [OPTION...] vipsfile\n"
-msgstr "Aufruf: %s [OPTION …] vipsfile\n"
-
-#: tools/edvips.c:157
-#, c-format
-msgid "could not open image %s"
-msgstr "Bild %s konnte nicht geöffnet werden"
-
-#: tools/edvips.c:160
-#, c-format
-msgid "could not read VIPS header for %s"
-msgstr "VIPS-Kopfzeilen für %s konnten nicht gelesen werden"
-
-#: tools/edvips.c:169
-#, c-format
-msgid "bad endian-ness %s, should be 'big' or 'little'"
-msgstr "falsche Byte-Reihenfolge %s, sollte »big« oder »little« sein"
-
-#: tools/edvips.c:182
-#, c-format
-msgid "bad format %s"
-msgstr "falsches Format %s"
-
-#: tools/edvips.c:190
-#, c-format
-msgid "bad interpretation %s"
-msgstr "falsche Interpretation »%s« "
-
-#: tools/edvips.c:198
-#, c-format
-msgid "bad coding %s"
-msgstr "falsche Kodierung %s"
-
-#: tools/edvips.c:211
-#, c-format
-msgid "could not seek on %s"
-msgstr "auf %s konnte nicht gesucht werden"
-
-#: tools/edvips.c:214
-#, c-format
-msgid "could not write to %s"
-msgstr "auf %s konnte nicht geschrieben werden"
-
-#: tools/edvips.c:221
-msgid "could not get ext data"
-msgstr "zusätzliche Daten konnten nicht abgefragt werden"
-
-#: tools/edvips.c:230
-msgid "could not set extension"
-msgstr "Erweiterung konnte nicht gesetzt werden"
-
-#: tools/find_mosaic.c:112 tools/find_mosaic.c:122 tools/find_mosaic.c:144
-#: tools/find_mosaic.c:154 tools/find_mosaic.c:163 tools/find_mosaic.c:184
-#: tools/find_mosaic.c:194 tools/find_mosaic.c:203 tools/mergeup.c:238
-#: tools/mergeup.c:248 tools/mergeup.c:270 tools/mergeup.c:280
-#: tools/mergeup.c:289 tools/mergeup.c:310 tools/mergeup.c:320
-#: tools/mergeup.c:329
-#, c-format
-msgid "bad file name format '%s'"
-msgstr "falsches Dateinamensformat »%s«"
-
-#: tools/header.c:85
-msgid "show all fields"
-msgstr "alle Felder anzeigen"
-
-#: tools/header.c:87
-msgid ""
-"print value of FIELD (\"getext\" reads extension block, \"Hist\" reads image "
-"history)"
+#: libvips/resample/mapim.c:556
+msgid "Index pixels with this"
 msgstr ""
-"Wert von FELD ausgeben (»getext« liest Erweiterungsblock, »Hist« liest "
-"Bildchronik)"
 
-#: tools/header.c:210
-msgid "- print image header"
-msgstr "- Bild-Kopfzeilen ausgeben"
+#: libvips/resample/nohalo.cpp:1551
+#, fuzzy
+msgid "edge sharpening resampler with halo reduction"
+msgstr "neues Kantenschärfungsmuster mit Halo-Reduzierung"
 
-#: tools/mergeup.c:381
-msgid "allocation failure in mergeup"
-msgstr "Reservierung in »mergeup« gescheitert"
+#: libvips/resample/quadratic.c:269
+msgid "coefficient matrix must have width 2"
+msgstr ""
 
-#: tools/mergeup.c:391
-msgid "Need more than one image"
-msgstr "Mehr als ein Bild benötigt"
+#: libvips/resample/quadratic.c:291
+msgid "coefficient matrix must have height 1, 3, 4 or 6"
+msgstr ""
 
-#: tools/vips.c:101
-msgid "load PLUGIN"
-msgstr "ERWEITERUNG laden"
+#: libvips/resample/quadratic.c:341
+msgid "resample an image with a quadratic transform"
+msgstr ""
 
-#: tools/vips.c:102
-msgid "PLUGIN"
-msgstr "ERWEITERUNG"
+#: libvips/resample/quadratic.c:345
+msgid "Coeff"
+msgstr ""
 
-#: tools/vips.c:104
-msgid "print version"
-msgstr "Version ausgeben"
+#: libvips/resample/quadratic.c:346
+msgid "Coefficient matrix"
+msgstr ""
 
-#: tools/vips.c:147
+#: libvips/resample/quadratic.c:352
+msgid "Interpolate values with this"
+msgstr ""
+
+#: libvips/resample/reduce.c:199
+#, fuzzy
+msgid "reduce an image"
+msgstr "ein Bild nachmachen"
+
+#: libvips/resample/reduce.c:205 libvips/resample/reduceh.cpp:586
+#: libvips/resample/shrink.c:149 libvips/resample/shrinkh.c:353
+#, fuzzy
+msgid "Hshrink"
+msgstr "verkleinern"
+
+#: libvips/resample/reduce.c:206 libvips/resample/reduce.c:236
+#: libvips/resample/reduceh.cpp:587 libvips/resample/reduceh.cpp:610
+#: libvips/resample/shrink.c:150 libvips/resample/shrink.c:166
+#: libvips/resample/shrinkh.c:354 libvips/resample/shrinkh.c:370
+#, fuzzy
+msgid "Horizontal shrink factor"
+msgstr "falscher Schrumpffaktor %d"
+
+#: libvips/resample/reduce.c:212 libvips/resample/reducev.cpp:1070
+#: libvips/resample/shrink.c:142 libvips/resample/shrinkv.c:427
+#, fuzzy
+msgid "Vshrink"
+msgstr "verkleinern"
+
+#: libvips/resample/reduce.c:213 libvips/resample/reduce.c:243
+#: libvips/resample/reducev.cpp:1071 libvips/resample/reducev.cpp:1094
+#: libvips/resample/shrink.c:143 libvips/resample/shrink.c:173
+#: libvips/resample/shrinkv.c:428 libvips/resample/shrinkv.c:444
+#, fuzzy
+msgid "Vertical shrink factor"
+msgstr "falscher Schrumpffaktor %d"
+
+#: libvips/resample/reduce.c:219 libvips/resample/reduceh.cpp:593
+#: libvips/resample/reducev.cpp:1077 libvips/resample/resize.c:343
+msgid "Kernel"
+msgstr ""
+
+#: libvips/resample/reduce.c:220 libvips/resample/reduceh.cpp:594
+#: libvips/resample/reducev.cpp:1078 libvips/resample/resize.c:344
+msgid "Resampling kernel"
+msgstr ""
+
+#: libvips/resample/reduce.c:226 libvips/resample/reduceh.cpp:600
+#: libvips/resample/reducev.cpp:1084 libvips/resample/resize.c:350
+msgid "Gap"
+msgstr ""
+
+#: libvips/resample/reduce.c:227 libvips/resample/reduceh.cpp:601
+#: libvips/resample/reducev.cpp:1085 libvips/resample/resize.c:351
+msgid "Reducing gap"
+msgstr ""
+
+#: libvips/resample/reduce.c:235 libvips/resample/reduceh.cpp:609
+#: libvips/resample/shrink.c:165 libvips/resample/shrinkh.c:369
+#, fuzzy
+msgid "Xshrink"
+msgstr "verkleinern"
+
+#: libvips/resample/reduce.c:242 libvips/resample/reducev.cpp:1093
+#: libvips/resample/shrink.c:172 libvips/resample/shrinkv.c:443
+#, fuzzy
+msgid "Yshrink"
+msgstr "verkleinern"
+
+#: libvips/resample/reduce.c:251 libvips/resample/reduceh.cpp:618
+#: libvips/resample/reducev.cpp:1102 libvips/resample/resize.c:384
+msgid "Centre"
+msgstr ""
+
+#: libvips/resample/reduce.c:252 libvips/resample/reduceh.cpp:619
+#: libvips/resample/reducev.cpp:1103 libvips/resample/resize.c:385
+msgid "Use centre sampling convention"
+msgstr ""
+
+#: libvips/resample/reduceh.cpp:414 libvips/resample/reducev.cpp:848
+#, fuzzy
+msgid "reduce factor should be >= 1.0"
+msgstr "Schrumpffaktoren sollten >=1 sein"
+
+#: libvips/resample/reduceh.cpp:437 libvips/resample/reducev.cpp:870
+#, fuzzy
+msgid "reduce gap should be >= 1.0"
+msgstr "Schrumpffaktoren sollten >=1 sein"
+
+#: libvips/resample/reduceh.cpp:467 libvips/resample/reducev.cpp:900
+#, fuzzy
+msgid "reduce factor too large"
+msgstr "Zoomfaktoren zu groß"
+
+#: libvips/resample/reduceh.cpp:580 libvips/resample/shrinkh.c:347
+#, fuzzy
+msgid "shrink an image horizontally"
+msgstr "horizontal so oft wiederholen"
+
+#: libvips/resample/reducev.cpp:1064 libvips/resample/shrinkv.c:421
+#, fuzzy
+msgid "shrink an image vertically"
+msgstr "vertikal so oft wiederholen"
+
+#: libvips/resample/resample.c:136
+#, fuzzy
+msgid "resample operations"
+msgstr "arithmetische Transaktionen"
+
+#: libvips/resample/resize.c:323
+#, fuzzy
+msgid "resize an image"
+msgstr "ein Bild nachmachen"
+
+#: libvips/resample/resize.c:329
+#, fuzzy
+msgid "Scale factor"
+msgstr "Q-Faktor"
+
+#: libvips/resample/resize.c:330
+msgid "Scale image by this factor"
+msgstr ""
+
+#: libvips/resample/resize.c:336
+#, fuzzy
+msgid "Vertical scale factor"
+msgstr "vertikaler Versatz vom Ursprung"
+
+#: libvips/resample/resize.c:337
+msgid "Vertical scale image by this factor"
+msgstr ""
+
+#: libvips/resample/shrink.c:133
+#, fuzzy
+msgid "shrink an image"
+msgstr "ein Bild invertieren"
+
+#: libvips/resample/shrink.c:156 libvips/resample/shrinkh.c:360
+#: libvips/resample/shrinkv.c:434
+msgid "Ceil"
+msgstr ""
+
+#: libvips/resample/shrink.c:157 libvips/resample/shrinkh.c:361
+#: libvips/resample/shrinkv.c:435
+#, fuzzy
+msgid "Round-up output dimensions"
+msgstr "falsche Abmessungen"
+
+#: libvips/resample/shrinkh.c:283 libvips/resample/shrinkv.c:327
+msgid "shrink factors should be >= 1"
+msgstr "Schrumpffaktoren sollten >=1 sein"
+
+#: libvips/resample/similarity.c:123
+msgid "base similarity transform"
+msgstr ""
+
+#: libvips/resample/similarity.c:197
+msgid "similarity transform of an image"
+msgstr ""
+
+#: libvips/resample/similarity.c:201
+msgid "Scale by this factor"
+msgstr ""
+
+#: libvips/resample/similarity.c:208 libvips/resample/similarity.c:277
+msgid "Rotate clockwise by this many degrees"
+msgstr ""
+
+#: libvips/resample/similarity.c:273
+#, fuzzy
+msgid "rotate an image by a number of degrees"
+msgstr "Tangens des Bildes (Winkel in Grad)"
+
+#: libvips/resample/thumbnail.c:959
+#, fuzzy
+msgid "thumbnail generation"
+msgstr "- Miniaturansichten-Generator"
+
+#: libvips/resample/thumbnail.c:974
+#, fuzzy
+msgid "Target width"
+msgstr "Kachelbreite"
+
+#: libvips/resample/thumbnail.c:975
+msgid "Size to this width"
+msgstr ""
+
+#: libvips/resample/thumbnail.c:981
+#, fuzzy
+msgid "Target height"
+msgstr "Kachelhöhe"
+
+#: libvips/resample/thumbnail.c:982
+#, fuzzy
+msgid "Size to this height"
+msgstr "Kachelhöhe"
+
+#: libvips/resample/thumbnail.c:989
+msgid "Only upsize, only downsize, or both"
+msgstr ""
+
+#: libvips/resample/thumbnail.c:995
+msgid "No rotate"
+msgstr ""
+
+#: libvips/resample/thumbnail.c:996
+msgid "Don't use orientation tags to rotate image upright"
+msgstr ""
+
+#: libvips/resample/thumbnail.c:1002
+msgid "Crop"
+msgstr ""
+
+#: libvips/resample/thumbnail.c:1003
+msgid "Reduce to fill target rectangle, then crop"
+msgstr ""
+
+#: libvips/resample/thumbnail.c:1009
+#, fuzzy
+msgid "Linear"
+msgstr "Zeilen"
+
+#: libvips/resample/thumbnail.c:1010
+msgid "Reduce in linear light"
+msgstr ""
+
+#: libvips/resample/thumbnail.c:1016
+#, fuzzy
+msgid "Import profile"
+msgstr "Profil"
+
+#: libvips/resample/thumbnail.c:1017
+msgid "Fallback import profile"
+msgstr ""
+
+#: libvips/resample/thumbnail.c:1023
+#, fuzzy
+msgid "Export profile"
+msgstr "Profil"
+
+#: libvips/resample/thumbnail.c:1024
+msgid "Fallback export profile"
+msgstr ""
+
+#: libvips/resample/thumbnail.c:1050
+#, fuzzy
+msgid "Auto rotate"
+msgstr "Winkel zum Drehen eines Bildes"
+
+#: libvips/resample/thumbnail.c:1051
+msgid "Use orientation tags to rotate image upright"
+msgstr ""
+
+# http://www.dateiendung.com/format/mat
+#: libvips/resample/thumbnail.c:1192
+#, fuzzy
+msgid "generate thumbnail from file"
+msgstr "Mat aus Datei laden"
+
+#: libvips/resample/thumbnail.c:1199
+#, fuzzy
+msgid "Filename to read from"
+msgstr "Name der Datei, aus der geladen werden soll"
+
+#: libvips/resample/thumbnail.c:1439
+msgid "generate thumbnail from buffer"
+msgstr ""
+
+#: libvips/resample/thumbnail.c:1452 libvips/resample/thumbnail.c:1665
+#, fuzzy
+msgid "Extra options"
+msgstr "unäre Transaktionen"
+
+#: libvips/resample/thumbnail.c:1453 libvips/resample/thumbnail.c:1666
+msgid "Options that are passed on to the underlying loader"
+msgstr ""
+
+#: libvips/resample/thumbnail.c:1652
+msgid "generate thumbnail from source"
+msgstr ""
+
+#: libvips/resample/thumbnail.c:1776
+#, fuzzy
+msgid "generate thumbnail from image"
+msgstr "Band aus einem Bild extrahieren"
+
+#: libvips/resample/vsqbs.cpp:378
+msgid "B-Splines with antialiasing smoothing"
+msgstr "B-Splines mit Kantenglättung"
+
+#: tools/vips.c:166
+#, c-format
+msgid "'%s' is not the name of a vips class"
+msgstr ""
+
+#: tools/vips.c:282
+#, fuzzy, c-format
+msgid "'%s' is not the name of a vips operation"
+msgstr "genannte VIPS-Transaktion ausführen"
+
+#: tools/vips.c:355
 #, c-format
 msgid "no package or function \"%s\""
 msgstr "kein Paket oder Funktion »%s«"
 
-#: tools/vips.c:917
-msgid "list classes|packages|all|package-name|operation-name"
-msgstr "classes|packages|all|package-name|operation-name aufführen"
+#: tools/vips.c:584
+#, fuzzy
+msgid "execute vips operation OPER"
+msgstr "genannte VIPS-Transaktion ausführen"
 
-#: tools/vips.c:919
-msgid "generate headers for C++ binding"
-msgstr "Header für C++-Anbindung erzeugen"
+#: tools/vips.c:627
+#, fuzzy
+msgid "Operation help"
+msgstr "Transaktion"
 
-#: tools/vips.c:921
-msgid "generate bodies for C++ binding"
-msgstr "Rumpfdaten für C++-Anbindung erzeugen"
-
-#: tools/vips.c:923
-msgid "generate links for vips/bin"
-msgstr "Verweise für VIPS/Bin erzeugen"
-
-#: tools/vips.c:1043
+#: tools/vips.c:706
 msgid "[ACTION] [OPTIONS] [PARAMETERS] - VIPS driver program"
 msgstr "[AKTION] [OPTIONEN] [PARAMETER] - VIPS-Treiberprogramm"
 
-#: tools/vips.c:1111
-msgid "possible actions:\n"
-msgstr "mögliche Aktionen:\n"
-
-#: tools/vips.c:1116
-msgid "execute named vips operation"
-msgstr "genannte VIPS-Transaktion ausführen"
-
-#: tools/vips.c:1118
+#: tools/vips.c:916
 #, c-format
 msgid "unknown action \"%s\""
 msgstr "unbekannte Aktion »%s«"
 
-#: tools/vipsthumbnail.c:54
-msgid "set thumbnail size to SIZE"
-msgstr "Miniaturansicht auf GRÖẞE setzen"
+#: tools/vipsedit.c:129
+#, c-format
+msgid "'%s' is not a positive integer"
+msgstr "»%s« ist keine positive Ganzzahl"
 
-#: tools/vipsthumbnail.c:55
-msgid "SIZE"
-msgstr "GRÖẞE"
+#: tools/vipsedit.c:142
+msgid "unable to start VIPS"
+msgstr "VIPS kann nicht gestartet werden"
 
-#: tools/vipsthumbnail.c:57
-msgid "set output to FORMAT"
-msgstr "Ausgabe auf FORMAT setzen"
+#: tools/vipsedit.c:165
+#, fuzzy
+msgid "vipsedit - edit vips file header"
+msgstr "»vipsfile« - »vipsfile«-Kopfzeilen bearbeiten"
 
-#: tools/vipsthumbnail.c:58
-msgid "FORMAT"
-msgstr "FORMAT"
+#: tools/vipsedit.c:193
+#, fuzzy, c-format
+msgid "usage: %s [OPTION...] vips-file\n"
+msgstr "Aufruf: %s [OPTION …] vipsfile\n"
 
-#: tools/vipsthumbnail.c:60
-msgid "resample with INTERPOLATOR"
-msgstr "neues Muster mit INTERPOLATOR erstellen"
+#: tools/vipsedit.c:200
+#, c-format
+msgid "could not open image %s"
+msgstr "Bild %s konnte nicht geöffnet werden"
 
-#: tools/vipsthumbnail.c:61
-msgid "INTERPOLATOR"
-msgstr "INTERPOLATOR"
+#: tools/vipsedit.c:206
+#, c-format
+msgid "could not read VIPS header for %s"
+msgstr "VIPS-Kopfzeilen für %s konnten nicht gelesen werden"
 
-#: tools/vipsthumbnail.c:63
-msgid "don't sharpen thumbnail"
-msgstr "Miniaturansicht nicht schärfen"
+#: tools/vipsedit.c:216
+#, c-format
+msgid "bad endian-ness %s, should be 'big' or 'little'"
+msgstr "falsche Byte-Reihenfolge %s, sollte »big« oder »little« sein"
 
-#: tools/vipsthumbnail.c:65
-msgid "export with PROFILE"
-msgstr "mit PROFIL exportieren"
+#: tools/vipsedit.c:230
+#, c-format
+msgid "bad format %s"
+msgstr "falsches Format %s"
 
-#: tools/vipsthumbnail.c:66 tools/vipsthumbnail.c:69
-msgid "PROFILE"
-msgstr "PROFIL"
+#: tools/vipsedit.c:244
+#, c-format
+msgid "bad interpretation %s"
+msgstr "falsche Interpretation »%s« "
 
-#: tools/vipsthumbnail.c:68
-msgid "import untagged images with PROFILE"
-msgstr "nicht gekennzeichnetes Bild mit PROFIL importieren"
+#: tools/vipsedit.c:254
+#, c-format
+msgid "bad coding %s"
+msgstr "falsche Kodierung %s"
 
-#: tools/vipsthumbnail.c:71
-msgid "don't delete profile from exported image"
-msgstr "Profil aus exportiertem Bild nicht löschen"
+#: tools/vipsedit.c:268
+#, c-format
+msgid "could not seek on %s"
+msgstr "auf %s konnte nicht gesucht werden"
 
-#: tools/vipsthumbnail.c:73
-msgid "verbose output"
-msgstr "detaillierte Ausgabe"
+#: tools/vipsedit.c:271
+#, c-format
+msgid "could not write to %s"
+msgstr "auf %s konnte nicht geschrieben werden"
 
-#: tools/vipsthumbnail.c:412
+#: tools/vipsedit.c:278
+msgid "could not get ext data"
+msgstr "zusätzliche Daten konnten nicht abgefragt werden"
+
+#: tools/vipsedit.c:287
+msgid "could not set extension"
+msgstr "Erweiterung konnte nicht gesetzt werden"
+
+#: tools/vipsheader.c:221
+msgid "- print image header"
+msgstr "- Bild-Kopfzeilen ausgeben"
+
+#: tools/vipsthumbnail.c:447
+#, fuzzy
+msgid "bad geometry spec"
+msgstr "falsche Gittergeometrie"
+
+#: tools/vipsthumbnail.c:516
 msgid "- thumbnail generator"
 msgstr "- Miniaturansichten-Generator"
 
-#: libvips/resample/bicubic.cpp:430
-msgid "Bicubic interpolation (Catmull-Rom)"
-msgstr "doppelt kubische Interpolation (Catmull-Rom)"
+#~ msgid "coords outside image"
+#~ msgstr "Koordinaten außerhalb des Bildes"
 
-#: libvips/resample/nohalo.cpp:1577
-msgid "Edge sharpening resampler with halo reduction"
-msgstr "neues Kantenschärfungsmuster mit Halo-Reduzierung"
+#~ msgid "absolute value"
+#~ msgstr "absoluter Wert"
 
-#: libvips/resample/vsqbs.cpp:400
-msgid "B-Splines with antialiasing smoothing"
-msgstr "B-Splines mit Kantenglättung"
+#~ msgid "average value of image"
+#~ msgstr "Durchschnittswert des Bildes"
 
-#: libvips/resample/lbb.cpp:861
-msgid "Reduced halo bicubic"
-msgstr "doppelt kubische Halo-Reduzierung"
+# im_exptra() transforms element x of input to
+# <function>pow</function>(e, x) in output.
+#~ msgid "10^pel of image"
+#~ msgstr "10^pel des Bildes"
+
+#~ msgid "e^pel of image"
+#~ msgstr "e^pel des Bildes"
+
+#~ msgid "x^pel of image"
+#~ msgstr "x^pel des Bildes"
+
+#~ msgid "[x,y,z]^pel of image"
+#~ msgstr "[x,y,z]^pel des Bildes"
+
+#~ msgid "photographic negative"
+#~ msgstr "Fotonegativ"
+
+#~ msgid "calculate a*in + b = outfile"
+#~ msgstr "Berechnen von a*in + b = Ausgabedatei"
+
+#~ msgid "vectors not equal length"
+#~ msgstr "Vektoren ungleicher Länge"
+
+#~ msgid "calculate a*in + b -> out, a and b vectors"
+#~ msgstr "Berechnen von a*in + b -> out, a und b Vektoren"
+
+#~ msgid "log10 of image"
+#~ msgstr "log10 des Bildes"
+
+#~ msgid "atan of image (result in degrees)"
+#~ msgstr "Arkustangens des Bildes (Ergebnis in Grad)"
+
+#~ msgid "cos of image (angles in degrees)"
+#~ msgstr "Kosinus des Bildes (Winkel in Grad)"
+
+#~ msgid "acos of image (result in degrees)"
+#~ msgstr "Arkuskosinus des Bildes (Ergebnis in Grad)"
+
+# hinter diesem String folgt ein Flag.
+#~ msgid "round to smallest integer value not less than"
+#~ msgstr "auf kleinsten ganzzahligen Wert runden, nicht weniger als"
+
+# hinter diesem String folgt ein Flag.
+#~ msgid "round to largest integer value not greater than"
+#~ msgstr "auf größten ganzzahligen Wert runden, nicht größer als"
+
+# hinter diesem String folgt ein Flag.
+#~ msgid "round to nearest integer value"
+#~ msgstr "auf nächsten ganzzahligen Wert runden"
+
+#~ msgid "sin of image (angles in degrees)"
+#~ msgstr "Sinus des Bildes (Winkel in Grad)"
+
+#~ msgid "average image bands"
+#~ msgstr "durchschnittliche Bildbänder"
+
+#~ msgid "unit vector in direction of value"
+#~ msgstr "Einheitsvektor in Richtung des Wertes"
+
+#~ msgid "asin of image (result in degrees)"
+#~ msgstr "Arkussinus des Bildes (Ergebnis in Grad)"
+
+#~ msgid "position of maximum value of image, averaging in case of draw"
+#~ msgstr ""
+#~ "Position des Maximalwerts des Bildes, durchschnittlich im Fall des "
+#~ "Zeichnens"
+
+#~ msgid "position and value of n maxima of image"
+#~ msgstr "Position und Wert von n Maxima des Bildes"
+
+#~ msgid "position and value of n minima of image"
+#~ msgstr "Position und Wert von n Minima des Bildes"
+
+#~ msgid "measure averages of a grid of patches"
+#~ msgstr "Durchschnittsmaße eine Gitters aus Flickstücken"
+
+#~ msgid "remainder after integer division by a constant"
+#~ msgstr "Rest nach Ganzzahldivision durch eine Konstante"
+
+#~ msgid "remainder after integer division by a vector of constants"
+#~ msgstr "Rest nach Ganzzahldivision durch einen Vektor von Konstanten"
+
+#~ msgid "pel^x of image"
+#~ msgstr "pel^x des Bildes"
+
+#~ msgid "pel^[x,y,z] of image"
+#~ msgstr "pel^[x,y,z] des Bildes"
+
+#~ msgid "many image statistics in one pass"
+#~ msgstr "viele Bildstatistiken in einem Durchgang"
+
+#~ msgid "pixelwise linear regression"
+#~ msgstr "bildpunktweise lineare Regression"
+
+#~ msgid "phase of cross power spectrum of two complex images"
+#~ msgstr "Phase des Kreuzleistungsspektrums zweier komplexer Bilder"
+
+#~ msgid "single band images only"
+#~ msgstr "nur Einzelbandbilder"
+
+#~ msgid "uncoded images only"
+#~ msgstr "nur unkodierte Bilder"
+
+#~ msgid "pow( left, right)"
+#~ msgstr "pow( links, rechts)"
+
+#~ msgid "pow( @in, @c )"
+#~ msgstr "pow( @in, @c )"
+
+#, c-format
+#~ msgid ""
+#~ "intent %d (%s) not supported by profile \"%s\"; falling back to default "
+#~ "intent (usually PERCEPTUAL)"
+#~ msgstr ""
+#~ "Ziel-%d (%s) nicht von Profil »%s« unterstützt; Rückfall auf "
+#~ "Standardabsicht (normalerweise WAHRNEHMUNG)"
+
+#~ msgid "CMYK input profile needs a 4 band input image"
+#~ msgstr "CMYK-Eingabeprofil benötigt ein Eingabebild mit vier Bändern"
+
+#~ msgid "RGB input profile needs a 3 band input image"
+#~ msgstr "RGB-Eingabeprofil benötigt ein Eingabebild mit drei Bändern"
+
+#~ msgid "uchar or ushort input only"
+#~ msgstr "nur »uchar« oder »ushort«-Eingabe"
+
+#, c-format
+#~ msgid ""
+#~ "intent %d (%s) not supported by profile; falling back to default intent "
+#~ "(usually PERCEPTUAL)"
+#~ msgstr ""
+#~ "Ziel-%d (%s) nicht vom Profil unterstützt; Rückfall auf Standardabsicht "
+#~ "(normalerweise WAHRNEHMUNG)"
+
+#~ msgid "CMYK profile needs a 4 band input image"
+#~ msgstr "CMYK-Profil benötigt ein Eingabebild mit vier Bändern"
+
+#~ msgid "RGB profile needs a 3 band input image"
+#~ msgstr "RGB-Profil benötigt ein Eingabebild mit drei Bändern"
+
+#~ msgid "lcms library not linked to this VIPS"
+#~ msgstr "gegen die »lcms«-Bibliothek wird in diesem VIPS nicht verlinkt"
+
+#~ msgid "lmcs library not linked to this VIPS"
+#~ msgstr "gegen die »lmcs«-Bibliothek wird in diesem VIPS nicht verlinkt"
+
+#~ msgid "out of range [0,255]"
+#~ msgstr "außerhalb des Bereichs [0,255]"
+
+#~ msgid "bad display type"
+#~ msgstr "falsche Anzeigetyp"
+
+#~ msgid "display unknown"
+#~ msgstr "Anzeige unbekannt"
+
+#~ msgid "input not 3-band uncoded char"
+#~ msgstr "Eingabe ist kein unkodiertes Zeichen mit drei Bändern"
+
+#~ msgid "3-band uncoded float only"
+#~ msgstr "nur unkodierte Fließkommazahlen mit drei Bändern"
+
+#~ msgid "bad greyscale mask size"
+#~ msgstr "falsche Grauskala-Maskengröße"
+
+#, c-format
+#~ msgid "bad greyscale mask value, row %d"
+#~ msgstr "falscher Grauskala-Maskenwert, Reihe %d"
+
+#, c-format
+#~ msgid "%d underflows and %d overflows detected"
+#~ msgstr "%d Unter- und %d Überläufe entdeckt"
+
+#~ msgid "pangoft2 support disabled"
+#~ msgstr "Pangoft2-Unterstützung deaktiviert"
+
+#~ msgid "zoom factors should be >= 0"
+#~ msgstr "Zoomfaktoren sollten >=0 sein"
+
+#~ msgid "vectors not same length"
+#~ msgstr "Vektoren ungleicher Länge"
+
+#~ msgid "direction"
+#~ msgstr "Richtung"
+
+#~ msgid "bad arguments"
+#~ msgstr "falsche Argumente"
+
+#~ msgid "image does not have that many bands"
+#~ msgstr "Bild hat nicht so viele Bänder"
+
+#~ msgid "factors should both be >= 1"
+#~ msgstr "beide Faktoren sollten >=1 sein"
+
+#~ msgid "parameters would result in zero size output image"
+#~ msgstr "Parameter würden zu einem Ausgabebild der Größe Null führen"
+
+#, c-format
+#~ msgid "%d overflows and %d underflows detected"
+#~ msgstr "%d Über- und %d Unterläufe entdeckt"
+
+#~ msgid "expect 1xN or Nx1 input mask"
+#~ msgstr "1xN- oder Nx1-Eingabemaske wird erwartet"
+
+# ref und in sind Objekte
+#~ msgid "ref not smaller than or equal to in"
+#~ msgstr "»ref« nicht kleiner oder gleich »in«"
+
+#~ msgid "end of file while skipping start"
+#~ msgstr "Dateiende während des Überspringens des Startes"
+
+#, c-format
+#~ msgid "unexpected EOF, line %d col %d"
+#~ msgstr "unerwartetes Dateiende, Zeile %d, Spalte %d"
+
+#, c-format
+#~ msgid "unexpected EOL, line %d col %d"
+#~ msgstr "unerwartetes Zeilenende, Zeile %d, Spalte %d"
+
+#, c-format
+#~ msgid "required field %d=%d, not %d"
+#~ msgstr "benötigtes Feld %d=%d, nicht %d"
+
+#~ msgid "4 or 5 bands CMYK TIFF only"
+#~ msgstr "nur CMYK-TIFF mit vier oder fünf Bändern"
+
+#, c-format
+#~ msgid ""
+#~ "no resolution information for TIFF image \"%s\" -- defaulting to 1 pixel "
+#~ "per mm"
+#~ msgstr ""
+#~ "Keine Auflösungsinformationen für TIFF-Bild »%s« – Standard auf 1 "
+#~ "Bildpunkt pro mm"
+
+#, c-format
+#~ msgid "unsupported sample format %d for lab image"
+#~ msgstr "nicht unterstütztes Musterformat %d für LAB-Bild"
+
+#, c-format
+#~ msgid "unsupported depth %d for LAB image"
+#~ msgstr "nicht unterstützte Tiefe %d für LAB-Bild"
+
+#, c-format
+#~ msgid "unsupported sample format %d for greyscale image"
+#~ msgstr "nicht unterstütztes Musterformat %d für Graustufenbild"
+
+#, c-format
+#~ msgid "unsupported depth %d for greyscale image"
+#~ msgstr "nicht unterstützte Tiefe %d für Graustufenbild"
+
+#, c-format
+#~ msgid "unsupported sample format %d for rgb image"
+#~ msgstr "nicht unterstütztes Musterformat %d für RGB-Bild"
+
+#, c-format
+#~ msgid "unsupported depth %d for RGB image"
+#~ msgstr "nicht unterstützte Tiefe %d für RGB-Bild"
+
+#~ msgid "error writing output"
+#~ msgstr "Fehler beim Schreiben der Ausgabe"
+
+#~ msgid "File descriptor"
+#~ msgstr "Datei-Deskriptor"
+
+#~ msgid "error setting JPEG resolution"
+#~ msgstr "Fehler beim Setzen der JPEG-Auflösung"
+
+#, c-format
+#~ msgid ""
+#~ "unable to ping file \"%s\"\n"
+#~ "libMagick error: %s %s"
+#~ msgstr ""
+#~ "Datei »%s« kann nicht angepingt werden\n"
+#~ "libMagick-Fehler: %s %s"
+
+#, c-format
+#~ msgid "unable to write \"%s\""
+#~ msgstr "»%s« kann nicht geschrieben werden"
+
+#~ msgid "error reading resolution"
+#~ msgstr "Fehler beim Lesen der Auflösung"
+
+#~ msgid "bad int"
+#~ msgstr "falsche Ganzzahl"
+
+#~ msgid "bad float"
+#~ msgstr "falsche Fließkommazahl"
+
+#~ msgid "not whitespace before start of binary data"
+#~ msgstr "kein Leerraum vor dem Start der binären Daten"
+
+#~ msgid "write error ... disc full?"
+#~ msgstr "Schreibfehler … Platte voll?"
+
+#~ msgid "binary >8 bit images must be float"
+#~ msgstr "binäre Bilder >8 Bit müssen aus Fließkommazahlen bestehen"
+
+#~ msgid "layer buffer exhausted -- try making TIFF output tiles smaller"
+#~ msgstr ""
+#~ "Ebenenpuffer aufgebraucht – versuchen Sie die TIFF-Ausgabekacheln zu "
+#~ "verkleinern"
+
+#~ msgid "internal error #9876345"
+#~ msgstr "interner Fehler #9876345"
+
+#~ msgid "can't have strip pyramid -- enabling tiling"
+#~ msgstr ""
+#~ "nicht ummantelte Pyramide nicht möglich – Zerteilung wird eingeschaltet"
+
+#~ msgid "unsigned 8-bit int, 16-bit int, and 32-bit float only"
+#~ msgstr "nur vorzeichenlose 8-Bit-Ganzzahl und 32-Bit-Fließkommazahl"
+
+#~ msgid "1 to 5 bands only"
+#~ msgstr "nur 1 bis 5 Bänder"
+
+#~ msgid "images do not match"
+#~ msgstr "Bilder passen nicht zusammen"
+
+#~ msgid "mask sizes power of 2 only"
+#~ msgstr "Maskengröße nur Potenzen von 2"
+
+#~ msgid "unimplemented mask type"
+#~ msgstr "nicht implementierter Maskentyp"
+
+#~ msgid "bad args"
+#~ msgstr "falsche Argumente"
+
+#~ msgid "bad args (f)"
+#~ msgstr "falsche Argumente (f)"
+
+#~ msgid "bad args (ac)"
+#~ msgstr "falsche Argumente (ac)"
+
+#~ msgid "dimension should be in (2,3)"
+#~ msgstr "Dimension sollte in (2,3) liegen"
+
+#~ msgid "window too small"
+#~ msgstr "Fenster zu klein"
+
+#~ msgid "bad input matrix size"
+#~ msgstr "falsche Eingabematrix-Größe"
+
+#~ msgid "bad in_max, out_max parameters"
+#~ msgstr "falsche »in_max«-, »out_max«-Parameter"
+
+#~ msgid "bad Lb, Lw parameters"
+#~ msgstr "falsche »Lb«-, »Lw«-Parameter"
+
+#~ msgid "Ps not in range [0.0,1.0]"
+#~ msgstr "»Ps« nicht im Bereich [0.0,1.0]"
+
+#~ msgid "Pm not in range [0.0,1.0]"
+#~ msgstr "»Pm« nicht im Bereich [0.0,1.0]"
+
+#~ msgid "Ph not in range [0.0,1.0]"
+#~ msgstr "»Ph« nicht im Bereich [0.0,1.0]"
+
+#~ msgid "S not in range [-30,+30]"
+#~ msgstr "»S« nicht im Bereich [-30,+30]"
+
+#~ msgid "M not in range [-30,+30]"
+#~ msgstr "»M« nicht im Bereich [-30,+30]"
+
+#~ msgid "H not in range [-30,+30]"
+#~ msgstr "»H« nicht im Bereich [-30,+30]"
+
+#~ msgid "bad lut_size"
+#~ msgstr "falsche »lut_size«"
+
+#~ msgid "mask image not 1 band 8 bit uncoded"
+#~ msgstr "Maskenbild nicht 8-Bit-kodiert mit einem Band"
+
+#, c-format
+#~ msgid "unable to set property \"%s\" to value \"%s\"."
+#~ msgstr "Eigenschaft »%s« kann nicht auf Wert »%s« gesetzt werden."
+
+#, c-format
+#~ msgid "start function failed for image %s"
+#~ msgstr "Startfunktion für Bild %s fehlgeschlagen"
+
+#~ msgid "evaluate with N concurrent threads"
+#~ msgstr "mit N gleichzeitigen Threads auswerten"
+
+#~ msgid "set tile width to N (DEBUG)"
+#~ msgstr "Bildbreite auf N setzen (DEBUG)"
+
+#~ msgid "set tile height to N (DEBUG)"
+#~ msgstr "Bildhöhe auf N setzen (DEBUG)"
+
+#~ msgid "set thinstrip height to N (DEBUG)"
+#~ msgstr "»thinstrip«-Höhe auf N setzen (DEBUG)"
+
+#~ msgid "set fatstrip height to N (DEBUG)"
+#~ msgstr "»fatstrip«-Höhe auf N setzen (DEBUG)"
+
+#~ msgid "show progress feedback"
+#~ msgstr "Fortschrittsrückmeldung anzeigen"
+
+#~ msgid "leak-check on exit"
+#~ msgstr "Lückenprüfung beim Beenden"
+
+#~ msgid "images larger than N are decompressed to disc"
+#~ msgstr "Bilder, die größer als N sind, werden auf die Platte dekomprimiert"
+
+#~ msgid "disable vectorised versions of operations"
+#~ msgstr "vektorgesteuerte Versionen von Transaktionen deaktivieren"
+
+#~ msgid "cache at most N operations"
+#~ msgstr "höchstens N Transaktionen zwischenspeichern"
+
+#~ msgid "cache at most N bytes in memory"
+#~ msgstr "höchstens N Byte zwischenspeichern"
+
+#~ msgid "allow at most N open files"
+#~ msgstr "höchstens N offene Dateien erlauben"
+
+#~ msgid "trace operation cache"
+#~ msgstr "Transaktionszwischenspeicher aufzeichnen"
+
+#~ msgid "dump operation cache on exit"
+#~ msgstr "Transaktionszwischenspeicher beim Beenden ausgeben"
+
+#~ msgid "VIPS Options"
+#~ msgstr "VIPS-Optionen"
+
+#~ msgid "Show VIPS options"
+#~ msgstr "VIPS-Optionen anzeigen"
+
+#, c-format
+#~ msgid "%dx%d %s, %d band, %s"
+#~ msgid_plural "%dx%d %s, %d bands, %s"
+#~ msgstr[0] "%dx%d %s, %d Band, %s"
+#~ msgstr[1] "%dx%d %s, %d Bänder, %s"
+
+#, c-format
+#~ msgid " %s, %d band, %s"
+#~ msgid_plural " %s, %d bands, %s"
+#~ msgstr[0] " %s, %d band, %s"
+#~ msgstr[1] " %s, %d Bänder, %s"
+
+#, c-format
+#~ msgid ""
+#~ "map failed (%s), running very low on system resources, expect a crash soon"
+#~ msgstr ""
+#~ "»map« fehlgeschlagen (%s), die Systemressourcen werden knapp, ein Absturz "
+#~ "steht bevor"
+
+#~ msgid "too little data"
+#~ msgstr "zu wenige Daten"
+
+#~ msgid "bytes"
+#~ msgstr "Byte"
+
+#~ msgid "KB"
+#~ msgstr "KB"
+
+#~ msgid "MB"
+#~ msgstr "MB"
+
+#~ msgid "TB"
+#~ msgstr "TB"
+
+#, c-format
+#~ msgid "unable to make temporary file %s"
+#~ msgstr "temporäre Datei %s kann nicht erstellt werden"
+
+#~ msgid "usage:"
+#~ msgstr "Aufruf:"
+
+#, c-format
+#~ msgid "%s: "
+#~ msgstr "%s: "
+
+#~ msgid "vips diagnostic"
+#~ msgstr "Vips-Diagnose"
+
+#~ msgid "vips warning"
+#~ msgstr "Vips-Warnung"
+
+#~ msgid "nonsense mask parameters"
+#~ msgstr "unsinnige Maskenparameter"
+
+#~ msgid "mask must be 1D"
+#~ msgstr "Maske muss 1D sein"
+
+#~ msgid "dir not 0 or 1"
+#~ msgstr "»dir« nicht 0 oder 1"
+
+#~ msgid "flag should be 0 (horizontal) or 1 (vertical)"
+#~ msgstr "Schalter sollte 0 (horizontal) oder 1 (vertikal) sein"
+
+#~ msgid "image too small for window"
+#~ msgstr "Bild zu klein für Fenster"
+
+#~ msgid "zero input images!"
+#~ msgstr "null Eingabebilder"
+
+#, c-format
+#~ msgid "index should be in range 0 - %d"
+#~ msgstr "Index sollte im Bereich 0 - %d liegen"
+
+#~ msgid "size must be even and positive"
+#~ msgstr "Größe muss gerade und positiv sein"
+
+#~ msgid "wrong sizes"
+#~ msgstr "falsche Größen"
+
+#~ msgid "calloc failed"
+#~ msgstr "»calloc« fehlgeschlagen"
+
+#~ msgid "factor should be in [1,0)"
+#~ msgstr "Faktor sollte in [0,1) liegen"
+
+#~ msgid "shift by zero: falling back to im_copy"
+#~ msgstr "verschieben um Null: Rückfall auf »im_copy«"
+
+#~ msgid "would result in zero size output image"
+#~ msgstr "würde in einem Ausgabebild der Größe Null resultieren"
+
+#~ msgid "image and band_fmt must match in sign"
+#~ msgstr "Bild und Band-Fmt müssen im Kennzeichen zusammenpassen"
+
+#, c-format
+#~ msgid "ioctl(0x%x) failed: %s"
+#~ msgstr "ioctl(0x%x) fehlgeschlagen: %s"
+
+#, c-format
+#~ msgid "cannot open video device \"%s\""
+#~ msgstr "Videogerät »%s« kann nicht geöffnet werden"
+
+#~ msgid "cannot get video capability"
+#~ msgstr "Videofähigkeit kann nicht abgefragt werden"
+
+#~ msgid "card cannot capture to memory"
+#~ msgstr "Karte kann nicht in Speicher digitalisiert werden"
+
+#~ msgid "unable to map memory"
+#~ msgstr "Speicher kann nicht abgebildet werden"
+
+#, c-format
+#~ msgid "channel not between 0 and %d"
+#~ msgstr "Kanal nicht zwischen 0 und %d"
+
+#~ msgid "compiled without im_video_v4l1 support"
+#~ msgstr "ohne »im_video_v4l1«-Unterstützung kompiliert"
+
+#~ msgid "tag file as big or little-endian"
+#~ msgstr "Kennzeichendatei als Big- oder Little-Endian"
+
+#~ msgid "set width to N pixels"
+#~ msgstr "Breite auf N Bildpunkte setzen"
+
+#~ msgid "set height to N pixels"
+#~ msgstr "Höhe auf N Bildpunkte setzen"
+
+#~ msgid "set BandFmt to F (eg. uchar, float)"
+#~ msgstr "»BandFmt« auf F setzen (z.B. uchar, float)"
+
+#~ msgid "set interpretation to I (eg. xyz)"
+#~ msgstr "Interpretation aif I setzen (z.B. xyz)"
+
+#~ msgid "set Coding to C (eg. labq)"
+#~ msgstr "Kodierung auf C setzen (z.B. labq)"
+
+#~ msgid "set Xres to R pixels/mm"
+#~ msgstr "»Xres« auf R Bildpunkte/mm setzen"
+
+#~ msgid "set Yres to R pixels/mm"
+#~ msgstr "»Yres« auf R Bildpunkte/mm setzen"
+
+#~ msgid "set Xoffset to N pixels"
+#~ msgstr "»Xoffset« auf N Bildpunkte setzen"
+
+#~ msgid "set Yoffset to N pixels"
+#~ msgstr "»Yoffset« auf N Bildpunkte setzen"
+
+#~ msgid "replace extension block with stdin"
+#~ msgstr "Erweiterungsblock mit STDIN ersetzen"
+
+#~ msgid "set Xsize to N (deprecated, use width)"
+#~ msgstr "»Xsize« auf N setzen (missbilligt, benutzen Sie »width«)"
+
+#~ msgid "set Ysize to N (deprecated, use height)"
+#~ msgstr "»Ysize« auf N setzen (missbilligt, benutzen Sie »height«)"
+
+#~ msgid "set Type to T (deprecated, use interpretation)"
+#~ msgstr "Typ auf N setzen (missbilligt, benutzen Sie »interpretation«"
+
+#, c-format
+#~ msgid "bad file name format '%s'"
+#~ msgstr "falsches Dateinamensformat »%s«"
+
+#~ msgid "show all fields"
+#~ msgstr "alle Felder anzeigen"
+
+#~ msgid ""
+#~ "print value of FIELD (\"getext\" reads extension block, \"Hist\" reads "
+#~ "image history)"
+#~ msgstr ""
+#~ "Wert von FELD ausgeben (»getext« liest Erweiterungsblock, »Hist« liest "
+#~ "Bildchronik)"
+
+#~ msgid "allocation failure in mergeup"
+#~ msgstr "Reservierung in »mergeup« gescheitert"
+
+#~ msgid "Need more than one image"
+#~ msgstr "Mehr als ein Bild benötigt"
+
+#~ msgid "load PLUGIN"
+#~ msgstr "ERWEITERUNG laden"
+
+#~ msgid "PLUGIN"
+#~ msgstr "ERWEITERUNG"
+
+#~ msgid "list classes|packages|all|package-name|operation-name"
+#~ msgstr "classes|packages|all|package-name|operation-name aufführen"
+
+#~ msgid "generate headers for C++ binding"
+#~ msgstr "Header für C++-Anbindung erzeugen"
+
+#~ msgid "generate bodies for C++ binding"
+#~ msgstr "Rumpfdaten für C++-Anbindung erzeugen"
+
+#~ msgid "generate links for vips/bin"
+#~ msgstr "Verweise für VIPS/Bin erzeugen"
+
+#~ msgid "possible actions:\n"
+#~ msgstr "mögliche Aktionen:\n"
+
+#~ msgid "SIZE"
+#~ msgstr "GRÖẞE"
+
+#~ msgid "set output to FORMAT"
+#~ msgstr "Ausgabe auf FORMAT setzen"
+
+#~ msgid "FORMAT"
+#~ msgstr "FORMAT"
+
+#~ msgid "resample with INTERPOLATOR"
+#~ msgstr "neues Muster mit INTERPOLATOR erstellen"
+
+#~ msgid "INTERPOLATOR"
+#~ msgstr "INTERPOLATOR"
+
+#~ msgid "don't sharpen thumbnail"
+#~ msgstr "Miniaturansicht nicht schärfen"
+
+#~ msgid "export with PROFILE"
+#~ msgstr "mit PROFIL exportieren"
+
+#~ msgid "PROFILE"
+#~ msgstr "PROFIL"
+
+#~ msgid "import untagged images with PROFILE"
+#~ msgstr "nicht gekennzeichnetes Bild mit PROFIL importieren"
+
+#~ msgid "don't delete profile from exported image"
+#~ msgstr "Profil aus exportiertem Bild nicht löschen"

--- a/po/en_GB.po
+++ b/po/en_GB.po
@@ -1,6262 +1,7547 @@
 # en_GB for vips
-
 # Copyright (C) 2017
 # This file is distributed under the same license as the vips package.
 # John Cupitt <jcupitt@gmail.com>, 2017.
 #
-#, fuzzy
-
 msgid ""
 msgstr ""
-"Project-Id-Version: vips 8.5\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2017-02-22 13:13+0000\n"
-"PO-Revision-Date: \n"
+"POT-Creation-Date: 2025-01-30 14:51+0000\n"
 "Last-Translator: John Cupitt <jcupitt@gmail.com>\n"
-"Language-Team: \n"
 "Language: en_GB\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 
-#: ../libvips/arithmetic/min.c:431
-msgid "find image minimum"
+#: libvips/arithmetic/abs.c:200
+msgid "absolute value of an image"
 msgstr ""
 
-#: ../libvips/arithmetic/min.c:439 ../libvips/arithmetic/stats.c:420
-#: ../libvips/arithmetic/deviate.c:221 ../libvips/arithmetic/max.c:438
-#: ../libvips/arithmetic/hist_find_ndim.c:298
-#: ../libvips/arithmetic/measure.c:210 ../libvips/arithmetic/hist_find.c:450
-#: ../libvips/arithmetic/hough.c:185 ../libvips/arithmetic/arithmetic.c:639
-#: ../libvips/arithmetic/avg.c:214
-#: ../libvips/arithmetic/hist_find_indexed.c:391 ../libvips/colour/colour.c:427
-#: ../libvips/colour/sRGB2scRGB.c:249 ../libvips/colour/scRGB2BW.c:243
-#: ../libvips/colour/scRGB2sRGB.c:271 ../libvips/colour/colourspace.c:592
-#: ../libvips/conversion/conversion.c:200
-#: ../libvips/convolution/convolution.c:135
-#: ../libvips/convolution/gaussblur.c:125 ../libvips/convolution/sharpen.c:319
-#: ../libvips/convolution/correlation.c:163 ../libvips/create/create.c:101
-#: ../libvips/foreign/foreign.c:984 ../libvips/freqfilt/freqfilt.c:104
-#: ../libvips/histogram/hist_equal.c:114 ../libvips/histogram/stdif.c:300
-#: ../libvips/histogram/histogram.c:232 ../libvips/histogram/hist_entropy.c:119
-#: ../libvips/histogram/hist_norm.c:147 ../libvips/histogram/hist_plot.c:348
-#: ../libvips/histogram/hist_local.c:364 ../libvips/histogram/maplut.c:700
-#: ../libvips/iofuncs/system.c:284 ../libvips/morphology/morph.c:143
-#: ../libvips/morphology/rank.c:413 ../libvips/mosaicing/merge.c:121
-#: ../libvips/mosaicing/im_remosaic.c:170
-#: ../libvips/mosaicing/global_balance.c:1777 ../libvips/mosaicing/mosaic.c:192
-#: ../libvips/mosaicing/match.c:216 ../libvips/mosaicing/mosaic1.c:501
-#: ../libvips/resample/resample.c:138 ../libvips/resample/thumbnail.c:520
-msgid "Output"
-msgstr ""
-
-#: ../libvips/arithmetic/min.c:440 ../libvips/arithmetic/deviate.c:222
-#: ../libvips/arithmetic/max.c:439 ../libvips/arithmetic/avg.c:215
-#: ../libvips/histogram/hist_entropy.c:120
-msgid "Output value"
-msgstr ""
-
-#: ../libvips/arithmetic/min.c:446 ../libvips/arithmetic/max.c:445
-#: ../libvips/arithmetic/getpoint.c:153 ../libvips/conversion/embed.c:569
-#: ../libvips/conversion/wrap.c:125 ../libvips/draw/draw_image.c:265
-#: ../libvips/draw/draw_mask.c:329 ../libvips/draw/draw_flood.c:552
-msgid "x"
-msgstr ""
-
-#: ../libvips/arithmetic/min.c:447
-msgid "Horizontal position of minimum"
-msgstr ""
-
-#: ../libvips/arithmetic/min.c:453 ../libvips/arithmetic/max.c:452
-#: ../libvips/arithmetic/getpoint.c:160 ../libvips/conversion/embed.c:576
-#: ../libvips/conversion/wrap.c:132 ../libvips/draw/draw_image.c:272
-#: ../libvips/draw/draw_mask.c:336 ../libvips/draw/draw_flood.c:559
-msgid "y"
-msgstr ""
-
-#: ../libvips/arithmetic/min.c:454
-msgid "Vertical position of minimum"
-msgstr ""
-
-#: ../libvips/arithmetic/min.c:460 ../libvips/arithmetic/max.c:459
-#: ../libvips/create/invertlut.c:295 ../libvips/create/identity.c:158
-msgid "Size"
-msgstr ""
-
-#: ../libvips/arithmetic/min.c:461
-msgid "Number of minimum values to find"
-msgstr ""
-
-#: ../libvips/arithmetic/min.c:467 ../libvips/arithmetic/max.c:466
-#: ../libvips/arithmetic/getpoint.c:146
-msgid "Output array"
-msgstr ""
-
-#: ../libvips/arithmetic/min.c:468 ../libvips/arithmetic/max.c:467
-#: ../libvips/arithmetic/getpoint.c:147
-msgid "Array of output values"
-msgstr ""
-
-#: ../libvips/arithmetic/min.c:474 ../libvips/arithmetic/max.c:473
-msgid "x array"
-msgstr ""
-
-#: ../libvips/arithmetic/min.c:475 ../libvips/arithmetic/max.c:474
-msgid "Array of horizontal positions"
-msgstr ""
-
-#: ../libvips/arithmetic/min.c:481 ../libvips/arithmetic/max.c:480
-msgid "y array"
-msgstr ""
-
-#: ../libvips/arithmetic/min.c:482 ../libvips/arithmetic/max.c:481
-msgid "Array of vertical positions"
-msgstr ""
-
-#: ../libvips/arithmetic/sum.c:141
-msgid "sum an array of images"
-msgstr ""
-
-#: ../libvips/arithmetic/stats.c:412 ../libvips/arithmetic/avg.c:206
-msgid "find image average"
-msgstr ""
-
-#: ../libvips/arithmetic/stats.c:421 ../libvips/arithmetic/measure.c:211
-msgid "Output array of statistics"
-msgstr ""
-
-#: ../libvips/arithmetic/project.c:322
-msgid "find image projections"
-msgstr ""
-
-#: ../libvips/arithmetic/project.c:330 ../libvips/arithmetic/profile.c:300
-msgid "Columns"
-msgstr ""
-
-#: ../libvips/arithmetic/project.c:331
-msgid "Sums of columns"
-msgstr ""
-
-#: ../libvips/arithmetic/project.c:336 ../libvips/arithmetic/profile.c:306
-msgid "Rows"
-msgstr ""
-
-#: ../libvips/arithmetic/project.c:337
-msgid "Sums of rows"
-msgstr ""
-
-#: ../libvips/arithmetic/hough_line.c:135
-msgid "find hough line transform"
-msgstr ""
-
-#: ../libvips/arithmetic/hough_line.c:142 ../libvips/arithmetic/measure.c:244
-#: ../libvips/conversion/embed.c:583 ../libvips/conversion/copy.c:284
-#: ../libvips/conversion/extract.c:219 ../libvips/create/xyz.c:193
-#: ../libvips/create/logmat.c:208 ../libvips/create/worley.c:310
-#: ../libvips/create/gaussnoise.c:172 ../libvips/create/perlin.c:297
-#: ../libvips/create/point.c:143 ../libvips/create/fractsurf.c:102
-#: ../libvips/create/text.c:297 ../libvips/create/black.c:129
-#: ../libvips/draw/draw_flood.c:593 ../libvips/foreign/rawload.c:123
-#: ../libvips/histogram/stdif.c:308 ../libvips/histogram/hist_local.c:370
-#: ../libvips/iofuncs/image.c:1130 ../libvips/morphology/rank.c:419
-msgid "Width"
-msgstr ""
-
-#: ../libvips/arithmetic/hough_line.c:143
-msgid "horizontal size of parameter space"
-msgstr ""
-
-#: ../libvips/arithmetic/hough_line.c:149 ../libvips/arithmetic/measure.c:251
-#: ../libvips/conversion/embed.c:590 ../libvips/conversion/copy.c:291
-#: ../libvips/conversion/extract.c:226 ../libvips/create/xyz.c:200
-#: ../libvips/create/worley.c:317 ../libvips/create/gaussnoise.c:179
-#: ../libvips/create/perlin.c:304 ../libvips/create/point.c:150
-#: ../libvips/create/fractsurf.c:109 ../libvips/create/black.c:136
-#: ../libvips/draw/draw_flood.c:600 ../libvips/foreign/rawload.c:130
-#: ../libvips/histogram/stdif.c:315 ../libvips/histogram/hist_local.c:377
-#: ../libvips/iofuncs/image.c:1137 ../libvips/morphology/rank.c:426
-msgid "Height"
-msgstr ""
-
-#: ../libvips/arithmetic/hough_line.c:150
-msgid "Vertical size of parameter space"
-msgstr ""
-
-#: ../libvips/arithmetic/binary.c:89
-msgid "binary operations"
-msgstr ""
-
-#: ../libvips/arithmetic/binary.c:96 ../libvips/arithmetic/measure.c:230
-#: ../libvips/colour/colour.c:699 ../libvips/conversion/extract.c:205
-#: ../libvips/draw/draw_smudge.c:197 ../libvips/draw/draw_flood.c:579
-#: ../libvips/draw/draw_rect.c:173
-msgid "Left"
-msgstr ""
-
-#: ../libvips/arithmetic/binary.c:97
-msgid "Left-hand image argument"
-msgstr ""
-
-#: ../libvips/arithmetic/binary.c:102 ../libvips/colour/colour.c:705
-msgid "Right"
-msgstr ""
-
-#: ../libvips/arithmetic/binary.c:103
-msgid "Right-hand image argument"
-msgstr ""
-
-#: ../libvips/arithmetic/deviate.c:213
-msgid "find image standard deviation"
-msgstr ""
-
-#: ../libvips/arithmetic/max.c:430
-msgid "find image maximum"
-msgstr ""
-
-#: ../libvips/arithmetic/max.c:446
-msgid "Horizontal position of maximum"
-msgstr ""
-
-#: ../libvips/arithmetic/max.c:453
-msgid "Vertical position of maximum"
-msgstr ""
-
-#: ../libvips/arithmetic/max.c:460
-msgid "Number of maximum values to find"
-msgstr ""
-
-#: ../libvips/arithmetic/statistic.c:161
-msgid "VIPS statistic operations"
-msgstr ""
-
-#: ../libvips/arithmetic/statistic.c:167 ../libvips/arithmetic/nary.c:87
-#: ../libvips/arithmetic/unary.c:88 ../libvips/colour/colour.c:493
-#: ../libvips/colour/colour.c:587 ../libvips/colour/sRGB2scRGB.c:243
-#: ../libvips/colour/scRGB2BW.c:237 ../libvips/colour/scRGB2sRGB.c:265
-#: ../libvips/colour/colourspace.c:586 ../libvips/conversion/embed.c:563
-#: ../libvips/conversion/zoom.c:383 ../libvips/conversion/replicate.c:196
-#: ../libvips/conversion/bandfold.c:160 ../libvips/conversion/wrap.c:119
-#: ../libvips/conversion/arrayjoin.c:304
-#: ../libvips/conversion/unpremultiply.c:268 ../libvips/conversion/flip.c:240
-#: ../libvips/conversion/flatten.c:386 ../libvips/conversion/copy.c:271
-#: ../libvips/conversion/bandjoin.c:176 ../libvips/conversion/bandjoin.c:395
-#: ../libvips/conversion/rot45.c:267 ../libvips/conversion/msb.c:244
-#: ../libvips/conversion/extract.c:199 ../libvips/conversion/extract.c:422
-#: ../libvips/conversion/cast.c:548 ../libvips/conversion/bandunfold.c:163
-#: ../libvips/conversion/tilecache.c:416 ../libvips/conversion/sequential.c:327
-#: ../libvips/conversion/premultiply.c:259 ../libvips/conversion/bandmean.c:198
-#: ../libvips/conversion/byteswap.c:206 ../libvips/conversion/subsample.c:274
-#: ../libvips/conversion/bandbool.c:214 ../libvips/conversion/recomb.c:207
-#: ../libvips/conversion/cache.c:101 ../libvips/conversion/grid.c:199
-#: ../libvips/conversion/scale.c:151 ../libvips/conversion/autorot.c:178
-#: ../libvips/conversion/rot.c:359 ../libvips/conversion/bandrank.c:244
-#: ../libvips/convolution/convolution.c:129
-#: ../libvips/convolution/gaussblur.c:119 ../libvips/convolution/sharpen.c:313
-#: ../libvips/convolution/correlation.c:151 ../libvips/create/invertlut.c:289
-#: ../libvips/create/buildlut.c:261 ../libvips/foreign/foreign.c:1522
-#: ../libvips/histogram/hist_match.c:161 ../libvips/histogram/hist_equal.c:108
-#: ../libvips/histogram/stdif.c:294 ../libvips/histogram/hist_entropy.c:113
-#: ../libvips/histogram/hist_ismonotonic.c:117
-#: ../libvips/histogram/hist_norm.c:141 ../libvips/histogram/hist_plot.c:342
-#: ../libvips/histogram/hist_unary.c:89 ../libvips/histogram/hist_local.c:358
-#: ../libvips/histogram/percent.c:110 ../libvips/histogram/maplut.c:694
-#: ../libvips/iofuncs/system.c:277 ../libvips/morphology/morphology.c:117
-#: ../libvips/mosaicing/im_remosaic.c:164
-#: ../libvips/mosaicing/global_balance.c:1771
-#: ../libvips/resample/resample.c:132
-msgid "Input"
-msgstr ""
-
-#: ../libvips/arithmetic/statistic.c:168 ../libvips/arithmetic/getpoint.c:141
-#: ../libvips/arithmetic/unary.c:89 ../libvips/colour/colour.c:494
-#: ../libvips/colour/colour.c:588 ../libvips/colour/sRGB2scRGB.c:244
-#: ../libvips/colour/scRGB2BW.c:238 ../libvips/colour/scRGB2sRGB.c:266
-#: ../libvips/colour/colourspace.c:587 ../libvips/conversion/embed.c:564
-#: ../libvips/conversion/zoom.c:384 ../libvips/conversion/replicate.c:197
-#: ../libvips/conversion/bandfold.c:161 ../libvips/conversion/wrap.c:120
-#: ../libvips/conversion/unpremultiply.c:269 ../libvips/conversion/flip.c:241
-#: ../libvips/conversion/flatten.c:387 ../libvips/conversion/copy.c:272
-#: ../libvips/conversion/bandjoin.c:396 ../libvips/conversion/rot45.c:268
-#: ../libvips/conversion/msb.c:245 ../libvips/conversion/extract.c:200
-#: ../libvips/conversion/extract.c:423 ../libvips/conversion/cast.c:549
-#: ../libvips/conversion/bandunfold.c:164 ../libvips/conversion/tilecache.c:417
-#: ../libvips/conversion/sequential.c:328
-#: ../libvips/conversion/premultiply.c:260
-#: ../libvips/conversion/falsecolour.c:382 ../libvips/conversion/byteswap.c:207
-#: ../libvips/conversion/subsample.c:275 ../libvips/conversion/gamma.c:144
-#: ../libvips/conversion/cache.c:102 ../libvips/conversion/grid.c:200
-#: ../libvips/conversion/scale.c:152 ../libvips/conversion/autorot.c:179
-#: ../libvips/conversion/rot.c:360 ../libvips/convolution/gaussblur.c:120
-#: ../libvips/convolution/sharpen.c:314 ../libvips/freqfilt/freqfilt.c:99
-#: ../libvips/histogram/hist_equal.c:109 ../libvips/histogram/stdif.c:295
-#: ../libvips/histogram/hist_norm.c:142 ../libvips/histogram/hist_plot.c:343
-#: ../libvips/histogram/hist_unary.c:90 ../libvips/histogram/hist_local.c:359
-#: ../libvips/histogram/percent.c:111 ../libvips/histogram/maplut.c:695
-#: ../libvips/mosaicing/im_remosaic.c:165
-#: ../libvips/mosaicing/global_balance.c:1772
-msgid "Input image"
-msgstr ""
-
-#: ../libvips/arithmetic/nary.c:80
-msgid "nary operations"
-msgstr ""
-
-#: ../libvips/arithmetic/nary.c:88 ../libvips/conversion/arrayjoin.c:305
-#: ../libvips/conversion/bandjoin.c:177 ../libvips/conversion/bandrank.c:245
-#: ../libvips/iofuncs/system.c:278
-msgid "Array of input images"
-msgstr ""
-
-#: ../libvips/arithmetic/invert.c:165
-msgid "invert an image"
-msgstr ""
-
-#: ../libvips/arithmetic/remainder.c:174
-msgid "remainder after integer division of two images"
-msgstr ""
-
-#: ../libvips/arithmetic/remainder.c:324
-msgid "remainder after integer division of an image and a constant"
-msgstr ""
-
-#: ../libvips/arithmetic/boolean.c:210
-msgid "boolean operation on two images"
-msgstr ""
-
-#: ../libvips/arithmetic/boolean.c:218 ../libvips/arithmetic/boolean.c:521
-#: ../libvips/arithmetic/relational.c:224
-#: ../libvips/arithmetic/relational.c:562 ../libvips/arithmetic/math2.c:205
-#: ../libvips/arithmetic/math2.c:404 ../libvips/arithmetic/complex.c:255
-#: ../libvips/arithmetic/complex.c:548 ../libvips/arithmetic/complex.c:763
-#: ../libvips/arithmetic/math.c:214 ../libvips/conversion/bandbool.c:220
-#: ../tools/vips.c:1070
-msgid "Operation"
-msgstr ""
-
-#: ../libvips/arithmetic/boolean.c:219 ../libvips/arithmetic/boolean.c:522
-#: ../libvips/conversion/bandbool.c:221
-msgid "boolean to perform"
-msgstr ""
-
-#: ../libvips/arithmetic/boolean.c:513
-msgid "boolean operations against a constant"
-msgstr ""
-
-#: ../libvips/arithmetic/sign.c:152
-msgid "unit vector of pixel"
-msgstr ""
-
-#: ../libvips/arithmetic/hist_find_ndim.c:112
-#, c-format
-msgid "bins out of range [1,%d]"
-msgstr ""
-
-#: ../libvips/arithmetic/hist_find_ndim.c:289
-msgid "find n-dimensional image histogram"
-msgstr ""
-
-#: ../libvips/arithmetic/hist_find_ndim.c:299
-#: ../libvips/arithmetic/hist_find.c:451
-#: ../libvips/arithmetic/hist_find_indexed.c:392
-msgid "Output histogram"
-msgstr ""
-
-#: ../libvips/arithmetic/hist_find_ndim.c:304
-msgid "Bins"
-msgstr ""
-
-#: ../libvips/arithmetic/hist_find_ndim.c:305
-msgid "Number of bins in each dimension"
-msgstr ""
-
-#: ../libvips/arithmetic/multiply.c:173
-msgid "multiply two images"
-msgstr ""
-
-#: ../libvips/arithmetic/hough_circle.c:113
-msgid "parameters out of range"
-msgstr ""
-
-#: ../libvips/arithmetic/hough_circle.c:233
-msgid "find hough circle transform"
-msgstr ""
-
-#: ../libvips/arithmetic/hough_circle.c:240 ../libvips/foreign/pdfload.c:489
-#: ../libvips/foreign/svgload.c:290 ../libvips/mosaicing/mosaic.c:275
-#: ../libvips/resample/similarity.c:171
-msgid "Scale"
-msgstr ""
-
-#: ../libvips/arithmetic/hough_circle.c:241
-msgid "Scale down dimensions by this factor"
-msgstr ""
-
-#: ../libvips/arithmetic/hough_circle.c:247
-msgid "Min radius"
-msgstr ""
-
-#: ../libvips/arithmetic/hough_circle.c:248
-msgid "Smallest radius to search for"
-msgstr ""
-
-#: ../libvips/arithmetic/hough_circle.c:254
-msgid "Max radius"
-msgstr ""
-
-#: ../libvips/arithmetic/hough_circle.c:255
-msgid "Largest radius to search for"
-msgstr ""
-
-#: ../libvips/arithmetic/measure.c:168
-#, c-format
-msgid "%s: patch %d x %d, band %d: avg = %g, sdev = %g"
-msgstr ""
-
-#: ../libvips/arithmetic/measure.c:200
-msgid "measure a set of patches on a color chart"
-msgstr "measure a set of patches on a colour chart"
-
-#: ../libvips/arithmetic/measure.c:204 ../libvips/arithmetic/getpoint.c:140
-#: ../libvips/conversion/falsecolour.c:381 ../libvips/conversion/gamma.c:143
-#: ../libvips/freqfilt/freqfilt.c:98
-msgid "in"
-msgstr ""
-
-#: ../libvips/arithmetic/measure.c:205
-msgid "Image to measure"
-msgstr ""
-
-#: ../libvips/arithmetic/measure.c:216 ../libvips/conversion/replicate.c:202
-#: ../libvips/conversion/arrayjoin.c:311 ../libvips/conversion/grid.c:212
-msgid "Across"
-msgstr ""
-
-#: ../libvips/arithmetic/measure.c:217
-msgid "Number of patches across chart"
-msgstr ""
-
-#: ../libvips/arithmetic/measure.c:223 ../libvips/conversion/replicate.c:209
-#: ../libvips/conversion/grid.c:219
-msgid "Down"
-msgstr ""
-
-#: ../libvips/arithmetic/measure.c:224
-msgid "Number of patches down chart"
-msgstr ""
-
-#: ../libvips/arithmetic/measure.c:231 ../libvips/conversion/extract.c:206
-msgid "Left edge of extract area"
-msgstr ""
-
-#: ../libvips/arithmetic/measure.c:237 ../libvips/conversion/extract.c:212
-#: ../libvips/draw/draw_flood.c:586
-msgid "Top"
-msgstr ""
-
-#: ../libvips/arithmetic/measure.c:238 ../libvips/conversion/extract.c:213
-msgid "Top edge of extract area"
-msgstr ""
-
-#: ../libvips/arithmetic/measure.c:245 ../libvips/conversion/extract.c:220
-msgid "Width of extract area"
-msgstr ""
-
-#: ../libvips/arithmetic/measure.c:252 ../libvips/conversion/extract.c:227
-msgid "Height of extract area"
-msgstr ""
-
-#: ../libvips/arithmetic/hist_find.c:441
-msgid "find image histogram"
-msgstr ""
-
-#: ../libvips/arithmetic/hist_find.c:456 ../libvips/conversion/msb.c:250
-#: ../libvips/conversion/extract.c:428 ../libvips/histogram/hist_equal.c:120
-msgid "Band"
-msgstr ""
-
-#: ../libvips/arithmetic/hist_find.c:457
-msgid "Find histogram of band"
-msgstr ""
-
-#: ../libvips/arithmetic/getpoint.c:136
-msgid "read a point from an image"
-msgstr ""
-
-#: ../libvips/arithmetic/getpoint.c:154 ../libvips/arithmetic/getpoint.c:161
-msgid "Point to read"
-msgstr ""
-
-#: ../libvips/arithmetic/add.c:172
+#: libvips/arithmetic/add.c:178
 msgid "add two images"
 msgstr ""
 
-#: ../libvips/arithmetic/divide.c:225
-msgid "divide two images"
-msgstr ""
-
-#: ../libvips/arithmetic/relational.c:216
-msgid "relational operation on two images"
-msgstr ""
-
-#: ../libvips/arithmetic/relational.c:225
-#: ../libvips/arithmetic/relational.c:563
-msgid "relational to perform"
-msgstr ""
-
-#: ../libvips/arithmetic/relational.c:553
-msgid "relational operations against a constant"
-msgstr ""
-
-#: ../libvips/arithmetic/hough.c:176
-msgid "find hough transform"
-msgstr ""
-
-#: ../libvips/arithmetic/hough.c:186 ../libvips/arithmetic/arithmetic.c:640
-#: ../libvips/colour/colour.c:428 ../libvips/colour/sRGB2scRGB.c:250
-#: ../libvips/colour/scRGB2BW.c:244 ../libvips/colour/scRGB2sRGB.c:272
-#: ../libvips/colour/colourspace.c:593 ../libvips/conversion/conversion.c:201
-#: ../libvips/convolution/convolution.c:136
-#: ../libvips/convolution/gaussblur.c:126 ../libvips/convolution/sharpen.c:320
-#: ../libvips/convolution/correlation.c:164 ../libvips/create/create.c:102
-#: ../libvips/foreign/foreign.c:985 ../libvips/freqfilt/freqfilt.c:105
-#: ../libvips/histogram/hist_equal.c:115 ../libvips/histogram/stdif.c:301
-#: ../libvips/histogram/histogram.c:233 ../libvips/histogram/hist_norm.c:148
-#: ../libvips/histogram/hist_plot.c:349 ../libvips/histogram/hist_local.c:365
-#: ../libvips/histogram/maplut.c:701 ../libvips/iofuncs/system.c:285
-#: ../libvips/morphology/morph.c:144 ../libvips/morphology/rank.c:414
-#: ../libvips/mosaicing/merge.c:122 ../libvips/mosaicing/im_remosaic.c:171
-#: ../libvips/mosaicing/global_balance.c:1778 ../libvips/mosaicing/mosaic.c:193
-#: ../libvips/mosaicing/match.c:217 ../libvips/mosaicing/mosaic1.c:502
-#: ../libvips/resample/resample.c:139 ../libvips/resample/thumbnail.c:521
-msgid "Output image"
-msgstr ""
-
-#: ../libvips/arithmetic/arithmetic.c:378
+#: libvips/arithmetic/arithmetic.c:392
 #, c-format
 msgid "not one band or %d bands"
 msgstr ""
 
-#: ../libvips/arithmetic/arithmetic.c:382
+#: libvips/arithmetic/arithmetic.c:397 libvips/foreign/spngsave.c:423
 msgid "bad bands"
 msgstr ""
 
-#: ../libvips/arithmetic/arithmetic.c:572 ../libvips/colour/colour.c:297
-#: ../libvips/conversion/bandary.c:140 ../libvips/conversion/bandrank.c:204
-msgid "too many input images"
-msgstr ""
-
-#: ../libvips/arithmetic/arithmetic.c:633
+#: libvips/arithmetic/arithmetic.c:725
 msgid "arithmetic operations"
 msgstr ""
 
-#: ../libvips/arithmetic/abs.c:230
-msgid "absolute value of an image"
+#: libvips/arithmetic/arithmetic.c:731 libvips/arithmetic/avg.c:235
+#: libvips/arithmetic/deviate.c:237 libvips/arithmetic/hist_find.c:431
+#: libvips/arithmetic/hist_find_indexed.c:475
+#: libvips/arithmetic/hist_find_ndim.c:313 libvips/arithmetic/hough.c:179
+#: libvips/arithmetic/max.c:452 libvips/arithmetic/measure.c:201
+#: libvips/arithmetic/min.c:452 libvips/arithmetic/stats.c:442
+#: libvips/colour/CMYK2XYZ.c:126 libvips/colour/colour.c:415
+#: libvips/colour/colourspace.c:563 libvips/colour/scRGB2BW.c:243
+#: libvips/colour/scRGB2sRGB.c:276 libvips/colour/scRGB2XYZ.c:197
+#: libvips/colour/sRGB2scRGB.c:294 libvips/colour/XYZ2CMYK.c:125
+#: libvips/colour/XYZ2scRGB.c:206 libvips/conversion/conversion.c:346
+#: libvips/conversion/switch.c:202 libvips/convolution/canny.c:448
+#: libvips/convolution/convolution.c:134 libvips/convolution/correlation.c:162
+#: libvips/convolution/edge.c:223 libvips/convolution/gaussblur.c:138
+#: libvips/convolution/sharpen.c:328 libvips/create/create.c:124
+#: libvips/foreign/foreign.c:1215 libvips/freqfilt/freqfilt.c:104
+#: libvips/histogram/case.c:252 libvips/histogram/hist_entropy.c:117
+#: libvips/histogram/hist_equal.c:120 libvips/histogram/hist_local.c:367
+#: libvips/histogram/hist_norm.c:147 libvips/histogram/histogram.c:232
+#: libvips/histogram/hist_plot.c:339 libvips/histogram/maplut.c:750
+#: libvips/histogram/stdif.c:300 libvips/iofuncs/system.c:284
+#: libvips/morphology/morph.c:959 libvips/morphology/rank.c:564
+#: libvips/mosaicing/global_balance.c:1930 libvips/mosaicing/match.c:208
+#: libvips/mosaicing/matrixinvert.c:449 libvips/mosaicing/merge.c:134
+#: libvips/mosaicing/mosaic1.c:510 libvips/mosaicing/mosaic.c:191
+#: libvips/mosaicing/remosaic.c:170 libvips/resample/resample.c:146
+#: libvips/resample/thumbnail.c:968
+msgid "Output"
 msgstr ""
 
-#: ../libvips/arithmetic/linear.c:386
-msgid "calculate (a * in + b)"
+#: libvips/arithmetic/arithmetic.c:732 libvips/arithmetic/hough.c:180
+#: libvips/colour/CMYK2XYZ.c:127 libvips/colour/colour.c:416
+#: libvips/colour/colourspace.c:564 libvips/colour/scRGB2BW.c:244
+#: libvips/colour/scRGB2sRGB.c:277 libvips/colour/scRGB2XYZ.c:198
+#: libvips/colour/sRGB2scRGB.c:295 libvips/colour/XYZ2CMYK.c:126
+#: libvips/colour/XYZ2scRGB.c:207 libvips/conversion/conversion.c:347
+#: libvips/conversion/switch.c:203 libvips/convolution/canny.c:449
+#: libvips/convolution/convolution.c:135 libvips/convolution/correlation.c:163
+#: libvips/convolution/edge.c:224 libvips/convolution/gaussblur.c:139
+#: libvips/convolution/sharpen.c:329 libvips/create/create.c:125
+#: libvips/foreign/foreign.c:1216 libvips/freqfilt/freqfilt.c:105
+#: libvips/histogram/case.c:253 libvips/histogram/hist_equal.c:121
+#: libvips/histogram/hist_local.c:368 libvips/histogram/hist_norm.c:148
+#: libvips/histogram/histogram.c:233 libvips/histogram/hist_plot.c:340
+#: libvips/histogram/maplut.c:751 libvips/histogram/stdif.c:301
+#: libvips/iofuncs/system.c:285 libvips/morphology/morph.c:960
+#: libvips/morphology/rank.c:565 libvips/mosaicing/global_balance.c:1931
+#: libvips/mosaicing/match.c:209 libvips/mosaicing/merge.c:135
+#: libvips/mosaicing/mosaic1.c:511 libvips/mosaicing/mosaic.c:192
+#: libvips/mosaicing/remosaic.c:171 libvips/resample/resample.c:147
+#: libvips/resample/thumbnail.c:969
+msgid "Output image"
 msgstr ""
 
-#: ../libvips/arithmetic/linear.c:394
-msgid "a"
+#: libvips/arithmetic/avg.c:227
+msgid "find image average"
 msgstr ""
 
-#: ../libvips/arithmetic/linear.c:395
-msgid "Multiply by this"
+#: libvips/arithmetic/avg.c:236 libvips/arithmetic/deviate.c:238
+#: libvips/arithmetic/max.c:453 libvips/arithmetic/min.c:453
+#: libvips/histogram/hist_entropy.c:118
+msgid "Output value"
 msgstr ""
 
-#: ../libvips/arithmetic/linear.c:401
-msgid "b"
+#: libvips/arithmetic/binary.c:89
+msgid "binary operations"
 msgstr ""
 
-#: ../libvips/arithmetic/linear.c:402
-msgid "Add this"
+#: libvips/arithmetic/binary.c:96 libvips/arithmetic/find_trim.c:216
+#: libvips/arithmetic/measure.c:221 libvips/colour/colour.c:684
+#: libvips/conversion/extract.c:200 libvips/draw/draw_flood.c:593
+#: libvips/draw/draw_rect.c:173 libvips/draw/draw_smudge.c:215
+msgid "Left"
 msgstr ""
 
-#: ../libvips/arithmetic/linear.c:408
-msgid "uchar"
+#: libvips/arithmetic/binary.c:97
+msgid "Left-hand image argument"
 msgstr ""
 
-#: ../libvips/arithmetic/linear.c:409
-msgid "Output should be uchar"
+#: libvips/arithmetic/binary.c:102 libvips/colour/colour.c:690
+msgid "Right"
 msgstr ""
 
-#: ../libvips/arithmetic/round.c:161
-msgid "perform a round function on an image"
+#: libvips/arithmetic/binary.c:103
+msgid "Right-hand image argument"
 msgstr ""
 
-#: ../libvips/arithmetic/round.c:169
-msgid "Round operation"
+#: libvips/arithmetic/boolean.c:269
+msgid "boolean operation on two images"
 msgstr ""
 
-#: ../libvips/arithmetic/round.c:170
-msgid "rounding operation to perform"
+#: libvips/arithmetic/boolean.c:277 libvips/arithmetic/boolean.c:577
+#: libvips/arithmetic/complex.c:258 libvips/arithmetic/complex.c:538
+#: libvips/arithmetic/complex.c:771 libvips/arithmetic/math2.c:241
+#: libvips/arithmetic/math2.c:471 libvips/arithmetic/math.c:261
+#: libvips/arithmetic/relational.c:246 libvips/arithmetic/relational.c:611
+#: libvips/conversion/bandbool.c:238 tools/vips.c:627
+msgid "Operation"
 msgstr ""
 
-#: ../libvips/arithmetic/math2.c:197
-msgid "binary math operations"
+#: libvips/arithmetic/boolean.c:278 libvips/arithmetic/boolean.c:578
+#: libvips/conversion/bandbool.c:239
+msgid "Boolean to perform"
 msgstr ""
 
-#: ../libvips/arithmetic/math2.c:206 ../libvips/arithmetic/math2.c:405
-#: ../libvips/arithmetic/math.c:215
-msgid "math to perform"
+#: libvips/arithmetic/boolean.c:569
+msgid "boolean operations against a constant"
 msgstr ""
 
-#: ../libvips/arithmetic/math2.c:396
-msgid "binary math operations with a constant"
+#: libvips/arithmetic/clamp.c:155
+msgid "clamp values of an image"
 msgstr ""
 
-#: ../libvips/arithmetic/unaryconst.c:203
-msgid "unary operations with a constant"
+#: libvips/arithmetic/clamp.c:162
+msgid "Min"
 msgstr ""
 
-#: ../libvips/arithmetic/unaryconst.c:207
-msgid "c"
+#: libvips/arithmetic/clamp.c:163
+msgid "Minimum value"
 msgstr ""
 
-#: ../libvips/arithmetic/unaryconst.c:208
-msgid "Array of constants"
+#: libvips/arithmetic/clamp.c:169
+msgid "Max"
 msgstr ""
 
-#: ../libvips/arithmetic/complex.c:248
+#: libvips/arithmetic/clamp.c:170
+msgid "Maximum value"
+msgstr ""
+
+#: libvips/arithmetic/complex.c:251
 msgid "perform a complex operation on an image"
 msgstr ""
 
-#: ../libvips/arithmetic/complex.c:256 ../libvips/arithmetic/complex.c:764
-msgid "complex to perform"
+#: libvips/arithmetic/complex.c:259 libvips/arithmetic/complex.c:772
+msgid "Complex to perform"
 msgstr ""
 
-#: ../libvips/arithmetic/complex.c:541
+#: libvips/arithmetic/complex.c:531
 msgid "complex binary operations on two images"
 msgstr ""
 
-#: ../libvips/arithmetic/complex.c:549
-msgid "binary complex operation to perform"
+#: libvips/arithmetic/complex.c:539
+msgid "Binary complex operation to perform"
 msgstr ""
 
-#: ../libvips/arithmetic/complex.c:754
+#: libvips/arithmetic/complex.c:762
 msgid "get a component from a complex image"
 msgstr ""
 
-#: ../libvips/arithmetic/complex.c:962
+#: libvips/arithmetic/complex.c:978
 msgid "form a complex image from two real images"
 msgstr ""
 
-#: ../libvips/arithmetic/profile.c:292
-msgid "find image profiles"
+#: libvips/arithmetic/deviate.c:229
+msgid "find image standard deviation"
 msgstr ""
 
-#: ../libvips/arithmetic/profile.c:301
-msgid "First non-zero pixel in column"
+#: libvips/arithmetic/divide.c:210
+msgid "divide two images"
 msgstr ""
 
-#: ../libvips/arithmetic/profile.c:307
-msgid "First non-zero pixel in row"
+#: libvips/arithmetic/find_trim.c:183
+msgid "search an image for non-edge areas"
 msgstr ""
 
-#: ../libvips/arithmetic/unary.c:81
-msgid "unary operations"
+#: libvips/arithmetic/find_trim.c:189 libvips/arithmetic/getpoint.c:153
+#: libvips/arithmetic/measure.c:195 libvips/arithmetic/nary.c:87
+#: libvips/arithmetic/statistic.c:167 libvips/arithmetic/unary.c:88
+#: libvips/colour/CMYK2XYZ.c:120 libvips/colour/colour.c:480
+#: libvips/colour/colour.c:573 libvips/colour/colourspace.c:557
+#: libvips/colour/scRGB2BW.c:237 libvips/colour/scRGB2sRGB.c:270
+#: libvips/colour/scRGB2XYZ.c:191 libvips/colour/sRGB2scRGB.c:288
+#: libvips/colour/XYZ2CMYK.c:119 libvips/colour/XYZ2scRGB.c:200
+#: libvips/conversion/addalpha.c:90 libvips/conversion/arrayjoin.c:394
+#: libvips/conversion/autorot.c:207 libvips/conversion/bandbool.c:232
+#: libvips/conversion/bandfold.c:161 libvips/conversion/bandjoin.c:201
+#: libvips/conversion/bandjoin.c:436 libvips/conversion/bandmean.c:212
+#: libvips/conversion/bandrank.c:254 libvips/conversion/bandunfold.c:164
+#: libvips/conversion/byteswap.c:238 libvips/conversion/cache.c:108
+#: libvips/conversion/cast.c:530 libvips/conversion/copy.c:271
+#: libvips/conversion/embed.c:568 libvips/conversion/extract.c:194
+#: libvips/conversion/extract.c:432 libvips/conversion/falsecolour.c:380
+#: libvips/conversion/flatten.c:419 libvips/conversion/flip.c:240
+#: libvips/conversion/gamma.c:142 libvips/conversion/grid.c:199
+#: libvips/conversion/msb.c:247 libvips/conversion/premultiply.c:261
+#: libvips/conversion/recomb.c:224 libvips/conversion/replicate.c:196
+#: libvips/conversion/rot45.c:268 libvips/conversion/rot.c:365
+#: libvips/conversion/scale.c:155 libvips/conversion/sequential.c:243
+#: libvips/conversion/smartcrop.c:433 libvips/conversion/subsample.c:267
+#: libvips/conversion/tilecache.c:398 libvips/conversion/transpose3d.c:167
+#: libvips/conversion/unpremultiply.c:323 libvips/conversion/wrap.c:119
+#: libvips/conversion/zoom.c:373 libvips/convolution/canny.c:442
+#: libvips/convolution/convolution.c:128 libvips/convolution/correlation.c:150
+#: libvips/convolution/edge.c:217 libvips/convolution/gaussblur.c:132
+#: libvips/convolution/sharpen.c:322 libvips/create/buildlut.c:263
+#: libvips/create/invertlut.c:288 libvips/foreign/foreign.c:1894
+#: libvips/freqfilt/freqfilt.c:98 libvips/histogram/hist_entropy.c:111
+#: libvips/histogram/hist_equal.c:114 libvips/histogram/hist_ismonotonic.c:118
+#: libvips/histogram/hist_local.c:361 libvips/histogram/hist_match.c:161
+#: libvips/histogram/hist_norm.c:141 libvips/histogram/hist_plot.c:333
+#: libvips/histogram/hist_unary.c:88 libvips/histogram/maplut.c:744
+#: libvips/histogram/percent.c:109 libvips/histogram/stdif.c:294
+#: libvips/iofuncs/ginputsource.c:274 libvips/iofuncs/sbuf.c:88
+#: libvips/iofuncs/system.c:277 libvips/morphology/morphology.c:121
+#: libvips/mosaicing/global_balance.c:1924 libvips/mosaicing/matrixinvert.c:443
+#: libvips/mosaicing/remosaic.c:164 libvips/resample/resample.c:140
+#: libvips/resample/thumbnail.c:1782
+msgid "Input"
 msgstr ""
 
-#: ../libvips/arithmetic/subtract.c:162
-msgid "subtract two images"
+#: libvips/arithmetic/find_trim.c:190
+msgid "Image to find_trim"
 msgstr ""
 
-#: ../libvips/arithmetic/hist_find_indexed.c:377
+#: libvips/arithmetic/find_trim.c:195 libvips/histogram/percent.c:122
+msgid "Threshold"
+msgstr ""
+
+#: libvips/arithmetic/find_trim.c:196
+msgid "Object threshold"
+msgstr ""
+
+#: libvips/arithmetic/find_trim.c:202 libvips/conversion/arrayjoin.c:415
+#: libvips/conversion/embed.c:595 libvips/conversion/flatten.c:425
+#: libvips/conversion/insert.c:499 libvips/conversion/join.c:270
+#: libvips/foreign/foreign.c:1908 libvips/foreign/pdfiumload.c:723
+#: libvips/foreign/popplerload.c:573 libvips/resample/affine.c:699
+#: libvips/resample/mapim.c:574 libvips/resample/similarity.c:133
+msgid "Background"
+msgstr ""
+
+#: libvips/arithmetic/find_trim.c:203 libvips/conversion/embed.c:596
+msgid "Color for background pixels"
+msgstr ""
+
+#: libvips/arithmetic/find_trim.c:209
+msgid "Line art mode"
+msgstr ""
+
+#: libvips/arithmetic/find_trim.c:210
+msgid "Enable line art mode"
+msgstr ""
+
+#: libvips/arithmetic/find_trim.c:217
+msgid "Left edge of image"
+msgstr ""
+
+#: libvips/arithmetic/find_trim.c:223 libvips/arithmetic/measure.c:228
+#: libvips/conversion/extract.c:207 libvips/draw/draw_flood.c:600
+#: libvips/draw/draw_rect.c:180 libvips/draw/draw_smudge.c:222
+msgid "Top"
+msgstr ""
+
+#: libvips/arithmetic/find_trim.c:224 libvips/arithmetic/measure.c:229
+#: libvips/conversion/extract.c:208
+msgid "Top edge of extract area"
+msgstr ""
+
+#: libvips/arithmetic/find_trim.c:230 libvips/arithmetic/hough_line.c:147
+#: libvips/arithmetic/measure.c:235 libvips/conversion/copy.c:284
+#: libvips/conversion/embed.c:574 libvips/conversion/extract.c:214
+#: libvips/conversion/smartcrop.c:439 libvips/create/black.c:140
+#: libvips/create/fractsurf.c:104 libvips/create/gaussnoise.c:167
+#: libvips/create/logmat.c:208 libvips/create/perlin.c:294
+#: libvips/create/point.c:141 libvips/create/sdf.c:304
+#: libvips/create/text.c:567 libvips/create/worley.c:307
+#: libvips/create/xyz.c:191 libvips/draw/draw_flood.c:607
+#: libvips/draw/draw_rect.c:187 libvips/draw/draw_smudge.c:229
+#: libvips/foreign/rawload.c:146 libvips/histogram/hist_local.c:373
+#: libvips/histogram/stdif.c:308 libvips/iofuncs/image.c:1102
+#: libvips/morphology/rank.c:570
+msgid "Width"
+msgstr ""
+
+#: libvips/arithmetic/find_trim.c:231 libvips/arithmetic/measure.c:236
+#: libvips/conversion/extract.c:215 libvips/conversion/smartcrop.c:440
+msgid "Width of extract area"
+msgstr ""
+
+#: libvips/arithmetic/find_trim.c:237 libvips/arithmetic/hough_line.c:154
+#: libvips/arithmetic/measure.c:242 libvips/conversion/copy.c:291
+#: libvips/conversion/embed.c:581 libvips/conversion/extract.c:221
+#: libvips/conversion/smartcrop.c:446 libvips/create/black.c:147
+#: libvips/create/fractsurf.c:111 libvips/create/gaussnoise.c:174
+#: libvips/create/perlin.c:301 libvips/create/point.c:148
+#: libvips/create/sdf.c:311 libvips/create/text.c:574
+#: libvips/create/worley.c:314 libvips/create/xyz.c:198
+#: libvips/draw/draw_flood.c:614 libvips/draw/draw_rect.c:194
+#: libvips/draw/draw_smudge.c:236 libvips/foreign/rawload.c:153
+#: libvips/histogram/hist_local.c:380 libvips/histogram/stdif.c:315
+#: libvips/iofuncs/image.c:1109 libvips/morphology/rank.c:577
+msgid "Height"
+msgstr ""
+
+#: libvips/arithmetic/find_trim.c:238 libvips/arithmetic/measure.c:243
+#: libvips/conversion/extract.c:222 libvips/conversion/smartcrop.c:447
+msgid "Height of extract area"
+msgstr ""
+
+#: libvips/arithmetic/getpoint.c:149
+msgid "read a point from an image"
+msgstr ""
+
+#: libvips/arithmetic/getpoint.c:154 libvips/arithmetic/statistic.c:168
+#: libvips/arithmetic/unary.c:89 libvips/colour/CMYK2XYZ.c:121
+#: libvips/colour/colour.c:481 libvips/colour/colour.c:574
+#: libvips/colour/colourspace.c:558 libvips/colour/scRGB2BW.c:238
+#: libvips/colour/scRGB2sRGB.c:271 libvips/colour/scRGB2XYZ.c:192
+#: libvips/colour/sRGB2scRGB.c:289 libvips/colour/XYZ2CMYK.c:120
+#: libvips/colour/XYZ2scRGB.c:201 libvips/conversion/addalpha.c:91
+#: libvips/conversion/autorot.c:208 libvips/conversion/bandfold.c:162
+#: libvips/conversion/bandjoin.c:437 libvips/conversion/bandunfold.c:165
+#: libvips/conversion/byteswap.c:239 libvips/conversion/cache.c:109
+#: libvips/conversion/cast.c:531 libvips/conversion/copy.c:272
+#: libvips/conversion/embed.c:569 libvips/conversion/extract.c:195
+#: libvips/conversion/extract.c:433 libvips/conversion/falsecolour.c:381
+#: libvips/conversion/flatten.c:420 libvips/conversion/flip.c:241
+#: libvips/conversion/gamma.c:143 libvips/conversion/grid.c:200
+#: libvips/conversion/msb.c:248 libvips/conversion/premultiply.c:262
+#: libvips/conversion/replicate.c:197 libvips/conversion/rot45.c:269
+#: libvips/conversion/rot.c:366 libvips/conversion/scale.c:156
+#: libvips/conversion/sequential.c:244 libvips/conversion/smartcrop.c:434
+#: libvips/conversion/subsample.c:268 libvips/conversion/tilecache.c:399
+#: libvips/conversion/transpose3d.c:168 libvips/conversion/unpremultiply.c:324
+#: libvips/conversion/wrap.c:120 libvips/conversion/zoom.c:374
+#: libvips/convolution/canny.c:443 libvips/convolution/edge.c:218
+#: libvips/convolution/gaussblur.c:133 libvips/convolution/sharpen.c:323
+#: libvips/freqfilt/freqfilt.c:99 libvips/histogram/hist_equal.c:115
+#: libvips/histogram/hist_local.c:362 libvips/histogram/hist_norm.c:142
+#: libvips/histogram/hist_plot.c:334 libvips/histogram/hist_unary.c:89
+#: libvips/histogram/maplut.c:745 libvips/histogram/percent.c:110
+#: libvips/histogram/stdif.c:295 libvips/mosaicing/global_balance.c:1925
+#: libvips/mosaicing/remosaic.c:165
+msgid "Input image"
+msgstr ""
+
+#: libvips/arithmetic/getpoint.c:159 libvips/arithmetic/max.c:480
+#: libvips/arithmetic/min.c:480
+msgid "Output array"
+msgstr ""
+
+#: libvips/arithmetic/getpoint.c:160 libvips/arithmetic/max.c:481
+#: libvips/arithmetic/min.c:481
+msgid "Array of output values"
+msgstr ""
+
+#: libvips/arithmetic/getpoint.c:166 libvips/arithmetic/max.c:459
+#: libvips/arithmetic/min.c:459 libvips/conversion/composite.cpp:1733
+#: libvips/conversion/embed.c:656 libvips/conversion/wrap.c:125
+#: libvips/draw/draw_flood.c:566 libvips/draw/draw_image.c:275
+#: libvips/draw/draw_mask.c:338
+msgid "x"
+msgstr ""
+
+#: libvips/arithmetic/getpoint.c:167 libvips/arithmetic/getpoint.c:174
+msgid "Point to read"
+msgstr ""
+
+#: libvips/arithmetic/getpoint.c:173 libvips/arithmetic/max.c:466
+#: libvips/arithmetic/min.c:466 libvips/conversion/composite.cpp:1740
+#: libvips/conversion/embed.c:663 libvips/conversion/wrap.c:132
+#: libvips/draw/draw_flood.c:573 libvips/draw/draw_image.c:282
+#: libvips/draw/draw_mask.c:345
+msgid "y"
+msgstr ""
+
+#: libvips/arithmetic/getpoint.c:180
+msgid "unpack_complex"
+msgstr ""
+
+#: libvips/arithmetic/getpoint.c:181
+msgid "Complex pixels should be unpacked"
+msgstr ""
+
+#: libvips/arithmetic/hist_find.c:422
+msgid "find image histogram"
+msgstr ""
+
+#: libvips/arithmetic/hist_find.c:432
+#: libvips/arithmetic/hist_find_indexed.c:476
+#: libvips/arithmetic/hist_find_ndim.c:314
+msgid "Output histogram"
+msgstr ""
+
+#: libvips/arithmetic/hist_find.c:437 libvips/conversion/extract.c:438
+#: libvips/conversion/msb.c:253 libvips/histogram/hist_equal.c:126
+#: libvips/histogram/maplut.c:762
+msgid "Band"
+msgstr ""
+
+#: libvips/arithmetic/hist_find.c:438
+msgid "Find histogram of band"
+msgstr ""
+
+#: libvips/arithmetic/hist_find_indexed.c:461
 msgid "find indexed image histogram"
 msgstr ""
 
-#: ../libvips/arithmetic/hist_find_indexed.c:385
-#: ../libvips/conversion/bandrank.c:251 ../libvips/resample/mapim.c:412
+#: libvips/arithmetic/hist_find_indexed.c:469 libvips/conversion/bandrank.c:261
+#: libvips/histogram/case.c:239 libvips/morphology/rank.c:584
+#: libvips/resample/mapim.c:555
 msgid "Index"
 msgstr ""
 
-#: ../libvips/arithmetic/hist_find_indexed.c:386
+#: libvips/arithmetic/hist_find_indexed.c:470 libvips/histogram/case.c:240
 msgid "Index image"
 msgstr ""
 
-#: ../libvips/arithmetic/math.c:206
+#: libvips/arithmetic/hist_find_indexed.c:481 libvips/convolution/compass.c:177
+msgid "Combine"
+msgstr ""
+
+#: libvips/arithmetic/hist_find_indexed.c:482
+msgid "Combine bins like this"
+msgstr ""
+
+#: libvips/arithmetic/hist_find_ndim.c:150
+msgid "image is not 1 - 3 bands"
+msgstr ""
+
+#: libvips/arithmetic/hist_find_ndim.c:159
+#, c-format
+msgid "bins out of range [1,%d]"
+msgstr ""
+
+#: libvips/arithmetic/hist_find_ndim.c:304
+msgid "find n-dimensional image histogram"
+msgstr ""
+
+#: libvips/arithmetic/hist_find_ndim.c:319
+msgid "Bins"
+msgstr ""
+
+#: libvips/arithmetic/hist_find_ndim.c:320
+msgid "Number of bins in each dimension"
+msgstr ""
+
+#: libvips/arithmetic/hough.c:170
+msgid "find hough transform"
+msgstr ""
+
+#: libvips/arithmetic/hough_circle.c:115
+msgid "parameters out of range"
+msgstr ""
+
+#: libvips/arithmetic/hough_circle.c:226
+msgid "find hough circle transform"
+msgstr ""
+
+#: libvips/arithmetic/hough_circle.c:233 libvips/foreign/pdfiumload.c:716
+#: libvips/foreign/popplerload.c:566 libvips/foreign/svgload.c:724
+#: libvips/foreign/webpload.c:192 libvips/mosaicing/mosaic.c:274
+#: libvips/resample/similarity.c:200
+msgid "Scale"
+msgstr ""
+
+#: libvips/arithmetic/hough_circle.c:234
+msgid "Scale down dimensions by this factor"
+msgstr ""
+
+#: libvips/arithmetic/hough_circle.c:240
+msgid "Min radius"
+msgstr ""
+
+#: libvips/arithmetic/hough_circle.c:241
+msgid "Smallest radius to search for"
+msgstr ""
+
+#: libvips/arithmetic/hough_circle.c:247
+msgid "Max radius"
+msgstr ""
+
+#: libvips/arithmetic/hough_circle.c:248
+msgid "Largest radius to search for"
+msgstr ""
+
+#: libvips/arithmetic/hough_line.c:140
+msgid "find hough line transform"
+msgstr ""
+
+#: libvips/arithmetic/hough_line.c:148
+msgid "Horizontal size of parameter space"
+msgstr ""
+
+#: libvips/arithmetic/hough_line.c:155
+msgid "Vertical size of parameter space"
+msgstr ""
+
+#: libvips/arithmetic/invert.c:178
+msgid "invert an image"
+msgstr ""
+
+#: libvips/arithmetic/linear.c:446
+msgid "calculate (a * in + b)"
+msgstr ""
+
+#: libvips/arithmetic/linear.c:454 libvips/create/sdf.c:332
+msgid "a"
+msgstr ""
+
+#: libvips/arithmetic/linear.c:455
+msgid "Multiply by this"
+msgstr ""
+
+#: libvips/arithmetic/linear.c:461 libvips/create/sdf.c:339
+msgid "b"
+msgstr ""
+
+#: libvips/arithmetic/linear.c:462
+msgid "Add this"
+msgstr ""
+
+#: libvips/arithmetic/linear.c:468
+msgid "uchar"
+msgstr ""
+
+#: libvips/arithmetic/linear.c:469
+msgid "Output should be uchar"
+msgstr ""
+
+#: libvips/arithmetic/math2.c:233
+msgid "binary math operations"
+msgstr ""
+
+#: libvips/arithmetic/math2.c:242 libvips/arithmetic/math2.c:472
+#: libvips/arithmetic/math.c:262
+msgid "Math to perform"
+msgstr ""
+
+#: libvips/arithmetic/math2.c:463
+msgid "binary math operations with a constant"
+msgstr ""
+
+#: libvips/arithmetic/math.c:253
 msgid "apply a math operation to an image"
 msgstr ""
 
-#: ../libvips/colour/LabQ2LabS.c:104
-msgid "unpack a LabQ image to short Lab"
+#: libvips/arithmetic/max.c:444
+msgid "find image maximum"
 msgstr ""
 
-#: ../libvips/colour/rad2float.c:188
-msgid "unpack Radiance coding to float RGB"
+#: libvips/arithmetic/max.c:460
+msgid "Horizontal position of maximum"
 msgstr ""
 
-#: ../libvips/colour/XYZ2scRGB.c:105
-msgid "transform XYZ to scRGB"
+#: libvips/arithmetic/max.c:467
+msgid "Vertical position of maximum"
 msgstr ""
 
-#: ../libvips/colour/Lab2LabS.c:80
-msgid "transform float Lab to signed short"
+#: libvips/arithmetic/max.c:473 libvips/arithmetic/min.c:473
+#: libvips/create/identity.c:157 libvips/create/invertlut.c:294
+#: libvips/resample/thumbnail.c:988
+msgid "Size"
 msgstr ""
 
-#: ../libvips/colour/LabS2LabQ.c:127
-msgid "transform short Lab to LabQ coding"
+#: libvips/arithmetic/max.c:474
+msgid "Number of maximum values to find"
 msgstr ""
 
-#: ../libvips/colour/float2rad.c:201
-msgid "transform float RGB to Radiance coding"
+#: libvips/arithmetic/max.c:487 libvips/arithmetic/min.c:487
+msgid "x array"
 msgstr ""
 
-#: ../libvips/colour/scRGB2XYZ.c:90
-msgid "transform scRGB to XYZ"
+#: libvips/arithmetic/max.c:488 libvips/arithmetic/min.c:488
+msgid "Array of horizontal positions"
 msgstr ""
 
-#: ../libvips/colour/LabQ2Lab.c:124
-msgid "unpack a LabQ image to float Lab"
+#: libvips/arithmetic/max.c:494 libvips/arithmetic/min.c:494
+msgid "y array"
 msgstr ""
 
-#: ../libvips/colour/HSV2sRGB.c:113
-msgid "transform HSV to sRGB"
+#: libvips/arithmetic/max.c:495 libvips/arithmetic/min.c:495
+msgid "Array of vertical positions"
 msgstr ""
 
-#: ../libvips/colour/XYZ2Lab.c:222
-msgid "transform XYZ to Lab"
+#: libvips/arithmetic/maxpair.c:151
+msgid "maximum of a pair of images"
 msgstr ""
 
-#: ../libvips/colour/XYZ2Lab.c:228 ../libvips/colour/Lab2XYZ.c:175
-msgid "Temperature"
+#: libvips/arithmetic/measure.c:164
+#, c-format
+msgid "%s: patch %d x %d, band %d: avg = %g, sdev = %g"
 msgstr ""
 
-#: ../libvips/colour/XYZ2Lab.c:229
-msgid "Colour temperature"
+#: libvips/arithmetic/measure.c:191
+msgid "measure a set of patches on a color chart"
+msgstr "measure a set of patches on a colour chart"
+
+#: libvips/arithmetic/measure.c:196
+msgid "Image to measure"
 msgstr ""
 
-#: ../libvips/colour/UCS2LCh.c:272 ../libvips/colour/LCh2UCS.c:206
-msgid "transform LCh to CMC"
+#: libvips/arithmetic/measure.c:202 libvips/arithmetic/stats.c:443
+msgid "Output array of statistics"
 msgstr ""
 
-#: ../libvips/colour/dE76.c:113
-msgid "calculate dE76"
+#: libvips/arithmetic/measure.c:207 libvips/conversion/arrayjoin.c:401
+#: libvips/conversion/grid.c:212 libvips/conversion/replicate.c:202
+msgid "Across"
 msgstr ""
 
-#: ../libvips/colour/colour.c:421
+#: libvips/arithmetic/measure.c:208
+msgid "Number of patches across chart"
+msgstr ""
+
+#: libvips/arithmetic/measure.c:214 libvips/conversion/grid.c:219
+#: libvips/conversion/replicate.c:209
+msgid "Down"
+msgstr ""
+
+#: libvips/arithmetic/measure.c:215
+msgid "Number of patches down chart"
+msgstr ""
+
+#: libvips/arithmetic/measure.c:222 libvips/conversion/extract.c:201
+msgid "Left edge of extract area"
+msgstr ""
+
+#: libvips/arithmetic/min.c:444
+msgid "find image minimum"
+msgstr ""
+
+#: libvips/arithmetic/min.c:460
+msgid "Horizontal position of minimum"
+msgstr ""
+
+#: libvips/arithmetic/min.c:467
+msgid "Vertical position of minimum"
+msgstr ""
+
+#: libvips/arithmetic/min.c:474
+msgid "Number of minimum values to find"
+msgstr ""
+
+#: libvips/arithmetic/minpair.c:151
+msgid "minimum of a pair of images"
+msgstr ""
+
+#: libvips/arithmetic/multiply.c:195
+msgid "multiply two images"
+msgstr ""
+
+#: libvips/arithmetic/nary.c:80
+msgid "nary operations"
+msgstr ""
+
+#: libvips/arithmetic/nary.c:88 libvips/conversion/arrayjoin.c:395
+#: libvips/conversion/bandjoin.c:202 libvips/conversion/bandrank.c:255
+#: libvips/conversion/composite.cpp:1581 libvips/iofuncs/system.c:278
+msgid "Array of input images"
+msgstr ""
+
+#: libvips/arithmetic/profile.c:293
+msgid "find image profiles"
+msgstr ""
+
+#: libvips/arithmetic/profile.c:301 libvips/arithmetic/project.c:332
+msgid "Columns"
+msgstr ""
+
+#: libvips/arithmetic/profile.c:302
+msgid "First non-zero pixel in column"
+msgstr ""
+
+#: libvips/arithmetic/profile.c:307 libvips/arithmetic/project.c:338
+msgid "Rows"
+msgstr ""
+
+#: libvips/arithmetic/profile.c:308
+msgid "First non-zero pixel in row"
+msgstr ""
+
+#: libvips/arithmetic/project.c:324
+msgid "find image projections"
+msgstr ""
+
+#: libvips/arithmetic/project.c:333
+msgid "Sums of columns"
+msgstr ""
+
+#: libvips/arithmetic/project.c:339
+msgid "Sums of rows"
+msgstr ""
+
+#: libvips/arithmetic/relational.c:238
+msgid "relational operation on two images"
+msgstr ""
+
+#: libvips/arithmetic/relational.c:247 libvips/arithmetic/relational.c:612
+msgid "Relational to perform"
+msgstr ""
+
+#: libvips/arithmetic/relational.c:603
+msgid "relational operations against a constant"
+msgstr ""
+
+#: libvips/arithmetic/remainder.c:192
+msgid "remainder after integer division of two images"
+msgstr ""
+
+#: libvips/arithmetic/remainder.c:353
+msgid "remainder after integer division of an image and a constant"
+msgstr ""
+
+#: libvips/arithmetic/round.c:173
+msgid "perform a round function on an image"
+msgstr ""
+
+#: libvips/arithmetic/round.c:181
+msgid "Round operation"
+msgstr ""
+
+#: libvips/arithmetic/round.c:182
+msgid "Rounding operation to perform"
+msgstr ""
+
+#: libvips/arithmetic/sign.c:174
+msgid "unit vector of pixel"
+msgstr ""
+
+#: libvips/arithmetic/statistic.c:161
+msgid "VIPS statistic operations"
+msgstr ""
+
+#: libvips/arithmetic/stats.c:434
+msgid "find many image stats"
+msgstr ""
+
+#: libvips/arithmetic/subtract.c:174
+msgid "subtract two images"
+msgstr ""
+
+#: libvips/arithmetic/sum.c:149
+msgid "sum an array of images"
+msgstr ""
+
+#: libvips/arithmetic/unary.c:81
+msgid "unary operations"
+msgstr ""
+
+#: libvips/arithmetic/unaryconst.c:138
+msgid "unary operations with a constant"
+msgstr ""
+
+#: libvips/arithmetic/unaryconst.c:142
+msgid "c"
+msgstr ""
+
+#: libvips/arithmetic/unaryconst.c:143
+msgid "Array of constants"
+msgstr ""
+
+#: libvips/colour/CMYK2XYZ.c:114 libvips/colour/CMYK2XYZ.c:182
+msgid "transform CMYK to XYZ"
+msgstr ""
+
+#: libvips/colour/colour.c:288
+msgid "too many input images"
+msgstr ""
+
+#: libvips/colour/colour.c:409
 msgid "color operations"
 msgstr "colour operations"
 
-#: ../libvips/colour/colour.c:489
+#: libvips/colour/colour.c:476
 msgid "color space transformations"
 msgstr "colour space transformations"
 
-#: ../libvips/colour/colour.c:583
+#: libvips/colour/colour.c:569
 msgid "change color coding"
 msgstr "change colour coding"
 
-#: ../libvips/colour/colour.c:695
+#: libvips/colour/colour.c:680
 msgid "calculate color difference"
 msgstr "calculate colour difference"
 
-#: ../libvips/colour/colour.c:700
+#: libvips/colour/colour.c:685
 msgid "Left-hand input image"
 msgstr ""
 
-#: ../libvips/colour/colour.c:706
+#: libvips/colour/colour.c:691
 msgid "Right-hand input image"
 msgstr ""
 
-#: ../libvips/colour/sRGB2HSV.c:134
-msgid "transform sRGB to HSV"
-msgstr ""
-
-#: ../libvips/colour/Lab2LabQ.c:137
-msgid "transform float Lab to LabQ coding"
-msgstr ""
-
-#: ../libvips/colour/sRGB2scRGB.c:237
-msgid "convert an sRGB image to scRGB"
-msgstr ""
-
-#: ../libvips/colour/dECMC.c:61
-msgid "calculate dECMC"
-msgstr ""
-
-#: ../libvips/colour/LCh2Lab.c:120
-msgid "transform LCh to Lab"
-msgstr ""
-
-#: ../libvips/colour/Yxy2XYZ.c:93
-msgid "transform Yxy to XYZ"
-msgstr ""
-
-#: ../libvips/colour/LabS2Lab.c:78
-msgid "transform signed short Lab to float"
-msgstr ""
-
-#: ../libvips/colour/LabQ2sRGB.c:514
-msgid "convert a LabQ image to sRGB"
-msgstr ""
-
-#: ../libvips/colour/scRGB2BW.c:190 ../libvips/colour/icc_transform.c:237
-#: ../libvips/colour/scRGB2sRGB.c:219
-msgid "depth must be 8 or 16"
-msgstr ""
-
-#: ../libvips/colour/scRGB2BW.c:231
-msgid "convert scRGB to BW"
-msgstr ""
-
-#: ../libvips/colour/scRGB2BW.c:249 ../libvips/colour/icc_transform.c:980
-#: ../libvips/colour/icc_transform.c:1121 ../libvips/colour/scRGB2sRGB.c:277
-#: ../libvips/foreign/dzsave.c:2163
-msgid "Depth"
-msgstr ""
-
-#: ../libvips/colour/scRGB2BW.c:250 ../libvips/colour/icc_transform.c:981
-#: ../libvips/colour/icc_transform.c:1122 ../libvips/colour/scRGB2sRGB.c:278
-msgid "Output device space depth in bits"
-msgstr ""
-
-#: ../libvips/colour/Lab2LCh.c:149
-msgid "transform Lab to LCh"
-msgstr ""
-
-#: ../libvips/colour/icc_transform.c:292
-#, c-format
-msgid "unimplemented input color space 0x%x"
-msgstr "unimplemented input colour space 0x%x"
-
-#: ../libvips/colour/icc_transform.c:357
-#, c-format
-msgid "unimplemented output color space 0x%x"
-msgstr "unimplemented output colour space 0x%x"
-
-#: ../libvips/colour/icc_transform.c:369
-msgid "no device profile"
-msgstr ""
-
-#: ../libvips/colour/icc_transform.c:400
-msgid "transform using ICC profiles"
-msgstr ""
-
-#: ../libvips/colour/icc_transform.c:404
-msgid "Intent"
-msgstr ""
-
-#: ../libvips/colour/icc_transform.c:405
-msgid "Rendering intent"
-msgstr ""
-
-#: ../libvips/colour/icc_transform.c:411
-msgid "PCS"
-msgstr ""
-
-#: ../libvips/colour/icc_transform.c:412
-msgid "Set Profile Connection Space"
-msgstr ""
-
-#: ../libvips/colour/icc_transform.c:455
-#, c-format
-msgid ""
-"%s: intent %d (%s) not supported by %s profile; falling back to default "
-"intent"
-msgstr ""
-
-#: ../libvips/colour/icc_transform.c:460 ../libvips/iofuncs/operation.c:377
-msgid "input"
-msgstr ""
-
-#: ../libvips/colour/icc_transform.c:460 ../libvips/iofuncs/operation.c:377
-msgid "output"
-msgstr ""
-
-#: ../libvips/colour/icc_transform.c:557
-msgid "corrupt embedded profile"
-msgstr ""
-
-#: ../libvips/colour/icc_transform.c:565
-msgid "embedded profile incompatible with image"
-msgstr ""
-
-#: ../libvips/colour/icc_transform.c:580 ../libvips/colour/icc_transform.c:822
-#: ../libvips/colour/icc_transform.c:1045
-#, c-format
-msgid "unable to open profile \"%s\""
-msgstr ""
-
-#: ../libvips/colour/icc_transform.c:587
-#, c-format
-msgid "profile \"%s\" incompatible with image"
-msgstr ""
-
-#: ../libvips/colour/icc_transform.c:626 ../libvips/colour/icc_transform.c:1037
-msgid "no input profile"
-msgstr ""
-
-#: ../libvips/colour/icc_transform.c:736
-msgid "import from device with ICC profile"
-msgstr ""
-
-#: ../libvips/colour/icc_transform.c:742 ../libvips/colour/icc_transform.c:1107
-msgid "Embedded"
-msgstr ""
-
-#: ../libvips/colour/icc_transform.c:743 ../libvips/colour/icc_transform.c:1108
-msgid "Use embedded input profile, if available"
-msgstr ""
-
-#: ../libvips/colour/icc_transform.c:749 ../libvips/colour/icc_transform.c:1114
-msgid "Input profile"
-msgstr ""
-
-#: ../libvips/colour/icc_transform.c:750 ../libvips/colour/icc_transform.c:1115
-msgid "Filename to load input profile from"
-msgstr ""
-
-#: ../libvips/colour/icc_transform.c:814
-msgid "unable to load embedded profile"
-msgstr ""
-
-#: ../libvips/colour/icc_transform.c:830
-msgid "no output profile"
-msgstr ""
-
-#: ../libvips/colour/icc_transform.c:967
-msgid "output to device with ICC profile"
-msgstr ""
-
-#: ../libvips/colour/icc_transform.c:973 ../libvips/colour/icc_transform.c:1100
-msgid "Output profile"
-msgstr ""
-
-#: ../libvips/colour/icc_transform.c:974 ../libvips/colour/icc_transform.c:1101
-msgid "Filename to load output profile from"
-msgstr ""
-
-#: ../libvips/colour/icc_transform.c:1094
-msgid "transform between devices with ICC profiles"
-msgstr ""
-
-#: ../libvips/colour/icc_transform.c:1166
-#: ../libvips/colour/icc_transform.c:1180
-msgid "unable to get media white point"
-msgstr ""
-
-#: ../libvips/colour/icc_transform.c:1240
-msgid "libvips configured without lcms support"
-msgstr ""
-
-#: ../libvips/colour/scRGB2sRGB.c:259
-msgid "convert an scRGB image to sRGB"
-msgstr ""
-
-#: ../libvips/colour/dE00.c:235
-msgid "calculate dE00"
-msgstr ""
-
-#: ../libvips/colour/Lab2XYZ.c:169
-msgid "transform CIELAB to XYZ"
-msgstr ""
-
-#: ../libvips/colour/Lab2XYZ.c:176
-msgid "Color temperature"
-msgstr ""
-
-#: ../libvips/colour/XYZ2Yxy.c:92
-msgid "transform XYZ to Yxy"
-msgstr ""
-
-#: ../libvips/colour/colourspace.c:145
+#: libvips/colour/colourspace.c:145
 msgid "too few bands for operation"
 msgstr ""
 
-#: ../libvips/colour/colourspace.c:548
+#: libvips/colour/colourspace.c:519
 #, c-format
 msgid "no known route from '%s' to '%s'"
 msgstr ""
 
-#: ../libvips/colour/colourspace.c:580
+#: libvips/colour/colourspace.c:551
 msgid "convert to a new colorspace"
 msgstr "convert to a new colourspace"
 
-#: ../libvips/colour/colourspace.c:598
+#: libvips/colour/colourspace.c:569
 msgid "Space"
 msgstr ""
 
-#: ../libvips/colour/colourspace.c:599
+#: libvips/colour/colourspace.c:570
 msgid "Destination color space"
 msgstr "Destination colour space"
 
-#: ../libvips/colour/colourspace.c:605
+#: libvips/colour/colourspace.c:576
 msgid "Source space"
 msgstr ""
 
-#: ../libvips/colour/colourspace.c:606
+#: libvips/colour/colourspace.c:577
 msgid "Source color space"
 msgstr "Source colour space"
 
-#: ../libvips/conversion/conversion.c:196
-msgid "conversion operations"
+#: libvips/colour/dE00.c:236
+msgid "calculate dE00"
 msgstr ""
 
-#: ../libvips/conversion/embed.c:474 ../libvips/iofuncs/image.c:2818
-msgid "bad dimensions"
+#: libvips/colour/dE76.c:113
+msgid "calculate dE76"
 msgstr ""
 
-#: ../libvips/conversion/embed.c:557
-msgid "embed an image in a larger image"
+#: libvips/colour/dECMC.c:61
+msgid "calculate dECMC"
 msgstr ""
 
-#: ../libvips/conversion/embed.c:570 ../libvips/conversion/wrap.c:126
-msgid "Left edge of input in output"
+#: libvips/colour/float2rad.c:206
+msgid "transform float RGB to Radiance coding"
 msgstr ""
 
-#: ../libvips/conversion/embed.c:577 ../libvips/conversion/wrap.c:133
-msgid "Top edge of input in output"
+#: libvips/colour/HSV2sRGB.c:112
+msgid "transform HSV to sRGB"
 msgstr ""
 
-#: ../libvips/conversion/embed.c:584 ../libvips/conversion/copy.c:285
-#: ../libvips/create/xyz.c:194 ../libvips/create/worley.c:311
-#: ../libvips/create/gaussnoise.c:173 ../libvips/create/perlin.c:298
-#: ../libvips/create/point.c:144 ../libvips/create/fractsurf.c:103
-#: ../libvips/create/black.c:130 ../libvips/foreign/rawload.c:124
-#: ../libvips/iofuncs/image.c:1131
-msgid "Image width in pixels"
+#: libvips/colour/icc_transform.c:272 libvips/colour/scRGB2BW.c:190
+#: libvips/colour/scRGB2sRGB.c:224
+msgid "depth must be 8 or 16"
 msgstr ""
 
-#: ../libvips/conversion/embed.c:591 ../libvips/conversion/copy.c:292
-#: ../libvips/create/xyz.c:201 ../libvips/create/worley.c:318
-#: ../libvips/create/gaussnoise.c:180 ../libvips/create/perlin.c:305
-#: ../libvips/create/point.c:151 ../libvips/create/fractsurf.c:110
-#: ../libvips/create/black.c:137 ../libvips/foreign/rawload.c:131
-#: ../libvips/iofuncs/image.c:1138
-msgid "Image height in pixels"
+#: libvips/colour/icc_transform.c:284
+#, c-format
+msgid "unimplemented input color space 0x%x"
+msgstr "unimplemented input colour space 0x%x"
+
+#: libvips/colour/icc_transform.c:360
+#, c-format
+msgid "unimplemented output color space 0x%x"
+msgstr "unimplemented output colour space 0x%x"
+
+#: libvips/colour/icc_transform.c:437
+msgid "no device profile"
 msgstr ""
 
-#: ../libvips/conversion/embed.c:597
-msgid "Extend"
+#: libvips/colour/icc_transform.c:612 libvips/colour/icc_transform.c:635
+#: libvips/colour/icc_transform.c:658 libvips/iofuncs/operation.c:442
+msgid "input"
 msgstr ""
 
-#: ../libvips/conversion/embed.c:598
-msgid "How to generate the extra pixels"
+#: libvips/colour/icc_transform.c:612 libvips/colour/icc_transform.c:635
+#: libvips/colour/icc_transform.c:658 libvips/iofuncs/operation.c:443
+msgid "output"
 msgstr ""
 
-#: ../libvips/conversion/embed.c:604 ../libvips/conversion/arrayjoin.c:325
-#: ../libvips/conversion/flatten.c:392 ../libvips/conversion/join.c:265
-#: ../libvips/conversion/insert.c:550 ../libvips/foreign/foreign.c:1535
-msgid "Background"
+#: libvips/colour/icc_transform.c:631
+#, c-format
+msgid ""
+"fallback to suggested %s intent, as profile does not support %s %s intent"
 msgstr ""
 
-#: ../libvips/conversion/embed.c:605
-msgid "Color for background pixels"
+#: libvips/colour/icc_transform.c:656
+#, c-format
+msgid "profile does not support %s %s intent"
 msgstr ""
 
-#: ../libvips/conversion/zoom.c:333
-msgid "zoom factors too large"
+#: libvips/colour/icc_transform.c:757
+msgid "unable to load or find any compatible input profile"
 msgstr ""
 
-#: ../libvips/conversion/zoom.c:377
-msgid "zoom an image"
+#: libvips/colour/icc_transform.c:775
+msgid "transform using ICC profiles"
 msgstr ""
 
-#: ../libvips/conversion/zoom.c:389 ../libvips/conversion/subsample.c:280
-msgid "Xfac"
+#: libvips/colour/icc_transform.c:779 libvips/resample/thumbnail.c:1030
+msgid "Intent"
 msgstr ""
 
-#: ../libvips/conversion/zoom.c:390
-msgid "Horizontal zoom factor"
+#: libvips/colour/icc_transform.c:780 libvips/resample/thumbnail.c:1031
+msgid "Rendering intent"
 msgstr ""
 
-#: ../libvips/conversion/zoom.c:396 ../libvips/conversion/subsample.c:287
-msgid "Yfac"
+#: libvips/colour/icc_transform.c:786
+msgid "PCS"
 msgstr ""
 
-#: ../libvips/conversion/zoom.c:397
-msgid "Vertical zoom factor"
+#: libvips/colour/icc_transform.c:787
+msgid "Set Profile Connection Space"
 msgstr ""
 
-#: ../libvips/conversion/replicate.c:192
-msgid "replicate an image"
+#: libvips/colour/icc_transform.c:793
+msgid "Black point compensation"
 msgstr ""
 
-#: ../libvips/conversion/replicate.c:203
-msgid "Repeat this many times horizontally"
+#: libvips/colour/icc_transform.c:794
+msgid "Enable black point compensation"
 msgstr ""
 
-#: ../libvips/conversion/replicate.c:210
-msgid "Repeat this many times vertically"
+#: libvips/colour/icc_transform.c:969
+msgid "import from device with ICC profile"
 msgstr ""
 
-#: ../libvips/conversion/bandfold.c:122
-msgid "@factor must be a factor of image width"
+#: libvips/colour/icc_transform.c:975 libvips/colour/icc_transform.c:1258
+msgid "Embedded"
 msgstr ""
 
-#: ../libvips/conversion/bandfold.c:154
-msgid "fold up x axis into bands"
+#: libvips/colour/icc_transform.c:976 libvips/colour/icc_transform.c:1259
+msgid "Use embedded input profile, if available"
 msgstr ""
 
-#: ../libvips/conversion/bandfold.c:166 ../libvips/conversion/bandunfold.c:169
-#: ../libvips/create/eye.c:103
-msgid "Factor"
+#: libvips/colour/icc_transform.c:982 libvips/colour/icc_transform.c:1265
+msgid "Input profile"
 msgstr ""
 
-#: ../libvips/conversion/bandfold.c:167
-msgid "Fold by this factor"
+#: libvips/colour/icc_transform.c:983 libvips/colour/icc_transform.c:1266
+msgid "Filename to load input profile from"
 msgstr ""
 
-#: ../libvips/conversion/wrap.c:115
-msgid "wrap image origin"
+#: libvips/colour/icc_transform.c:1046 libvips/colour/icc_transform.c:1212
+msgid "no output profile"
 msgstr ""
 
-#: ../libvips/conversion/arrayjoin.c:298
+#: libvips/colour/icc_transform.c:1141
+msgid "output to device with ICC profile"
+msgstr ""
+
+#: libvips/colour/icc_transform.c:1147 libvips/colour/icc_transform.c:1251
+msgid "Output profile"
+msgstr ""
+
+#: libvips/colour/icc_transform.c:1148 libvips/colour/icc_transform.c:1252
+msgid "Filename to load output profile from"
+msgstr ""
+
+#: libvips/colour/icc_transform.c:1154 libvips/colour/icc_transform.c:1272
+#: libvips/colour/scRGB2BW.c:249 libvips/colour/scRGB2sRGB.c:282
+#: libvips/foreign/dzsave.c:2364 libvips/foreign/tiffsave.c:378
+msgid "Depth"
+msgstr ""
+
+#: libvips/colour/icc_transform.c:1155 libvips/colour/icc_transform.c:1273
+#: libvips/colour/scRGB2BW.c:250 libvips/colour/scRGB2sRGB.c:283
+msgid "Output device space depth in bits"
+msgstr ""
+
+#: libvips/colour/icc_transform.c:1245
+msgid "transform between devices with ICC profiles"
+msgstr ""
+
+#: libvips/colour/icc_transform.c:1321
+msgid "unable to get media white point"
+msgstr ""
+
+#: libvips/colour/icc_transform.c:1416
+msgid "libvips configured without lcms support"
+msgstr ""
+
+#: libvips/colour/Lab2LabQ.c:137
+msgid "transform float Lab to LabQ coding"
+msgstr ""
+
+#: libvips/colour/Lab2LabS.c:82
+msgid "transform float Lab to signed short"
+msgstr ""
+
+#: libvips/colour/Lab2LCh.c:132
+msgid "transform Lab to LCh"
+msgstr ""
+
+#: libvips/colour/Lab2XYZ.c:177
+msgid "transform CIELAB to XYZ"
+msgstr ""
+
+#: libvips/colour/Lab2XYZ.c:183 libvips/colour/XYZ2Lab.c:236
+msgid "Temperature"
+msgstr ""
+
+#: libvips/colour/Lab2XYZ.c:184
+msgid "Color temperature"
+msgstr ""
+
+#: libvips/colour/LabQ2Lab.c:125
+msgid "unpack a LabQ image to float Lab"
+msgstr ""
+
+#: libvips/colour/LabQ2LabS.c:104
+msgid "unpack a LabQ image to short Lab"
+msgstr ""
+
+#: libvips/colour/LabQ2sRGB.c:549
+msgid "convert a LabQ image to sRGB"
+msgstr ""
+
+#: libvips/colour/LabS2Lab.c:78
+msgid "transform signed short Lab to float"
+msgstr ""
+
+#: libvips/colour/LabS2LabQ.c:127
+msgid "transform short Lab to LabQ coding"
+msgstr ""
+
+#: libvips/colour/LCh2Lab.c:111
+msgid "transform LCh to Lab"
+msgstr ""
+
+#: libvips/colour/LCh2UCS.c:206 libvips/colour/UCS2LCh.c:273
+msgid "transform LCh to CMC"
+msgstr ""
+
+#: libvips/colour/profile_load.c:123
+#, c-format
+msgid "unable to load profile \"%s\""
+msgstr ""
+
+#: libvips/colour/profile_load.c:147
+msgid "load named ICC profile"
+msgstr ""
+
+#: libvips/colour/profile_load.c:151
+msgid "Name"
+msgstr ""
+
+#: libvips/colour/profile_load.c:152
+msgid "Profile name"
+msgstr ""
+
+#: libvips/colour/profile_load.c:158 libvips/foreign/foreign.c:1922
+msgid "Profile"
+msgstr ""
+
+#: libvips/colour/profile_load.c:159
+msgid "Loaded profile"
+msgstr ""
+
+#: libvips/colour/rad2float.c:184
+msgid "unpack Radiance coding to float RGB"
+msgstr ""
+
+#: libvips/colour/scRGB2BW.c:231
+msgid "convert scRGB to BW"
+msgstr ""
+
+#: libvips/colour/scRGB2sRGB.c:264
+msgid "convert an scRGB image to sRGB"
+msgstr ""
+
+#: libvips/colour/scRGB2XYZ.c:185
+msgid "transform scRGB to XYZ"
+msgstr ""
+
+#: libvips/colour/sRGB2HSV.c:133
+msgid "transform sRGB to HSV"
+msgstr ""
+
+#: libvips/colour/sRGB2scRGB.c:282
+msgid "convert an sRGB image to scRGB"
+msgstr ""
+
+#: libvips/colour/XYZ2CMYK.c:113 libvips/colour/XYZ2CMYK.c:193
+msgid "transform XYZ to CMYK"
+msgstr ""
+
+#: libvips/colour/XYZ2Lab.c:230
+msgid "transform XYZ to Lab"
+msgstr ""
+
+#: libvips/colour/XYZ2Lab.c:237
+msgid "Colour temperature"
+msgstr ""
+
+#: libvips/colour/XYZ2scRGB.c:194
+msgid "transform XYZ to scRGB"
+msgstr ""
+
+#: libvips/colour/XYZ2Yxy.c:98
+msgid "transform XYZ to Yxy"
+msgstr ""
+
+#: libvips/colour/Yxy2XYZ.c:103
+msgid "transform Yxy to XYZ"
+msgstr ""
+
+#: libvips/conversion/addalpha.c:84
+msgid "append an alpha channel"
+msgstr ""
+
+#: libvips/conversion/arrayjoin.c:388
 msgid "join an array of images"
 msgstr ""
 
-#: ../libvips/conversion/arrayjoin.c:312
+#: libvips/conversion/arrayjoin.c:402
 msgid "Number of images across grid"
 msgstr ""
 
-#: ../libvips/conversion/arrayjoin.c:318 ../libvips/conversion/join.c:258
+#: libvips/conversion/arrayjoin.c:408 libvips/conversion/join.c:263
 msgid "Shim"
 msgstr ""
 
-#: ../libvips/conversion/arrayjoin.c:319 ../libvips/conversion/join.c:259
+#: libvips/conversion/arrayjoin.c:409 libvips/conversion/join.c:264
 msgid "Pixels between images"
 msgstr ""
 
-#: ../libvips/conversion/arrayjoin.c:326 ../libvips/conversion/join.c:266
+#: libvips/conversion/arrayjoin.c:416 libvips/conversion/join.c:271
 msgid "Colour for new pixels"
 msgstr ""
 
-#: ../libvips/conversion/arrayjoin.c:332
+#: libvips/conversion/arrayjoin.c:422
 msgid "Horizontal align"
 msgstr ""
 
-#: ../libvips/conversion/arrayjoin.c:333
+#: libvips/conversion/arrayjoin.c:423
 msgid "Align on the left, centre or right"
 msgstr ""
 
-#: ../libvips/conversion/arrayjoin.c:339
+#: libvips/conversion/arrayjoin.c:429
 msgid "Vertical align"
 msgstr ""
 
-#: ../libvips/conversion/arrayjoin.c:340
+#: libvips/conversion/arrayjoin.c:430
 msgid "Align on the top, centre or bottom"
 msgstr ""
 
-#: ../libvips/conversion/arrayjoin.c:346
+#: libvips/conversion/arrayjoin.c:436
 msgid "Horizontal spacing"
 msgstr ""
 
-#: ../libvips/conversion/arrayjoin.c:347
+#: libvips/conversion/arrayjoin.c:437
 msgid "Horizontal spacing between images"
 msgstr ""
 
-#: ../libvips/conversion/arrayjoin.c:353
+#: libvips/conversion/arrayjoin.c:443
 msgid "Vertical spacing"
 msgstr ""
 
-#: ../libvips/conversion/arrayjoin.c:354
+#: libvips/conversion/arrayjoin.c:444
 msgid "Vertical spacing between images"
 msgstr ""
 
-#: ../libvips/conversion/unpremultiply.c:262
-msgid "unpremultiply image alpha"
+#: libvips/conversion/autorot.c:203
+msgid "autorotate image by exif tag"
 msgstr ""
 
-#: ../libvips/conversion/unpremultiply.c:274
-#: ../libvips/conversion/flatten.c:399 ../libvips/conversion/premultiply.c:265
-msgid "Maximum alpha"
-msgstr ""
-
-#: ../libvips/conversion/unpremultiply.c:275
-#: ../libvips/conversion/flatten.c:400 ../libvips/conversion/premultiply.c:266
-msgid "Maximum value of alpha channel"
-msgstr ""
-
-#: ../libvips/conversion/flip.c:236
-msgid "flip an image"
-msgstr ""
-
-#: ../libvips/conversion/flip.c:246 ../libvips/mosaicing/merge.c:127
-#: ../libvips/mosaicing/mosaic.c:198 ../libvips/mosaicing/mosaic1.c:507
-msgid "Direction"
-msgstr ""
-
-#: ../libvips/conversion/flip.c:247
-msgid "Direction to flip image"
-msgstr ""
-
-#: ../libvips/conversion/flatten.c:380
-msgid "flatten alpha out of an image"
-msgstr ""
-
-#: ../libvips/conversion/flatten.c:393 ../libvips/foreign/foreign.c:1536
-msgid "Background value"
-msgstr ""
-
-#: ../libvips/conversion/copy.c:235
-msgid "must not change pel size"
-msgstr ""
-
-#: ../libvips/conversion/copy.c:260
-msgid "copy an image"
-msgstr ""
-
-#: ../libvips/conversion/copy.c:277
-msgid "Swap"
-msgstr ""
-
-#: ../libvips/conversion/copy.c:278
-msgid "Swap bytes in image between little and big-endian"
-msgstr ""
-
-#: ../libvips/conversion/copy.c:298 ../libvips/create/identity.c:144
-#: ../libvips/create/black.c:143 ../libvips/foreign/rawload.c:137
-#: ../libvips/iofuncs/image.c:1144
-msgid "Bands"
-msgstr ""
-
-#: ../libvips/conversion/copy.c:299 ../libvips/create/black.c:144
-#: ../libvips/foreign/rawload.c:138 ../libvips/iofuncs/image.c:1145
-msgid "Number of bands in image"
-msgstr ""
-
-#: ../libvips/conversion/copy.c:305 ../libvips/conversion/cast.c:554
-#: ../libvips/iofuncs/image.c:1151
-msgid "Format"
-msgstr ""
-
-#: ../libvips/conversion/copy.c:306 ../libvips/iofuncs/image.c:1152
-msgid "Pixel format in image"
-msgstr ""
-
-#: ../libvips/conversion/copy.c:312 ../libvips/iofuncs/image.c:1158
-msgid "Coding"
-msgstr ""
-
-#: ../libvips/conversion/copy.c:313 ../libvips/iofuncs/image.c:1159
-msgid "Pixel coding"
-msgstr ""
-
-#: ../libvips/conversion/copy.c:319 ../libvips/iofuncs/image.c:1165
-msgid "Interpretation"
-msgstr ""
-
-#: ../libvips/conversion/copy.c:320 ../libvips/iofuncs/image.c:1166
-msgid "Pixel interpretation"
-msgstr ""
-
-#: ../libvips/conversion/copy.c:326 ../libvips/foreign/tiffsave.c:260
-#: ../libvips/iofuncs/image.c:1172
-msgid "Xres"
-msgstr ""
-
-#: ../libvips/conversion/copy.c:327 ../libvips/foreign/tiffsave.c:261
-#: ../libvips/iofuncs/image.c:1173
-msgid "Horizontal resolution in pixels/mm"
-msgstr ""
-
-#: ../libvips/conversion/copy.c:333 ../libvips/foreign/tiffsave.c:267
-#: ../libvips/iofuncs/image.c:1179
-msgid "Yres"
-msgstr ""
-
-#: ../libvips/conversion/copy.c:334 ../libvips/foreign/tiffsave.c:268
-#: ../libvips/iofuncs/image.c:1180
-msgid "Vertical resolution in pixels/mm"
-msgstr ""
-
-#: ../libvips/conversion/copy.c:340 ../libvips/iofuncs/image.c:1186
-msgid "Xoffset"
-msgstr ""
-
-#: ../libvips/conversion/copy.c:341 ../libvips/iofuncs/image.c:1187
-msgid "Horizontal offset of origin"
-msgstr ""
-
-#: ../libvips/conversion/copy.c:347 ../libvips/iofuncs/image.c:1193
-msgid "Yoffset"
-msgstr ""
-
-#: ../libvips/conversion/copy.c:348 ../libvips/iofuncs/image.c:1194
-msgid "Vertical offset of origin"
-msgstr ""
-
-#: ../libvips/conversion/bandjoin.c:170
-msgid "bandwise join a set of images"
-msgstr ""
-
-#: ../libvips/conversion/bandjoin.c:389
-msgid "append a constant band to an image"
-msgstr ""
-
-#: ../libvips/conversion/bandjoin.c:401
-msgid "Constants"
-msgstr ""
-
-#: ../libvips/conversion/bandjoin.c:402
-msgid "Array of constants to add"
-msgstr ""
-
-#: ../libvips/conversion/rot45.c:263 ../libvips/conversion/rot.c:355
-msgid "rotate an image"
-msgstr ""
-
-#: ../libvips/conversion/rot45.c:273 ../libvips/conversion/autorot.c:184
-#: ../libvips/conversion/rot.c:365 ../libvips/convolution/compass.c:157
-#: ../libvips/foreign/dzsave.c:2178 ../libvips/mosaicing/mosaic.c:282
-#: ../libvips/resample/similarity.c:178
+#: libvips/conversion/autorot.c:213 libvips/conversion/rot45.c:274
+#: libvips/conversion/rot.c:371 libvips/convolution/compass.c:170
+#: libvips/foreign/dzsave.c:2378 libvips/mosaicing/mosaic.c:281
+#: libvips/resample/similarity.c:207 libvips/resample/similarity.c:276
 msgid "Angle"
 msgstr ""
 
-#: ../libvips/conversion/rot45.c:274 ../libvips/conversion/rot.c:366
-msgid "Angle to rotate image"
+#: libvips/conversion/autorot.c:214
+msgid "Angle image was rotated by"
 msgstr ""
 
-#: ../libvips/conversion/msb.c:166
-msgid "bad band"
+#: libvips/conversion/autorot.c:220
+msgid "Flip"
 msgstr ""
 
-#: ../libvips/conversion/msb.c:238
-msgid "pick most-significant byte from an image"
+#: libvips/conversion/autorot.c:221
+msgid "Whether the image was flipped or not"
 msgstr ""
 
-#: ../libvips/conversion/msb.c:251
-msgid "Band to msb"
+#: libvips/conversion/bandary.c:211 libvips/conversion/bandary.c:280
+#: libvips/conversion/composite.cpp:1299
+msgid "no input images"
 msgstr ""
 
-#: ../libvips/conversion/extract.c:150
-msgid "bad extract area"
+#: libvips/conversion/bandary.c:257
+msgid "operations on image bands"
 msgstr ""
 
-#: ../libvips/conversion/extract.c:193
-msgid "extract an area from an image"
-msgstr ""
-
-#: ../libvips/conversion/extract.c:387
-msgid "bad extract band"
-msgstr ""
-
-#: ../libvips/conversion/extract.c:416
-msgid "extract band from an image"
-msgstr ""
-
-#: ../libvips/conversion/extract.c:429
-msgid "Band to extract"
-msgstr ""
-
-#: ../libvips/conversion/extract.c:435 ../libvips/foreign/magickload.c:138
-#: ../libvips/foreign/gifload.c:823 ../libvips/foreign/magick7load.c:400
-#: ../libvips/foreign/pdfload.c:475 ../libvips/foreign/tiffload.c:106
-msgid "n"
-msgstr ""
-
-#: ../libvips/conversion/extract.c:436
-msgid "Number of bands to extract"
-msgstr ""
-
-#: ../libvips/conversion/cast.c:131
-#, c-format
-msgid "%d underflows and %d overflows detected"
-msgstr ""
-
-#: ../libvips/conversion/cast.c:542
-msgid "cast an image"
-msgstr ""
-
-#: ../libvips/conversion/cast.c:555
-msgid "Format to cast to"
-msgstr ""
-
-#: ../libvips/conversion/cast.c:561
-msgid "Shift"
-msgstr ""
-
-#: ../libvips/conversion/cast.c:562
-msgid "Shift integer values up and down"
-msgstr ""
-
-#: ../libvips/conversion/bandunfold.c:125
-msgid "@factor must be a factor of image bands"
-msgstr ""
-
-#: ../libvips/conversion/bandunfold.c:157
-msgid "unfold image bands into x axis"
-msgstr ""
-
-#: ../libvips/conversion/bandunfold.c:170
-msgid "Unfold by this factor"
-msgstr ""
-
-#: ../libvips/conversion/tilecache.c:410 ../libvips/conversion/cache.c:97
-msgid "cache an image"
-msgstr ""
-
-#: ../libvips/conversion/tilecache.c:422 ../libvips/conversion/sequential.c:340
-#: ../libvips/conversion/cache.c:114 ../libvips/conversion/grid.c:205
-#: ../libvips/foreign/tiffsave.c:225 ../libvips/foreign/dzsave.c:2224
-msgid "Tile height"
-msgstr ""
-
-#: ../libvips/conversion/tilecache.c:423 ../libvips/conversion/sequential.c:341
-#: ../libvips/conversion/cache.c:115 ../libvips/foreign/tiffsave.c:226
-#: ../libvips/foreign/dzsave.c:2225
-msgid "Tile height in pixels"
-msgstr ""
-
-#: ../libvips/conversion/tilecache.c:429 ../libvips/conversion/tilecache.c:999
-#: ../libvips/foreign/foreign.c:1004
-msgid "Access"
-msgstr ""
-
-#: ../libvips/conversion/tilecache.c:430 ../libvips/conversion/tilecache.c:1000
-#: ../libvips/conversion/sequential.c:348
-msgid "Expected access pattern"
-msgstr ""
-
-#: ../libvips/conversion/tilecache.c:436
-msgid "Threaded"
-msgstr ""
-
-#: ../libvips/conversion/tilecache.c:437
-msgid "Allow threaded access"
-msgstr ""
-
-#: ../libvips/conversion/tilecache.c:443
-msgid "Persistent"
-msgstr ""
-
-#: ../libvips/conversion/tilecache.c:444
-msgid "Keep cache between evaluations"
-msgstr ""
-
-#: ../libvips/conversion/tilecache.c:704
-#, c-format
-msgid "error in tile %d x %d"
-msgstr ""
-
-#: ../libvips/conversion/tilecache.c:795
-msgid "cache an image as a set of tiles"
-msgstr ""
-
-#: ../libvips/conversion/tilecache.c:799 ../libvips/conversion/cache.c:107
-#: ../libvips/foreign/tiffsave.c:218 ../libvips/foreign/dzsave.c:2217
-msgid "Tile width"
-msgstr ""
-
-#: ../libvips/conversion/tilecache.c:800 ../libvips/conversion/cache.c:108
-#: ../libvips/foreign/tiffsave.c:219 ../libvips/foreign/dzsave.c:2218
-msgid "Tile width in pixels"
-msgstr ""
-
-#: ../libvips/conversion/tilecache.c:806 ../libvips/conversion/cache.c:121
-msgid "Max tiles"
-msgstr ""
-
-#: ../libvips/conversion/tilecache.c:807 ../libvips/conversion/cache.c:122
-msgid "Maximum number of tiles to cache"
-msgstr ""
-
-#: ../libvips/conversion/tilecache.c:995
-msgid "cache an image as a set of lines"
-msgstr ""
-
-#: ../libvips/conversion/sequential.c:323
-msgid "check sequential access"
-msgstr ""
-
-#: ../libvips/conversion/sequential.c:333
-msgid "trace"
-msgstr ""
-
-#: ../libvips/conversion/sequential.c:334
-msgid "trace pixel requests"
-msgstr ""
-
-#: ../libvips/conversion/sequential.c:347
-msgid "Strategy"
-msgstr ""
-
-#: ../libvips/conversion/premultiply.c:253
-msgid "premultiply image alpha"
-msgstr ""
-
-#: ../libvips/conversion/bandmean.c:192
-msgid "band-wise average"
-msgstr ""
-
-#: ../libvips/conversion/bandmean.c:199 ../libvips/conversion/bandbool.c:215
-#: ../libvips/conversion/recomb.c:208 ../libvips/convolution/convolution.c:130
-#: ../libvips/convolution/correlation.c:152
-#: ../libvips/morphology/morphology.c:118 ../libvips/resample/resample.c:133
-msgid "Input image argument"
-msgstr ""
-
-#: ../libvips/conversion/falsecolour.c:375
-msgid "false-color an image"
-msgstr "false-colour an image"
-
-#: ../libvips/conversion/byteswap.c:200
-msgid "byteswap an image"
-msgstr ""
-
-#: ../libvips/conversion/subsample.c:230 ../libvips/resample/shrinkv.c:393
-#: ../libvips/resample/shrinkh.c:289 ../libvips/resample/reduceh.cpp:528
-#: ../libvips/resample/reducev.cpp:801
-msgid "image has shrunk to nothing"
-msgstr ""
-
-#: ../libvips/conversion/subsample.c:266
-msgid "subsample an image"
-msgstr ""
-
-#: ../libvips/conversion/subsample.c:281
-msgid "Horizontal subsample factor"
-msgstr ""
-
-#: ../libvips/conversion/subsample.c:288
-msgid "Vertical subsample factor"
-msgstr ""
-
-#: ../libvips/conversion/subsample.c:294
-msgid "Point"
-msgstr ""
-
-#: ../libvips/conversion/subsample.c:295
-msgid "Point sample"
-msgstr ""
-
-#: ../libvips/conversion/bandbool.c:75
+#: libvips/conversion/bandbool.c:75
 #, c-format
 msgid "operator %s not supported across image bands"
 msgstr ""
 
-#: ../libvips/conversion/bandbool.c:207
+#: libvips/conversion/bandbool.c:225
 msgid "boolean operation across image bands"
 msgstr ""
 
-#: ../libvips/conversion/recomb.c:166
-msgid "bands in must equal matrix width"
+#: libvips/conversion/bandbool.c:233 libvips/conversion/bandmean.c:213
+#: libvips/conversion/recomb.c:225 libvips/convolution/convolution.c:129
+#: libvips/convolution/correlation.c:151 libvips/morphology/morphology.c:122
+#: libvips/resample/resample.c:141 libvips/resample/thumbnail.c:1783
+msgid "Input image argument"
 msgstr ""
 
-#: ../libvips/conversion/recomb.c:201
-msgid "linear recombination with matrix"
+#: libvips/conversion/bandfold.c:123
+msgid "@factor must be a factor of image width"
 msgstr ""
 
-#: ../libvips/conversion/recomb.c:213
-msgid "M"
+#: libvips/conversion/bandfold.c:155
+msgid "fold up x axis into bands"
 msgstr ""
 
-#: ../libvips/conversion/recomb.c:214
-msgid "matrix of coefficients"
+#: libvips/conversion/bandfold.c:167 libvips/conversion/bandunfold.c:170
+#: libvips/create/eye.c:108
+msgid "Factor"
 msgstr ""
 
-#: ../libvips/conversion/bandary.c:135
-msgid "no input images"
+#: libvips/conversion/bandfold.c:168
+msgid "Fold by this factor"
 msgstr ""
 
-#: ../libvips/conversion/bandary.c:186
-msgid "operations on image bands"
+#: libvips/conversion/bandjoin.c:195
+msgid "bandwise join a set of images"
 msgstr ""
 
-#: ../libvips/conversion/ifthenelse.c:479
-msgid "ifthenelse an image"
+#: libvips/conversion/bandjoin.c:430
+msgid "append a constant band to an image"
 msgstr ""
 
-#: ../libvips/conversion/ifthenelse.c:483
-msgid "Condition"
+#: libvips/conversion/bandjoin.c:442
+msgid "Constants"
 msgstr ""
 
-#: ../libvips/conversion/ifthenelse.c:484
-msgid "Condition input image"
+#: libvips/conversion/bandjoin.c:443
+msgid "Array of constants to add"
 msgstr ""
 
-#: ../libvips/conversion/ifthenelse.c:489
-msgid "Then image"
+#: libvips/conversion/bandmean.c:206
+msgid "band-wise average"
 msgstr ""
 
-#: ../libvips/conversion/ifthenelse.c:490
-msgid "Source for TRUE pixels"
-msgstr ""
-
-#: ../libvips/conversion/ifthenelse.c:495
-msgid "Else image"
-msgstr ""
-
-#: ../libvips/conversion/ifthenelse.c:496
-msgid "Source for FALSE pixels"
-msgstr ""
-
-#: ../libvips/conversion/ifthenelse.c:501
-msgid "blend"
-msgstr ""
-
-#: ../libvips/conversion/ifthenelse.c:502
-msgid "Blend smoothly between then and else parts"
-msgstr ""
-
-#: ../libvips/conversion/gamma.c:137
-msgid "gamma an image"
-msgstr ""
-
-#: ../libvips/conversion/gamma.c:149
-msgid "exponent"
-msgstr ""
-
-#: ../libvips/conversion/gamma.c:150
-msgid "Gamma factor"
-msgstr ""
-
-#: ../libvips/conversion/join.c:228
-msgid "join a pair of images"
-msgstr ""
-
-#: ../libvips/conversion/join.c:232
-msgid "in1"
-msgstr ""
-
-#: ../libvips/conversion/join.c:233
-msgid "First input image"
-msgstr ""
-
-#: ../libvips/conversion/join.c:238 ../libvips/freqfilt/phasecor.c:112
-msgid "in2"
-msgstr ""
-
-#: ../libvips/conversion/join.c:239 ../libvips/freqfilt/phasecor.c:113
-msgid "Second input image"
-msgstr ""
-
-#: ../libvips/conversion/join.c:244 ../libvips/morphology/countlines.c:142
-msgid "direction"
-msgstr ""
-
-#: ../libvips/conversion/join.c:245
-msgid "Join left-right or up-down"
-msgstr ""
-
-#: ../libvips/conversion/join.c:251 ../libvips/conversion/insert.c:543
-msgid "Expand"
-msgstr ""
-
-#: ../libvips/conversion/join.c:252 ../libvips/conversion/insert.c:544
-msgid "Expand output to hold all of both inputs"
-msgstr ""
-
-#: ../libvips/conversion/join.c:272 ../libvips/create/text.c:304
-msgid "Align"
-msgstr ""
-
-#: ../libvips/conversion/join.c:273
-msgid "Align on the low, centre or high coordinate edge"
-msgstr ""
-
-#: ../libvips/conversion/grid.c:165
-msgid "bad grid geometry"
-msgstr ""
-
-#: ../libvips/conversion/grid.c:195
-msgid "grid an image"
-msgstr ""
-
-#: ../libvips/conversion/grid.c:206
-msgid "chop into tiles this high"
-msgstr ""
-
-#: ../libvips/conversion/grid.c:213
-msgid "number of tiles across"
-msgstr ""
-
-#: ../libvips/conversion/grid.c:220
-msgid "number of tiles down"
-msgstr ""
-
-#: ../libvips/conversion/scale.c:147
-msgid "scale an image to uchar"
-msgstr ""
-
-#: ../libvips/conversion/scale.c:157 ../libvips/iofuncs/system.c:311
-msgid "Log"
-msgstr ""
-
-#: ../libvips/conversion/scale.c:158
-msgid "Log scale"
-msgstr ""
-
-#: ../libvips/conversion/scale.c:164
-msgid "Exponent"
-msgstr ""
-
-#: ../libvips/conversion/scale.c:165
-msgid "Exponent for log scale"
-msgstr ""
-
-#: ../libvips/conversion/insert.c:509
-msgid "insert image @sub into @main at @x, @y"
-msgstr ""
-
-#: ../libvips/conversion/insert.c:517
-msgid "Main"
-msgstr ""
-
-#: ../libvips/conversion/insert.c:518
-msgid "Main input image"
-msgstr ""
-
-#: ../libvips/conversion/insert.c:523 ../libvips/draw/draw_image.c:259
-msgid "Sub-image"
-msgstr ""
-
-#: ../libvips/conversion/insert.c:524 ../libvips/draw/draw_image.c:260
-msgid "Sub-image to insert into main image"
-msgstr ""
-
-#: ../libvips/conversion/insert.c:529
-msgid "X"
-msgstr ""
-
-#: ../libvips/conversion/insert.c:530
-msgid "Left edge of sub in main"
-msgstr ""
-
-#: ../libvips/conversion/insert.c:536
-msgid "Y"
-msgstr ""
-
-#: ../libvips/conversion/insert.c:537
-msgid "Top edge of sub in main"
-msgstr ""
-
-#: ../libvips/conversion/insert.c:551
-msgid "Color for new pixels"
-msgstr ""
-
-#: ../libvips/conversion/autorot.c:174
-msgid "autorotate image by exif tag"
-msgstr ""
-
-#: ../libvips/conversion/autorot.c:185
-msgid "Angle image was rotated by"
-msgstr ""
-
-#: ../libvips/conversion/bandrank.c:238
+#: libvips/conversion/bandrank.c:248
 msgid "band-wise rank of a set of images"
 msgstr ""
 
-#: ../libvips/conversion/bandrank.c:252
+#: libvips/conversion/bandrank.c:262
 msgid "Select this band element from sorted list"
 msgstr ""
 
-#: ../libvips/convolution/spcor.c:315
-msgid "spatial correlation"
+#: libvips/conversion/bandunfold.c:126
+msgid "@factor must be a factor of image bands"
 msgstr ""
 
-#: ../libvips/convolution/conva.c:237 ../libvips/convolution/conva.c:243
-#: ../libvips/convolution/conva.c:760 ../libvips/convolution/convasep.c:152
-msgid "mask too complex"
+#: libvips/conversion/bandunfold.c:158
+msgid "unfold image bands into x axis"
 msgstr ""
 
-#: ../libvips/convolution/conva.c:988 ../libvips/convolution/conva.c:1216
-#: ../libvips/convolution/convasep.c:823 ../libvips/morphology/hitmiss.c:732
-msgid "image too small for mask"
+#: libvips/conversion/bandunfold.c:171
+msgid "Unfold by this factor"
 msgstr ""
 
-#: ../libvips/convolution/conva.c:1288
-msgid "approximate integer convolution"
+#: libvips/conversion/byteswap.c:232
+msgid "byteswap an image"
 msgstr ""
 
-#: ../libvips/convolution/conva.c:1292 ../libvips/convolution/compass.c:178
-#: ../libvips/convolution/convasep.c:901 ../libvips/convolution/convsep.c:134
-#: ../libvips/convolution/conv.c:143
-msgid "Layers"
+#: libvips/conversion/cache.c:98 libvips/conversion/tilecache.c:392
+msgid "cache an image"
 msgstr ""
 
-#: ../libvips/convolution/conva.c:1293 ../libvips/convolution/compass.c:179
-#: ../libvips/convolution/convasep.c:902 ../libvips/convolution/convsep.c:135
-#: ../libvips/convolution/conv.c:144
-msgid "Use this many layers in approximation"
+#: libvips/conversion/cache.c:114 libvips/conversion/tilecache.c:800
+#: libvips/foreign/dzsave.c:2451 libvips/foreign/jp2ksave.c:971
+#: libvips/foreign/tiffsave.c:287
+msgid "Tile width"
 msgstr ""
 
-#: ../libvips/convolution/conva.c:1299 ../libvips/convolution/compass.c:185
-#: ../libvips/convolution/convsep.c:141 ../libvips/convolution/conv.c:150
-msgid "Cluster"
+#: libvips/conversion/cache.c:115 libvips/conversion/tilecache.c:801
+#: libvips/foreign/dzsave.c:2452 libvips/foreign/jp2ksave.c:972
+#: libvips/foreign/tiffsave.c:288
+msgid "Tile width in pixels"
 msgstr ""
 
-#: ../libvips/convolution/conva.c:1300 ../libvips/convolution/compass.c:186
-#: ../libvips/convolution/convsep.c:142 ../libvips/convolution/conv.c:151
-msgid "Cluster lines closer than this in approximation"
+#: libvips/conversion/cache.c:121 libvips/conversion/grid.c:205
+#: libvips/conversion/sequential.c:249 libvips/conversion/tilecache.c:404
+#: libvips/foreign/dzsave.c:2458 libvips/foreign/jp2ksave.c:978
+#: libvips/foreign/tiffsave.c:294
+msgid "Tile height"
 msgstr ""
 
-#: ../libvips/convolution/fastcor.c:215
-msgid "fast correlation"
+#: libvips/conversion/cache.c:122 libvips/conversion/sequential.c:250
+#: libvips/conversion/tilecache.c:405 libvips/foreign/dzsave.c:2459
+#: libvips/foreign/jp2ksave.c:979 libvips/foreign/tiffsave.c:295
+msgid "Tile height in pixels"
 msgstr ""
 
-#: ../libvips/convolution/convi.c:1012
-msgid "int convolution operation"
+#: libvips/conversion/cache.c:128 libvips/conversion/tilecache.c:807
+msgid "Max tiles"
 msgstr ""
 
-#: ../libvips/convolution/compass.c:146
-msgid "convolve with rotating mask"
+#: libvips/conversion/cache.c:129 libvips/conversion/tilecache.c:808
+msgid "Maximum number of tiles to cache"
 msgstr ""
 
-#: ../libvips/convolution/compass.c:150
-msgid "Times"
+#: libvips/conversion/cast.c:524
+msgid "cast an image"
 msgstr ""
 
-#: ../libvips/convolution/compass.c:151
-msgid "Rotate and convolve this many times"
+#: libvips/conversion/cast.c:536 libvips/conversion/copy.c:305
+#: libvips/foreign/ppmsave.c:506 libvips/foreign/rawload.c:174
+#: libvips/foreign/vips2magick.c:482 libvips/iofuncs/image.c:1123
+msgid "Format"
 msgstr ""
 
-#: ../libvips/convolution/compass.c:158
-msgid "Rotate mask by this much between convolutions"
+#: libvips/conversion/cast.c:537
+msgid "Format to cast to"
 msgstr ""
 
-#: ../libvips/convolution/compass.c:164
-msgid "Combine"
+#: libvips/conversion/cast.c:543
+msgid "Shift"
 msgstr ""
 
-#: ../libvips/convolution/compass.c:165
-msgid "Combine convolution results like this"
+#: libvips/conversion/cast.c:544
+msgid "Shift integer values up and down"
 msgstr ""
 
-#: ../libvips/convolution/compass.c:171 ../libvips/convolution/gaussblur.c:145
-#: ../libvips/convolution/convsep.c:127 ../libvips/convolution/conv.c:136
-#: ../libvips/create/logmat.c:229 ../libvips/create/gaussmat.c:212
-msgid "Precision"
+#: libvips/conversion/composite.cpp:1304
+#, c-format
+msgid "must be 1 or %d blend modes"
 msgstr ""
 
-#: ../libvips/convolution/compass.c:172 ../libvips/convolution/gaussblur.c:146
-#: ../libvips/convolution/convsep.c:128 ../libvips/convolution/conv.c:137
-msgid "Convolve with this precision"
+#: libvips/conversion/composite.cpp:1314
+#, c-format
+msgid "blend mode index %d (%d) invalid"
 msgstr ""
 
-#: ../libvips/convolution/convolution.c:120
-msgid "convolution operations"
+#: libvips/conversion/composite.cpp:1413
+msgid "images do not have same numbers of bands"
 msgstr ""
 
-#: ../libvips/convolution/convolution.c:141
-#: ../libvips/convolution/correlation.c:157 ../libvips/draw/draw_mask.c:323
-#: ../libvips/morphology/morph.c:149 ../libvips/morphology/labelregions.c:125
-msgid "Mask"
+#: libvips/conversion/composite.cpp:1420
+msgid "too many input bands"
 msgstr ""
 
-#: ../libvips/convolution/convolution.c:142 ../libvips/morphology/morph.c:150
-msgid "Input matrix image"
+#: libvips/conversion/composite.cpp:1430
+#, fuzzy
+msgid "unsupported compositing space"
+msgstr "unsupported colourspace %d"
+
+#: libvips/conversion/composite.cpp:1478
+msgid "blend images together"
 msgstr ""
 
-#: ../libvips/convolution/convf.c:365
-msgid "float convolution operation"
+#: libvips/conversion/composite.cpp:1484
+msgid "Compositing space"
 msgstr ""
 
-#: ../libvips/convolution/gaussblur.c:113
-msgid "gaussian blur"
+#: libvips/conversion/composite.cpp:1485
+#, fuzzy
+msgid "Composite images in this colour space"
+msgstr "Destination colour space"
+
+#: libvips/conversion/composite.cpp:1491 libvips/conversion/smartcrop.c:474
+#: libvips/resample/affine.c:706 libvips/resample/mapim.c:581
+msgid "Premultiplied"
 msgstr ""
 
-#: ../libvips/convolution/gaussblur.c:131 ../libvips/convolution/sharpen.c:325
-#: ../libvips/create/gaussmat.c:184 ../libvips/create/gaussnoise.c:193
+#: libvips/conversion/composite.cpp:1492 libvips/resample/affine.c:707
+#: libvips/resample/mapim.c:582
+msgid "Images have premultiplied alpha"
+msgstr ""
+
+#: libvips/conversion/composite.cpp:1540
+#, c-format
+msgid "must be %d x coordinates"
+msgstr ""
+
+#: libvips/conversion/composite.cpp:1548
+#, c-format
+msgid "must be %d y coordinates"
+msgstr ""
+
+#: libvips/conversion/composite.cpp:1574
+msgid "blend an array of images with an array of blend modes"
+msgstr ""
+
+#: libvips/conversion/composite.cpp:1580
+msgid "Inputs"
+msgstr ""
+
+#: libvips/conversion/composite.cpp:1587
+msgid "Blend modes"
+msgstr ""
+
+#: libvips/conversion/composite.cpp:1588
+msgid "Array of VipsBlendMode to join with"
+msgstr ""
+
+#: libvips/conversion/composite.cpp:1594
+msgid "x coordinates"
+msgstr ""
+
+#: libvips/conversion/composite.cpp:1595
+msgid "Array of x coordinates to join at"
+msgstr ""
+
+#: libvips/conversion/composite.cpp:1601
+msgid "y coordinates"
+msgstr ""
+
+#: libvips/conversion/composite.cpp:1602
+msgid "Array of y coordinates to join at"
+msgstr ""
+
+#: libvips/conversion/composite.cpp:1708
+msgid "blend a pair of images with a blend mode"
+msgstr ""
+
+#: libvips/conversion/composite.cpp:1714
+msgid "Base"
+msgstr ""
+
+#: libvips/conversion/composite.cpp:1715
+#, fuzzy
+msgid "Base image"
+msgstr "false-colour an image"
+
+#: libvips/conversion/composite.cpp:1720
+msgid "Overlay"
+msgstr ""
+
+#: libvips/conversion/composite.cpp:1721
+msgid "Overlay image"
+msgstr ""
+
+#: libvips/conversion/composite.cpp:1726
+msgid "Blend mode"
+msgstr ""
+
+#: libvips/conversion/composite.cpp:1727
+msgid "VipsBlendMode to join with"
+msgstr ""
+
+#: libvips/conversion/composite.cpp:1734
+msgid "x position of overlay"
+msgstr ""
+
+#: libvips/conversion/composite.cpp:1741
+msgid "y position of overlay"
+msgstr ""
+
+#: libvips/conversion/conversion.c:342
+msgid "conversion operations"
+msgstr ""
+
+#: libvips/conversion/copy.c:235
+msgid "must not change pel size"
+msgstr ""
+
+#: libvips/conversion/copy.c:260
+msgid "copy an image"
+msgstr ""
+
+#: libvips/conversion/copy.c:277
+msgid "Swap"
+msgstr ""
+
+#: libvips/conversion/copy.c:278
+msgid "Swap bytes in image between little and big-endian"
+msgstr ""
+
+#: libvips/conversion/copy.c:285 libvips/conversion/embed.c:575
+#: libvips/create/black.c:141 libvips/create/fractsurf.c:105
+#: libvips/create/gaussnoise.c:168 libvips/create/perlin.c:295
+#: libvips/create/point.c:142 libvips/create/sdf.c:305
+#: libvips/create/worley.c:308 libvips/create/xyz.c:192
+#: libvips/foreign/rawload.c:147 libvips/iofuncs/image.c:1103
+msgid "Image width in pixels"
+msgstr ""
+
+#: libvips/conversion/copy.c:292 libvips/conversion/embed.c:582
+#: libvips/create/black.c:148 libvips/create/fractsurf.c:112
+#: libvips/create/gaussnoise.c:175 libvips/create/perlin.c:302
+#: libvips/create/point.c:149 libvips/create/sdf.c:312
+#: libvips/create/worley.c:315 libvips/create/xyz.c:199
+#: libvips/foreign/rawload.c:154 libvips/iofuncs/image.c:1110
+msgid "Image height in pixels"
+msgstr ""
+
+#: libvips/conversion/copy.c:298 libvips/create/black.c:154
+#: libvips/create/identity.c:143 libvips/foreign/rawload.c:160
+#: libvips/iofuncs/image.c:1116
+msgid "Bands"
+msgstr ""
+
+#: libvips/conversion/copy.c:299 libvips/create/black.c:155
+#: libvips/foreign/rawload.c:161 libvips/iofuncs/image.c:1117
+msgid "Number of bands in image"
+msgstr ""
+
+#: libvips/conversion/copy.c:306 libvips/foreign/rawload.c:175
+#: libvips/iofuncs/image.c:1124
+msgid "Pixel format in image"
+msgstr ""
+
+#: libvips/conversion/copy.c:312 libvips/iofuncs/image.c:1130
+msgid "Coding"
+msgstr ""
+
+#: libvips/conversion/copy.c:313 libvips/iofuncs/image.c:1131
+msgid "Pixel coding"
+msgstr ""
+
+#: libvips/conversion/copy.c:319 libvips/foreign/rawload.c:181
+#: libvips/iofuncs/image.c:1137
+msgid "Interpretation"
+msgstr ""
+
+#: libvips/conversion/copy.c:320 libvips/foreign/rawload.c:182
+#: libvips/iofuncs/image.c:1138
+msgid "Pixel interpretation"
+msgstr ""
+
+#: libvips/conversion/copy.c:326 libvips/foreign/tiffsave.c:329
+#: libvips/iofuncs/image.c:1144
+msgid "Xres"
+msgstr ""
+
+#: libvips/conversion/copy.c:327 libvips/foreign/tiffsave.c:330
+#: libvips/iofuncs/image.c:1145
+msgid "Horizontal resolution in pixels/mm"
+msgstr ""
+
+#: libvips/conversion/copy.c:333 libvips/foreign/tiffsave.c:336
+#: libvips/iofuncs/image.c:1151
+msgid "Yres"
+msgstr ""
+
+#: libvips/conversion/copy.c:334 libvips/foreign/tiffsave.c:337
+#: libvips/iofuncs/image.c:1152
+msgid "Vertical resolution in pixels/mm"
+msgstr ""
+
+#: libvips/conversion/copy.c:340 libvips/iofuncs/image.c:1158
+msgid "Xoffset"
+msgstr ""
+
+#: libvips/conversion/copy.c:341 libvips/iofuncs/image.c:1159
+msgid "Horizontal offset of origin"
+msgstr ""
+
+#: libvips/conversion/copy.c:347 libvips/iofuncs/image.c:1165
+msgid "Yoffset"
+msgstr ""
+
+#: libvips/conversion/copy.c:348 libvips/iofuncs/image.c:1166
+msgid "Vertical offset of origin"
+msgstr ""
+
+#: libvips/conversion/embed.c:479 libvips/foreign/heifload.c:571
+#: libvips/foreign/svgload.c:502 libvips/iofuncs/image.c:3143
+msgid "bad dimensions"
+msgstr ""
+
+#: libvips/conversion/embed.c:561 libvips/conversion/embed.c:652
+msgid "embed an image in a larger image"
+msgstr ""
+
+#: libvips/conversion/embed.c:588 libvips/resample/affine.c:692
+#: libvips/resample/mapim.c:567
+msgid "Extend"
+msgstr ""
+
+#: libvips/conversion/embed.c:589 libvips/resample/affine.c:693
+#: libvips/resample/mapim.c:568
+msgid "How to generate the extra pixels"
+msgstr ""
+
+#: libvips/conversion/embed.c:657 libvips/conversion/wrap.c:126
+msgid "Left edge of input in output"
+msgstr ""
+
+#: libvips/conversion/embed.c:664 libvips/conversion/wrap.c:133
+msgid "Top edge of input in output"
+msgstr ""
+
+#: libvips/conversion/embed.c:806
+msgid "place an image within a larger image with a certain gravity"
+msgstr ""
+
+#: libvips/conversion/embed.c:811 libvips/conversion/flip.c:246
+#: libvips/conversion/join.c:249 libvips/morphology/countlines.c:146
+#: libvips/mosaicing/merge.c:140 libvips/mosaicing/mosaic1.c:516
+#: libvips/mosaicing/mosaic.c:197
+msgid "Direction"
+msgstr ""
+
+#: libvips/conversion/embed.c:812
+msgid "Direction to place image within width/height"
+msgstr ""
+
+#: libvips/conversion/extract.c:150 libvips/conversion/smartcrop.c:341
+msgid "bad extract area"
+msgstr ""
+
+#: libvips/conversion/extract.c:188 libvips/conversion/smartcrop.c:429
+msgid "extract an area from an image"
+msgstr ""
+
+#: libvips/conversion/extract.c:398
+msgid "bad extract band"
+msgstr ""
+
+#: libvips/conversion/extract.c:426
+msgid "extract band from an image"
+msgstr ""
+
+#: libvips/conversion/extract.c:439
+msgid "Band to extract"
+msgstr ""
+
+#: libvips/conversion/extract.c:445 libvips/foreign/heifload.c:1090
+#: libvips/foreign/jxlload.c:1139 libvips/foreign/magick6load.c:148
+#: libvips/foreign/magick7load.c:389 libvips/foreign/nsgifload.c:627
+#: libvips/foreign/pdfiumload.c:702 libvips/foreign/popplerload.c:552
+#: libvips/foreign/tiffload.c:203 libvips/foreign/webpload.c:185
+msgid "n"
+msgstr ""
+
+#: libvips/conversion/extract.c:446
+msgid "Number of bands to extract"
+msgstr ""
+
+#: libvips/conversion/falsecolour.c:374
+msgid "false-color an image"
+msgstr "false-colour an image"
+
+#: libvips/conversion/flatten.c:413
+msgid "flatten alpha out of an image"
+msgstr ""
+
+#: libvips/conversion/flatten.c:426 libvips/foreign/foreign.c:1909
+#: libvips/resample/affine.c:700 libvips/resample/mapim.c:575
+#: libvips/resample/similarity.c:134
+msgid "Background value"
+msgstr ""
+
+#: libvips/conversion/flatten.c:432 libvips/conversion/premultiply.c:267
+#: libvips/conversion/unpremultiply.c:329
+msgid "Maximum alpha"
+msgstr ""
+
+#: libvips/conversion/flatten.c:433 libvips/conversion/premultiply.c:268
+#: libvips/conversion/unpremultiply.c:330
+msgid "Maximum value of alpha channel"
+msgstr ""
+
+#: libvips/conversion/flip.c:236
+msgid "flip an image"
+msgstr ""
+
+#: libvips/conversion/flip.c:247
+msgid "Direction to flip image"
+msgstr ""
+
+#: libvips/conversion/gamma.c:136
+msgid "gamma an image"
+msgstr ""
+
+#: libvips/conversion/gamma.c:148 libvips/conversion/scale.c:168
+msgid "Exponent"
+msgstr ""
+
+#: libvips/conversion/gamma.c:149
+msgid "Gamma factor"
+msgstr ""
+
+#: libvips/conversion/grid.c:165
+msgid "bad grid geometry"
+msgstr ""
+
+#: libvips/conversion/grid.c:195
+msgid "grid an image"
+msgstr ""
+
+#: libvips/conversion/grid.c:206
+msgid "Chop into tiles this high"
+msgstr ""
+
+#: libvips/conversion/grid.c:213
+msgid "Number of tiles across"
+msgstr ""
+
+#: libvips/conversion/grid.c:220
+msgid "Number of tiles down"
+msgstr ""
+
+#: libvips/conversion/ifthenelse.c:525
+msgid "ifthenelse an image"
+msgstr ""
+
+#: libvips/conversion/ifthenelse.c:529
+msgid "Condition"
+msgstr ""
+
+#: libvips/conversion/ifthenelse.c:530
+msgid "Condition input image"
+msgstr ""
+
+#: libvips/conversion/ifthenelse.c:535
+msgid "Then image"
+msgstr ""
+
+#: libvips/conversion/ifthenelse.c:536
+msgid "Source for TRUE pixels"
+msgstr ""
+
+#: libvips/conversion/ifthenelse.c:541
+msgid "Else image"
+msgstr ""
+
+#: libvips/conversion/ifthenelse.c:542
+msgid "Source for FALSE pixels"
+msgstr ""
+
+#: libvips/conversion/ifthenelse.c:547
+msgid "Blend"
+msgstr ""
+
+#: libvips/conversion/ifthenelse.c:548
+msgid "Blend smoothly between then and else parts"
+msgstr ""
+
+#: libvips/conversion/insert.c:460
+msgid "insert image @sub into @main at @x, @y"
+msgstr ""
+
+#: libvips/conversion/insert.c:466
+msgid "Main"
+msgstr ""
+
+#: libvips/conversion/insert.c:467
+msgid "Main input image"
+msgstr ""
+
+#: libvips/conversion/insert.c:472 libvips/draw/draw_image.c:269
+msgid "Sub-image"
+msgstr ""
+
+#: libvips/conversion/insert.c:473 libvips/draw/draw_image.c:270
+msgid "Sub-image to insert into main image"
+msgstr ""
+
+#: libvips/conversion/insert.c:478
+msgid "X"
+msgstr ""
+
+#: libvips/conversion/insert.c:479
+msgid "Left edge of sub in main"
+msgstr ""
+
+#: libvips/conversion/insert.c:485
+msgid "Y"
+msgstr ""
+
+#: libvips/conversion/insert.c:486
+msgid "Top edge of sub in main"
+msgstr ""
+
+#: libvips/conversion/insert.c:492 libvips/conversion/join.c:256
+msgid "Expand"
+msgstr ""
+
+#: libvips/conversion/insert.c:493 libvips/conversion/join.c:257
+msgid "Expand output to hold all of both inputs"
+msgstr ""
+
+#: libvips/conversion/insert.c:500
+msgid "Color for new pixels"
+msgstr ""
+
+#: libvips/conversion/join.c:231
+msgid "join a pair of images"
+msgstr ""
+
+#: libvips/conversion/join.c:237
+msgid "in1"
+msgstr ""
+
+#: libvips/conversion/join.c:238
+msgid "First input image"
+msgstr ""
+
+#: libvips/conversion/join.c:243 libvips/freqfilt/phasecor.c:111
+msgid "in2"
+msgstr ""
+
+#: libvips/conversion/join.c:244 libvips/freqfilt/phasecor.c:112
+msgid "Second input image"
+msgstr ""
+
+#: libvips/conversion/join.c:250
+msgid "Join left-right or up-down"
+msgstr ""
+
+#: libvips/conversion/join.c:277 libvips/create/text.c:581
+msgid "Align"
+msgstr ""
+
+#: libvips/conversion/join.c:278
+msgid "Align on the low, centre or high coordinate edge"
+msgstr ""
+
+#: libvips/conversion/msb.c:168
+msgid "bad band"
+msgstr ""
+
+#: libvips/conversion/msb.c:241
+msgid "pick most-significant byte from an image"
+msgstr ""
+
+#: libvips/conversion/msb.c:254
+msgid "Band to msb"
+msgstr ""
+
+#: libvips/conversion/premultiply.c:255
+msgid "premultiply image alpha"
+msgstr ""
+
+#: libvips/conversion/recomb.c:183
+msgid "bands in must equal matrix width"
+msgstr ""
+
+#: libvips/conversion/recomb.c:218
+msgid "linear recombination with matrix"
+msgstr ""
+
+#: libvips/conversion/recomb.c:230
+msgid "M"
+msgstr ""
+
+#: libvips/conversion/recomb.c:231
+msgid "Matrix of coefficients"
+msgstr ""
+
+#: libvips/conversion/replicate.c:192
+msgid "replicate an image"
+msgstr ""
+
+#: libvips/conversion/replicate.c:203
+msgid "Repeat this many times horizontally"
+msgstr ""
+
+#: libvips/conversion/replicate.c:210
+msgid "Repeat this many times vertically"
+msgstr ""
+
+#: libvips/conversion/rot45.c:264 libvips/conversion/rot.c:361
+msgid "rotate an image"
+msgstr ""
+
+#: libvips/conversion/rot45.c:275 libvips/conversion/rot.c:372
+msgid "Angle to rotate image"
+msgstr ""
+
+#: libvips/conversion/scale.c:151
+msgid "scale an image to uchar"
+msgstr ""
+
+#: libvips/conversion/scale.c:161 libvips/iofuncs/system.c:311
+msgid "Log"
+msgstr ""
+
+#: libvips/conversion/scale.c:162
+msgid "Log scale"
+msgstr ""
+
+#: libvips/conversion/scale.c:169
+msgid "Exponent for log scale"
+msgstr ""
+
+#: libvips/conversion/sequential.c:239
+msgid "check sequential access"
+msgstr ""
+
+#: libvips/conversion/sequential.c:256
+msgid "Strategy"
+msgstr ""
+
+#: libvips/conversion/sequential.c:257 libvips/conversion/tilecache.c:412
+msgid "Expected access pattern"
+msgstr ""
+
+#: libvips/conversion/sequential.c:263
+msgid "Trace"
+msgstr ""
+
+#: libvips/conversion/sequential.c:264
+msgid "Trace pixel requests"
+msgstr ""
+
+#: libvips/conversion/smartcrop.c:453
+msgid "Interesting"
+msgstr ""
+
+#: libvips/conversion/smartcrop.c:454
+msgid "How to measure interestingness"
+msgstr ""
+
+#: libvips/conversion/smartcrop.c:460
+msgid "Attention x"
+msgstr ""
+
+#: libvips/conversion/smartcrop.c:461
+msgid "Horizontal position of attention centre"
+msgstr ""
+
+#: libvips/conversion/smartcrop.c:467
+msgid "Attention y"
+msgstr ""
+
+#: libvips/conversion/smartcrop.c:468
+msgid "Vertical position of attention centre"
+msgstr ""
+
+#: libvips/conversion/smartcrop.c:475
+msgid "Input image already has premultiplied alpha"
+msgstr ""
+
+#: libvips/conversion/subsample.c:228 libvips/resample/reduceh.cpp:546
+#: libvips/resample/reducev.cpp:1001 libvips/resample/shrinkh.c:316
+#: libvips/resample/shrinkv.c:364
+msgid "image has shrunk to nothing"
+msgstr ""
+
+#: libvips/conversion/subsample.c:259
+msgid "subsample an image"
+msgstr ""
+
+#: libvips/conversion/subsample.c:273 libvips/conversion/zoom.c:379
+msgid "Xfac"
+msgstr ""
+
+#: libvips/conversion/subsample.c:274
+msgid "Horizontal subsample factor"
+msgstr ""
+
+#: libvips/conversion/subsample.c:280 libvips/conversion/zoom.c:386
+msgid "Yfac"
+msgstr ""
+
+#: libvips/conversion/subsample.c:281
+msgid "Vertical subsample factor"
+msgstr ""
+
+#: libvips/conversion/subsample.c:287
+msgid "Point"
+msgstr ""
+
+#: libvips/conversion/subsample.c:288
+msgid "Point sample"
+msgstr ""
+
+#: libvips/conversion/switch.c:129
+msgid "bad number of tests"
+msgstr ""
+
+#: libvips/conversion/switch.c:161
+msgid "test images not 1-band"
+msgstr ""
+
+#: libvips/conversion/switch.c:189
+msgid "find the index of the first non-zero pixel in tests"
+msgstr ""
+
+#: libvips/conversion/switch.c:195
+msgid "Tests"
+msgstr ""
+
+#: libvips/conversion/switch.c:196
+msgid "Table of images to test"
+msgstr ""
+
+#: libvips/conversion/tilecache.c:411 libvips/foreign/foreign.c:1235
+msgid "Access"
+msgstr ""
+
+#: libvips/conversion/tilecache.c:418
+msgid "Threaded"
+msgstr ""
+
+#: libvips/conversion/tilecache.c:419
+msgid "Allow threaded access"
+msgstr ""
+
+#: libvips/conversion/tilecache.c:425
+msgid "Persistent"
+msgstr ""
+
+#: libvips/conversion/tilecache.c:426
+msgid "Keep cache between evaluations"
+msgstr ""
+
+#: libvips/conversion/tilecache.c:708
+#, c-format
+msgid "error in tile %d x %d"
+msgstr ""
+
+#: libvips/conversion/tilecache.c:796
+msgid "cache an image as a set of tiles"
+msgstr ""
+
+#: libvips/conversion/tilecache.c:983
+msgid "cache an image as a set of lines"
+msgstr ""
+
+#: libvips/conversion/transpose3d.c:135
+msgid "bad page_height"
+msgstr ""
+
+#: libvips/conversion/transpose3d.c:163
+#, fuzzy
+msgid "transpose3d an image"
+msgstr "false-colour an image"
+
+#: libvips/conversion/transpose3d.c:173 libvips/foreign/foreign.c:1915
+msgid "Page height"
+msgstr ""
+
+#: libvips/conversion/transpose3d.c:174
+msgid "Height of each input page"
+msgstr ""
+
+#: libvips/conversion/unpremultiply.c:317
+msgid "unpremultiply image alpha"
+msgstr ""
+
+#: libvips/conversion/unpremultiply.c:336
+msgid "Alpha band"
+msgstr ""
+
+#: libvips/conversion/unpremultiply.c:337
+msgid "Unpremultiply with this alpha"
+msgstr ""
+
+#: libvips/conversion/wrap.c:115
+msgid "wrap image origin"
+msgstr ""
+
+#: libvips/conversion/zoom.c:328
+msgid "zoom factors too large"
+msgstr ""
+
+#: libvips/conversion/zoom.c:367
+msgid "zoom an image"
+msgstr ""
+
+#: libvips/conversion/zoom.c:380
+msgid "Horizontal zoom factor"
+msgstr ""
+
+#: libvips/conversion/zoom.c:387
+msgid "Vertical zoom factor"
+msgstr ""
+
+#: libvips/convolution/canny.c:436
+msgid "Canny edge detector"
+msgstr ""
+
+#: libvips/convolution/canny.c:454 libvips/convolution/gaussblur.c:144
+#: libvips/convolution/sharpen.c:334 libvips/create/gaussmat.c:185
+#: libvips/create/gaussnoise.c:188
 msgid "Sigma"
 msgstr ""
 
-#: ../libvips/convolution/gaussblur.c:132 ../libvips/convolution/sharpen.c:326
-#: ../libvips/create/gaussmat.c:185
+#: libvips/convolution/canny.c:455 libvips/convolution/gaussblur.c:145
+#: libvips/convolution/sharpen.c:335 libvips/create/gaussmat.c:186
 msgid "Sigma of Gaussian"
 msgstr ""
 
-#: ../libvips/convolution/gaussblur.c:138 ../libvips/create/gaussmat.c:191
-msgid "Minimum amplitude"
+#: libvips/convolution/canny.c:461 libvips/convolution/compass.c:184
+#: libvips/convolution/conv.c:134 libvips/convolution/convsep.c:130
+#: libvips/convolution/gaussblur.c:158 libvips/create/gaussmat.c:213
+#: libvips/create/logmat.c:229
+msgid "Precision"
 msgstr ""
 
-#: ../libvips/convolution/gaussblur.c:139 ../libvips/create/gaussmat.c:192
-msgid "Minimum amplitude of Gaussian"
+#: libvips/convolution/canny.c:462 libvips/convolution/compass.c:185
+#: libvips/convolution/conv.c:135 libvips/convolution/convsep.c:131
+#: libvips/convolution/gaussblur.c:159
+msgid "Convolve with this precision"
 msgstr ""
 
-#: ../libvips/convolution/convasep.c:897
+#: libvips/convolution/compass.c:159
+msgid "convolve with rotating mask"
+msgstr ""
+
+#: libvips/convolution/compass.c:163
+msgid "Times"
+msgstr ""
+
+#: libvips/convolution/compass.c:164
+msgid "Rotate and convolve this many times"
+msgstr ""
+
+#: libvips/convolution/compass.c:171
+msgid "Rotate mask by this much between convolutions"
+msgstr ""
+
+#: libvips/convolution/compass.c:178
+msgid "Combine convolution results like this"
+msgstr ""
+
+#: libvips/convolution/compass.c:191 libvips/convolution/conva.c:1323
+#: libvips/convolution/convasep.c:918 libvips/convolution/conv.c:141
+#: libvips/convolution/convsep.c:137
+msgid "Layers"
+msgstr ""
+
+#: libvips/convolution/compass.c:192 libvips/convolution/conva.c:1324
+#: libvips/convolution/convasep.c:919 libvips/convolution/conv.c:142
+#: libvips/convolution/convsep.c:138
+msgid "Use this many layers in approximation"
+msgstr ""
+
+#: libvips/convolution/compass.c:198 libvips/convolution/conva.c:1330
+#: libvips/convolution/conv.c:148 libvips/convolution/convsep.c:144
+msgid "Cluster"
+msgstr ""
+
+#: libvips/convolution/compass.c:199 libvips/convolution/conva.c:1331
+#: libvips/convolution/conv.c:149 libvips/convolution/convsep.c:145
+msgid "Cluster lines closer than this in approximation"
+msgstr ""
+
+#: libvips/convolution/conva.c:236 libvips/convolution/conva.c:242
+#: libvips/convolution/conva.c:760 libvips/convolution/convasep.c:151
+msgid "mask too complex"
+msgstr ""
+
+#: libvips/convolution/conva.c:997 libvips/convolution/conva.c:1247
+#: libvips/convolution/convasep.c:840
+msgid "image too small for mask"
+msgstr ""
+
+#: libvips/convolution/conva.c:1319
+msgid "approximate integer convolution"
+msgstr ""
+
+#: libvips/convolution/convasep.c:914
 msgid "approximate separable integer convolution"
 msgstr ""
 
-#: ../libvips/convolution/convsep.c:123
-msgid "seperable convolution operation"
-msgstr ""
-
-#: ../libvips/convolution/sharpen.c:307
-msgid "unsharp masking for print"
-msgstr ""
-
-#: ../libvips/convolution/sharpen.c:332 ../libvips/draw/draw_line.c:284
-msgid "x1"
-msgstr ""
-
-#: ../libvips/convolution/sharpen.c:333
-msgid "Flat/jaggy threshold"
-msgstr ""
-
-#: ../libvips/convolution/sharpen.c:339 ../libvips/draw/draw_line.c:305
-msgid "y2"
-msgstr ""
-
-#: ../libvips/convolution/sharpen.c:340
-msgid "Maximum brightening"
-msgstr ""
-
-#: ../libvips/convolution/sharpen.c:346
-msgid "y3"
-msgstr ""
-
-#: ../libvips/convolution/sharpen.c:347
-msgid "Maximum darkening"
-msgstr ""
-
-#: ../libvips/convolution/sharpen.c:353
-msgid "m1"
-msgstr ""
-
-#: ../libvips/convolution/sharpen.c:354
-msgid "Slope for flat areas"
-msgstr ""
-
-#: ../libvips/convolution/sharpen.c:360
-msgid "m2"
-msgstr ""
-
-#: ../libvips/convolution/sharpen.c:361
-msgid "Slope for jaggy areas"
-msgstr ""
-
-#: ../libvips/convolution/sharpen.c:369 ../libvips/create/logmat.c:201
-#: ../libvips/draw/draw_circle.c:249
-msgid "Radius"
-msgstr ""
-
-#: ../libvips/convolution/sharpen.c:370
-msgid "radius of Gaussian"
-msgstr ""
-
-#: ../libvips/convolution/conv.c:132
+#: libvips/convolution/conv.c:130
 msgid "convolution operation"
 msgstr ""
 
-#: ../libvips/convolution/correlation.c:145
+#: libvips/convolution/convf.c:374
+msgid "float convolution operation"
+msgstr ""
+
+#: libvips/convolution/convi.c:1245
+msgid "int convolution operation"
+msgstr ""
+
+#: libvips/convolution/convolution.c:119
+msgid "convolution operations"
+msgstr ""
+
+#: libvips/convolution/convolution.c:140 libvips/convolution/correlation.c:156
+#: libvips/draw/draw_mask.c:332 libvips/freqfilt/freqmult.c:130
+#: libvips/morphology/labelregions.c:124 libvips/morphology/morph.c:965
+msgid "Mask"
+msgstr ""
+
+#: libvips/convolution/convolution.c:141 libvips/morphology/morph.c:966
+msgid "Input matrix image"
+msgstr ""
+
+#: libvips/convolution/convsep.c:126
+msgid "separable convolution operation"
+msgstr ""
+
+#: libvips/convolution/correlation.c:144
 msgid "correlation operation"
 msgstr ""
 
-#: ../libvips/convolution/correlation.c:158
+#: libvips/convolution/correlation.c:157
 msgid "Input reference image"
 msgstr ""
 
-#: ../libvips/create/sines.c:121
-msgid "make a 2D sine wave"
+#: libvips/convolution/edge.c:213
+msgid "Edge detector"
 msgstr ""
 
-#: ../libvips/create/sines.c:127
-msgid "hfreq"
+#: libvips/convolution/edge.c:258
+msgid "Sobel edge detector"
 msgstr ""
 
-#: ../libvips/create/sines.c:128
-msgid "Horizontal spatial frequency"
+#: libvips/convolution/edge.c:291
+msgid "Scharr edge detector"
 msgstr ""
 
-#: ../libvips/create/sines.c:134
-msgid "vfreq"
+#: libvips/convolution/edge.c:324
+msgid "Prewitt edge detector"
 msgstr ""
 
-#: ../libvips/create/sines.c:135
-msgid "Vertical spatial frequency"
+#: libvips/convolution/fastcor.c:218
+msgid "fast correlation"
 msgstr ""
 
-#: ../libvips/create/grey.c:89
-msgid "make a grey ramp image"
+#: libvips/convolution/gaussblur.c:126
+msgid "gaussian blur"
 msgstr ""
 
-#: ../libvips/create/mask_ideal.c:79
-msgid "make an ideal filter"
+#: libvips/convolution/gaussblur.c:151 libvips/create/gaussmat.c:192
+msgid "Minimum amplitude"
 msgstr ""
 
-#: ../libvips/create/mask_ideal.c:84 ../libvips/create/mask_ideal.c:85
-#: ../libvips/create/mask_gaussian.c:86 ../libvips/create/mask_gaussian.c:87
-#: ../libvips/create/mask_butterworth.c:95
-#: ../libvips/create/mask_butterworth.c:96
-msgid "Frequency cutoff"
+#: libvips/convolution/gaussblur.c:152 libvips/create/gaussmat.c:193
+#: libvips/create/logmat.c:209
+msgid "Minimum amplitude of Gaussian"
 msgstr ""
 
-#: ../libvips/create/create.c:97
-msgid "create operations"
+#: libvips/convolution/sharpen.c:316
+msgid "unsharp masking for print"
 msgstr ""
 
-#: ../libvips/create/mask_gaussian.c:81
-#: ../libvips/create/mask_gaussian_band.c:102
-msgid "make a gaussian filter"
+#: libvips/convolution/sharpen.c:341 libvips/draw/draw_line.c:284
+msgid "x1"
 msgstr ""
 
-#: ../libvips/create/mask_gaussian.c:93 ../libvips/create/mask_gaussian.c:94
-#: ../libvips/create/mask_butterworth_band.c:141
-#: ../libvips/create/mask_butterworth_band.c:142
-#: ../libvips/create/mask_butterworth.c:102
-#: ../libvips/create/mask_butterworth.c:103
-#: ../libvips/create/mask_gaussian_band.c:128
-#: ../libvips/create/mask_gaussian_band.c:129
-msgid "Amplitude cutoff"
+#: libvips/convolution/sharpen.c:342
+msgid "Flat/jaggy threshold"
 msgstr ""
 
-#: ../libvips/create/xyz.c:139
-msgid "lower dimensions not set"
+#: libvips/convolution/sharpen.c:348 libvips/draw/draw_line.c:305
+msgid "y2"
 msgstr ""
 
-#: ../libvips/create/xyz.c:156
-msgid "image too large"
+#: libvips/convolution/sharpen.c:349
+msgid "Maximum brightening"
 msgstr ""
 
-#: ../libvips/create/xyz.c:189
-msgid "make an image where pixel values are coordinates"
+#: libvips/convolution/sharpen.c:355
+msgid "y3"
 msgstr ""
 
-#: ../libvips/create/xyz.c:207
-msgid "csize"
+#: libvips/convolution/sharpen.c:356
+msgid "Maximum darkening"
 msgstr ""
 
-#: ../libvips/create/xyz.c:208
-msgid "Size of third dimension"
+#: libvips/convolution/sharpen.c:362
+msgid "m1"
 msgstr ""
 
-#: ../libvips/create/xyz.c:214
-msgid "dsize"
+#: libvips/convolution/sharpen.c:363
+msgid "Slope for flat areas"
 msgstr ""
 
-#: ../libvips/create/xyz.c:215
-msgid "Size of fourth dimension"
+#: libvips/convolution/sharpen.c:369
+msgid "m2"
 msgstr ""
 
-#: ../libvips/create/xyz.c:221
-msgid "esize"
+#: libvips/convolution/sharpen.c:370
+msgid "Slope for jaggy areas"
 msgstr ""
 
-#: ../libvips/create/xyz.c:222
-msgid "Size of fifth dimension"
+#: libvips/convolution/sharpen.c:378 libvips/create/logmat.c:201
+#: libvips/create/mask_butterworth_band.c:136
+#: libvips/create/mask_gaussian_band.c:121 libvips/create/mask_ideal_band.c:112
+#: libvips/create/sdf.c:326 libvips/draw/draw_circle.c:248
+msgid "Radius"
 msgstr ""
 
-#: ../libvips/create/invertlut.c:124
-msgid "bad input matrix"
+#: libvips/convolution/sharpen.c:379 libvips/create/logmat.c:202
+msgid "Radius of Gaussian"
 msgstr ""
 
-#: ../libvips/create/invertlut.c:129
-msgid "bad size"
+#: libvips/convolution/spcor.c:317
+msgid "spatial correlation"
 msgstr ""
 
-#: ../libvips/create/invertlut.c:149
-#, c-format
-msgid "element (%d, %d) is %g, outside range [0,1]"
-msgstr ""
-
-#: ../libvips/create/invertlut.c:285
-msgid "build an inverted look-up table"
-msgstr ""
-
-#: ../libvips/create/invertlut.c:290 ../libvips/create/buildlut.c:262
-msgid "Matrix of XY coordinates"
-msgstr ""
-
-#: ../libvips/create/invertlut.c:296
-msgid "LUT size to generate"
-msgstr ""
-
-#: ../libvips/create/mask_butterworth_ring.c:101
-msgid "make a butterworth ring filter"
-msgstr ""
-
-#: ../libvips/create/mask_butterworth_ring.c:106
-#: ../libvips/create/mask_butterworth_ring.c:107
-#: ../libvips/create/mask_gaussian_ring.c:101
-#: ../libvips/create/mask_gaussian_ring.c:102
-#: ../libvips/create/mask_ideal_ring.c:98
-#: ../libvips/create/mask_ideal_ring.c:99
-msgid "Ringwidth"
-msgstr ""
-
-#: ../libvips/create/logmat.c:147 ../libvips/create/gaussmat.c:133
-msgid "mask too large"
-msgstr ""
-
-#: ../libvips/create/logmat.c:197
-msgid "make a laplacian of gaussian image"
-msgstr ""
-
-#: ../libvips/create/logmat.c:202
-msgid "Radius of Logmatian"
-msgstr ""
-
-#: ../libvips/create/logmat.c:209
-msgid "Minimum amplitude of Logmatian"
-msgstr ""
-
-#: ../libvips/create/logmat.c:215 ../libvips/create/gaussmat.c:198
-msgid "Separable"
-msgstr ""
-
-#: ../libvips/create/logmat.c:216
-msgid "Generate separable Logmatian"
-msgstr ""
-
-#: ../libvips/create/logmat.c:222 ../libvips/create/gaussmat.c:205
-msgid "Integer"
-msgstr ""
-
-#: ../libvips/create/logmat.c:223
-msgid "Generate integer Logmatian"
-msgstr ""
-
-#: ../libvips/create/logmat.c:230 ../libvips/create/gaussmat.c:213
-msgid "Generate with this precision"
-msgstr ""
-
-#: ../libvips/create/gaussmat.c:180
-msgid "make a gaussian image"
-msgstr ""
-
-#: ../libvips/create/gaussmat.c:199
-msgid "Generate separable Gaussian"
-msgstr ""
-
-#: ../libvips/create/gaussmat.c:206
-msgid "Generate integer Gaussian"
-msgstr ""
-
-#: ../libvips/create/worley.c:306
-msgid "make a worley noise image"
-msgstr ""
-
-#: ../libvips/create/worley.c:324 ../libvips/create/perlin.c:311
-msgid "Cell size"
-msgstr ""
-
-#: ../libvips/create/worley.c:325
-msgid "Size of Worley cells"
-msgstr ""
-
-#: ../libvips/create/mask_gaussian_ring.c:96
-msgid "make a gaussian ring filter"
-msgstr ""
-
-#: ../libvips/create/gaussnoise.c:164
-msgid "make a gaussnoise image"
-msgstr ""
-
-#: ../libvips/create/gaussnoise.c:186 ../libvips/histogram/stdif.c:329
-msgid "Mean"
-msgstr ""
-
-#: ../libvips/create/gaussnoise.c:187
-msgid "Mean of pixels in generated image"
-msgstr ""
-
-#: ../libvips/create/gaussnoise.c:194
-msgid "Standard deviation of pixels in generated image"
-msgstr ""
-
-#: ../libvips/create/zone.c:90
-msgid "make a zone plate"
-msgstr ""
-
-#: ../libvips/create/tonelut.c:221 ../libvips/create/buildlut.c:257
-msgid "build a look-up table"
-msgstr ""
-
-#: ../libvips/create/tonelut.c:225
-msgid "In-max"
-msgstr ""
-
-#: ../libvips/create/tonelut.c:226
-msgid "Size of LUT to build"
-msgstr ""
-
-#: ../libvips/create/tonelut.c:232
-msgid "Out-max"
-msgstr ""
-
-#: ../libvips/create/tonelut.c:233
-msgid "Maximum value in output LUT"
-msgstr ""
-
-#: ../libvips/create/tonelut.c:239
-msgid "Black point"
-msgstr ""
-
-#: ../libvips/create/tonelut.c:240
-msgid "Lowest value in output"
-msgstr ""
-
-#: ../libvips/create/tonelut.c:246
-msgid "White point"
-msgstr ""
-
-#: ../libvips/create/tonelut.c:247
-msgid "Highest value in output"
-msgstr ""
-
-#: ../libvips/create/tonelut.c:253
-msgid "Shadow point"
-msgstr ""
-
-#: ../libvips/create/tonelut.c:254
-msgid "Position of shadow"
-msgstr ""
-
-#: ../libvips/create/tonelut.c:260
-msgid "Mid-tone point"
-msgstr ""
-
-#: ../libvips/create/tonelut.c:261
-msgid "Position of mid-tones"
-msgstr ""
-
-#: ../libvips/create/tonelut.c:267
-msgid "Highlight point"
-msgstr ""
-
-#: ../libvips/create/tonelut.c:268
-msgid "Position of highlights"
-msgstr ""
-
-#: ../libvips/create/tonelut.c:274
-msgid "Shadow adjust"
-msgstr ""
-
-#: ../libvips/create/tonelut.c:275
-msgid "Adjust shadows by this much"
-msgstr ""
-
-#: ../libvips/create/tonelut.c:281
-msgid "Mid-tone adjust"
-msgstr ""
-
-#: ../libvips/create/tonelut.c:282
-msgid "Adjust mid-tones by this much"
-msgstr ""
-
-#: ../libvips/create/tonelut.c:288
-msgid "Highlight adjust"
-msgstr ""
-
-#: ../libvips/create/tonelut.c:289
-msgid "Adjust highlights by this much"
-msgstr ""
-
-#: ../libvips/create/perlin.c:293
-msgid "make a perlin noise image"
-msgstr ""
-
-#: ../libvips/create/perlin.c:312
-msgid "Size of Perlin cells"
-msgstr ""
-
-#: ../libvips/create/perlin.c:318 ../libvips/create/point.c:157
-msgid "Uchar"
-msgstr ""
-
-#: ../libvips/create/perlin.c:319 ../libvips/create/point.c:158
-msgid "Output an unsigned char image"
-msgstr ""
-
-#: ../libvips/create/point.c:134
-msgid "make a point image"
-msgstr ""
-
-#: ../libvips/create/mask.c:111
-msgid "base class for frequency filters"
-msgstr ""
-
-#: ../libvips/create/mask.c:119
-msgid "Optical"
-msgstr ""
-
-#: ../libvips/create/mask.c:120
-msgid "Rotate quadrants to optical space"
-msgstr ""
-
-#: ../libvips/create/mask.c:126
-msgid "Reject"
-msgstr ""
-
-#: ../libvips/create/mask.c:127
-msgid "Invert the sense of the filter"
-msgstr ""
-
-#: ../libvips/create/mask.c:133
-msgid "Nodc"
-msgstr ""
-
-#: ../libvips/create/mask.c:134
-msgid "Remove DC component"
-msgstr ""
-
-#: ../libvips/create/mask_butterworth_band.c:108
-msgid "make a butterworth_band filter"
-msgstr ""
-
-#: ../libvips/create/mask_butterworth_band.c:113
-#: ../libvips/create/mask_butterworth.c:88
-msgid "Order"
-msgstr ""
-
-#: ../libvips/create/mask_butterworth_band.c:114
-#: ../libvips/create/mask_butterworth.c:89
-msgid "Filter order"
-msgstr ""
-
-#: ../libvips/create/mask_butterworth_band.c:120
-#: ../libvips/create/mask_butterworth_band.c:121
-#: ../libvips/create/mask_gaussian_band.c:107
-#: ../libvips/create/mask_gaussian_band.c:108
-#: ../libvips/create/mask_ideal_band.c:98
-#: ../libvips/create/mask_ideal_band.c:99
-msgid "Frequency cutoff x"
-msgstr ""
-
-#: ../libvips/create/mask_butterworth_band.c:127
-#: ../libvips/create/mask_butterworth_band.c:128
-#: ../libvips/create/mask_gaussian_band.c:114
-#: ../libvips/create/mask_gaussian_band.c:115
-#: ../libvips/create/mask_ideal_band.c:105
-#: ../libvips/create/mask_ideal_band.c:106
-msgid "Frequency cutoff y"
-msgstr ""
-
-#: ../libvips/create/mask_butterworth_band.c:134
-#: ../libvips/create/mask_gaussian_band.c:121
-#: ../libvips/create/mask_ideal_band.c:112
-msgid "radius"
-msgstr ""
-
-#: ../libvips/create/mask_butterworth_band.c:135
-#: ../libvips/create/mask_gaussian_band.c:122
-#: ../libvips/create/mask_ideal_band.c:113
-msgid "radius of circle"
-msgstr ""
-
-#: ../libvips/create/mask_ideal_ring.c:93
-msgid "make an ideal ring filter"
-msgstr ""
-
-#: ../libvips/create/mask_butterworth.c:83
-msgid "make a butterworth filter"
-msgstr ""
-
-#: ../libvips/create/fractsurf.c:98
-msgid "make a fractal surface"
-msgstr ""
-
-#: ../libvips/create/fractsurf.c:116 ../libvips/create/fractsurf.c:117
-#: ../libvips/create/mask_fractal.c:93 ../libvips/create/mask_fractal.c:94
-msgid "Fractal dimension"
-msgstr ""
-
-#: ../libvips/create/identity.c:140
-msgid "make a 1D image where pixel values are indexes"
-msgstr ""
-
-#: ../libvips/create/identity.c:145
-msgid "Number of bands in LUT"
-msgstr ""
-
-#: ../libvips/create/identity.c:151
-msgid "Ushort"
-msgstr ""
-
-#: ../libvips/create/identity.c:152
-msgid "Create a 16-bit LUT"
-msgstr ""
-
-#: ../libvips/create/identity.c:159
-msgid "Size of 16-bit LUT"
-msgstr ""
-
-#: ../libvips/create/text.c:170
-msgid "invalid markup in text"
-msgstr ""
-
-#: ../libvips/create/text.c:212
-msgid "no text to render"
-msgstr ""
-
-#: ../libvips/create/text.c:279
-msgid "make a text image"
-msgstr ""
-
-#: ../libvips/create/text.c:283
-msgid "Text"
-msgstr ""
-
-#: ../libvips/create/text.c:284
-msgid "Text to render"
-msgstr ""
-
-#: ../libvips/create/text.c:290
-msgid "Font"
-msgstr ""
-
-#: ../libvips/create/text.c:291
-msgid "Font to render with"
-msgstr ""
-
-#: ../libvips/create/text.c:298
-msgid "Maximum image width in pixels"
-msgstr ""
-
-#: ../libvips/create/text.c:305
-msgid "Align on the low, centre or high edge"
-msgstr ""
-
-#: ../libvips/create/text.c:311 ../libvips/foreign/pdfload.c:482
-#: ../libvips/foreign/svgload.c:283
-msgid "DPI"
-msgstr ""
-
-#: ../libvips/create/text.c:312
-msgid "DPI to render at"
-msgstr ""
-
-#: ../libvips/create/text.c:318
-msgid "Spacing"
-msgstr ""
-
-#: ../libvips/create/text.c:319
-msgid "Line spacing"
-msgstr ""
-
-#: ../libvips/create/mask_fractal.c:88
-msgid "make fractal filter"
-msgstr ""
-
-#: ../libvips/create/eye.c:98
-msgid "make an image showing the eye's spatial response"
-msgstr ""
-
-#: ../libvips/create/eye.c:104
-msgid "Maximum spatial frequency"
-msgstr ""
-
-#: ../libvips/create/black.c:125
+#: libvips/create/black.c:136
 msgid "make a black image"
 msgstr ""
 
-#: ../libvips/create/mask_ideal_band.c:93
-msgid "make an ideal band filter"
-msgstr ""
-
-#: ../libvips/create/buildlut.c:134
+#: libvips/create/buildlut.c:134
 #, c-format
 msgid "x value row %d not an int"
 msgstr ""
 
-#: ../libvips/create/buildlut.c:149
+#: libvips/create/buildlut.c:149
 msgid "x range too small"
 msgstr ""
 
-#: ../libvips/draw/draw_line.c:280
-msgid "draw a line on an image"
+#: libvips/create/buildlut.c:259 libvips/create/tonelut.c:221
+msgid "build a look-up table"
 msgstr ""
 
-#: ../libvips/draw/draw_line.c:285 ../libvips/draw/draw_line.c:292
-msgid "Start of draw_line"
+#: libvips/create/buildlut.c:264 libvips/create/invertlut.c:289
+msgid "Matrix of XY coordinates"
 msgstr ""
 
-#: ../libvips/draw/draw_line.c:291
-msgid "y1"
+#: libvips/create/create.c:120
+msgid "create operations"
 msgstr ""
 
-#: ../libvips/draw/draw_line.c:298
-msgid "x2"
+#: libvips/create/eye.c:103
+msgid "make an image showing the eye's spatial response"
 msgstr ""
 
-#: ../libvips/draw/draw_line.c:299 ../libvips/draw/draw_line.c:306
-msgid "End of draw_line"
+#: libvips/create/eye.c:109
+msgid "Maximum spatial frequency"
 msgstr ""
 
-#: ../libvips/draw/draw_image.c:255
-msgid "paint an image into another image"
+#: libvips/create/fractsurf.c:100
+msgid "make a fractal surface"
 msgstr ""
 
-#: ../libvips/draw/draw_image.c:266 ../libvips/draw/draw_image.c:273
-msgid "Draw image here"
+#: libvips/create/fractsurf.c:118 libvips/create/fractsurf.c:119
+#: libvips/create/mask_fractal.c:93 libvips/create/mask_fractal.c:94
+msgid "Fractal dimension"
 msgstr ""
 
-#: ../libvips/draw/draw_image.c:279 ../libvips/iofuncs/image.c:1207
-msgid "Mode"
+#: libvips/create/gaussmat.c:129 libvips/create/logmat.c:147
+msgid "mask too large"
 msgstr ""
 
-#: ../libvips/draw/draw_image.c:280
-msgid "Combining mode"
+#: libvips/create/gaussmat.c:181
+msgid "make a gaussian image"
 msgstr ""
 
-#: ../libvips/draw/draw_mask.c:319
-msgid "draw a mask on an image"
+#: libvips/create/gaussmat.c:199 libvips/create/logmat.c:215
+msgid "Separable"
 msgstr ""
 
-#: ../libvips/draw/draw_mask.c:324
-msgid "Mask of pixels to draw"
+#: libvips/create/gaussmat.c:200 libvips/create/logmat.c:216
+msgid "Generate separable Gaussian"
 msgstr ""
 
-#: ../libvips/draw/draw_mask.c:330 ../libvips/draw/draw_mask.c:337
-msgid "Draw mask here"
+#: libvips/create/gaussmat.c:206 libvips/create/logmat.c:222
+msgid "Integer"
 msgstr ""
 
-#: ../libvips/draw/draw.c:129
+#: libvips/create/gaussmat.c:207 libvips/create/logmat.c:223
+msgid "Generate integer Gaussian"
+msgstr ""
+
+#: libvips/create/gaussmat.c:214 libvips/create/logmat.c:230
+msgid "Generate with this precision"
+msgstr ""
+
+#: libvips/create/gaussnoise.c:159
+msgid "make a gaussnoise image"
+msgstr ""
+
+#: libvips/create/gaussnoise.c:181 libvips/histogram/stdif.c:329
+msgid "Mean"
+msgstr ""
+
+#: libvips/create/gaussnoise.c:182
+msgid "Mean of pixels in generated image"
+msgstr ""
+
+#: libvips/create/gaussnoise.c:189
+msgid "Standard deviation of pixels in generated image"
+msgstr ""
+
+#: libvips/create/gaussnoise.c:195 libvips/create/perlin.c:322
+#: libvips/create/worley.c:328
+msgid "Seed"
+msgstr ""
+
+#: libvips/create/gaussnoise.c:196 libvips/create/perlin.c:323
+#: libvips/create/worley.c:329
+msgid "Random number seed"
+msgstr ""
+
+#: libvips/create/grey.c:89
+msgid "make a grey ramp image"
+msgstr ""
+
+#: libvips/create/identity.c:139
+msgid "make a 1D image where pixel values are indexes"
+msgstr ""
+
+#: libvips/create/identity.c:144
+msgid "Number of bands in LUT"
+msgstr ""
+
+#: libvips/create/identity.c:150
+msgid "Ushort"
+msgstr ""
+
+#: libvips/create/identity.c:151
+msgid "Create a 16-bit LUT"
+msgstr ""
+
+#: libvips/create/identity.c:158
+msgid "Size of 16-bit LUT"
+msgstr ""
+
+#: libvips/create/invertlut.c:124
+msgid "bad input matrix"
+msgstr ""
+
+#: libvips/create/invertlut.c:129
+msgid "bad size"
+msgstr ""
+
+#: libvips/create/invertlut.c:149
+#, c-format
+msgid "element (%d, %d) is %g, outside range [0,1]"
+msgstr ""
+
+#: libvips/create/invertlut.c:284
+msgid "build an inverted look-up table"
+msgstr ""
+
+#: libvips/create/invertlut.c:295
+msgid "LUT size to generate"
+msgstr ""
+
+#: libvips/create/logmat.c:197
+msgid "make a Laplacian of Gaussian image"
+msgstr ""
+
+#: libvips/create/mask_butterworth_band.c:110
+msgid "make a butterworth_band filter"
+msgstr ""
+
+#: libvips/create/mask_butterworth_band.c:115
+#: libvips/create/mask_butterworth.c:91
+msgid "Order"
+msgstr ""
+
+#: libvips/create/mask_butterworth_band.c:116
+#: libvips/create/mask_butterworth.c:92
+msgid "Filter order"
+msgstr ""
+
+#: libvips/create/mask_butterworth_band.c:122
+#: libvips/create/mask_butterworth_band.c:123
+#: libvips/create/mask_gaussian_band.c:107
+#: libvips/create/mask_gaussian_band.c:108 libvips/create/mask_ideal_band.c:98
+#: libvips/create/mask_ideal_band.c:99
+msgid "Frequency cutoff x"
+msgstr ""
+
+#: libvips/create/mask_butterworth_band.c:129
+#: libvips/create/mask_butterworth_band.c:130
+#: libvips/create/mask_gaussian_band.c:114
+#: libvips/create/mask_gaussian_band.c:115 libvips/create/mask_ideal_band.c:105
+#: libvips/create/mask_ideal_band.c:106
+msgid "Frequency cutoff y"
+msgstr ""
+
+#: libvips/create/mask_butterworth_band.c:137
+#: libvips/create/mask_gaussian_band.c:122 libvips/create/mask_ideal_band.c:113
+msgid "Radius of circle"
+msgstr ""
+
+#: libvips/create/mask_butterworth_band.c:143
+#: libvips/create/mask_butterworth_band.c:144
+#: libvips/create/mask_butterworth.c:105 libvips/create/mask_butterworth.c:106
+#: libvips/create/mask_gaussian_band.c:128
+#: libvips/create/mask_gaussian_band.c:129 libvips/create/mask_gaussian.c:93
+#: libvips/create/mask_gaussian.c:94
+msgid "Amplitude cutoff"
+msgstr ""
+
+#: libvips/create/mask_butterworth.c:86
+msgid "make a butterworth filter"
+msgstr ""
+
+#: libvips/create/mask_butterworth.c:98 libvips/create/mask_butterworth.c:99
+#: libvips/create/mask_gaussian.c:86 libvips/create/mask_gaussian.c:87
+#: libvips/create/mask_ideal.c:84 libvips/create/mask_ideal.c:85
+msgid "Frequency cutoff"
+msgstr ""
+
+#: libvips/create/mask_butterworth_ring.c:101
+msgid "make a butterworth ring filter"
+msgstr ""
+
+#: libvips/create/mask_butterworth_ring.c:106
+#: libvips/create/mask_butterworth_ring.c:107
+#: libvips/create/mask_gaussian_ring.c:101
+#: libvips/create/mask_gaussian_ring.c:102 libvips/create/mask_ideal_ring.c:98
+#: libvips/create/mask_ideal_ring.c:99
+msgid "Ringwidth"
+msgstr ""
+
+#: libvips/create/mask.c:114
+msgid "base class for frequency filters"
+msgstr ""
+
+#: libvips/create/mask.c:122
+msgid "Optical"
+msgstr ""
+
+#: libvips/create/mask.c:123
+msgid "Rotate quadrants to optical space"
+msgstr ""
+
+#: libvips/create/mask.c:129
+msgid "Reject"
+msgstr ""
+
+#: libvips/create/mask.c:130
+msgid "Invert the sense of the filter"
+msgstr ""
+
+#: libvips/create/mask.c:136
+msgid "Nodc"
+msgstr ""
+
+#: libvips/create/mask.c:137
+msgid "Remove DC component"
+msgstr ""
+
+#: libvips/create/mask_fractal.c:88
+msgid "make fractal filter"
+msgstr ""
+
+#: libvips/create/mask_gaussian_band.c:102 libvips/create/mask_gaussian.c:81
+msgid "make a gaussian filter"
+msgstr ""
+
+#: libvips/create/mask_gaussian_ring.c:96
+msgid "make a gaussian ring filter"
+msgstr ""
+
+#: libvips/create/mask_ideal_band.c:93
+msgid "make an ideal band filter"
+msgstr ""
+
+#: libvips/create/mask_ideal.c:79
+msgid "make an ideal filter"
+msgstr ""
+
+#: libvips/create/mask_ideal_ring.c:93
+msgid "make an ideal ring filter"
+msgstr ""
+
+#: libvips/create/perlin.c:290
+msgid "make a perlin noise image"
+msgstr ""
+
+#: libvips/create/perlin.c:308 libvips/create/worley.c:321
+msgid "Cell size"
+msgstr ""
+
+#: libvips/create/perlin.c:309
+msgid "Size of Perlin cells"
+msgstr ""
+
+#: libvips/create/perlin.c:315 libvips/create/point.c:155
+msgid "Uchar"
+msgstr ""
+
+#: libvips/create/perlin.c:316 libvips/create/point.c:156
+msgid "Output an unsigned char image"
+msgstr ""
+
+#: libvips/create/point.c:132
+msgid "make a point image"
+msgstr ""
+
+#: libvips/create/sdf.c:178
+msgid "circle needs a, r to be set"
+msgstr ""
+
+#: libvips/create/sdf.c:183
+msgid "rounded-box needs 2 values for a"
+msgstr ""
+
+#: libvips/create/sdf.c:196
+msgid "box needs a, b to be set"
+msgstr ""
+
+#: libvips/create/sdf.c:202
+msgid "box needs 2 values for a, b"
+msgstr ""
+
+#: libvips/create/sdf.c:216
+msgid "rounded-box needs a, b to be set"
+msgstr ""
+
+#: libvips/create/sdf.c:222
+msgid "rounded-box needs 2 values for a, b"
+msgstr ""
+
+#: libvips/create/sdf.c:227
+msgid "rounded-box needs 4 values for corners"
+msgstr ""
+
+#: libvips/create/sdf.c:242
+msgid "line needs sx, sy to be set"
+msgstr ""
+
+#: libvips/create/sdf.c:248
+msgid "line needs 2 values for a, b"
+msgstr ""
+
+#: libvips/create/sdf.c:259
+#, c-format
+msgid "unknown SDF %d"
+msgstr ""
+
+#: libvips/create/sdf.c:300
+msgid "create an SDF image"
+msgstr ""
+
+#: libvips/create/sdf.c:318
+msgid "Shape"
+msgstr ""
+
+#: libvips/create/sdf.c:319
+msgid "SDF shape to create"
+msgstr ""
+
+#: libvips/create/sdf.c:325
+msgid "r"
+msgstr ""
+
+#: libvips/create/sdf.c:333
+msgid "Point a"
+msgstr ""
+
+#: libvips/create/sdf.c:340
+msgid "Point b"
+msgstr ""
+
+#: libvips/create/sdf.c:346
+msgid "corners"
+msgstr ""
+
+#: libvips/create/sdf.c:347
+msgid "Corner radii"
+msgstr ""
+
+#: libvips/create/sines.c:122
+msgid "make a 2D sine wave"
+msgstr ""
+
+#: libvips/create/sines.c:128
+msgid "hfreq"
+msgstr ""
+
+#: libvips/create/sines.c:129
+msgid "Horizontal spatial frequency"
+msgstr ""
+
+#: libvips/create/sines.c:135
+msgid "vfreq"
+msgstr ""
+
+#: libvips/create/sines.c:136
+msgid "Vertical spatial frequency"
+msgstr ""
+
+#: libvips/create/text.c:406
+msgid "invalid markup in text"
+msgstr ""
+
+#: libvips/create/text.c:428
+#, c-format
+msgid "unable to load fontfile \"%s\""
+msgstr ""
+
+#: libvips/create/text.c:467
+msgid "no text to render"
+msgstr ""
+
+#: libvips/create/text.c:549
+msgid "make a text image"
+msgstr ""
+
+#: libvips/create/text.c:553
+msgid "Text"
+msgstr ""
+
+#: libvips/create/text.c:554
+msgid "Text to render"
+msgstr ""
+
+#: libvips/create/text.c:560
+msgid "Font"
+msgstr ""
+
+#: libvips/create/text.c:561
+msgid "Font to render with"
+msgstr ""
+
+#: libvips/create/text.c:568
+msgid "Maximum image width in pixels"
+msgstr ""
+
+#: libvips/create/text.c:575
+msgid "Maximum image height in pixels"
+msgstr ""
+
+#: libvips/create/text.c:582
+msgid "Align on the low, centre or high edge"
+msgstr ""
+
+#: libvips/create/text.c:588
+msgid "Justify"
+msgstr ""
+
+#: libvips/create/text.c:589
+msgid "Justify lines"
+msgstr ""
+
+#: libvips/create/text.c:595 libvips/foreign/pdfiumload.c:709
+#: libvips/foreign/popplerload.c:559 libvips/foreign/svgload.c:717
+msgid "DPI"
+msgstr ""
+
+#: libvips/create/text.c:596 libvips/foreign/pdfiumload.c:710
+#: libvips/foreign/popplerload.c:560
+msgid "DPI to render at"
+msgstr ""
+
+#: libvips/create/text.c:602
+msgid "Autofit DPI"
+msgstr ""
+
+#: libvips/create/text.c:603
+msgid "DPI selected by autofit"
+msgstr ""
+
+#: libvips/create/text.c:609
+msgid "Spacing"
+msgstr ""
+
+#: libvips/create/text.c:610
+msgid "Line spacing"
+msgstr ""
+
+#: libvips/create/text.c:616
+msgid "Font file"
+msgstr ""
+
+#: libvips/create/text.c:617
+msgid "Load this font file"
+msgstr ""
+
+#: libvips/create/text.c:623
+msgid "RGBA"
+msgstr ""
+
+#: libvips/create/text.c:624
+msgid "Enable RGBA output"
+msgstr ""
+
+#: libvips/create/text.c:630
+msgid "Wrap"
+msgstr ""
+
+#: libvips/create/text.c:631
+msgid "Wrap lines on word or character boundaries"
+msgstr ""
+
+#: libvips/create/tonelut.c:225
+msgid "In-max"
+msgstr ""
+
+#: libvips/create/tonelut.c:226
+msgid "Size of LUT to build"
+msgstr ""
+
+#: libvips/create/tonelut.c:232
+msgid "Out-max"
+msgstr ""
+
+#: libvips/create/tonelut.c:233
+msgid "Maximum value in output LUT"
+msgstr ""
+
+#: libvips/create/tonelut.c:239
+msgid "Black point"
+msgstr ""
+
+#: libvips/create/tonelut.c:240
+msgid "Lowest value in output"
+msgstr ""
+
+#: libvips/create/tonelut.c:246
+msgid "White point"
+msgstr ""
+
+#: libvips/create/tonelut.c:247
+msgid "Highest value in output"
+msgstr ""
+
+#: libvips/create/tonelut.c:253
+msgid "Shadow point"
+msgstr ""
+
+#: libvips/create/tonelut.c:254
+msgid "Position of shadow"
+msgstr ""
+
+#: libvips/create/tonelut.c:260
+msgid "Mid-tone point"
+msgstr ""
+
+#: libvips/create/tonelut.c:261
+msgid "Position of mid-tones"
+msgstr ""
+
+#: libvips/create/tonelut.c:267
+msgid "Highlight point"
+msgstr ""
+
+#: libvips/create/tonelut.c:268
+msgid "Position of highlights"
+msgstr ""
+
+#: libvips/create/tonelut.c:274
+msgid "Shadow adjust"
+msgstr ""
+
+#: libvips/create/tonelut.c:275
+msgid "Adjust shadows by this much"
+msgstr ""
+
+#: libvips/create/tonelut.c:281
+msgid "Mid-tone adjust"
+msgstr ""
+
+#: libvips/create/tonelut.c:282
+msgid "Adjust mid-tones by this much"
+msgstr ""
+
+#: libvips/create/tonelut.c:288
+msgid "Highlight adjust"
+msgstr ""
+
+#: libvips/create/tonelut.c:289
+msgid "Adjust highlights by this much"
+msgstr ""
+
+#: libvips/create/worley.c:303
+msgid "make a worley noise image"
+msgstr ""
+
+#: libvips/create/worley.c:322
+msgid "Size of Worley cells"
+msgstr ""
+
+#: libvips/create/xyz.c:139
+msgid "lower dimensions not set"
+msgstr ""
+
+#: libvips/create/xyz.c:156 libvips/foreign/heifsave.c:682
+#: libvips/foreign/webpsave.c:734
+msgid "image too large"
+msgstr ""
+
+#: libvips/create/xyz.c:187
+msgid "make an image where pixel values are coordinates"
+msgstr ""
+
+#: libvips/create/xyz.c:205
+msgid "csize"
+msgstr ""
+
+#: libvips/create/xyz.c:206
+msgid "Size of third dimension"
+msgstr ""
+
+#: libvips/create/xyz.c:212
+msgid "dsize"
+msgstr ""
+
+#: libvips/create/xyz.c:213
+msgid "Size of fourth dimension"
+msgstr ""
+
+#: libvips/create/xyz.c:219
+msgid "esize"
+msgstr ""
+
+#: libvips/create/xyz.c:220
+msgid "Size of fifth dimension"
+msgstr ""
+
+#: libvips/create/zone.c:90
+msgid "make a zone plate"
+msgstr ""
+
+#: libvips/draw/draw.c:131
 msgid "draw operations"
 msgstr ""
 
-#: ../libvips/draw/draw.c:133
+#: libvips/draw/draw.c:138
 msgid "Image"
 msgstr ""
 
-#: ../libvips/draw/draw.c:134
+#: libvips/draw/draw.c:139
 msgid "Image to draw on"
 msgstr ""
 
-#: ../libvips/draw/draw_smudge.c:193
-msgid "blur a rectangle on an image"
-msgstr ""
-
-#: ../libvips/draw/draw_smudge.c:198 ../libvips/draw/draw_smudge.c:205
-#: ../libvips/draw/draw_smudge.c:212 ../libvips/draw/draw_smudge.c:219
-#: ../libvips/draw/draw_rect.c:174 ../libvips/draw/draw_rect.c:181
-#: ../libvips/draw/draw_rect.c:188 ../libvips/draw/draw_rect.c:195
-msgid "Rect to fill"
-msgstr ""
-
-#: ../libvips/draw/draw_smudge.c:204 ../libvips/draw/draw_rect.c:180
-msgid "top"
-msgstr ""
-
-#: ../libvips/draw/draw_smudge.c:211 ../libvips/draw/draw_rect.c:187
-msgid "width"
-msgstr ""
-
-#: ../libvips/draw/draw_smudge.c:218 ../libvips/draw/draw_rect.c:194
-msgid "height"
-msgstr ""
-
-#: ../libvips/draw/drawink.c:86
-msgid "draw with ink operations"
-msgstr ""
-
-#: ../libvips/draw/drawink.c:90
-msgid "Ink"
-msgstr ""
-
-#: ../libvips/draw/drawink.c:91
-msgid "Color for pixels"
-msgstr ""
-
-#: ../libvips/draw/draw_circle.c:231
+#: libvips/draw/draw_circle.c:230
 msgid "draw a circle on an image"
 msgstr ""
 
-#: ../libvips/draw/draw_circle.c:235
+#: libvips/draw/draw_circle.c:234
 msgid "cx"
 msgstr ""
 
-#: ../libvips/draw/draw_circle.c:236 ../libvips/draw/draw_circle.c:243
+#: libvips/draw/draw_circle.c:235 libvips/draw/draw_circle.c:242
 msgid "Centre of draw_circle"
 msgstr ""
 
-#: ../libvips/draw/draw_circle.c:242
+#: libvips/draw/draw_circle.c:241
 msgid "cy"
 msgstr ""
 
-#: ../libvips/draw/draw_circle.c:250
+#: libvips/draw/draw_circle.c:249
 msgid "Radius in pixels"
 msgstr ""
 
-#: ../libvips/draw/draw_circle.c:256 ../libvips/draw/draw_rect.c:201
+#: libvips/draw/draw_circle.c:255 libvips/draw/draw_rect.c:201
 msgid "Fill"
 msgstr ""
 
-#: ../libvips/draw/draw_circle.c:257 ../libvips/draw/draw_rect.c:202
+#: libvips/draw/draw_circle.c:256 libvips/draw/draw_rect.c:202
 msgid "Draw a solid object"
 msgstr ""
 
-#: ../libvips/draw/draw_flood.c:548
+#: libvips/draw/draw_flood.c:562
 msgid "flood-fill an area"
 msgstr ""
 
-#: ../libvips/draw/draw_flood.c:553 ../libvips/draw/draw_flood.c:560
+#: libvips/draw/draw_flood.c:567 libvips/draw/draw_flood.c:574
 msgid "DrawFlood start point"
 msgstr ""
 
-#: ../libvips/draw/draw_flood.c:566
+#: libvips/draw/draw_flood.c:580
 msgid "Test"
 msgstr ""
 
-#: ../libvips/draw/draw_flood.c:567
+#: libvips/draw/draw_flood.c:581
 msgid "Test pixels in this image"
 msgstr ""
 
-#: ../libvips/draw/draw_flood.c:572
+#: libvips/draw/draw_flood.c:586
 msgid "Equal"
 msgstr ""
 
-#: ../libvips/draw/draw_flood.c:573
+#: libvips/draw/draw_flood.c:587
 msgid "DrawFlood while equal to edge"
 msgstr ""
 
-#: ../libvips/draw/draw_flood.c:580
+#: libvips/draw/draw_flood.c:594
 msgid "Left edge of modified area"
 msgstr ""
 
-#: ../libvips/draw/draw_flood.c:587
-msgid "top edge of modified area"
+#: libvips/draw/draw_flood.c:601
+msgid "Top edge of modified area"
 msgstr ""
 
-#: ../libvips/draw/draw_flood.c:594
-msgid "width of modified area"
+#: libvips/draw/draw_flood.c:608
+msgid "Width of modified area"
 msgstr ""
 
-#: ../libvips/draw/draw_flood.c:601
-msgid "height of modified area"
+#: libvips/draw/draw_flood.c:615
+msgid "Height of modified area"
 msgstr ""
 
-#: ../libvips/draw/draw_rect.c:169
+#: libvips/draw/draw_image.c:265
+msgid "paint an image into another image"
+msgstr ""
+
+#: libvips/draw/draw_image.c:276 libvips/draw/draw_image.c:283
+msgid "Draw image here"
+msgstr ""
+
+#: libvips/draw/draw_image.c:289 libvips/iofuncs/image.c:1179
+msgid "Mode"
+msgstr ""
+
+#: libvips/draw/draw_image.c:290
+msgid "Combining mode"
+msgstr ""
+
+#: libvips/draw/drawink.c:86
+msgid "draw with ink operations"
+msgstr ""
+
+#: libvips/draw/drawink.c:90
+msgid "Ink"
+msgstr ""
+
+#: libvips/draw/drawink.c:91
+msgid "Color for pixels"
+msgstr ""
+
+#: libvips/draw/draw_line.c:280
+msgid "draw a line on an image"
+msgstr ""
+
+#: libvips/draw/draw_line.c:285 libvips/draw/draw_line.c:292
+msgid "Start of draw_line"
+msgstr ""
+
+#: libvips/draw/draw_line.c:291
+msgid "y1"
+msgstr ""
+
+#: libvips/draw/draw_line.c:298
+msgid "x2"
+msgstr ""
+
+#: libvips/draw/draw_line.c:299 libvips/draw/draw_line.c:306
+msgid "End of draw_line"
+msgstr ""
+
+#: libvips/draw/draw_mask.c:328
+msgid "draw a mask on an image"
+msgstr ""
+
+#: libvips/draw/draw_mask.c:333
+msgid "Mask of pixels to draw"
+msgstr ""
+
+#: libvips/draw/draw_mask.c:339 libvips/draw/draw_mask.c:346
+msgid "Draw mask here"
+msgstr ""
+
+#: libvips/draw/draw_rect.c:169
 msgid "paint a rectangle on an image"
 msgstr ""
 
-#: ../libvips/foreign/foreign.c:357
-msgid "load and save image files"
+#: libvips/draw/draw_rect.c:174 libvips/draw/draw_rect.c:181
+#: libvips/draw/draw_rect.c:188 libvips/draw/draw_rect.c:195
+#: libvips/draw/draw_smudge.c:216 libvips/draw/draw_smudge.c:223
+#: libvips/draw/draw_smudge.c:230 libvips/draw/draw_smudge.c:237
+msgid "Rect to fill"
 msgstr ""
 
-#: ../libvips/foreign/foreign.c:520 ../libvips/mosaicing/im_remosaic.c:87
-#, c-format
-msgid "file \"%s\" not found"
+#: libvips/draw/draw_smudge.c:211
+msgid "blur a rectangle on an image"
 msgstr ""
 
-#: ../libvips/foreign/foreign.c:529 ../libvips/foreign/foreign.c:1592
-#, c-format
-msgid "\"%s\" is not a known file format"
-msgstr ""
-
-#: ../libvips/foreign/foreign.c:605
-msgid "buffer is not in a known format"
-msgstr ""
-
-#: ../libvips/foreign/foreign.c:773
-msgid "images do not match"
-msgstr ""
-
-#: ../libvips/foreign/foreign.c:979
-msgid "file loaders"
-msgstr ""
-
-#: ../libvips/foreign/foreign.c:990
-msgid "Flags"
-msgstr ""
-
-#: ../libvips/foreign/foreign.c:991
-msgid "Flags for this file"
-msgstr ""
-
-#: ../libvips/foreign/foreign.c:997
-msgid "Disc"
-msgstr ""
-
-#: ../libvips/foreign/foreign.c:998
-msgid "Open to disc"
-msgstr ""
-
-#: ../libvips/foreign/foreign.c:1005
-msgid "Required access pattern for this file"
-msgstr ""
-
-#: ../libvips/foreign/foreign.c:1011
-msgid "Sequential"
-msgstr ""
-
-#: ../libvips/foreign/foreign.c:1012
-msgid "Sequential read only"
-msgstr ""
-
-#: ../libvips/foreign/foreign.c:1018
-msgid "Fail"
-msgstr ""
-
-#: ../libvips/foreign/foreign.c:1019
-msgid "Fail on first warning"
-msgstr ""
-
-#: ../libvips/foreign/foreign.c:1499
-msgid "file savers"
-msgstr ""
-
-#: ../libvips/foreign/foreign.c:1523
-msgid "Image to save"
-msgstr ""
-
-#: ../libvips/foreign/foreign.c:1528
-msgid "Strip"
-msgstr ""
-
-#: ../libvips/foreign/foreign.c:1529
-msgid "Strip all metadata from image"
-msgstr ""
-
-#: ../libvips/foreign/foreign.c:1667
-#, c-format
-msgid "\"%s\" is not a known buffer format"
-msgstr ""
-
-#: ../libvips/foreign/ppm.c:116
-msgid "bad int"
-msgstr ""
-
-#: ../libvips/foreign/ppm.c:128
-msgid "bad float"
-msgstr ""
-
-#: ../libvips/foreign/ppm.c:179
-msgid "bad magic number"
-msgstr ""
-
-#: ../libvips/foreign/ppm.c:230
-msgid "not whitespace before start of binary data"
-msgstr ""
-
-#: ../libvips/foreign/ppm.c:621 ../libvips/foreign/ppm.c:638
-#: ../libvips/foreign/ppm.c:672 ../libvips/foreign/ppm.c:686
-msgid "write error"
-msgstr ""
-
-#: ../libvips/foreign/ppm.c:813 ../libvips/foreign/vips2tiff.c:1001
-msgid "can only squash 1 band uchar images -- disabling squash"
-msgstr ""
-
-#: ../libvips/foreign/csvsave.c:95
-msgid "save image to csv file"
-msgstr ""
-
-#: ../libvips/foreign/csvsave.c:103 ../libvips/foreign/pngload.c:144
-#: ../libvips/foreign/webpload.c:192 ../libvips/foreign/pngsave.c:189
-#: ../libvips/foreign/fitsload.c:123 ../libvips/foreign/matrixsave.c:121
-#: ../libvips/foreign/ppmsave.c:123 ../libvips/foreign/csvload.c:141
-#: ../libvips/foreign/ppmload.c:135 ../libvips/foreign/magickload.c:223
-#: ../libvips/foreign/gifload.c:892 ../libvips/foreign/magick7load.c:803
-#: ../libvips/foreign/fitssave.c:138 ../libvips/foreign/pdfload.c:590
-#: ../libvips/foreign/openslideload.c:187 ../libvips/foreign/rawload.c:116
-#: ../libvips/foreign/tiffsave.c:362 ../libvips/foreign/svgload.c:368
-#: ../libvips/foreign/radsave.c:154 ../libvips/foreign/dzsave.c:2319
-#: ../libvips/foreign/radload.c:138 ../libvips/foreign/openexrload.c:144
-#: ../libvips/foreign/vipssave.c:114 ../libvips/foreign/webpsave.c:214
-#: ../libvips/foreign/rawsave.c:145 ../libvips/foreign/jpegsave.c:268
-#: ../libvips/foreign/matrixload.c:153 ../libvips/foreign/jpegload.c:232
-#: ../libvips/foreign/analyzeload.c:135 ../libvips/foreign/matload.c:133
-#: ../libvips/foreign/vipsload.c:138 ../libvips/foreign/tiffload.c:223
-#: ../libvips/iofuncs/image.c:1200 ../libvips/resample/thumbnail.c:669
-msgid "Filename"
-msgstr ""
-
-#: ../libvips/foreign/csvsave.c:104 ../libvips/foreign/pngsave.c:190
-#: ../libvips/foreign/matrixsave.c:122 ../libvips/foreign/ppmsave.c:124
-#: ../libvips/foreign/fitssave.c:139 ../libvips/foreign/tiffsave.c:363
-#: ../libvips/foreign/radsave.c:155 ../libvips/foreign/dzsave.c:2320
-#: ../libvips/foreign/vipssave.c:115 ../libvips/foreign/webpsave.c:215
-#: ../libvips/foreign/rawsave.c:146 ../libvips/foreign/jpegsave.c:269
-msgid "Filename to save to"
-msgstr ""
-
-#: ../libvips/foreign/csvsave.c:110 ../libvips/foreign/csvload.c:169
-msgid "Separator"
-msgstr ""
-
-#: ../libvips/foreign/csvsave.c:111
-msgid "Separator characters"
-msgstr ""
-
-#: ../libvips/foreign/webp2vips.c:199
-msgid "bad setting for shrink"
-msgstr ""
-
-#: ../libvips/foreign/webp2vips.c:247
-msgid "unable to read image metadata"
-msgstr ""
-
-#: ../libvips/foreign/webp2vips.c:290 ../libvips/foreign/webp2vips.c:340
-#: ../libvips/foreign/matlab.c:113 ../libvips/foreign/fits.c:189
-#: ../libvips/iofuncs/vips.c:163 ../libvips/mosaicing/global_balance.c:1192
-#: ../libvips/mosaicing/global_balance.c:1530
-#, c-format
-msgid "unable to open \"%s\""
-msgstr ""
-
-#: ../libvips/foreign/webp2vips.c:323 ../libvips/foreign/magick2vips.c:723
-msgid "unable to read pixels"
-msgstr ""
-
-#: ../libvips/foreign/webp2vips.c:360 ../libvips/foreign/webp2vips.c:382
-msgid "unable to open buffer"
-msgstr ""
-
-#: ../libvips/foreign/pngload.c:128
-msgid "load png from file"
-msgstr ""
-
-#: ../libvips/foreign/pngload.c:145 ../libvips/foreign/webpload.c:193
-#: ../libvips/foreign/fitsload.c:124 ../libvips/foreign/csvload.c:142
-#: ../libvips/foreign/ppmload.c:136 ../libvips/foreign/magickload.c:224
-#: ../libvips/foreign/gifload.c:893 ../libvips/foreign/magick7load.c:804
-#: ../libvips/foreign/pdfload.c:591 ../libvips/foreign/openslideload.c:188
-#: ../libvips/foreign/rawload.c:117 ../libvips/foreign/svgload.c:369
-#: ../libvips/foreign/radload.c:139 ../libvips/foreign/openexrload.c:145
-#: ../libvips/foreign/matrixload.c:154 ../libvips/foreign/jpegload.c:233
-#: ../libvips/foreign/analyzeload.c:136 ../libvips/foreign/matload.c:134
-#: ../libvips/foreign/vipsload.c:139 ../libvips/foreign/tiffload.c:224
-msgid "Filename to load from"
-msgstr ""
-
-#: ../libvips/foreign/pngload.c:222
-msgid "load png from buffer"
-msgstr ""
-
-#: ../libvips/foreign/pngload.c:230 ../libvips/foreign/webpload.c:268
-#: ../libvips/foreign/pngsave.c:255 ../libvips/foreign/magickload.c:307
-#: ../libvips/foreign/gifload.c:977 ../libvips/foreign/magick7load.c:900
-#: ../libvips/foreign/pdfload.c:652 ../libvips/foreign/tiffsave.c:437
-#: ../libvips/foreign/svgload.c:531 ../libvips/foreign/radsave.c:217
-#: ../libvips/foreign/dzsave.c:2406 ../libvips/foreign/webpsave.c:285
-#: ../libvips/foreign/jpegsave.c:340 ../libvips/foreign/jpegload.c:311
-#: ../libvips/foreign/tiffload.c:314 ../libvips/resample/thumbnail.c:836
-msgid "Buffer"
-msgstr ""
-
-#: ../libvips/foreign/pngload.c:231 ../libvips/foreign/webpload.c:269
-#: ../libvips/foreign/magickload.c:308 ../libvips/foreign/gifload.c:978
-#: ../libvips/foreign/magick7load.c:901 ../libvips/foreign/pdfload.c:653
-#: ../libvips/foreign/svgload.c:532 ../libvips/foreign/jpegload.c:312
-#: ../libvips/foreign/tiffload.c:315 ../libvips/resample/thumbnail.c:837
-msgid "Buffer to load from"
-msgstr ""
-
-#: ../libvips/foreign/matlab.c:121
-#, c-format
-msgid "no matrix variables in \"%s\""
-msgstr ""
-
-#: ../libvips/foreign/matlab.c:203
-#, c-format
-msgid "unsupported rank %d\n"
-msgstr ""
-
-#: ../libvips/foreign/matlab.c:211
-#, c-format
-msgid "unsupported class type %d\n"
-msgstr ""
-
-#: ../libvips/foreign/matlab.c:260
-msgid "Mat_VarReadDataAll failed"
-msgstr ""
-
-#: ../libvips/foreign/webpload.c:94
-msgid "load webp"
-msgstr ""
-
-#: ../libvips/foreign/webpload.c:100 ../libvips/foreign/jpegload.c:137
-msgid "Shrink"
-msgstr ""
-
-#: ../libvips/foreign/webpload.c:101 ../libvips/foreign/jpegload.c:138
-msgid "Shrink factor on load"
-msgstr ""
-
-#: ../libvips/foreign/webpload.c:181
-msgid "load webp from file"
-msgstr ""
-
-#: ../libvips/foreign/webpload.c:257
-msgid "load webp from buffer"
-msgstr ""
-
-#: ../libvips/foreign/pngsave.c:100
-msgid "save png"
-msgstr ""
-
-#: ../libvips/foreign/pngsave.c:108 ../libvips/foreign/tiffsave.c:181
-#: ../libvips/foreign/dzsave.c:2200
-msgid "Compression"
-msgstr ""
-
-#: ../libvips/foreign/pngsave.c:109
-msgid "Compression factor"
-msgstr ""
-
-#: ../libvips/foreign/pngsave.c:115 ../libvips/foreign/jpegsave.c:170
-msgid "Interlace"
-msgstr ""
-
-#: ../libvips/foreign/pngsave.c:116
-msgid "Interlace image"
-msgstr ""
-
-#: ../libvips/foreign/pngsave.c:122 ../libvips/foreign/jpegsave.c:156
-msgid "Profile"
-msgstr ""
-
-#: ../libvips/foreign/pngsave.c:123 ../libvips/foreign/tiffsave.c:205
-#: ../libvips/foreign/jpegsave.c:157
-msgid "ICC profile to embed"
-msgstr ""
-
-#: ../libvips/foreign/pngsave.c:129
-msgid "Filter"
-msgstr ""
-
-#: ../libvips/foreign/pngsave.c:130
-msgid "libpng row filter flag(s)"
-msgstr ""
-
-#: ../libvips/foreign/pngsave.c:185
-msgid "save image to png file"
-msgstr ""
-
-#: ../libvips/foreign/pngsave.c:251
-msgid "save image to png buffer"
-msgstr ""
-
-#: ../libvips/foreign/pngsave.c:256 ../libvips/foreign/tiffsave.c:438
-#: ../libvips/foreign/radsave.c:218 ../libvips/foreign/dzsave.c:2407
-#: ../libvips/foreign/webpsave.c:286 ../libvips/foreign/jpegsave.c:341
-msgid "Buffer to save to"
-msgstr ""
-
-#: ../libvips/foreign/tiff2vips.c:333 ../libvips/foreign/tiff2vips.c:351
-#, c-format
-msgid "required field %d missing"
-msgstr ""
-
-#: ../libvips/foreign/tiff2vips.c:393
-msgid "unknown resolution unit"
-msgstr ""
-
-#: ../libvips/foreign/tiff2vips.c:398
-#, c-format
-msgid ""
-"no resolution information for TIFF image \"%s\" -- defaulting to 1 pixel per "
-"mm"
-msgstr ""
-
-#: ../libvips/foreign/tiff2vips.c:465
-msgid "read error"
-msgstr ""
-
-#: ../libvips/foreign/tiff2vips.c:482
-#, c-format
-msgid "TIFF does not contain page %d"
-msgstr ""
-
-#: ../libvips/foreign/tiff2vips.c:516
-#, c-format
-msgid "not %d bands"
-msgstr ""
-
-#: ../libvips/foreign/tiff2vips.c:530
-#, c-format
-msgid "not at least %d samples per pixel"
-msgstr ""
-
-#: ../libvips/foreign/tiff2vips.c:544
-#, c-format
-msgid "not photometric interpretation %d"
-msgstr ""
-
-#: ../libvips/foreign/tiff2vips.c:557
-#, c-format
-msgid "not %d bits per sample"
-msgstr ""
-
-#: ../libvips/foreign/tiff2vips.c:573
-#, c-format
-msgid "%d bits per sample palette image not supported"
-msgstr ""
-
-#: ../libvips/foreign/tiff2vips.c:630
-msgid "unsupported tiff image type\n"
-msgstr ""
-
-#: ../libvips/foreign/tiff2vips.c:1038
-msgid "bad colormap"
-msgstr "bad colourmap"
-
-#: ../libvips/foreign/tiff2vips.c:1059
-msgid "assuming 8-bit palette"
-msgstr ""
-
-#: ../libvips/foreign/tiff2vips.c:1594
-msgid "tiled separate planes not supported"
-msgstr ""
-
-#: ../libvips/foreign/tiff2vips.c:1616 ../libvips/foreign/tiff2vips.c:1883
-msgid "unsupported tiff image type"
-msgstr ""
-
-#: ../libvips/foreign/tiff2vips.c:1981
-#, c-format
-msgid "bad page number %d"
-msgstr ""
-
-#: ../libvips/foreign/tiff2vips.c:1991
-#, c-format
-msgid "bad number of pages %d"
-msgstr ""
-
-#: ../libvips/foreign/tiff2vips.c:2022
-msgid "width/height out of range"
-msgstr ""
-
-#: ../libvips/foreign/tiff2vips.c:2031
-msgid "samples out of range"
-msgstr ""
-
-#: ../libvips/foreign/tiff2vips.c:2160
-#, c-format
-msgid "page %d differs from page %d"
-msgstr ""
-
-#: ../libvips/foreign/fitsload.c:110
-msgid "load a FITS image"
-msgstr ""
-
-#: ../libvips/foreign/matrixsave.c:112
-msgid "save image to matrix file"
-msgstr ""
-
-#: ../libvips/foreign/matrixsave.c:192
-msgid "print matrix"
-msgstr ""
-
-#: ../libvips/foreign/vips2webp.c:128
-msgid "output webp image too large"
-msgstr ""
-
-#: ../libvips/foreign/vips2webp.c:134 ../libvips/iofuncs/util.c:738
-msgid "out of memory"
-msgstr ""
-
-#: ../libvips/foreign/vips2webp.c:242 ../libvips/foreign/vips2webp.c:252
-msgid "config version error"
-msgstr ""
-
-#: ../libvips/foreign/vips2webp.c:266
-msgid "lossless unsupported"
-msgstr ""
-
-#: ../libvips/foreign/vips2webp.c:268
-msgid "alpha_q unsupported"
-msgstr ""
-
-#: ../libvips/foreign/vips2webp.c:278
-msgid "near_lossless unsupported"
-msgstr ""
-
-#: ../libvips/foreign/vips2webp.c:280
-msgid "smart_subsample unsupported"
-msgstr ""
-
-#: ../libvips/foreign/vips2webp.c:284
-msgid "invalid configuration"
-msgstr ""
-
-#: ../libvips/foreign/vips2webp.c:302
-msgid "picture memory error"
-msgstr ""
-
-#: ../libvips/foreign/vips2webp.c:308
-msgid "unable to encode"
-msgstr ""
-
-#: ../libvips/foreign/vips2webp.c:526 ../libvips/foreign/vips2webp.c:579
-msgid "picture version error"
-msgstr ""
-
-#: ../libvips/foreign/tiff.c:123
-#, c-format
-msgid "unable to open \"%s\" for output"
-msgstr ""
-
-#: ../libvips/foreign/tiff.c:169
-#, c-format
-msgid "unable to open \"%s\" for input"
-msgstr ""
-
-#: ../libvips/foreign/tiff.c:195
-msgid "read beyond end of buffer"
-msgstr ""
-
-#: ../libvips/foreign/tiff.c:291
-msgid "unable to open memory buffer for input"
-msgstr ""
-
-#: ../libvips/foreign/tiff.c:348
-msgid "Out of memory."
-msgstr ""
-
-#: ../libvips/foreign/tiff.c:450
-msgid "unable to open memory buffer for output"
-msgstr ""
-
-#: ../libvips/foreign/ppmsave.c:114
-msgid "save image to ppm file"
-msgstr ""
-
-#: ../libvips/foreign/ppmsave.c:130
-msgid "ASCII"
-msgstr ""
-
-#: ../libvips/foreign/ppmsave.c:131
-msgid "save as ascii"
-msgstr ""
-
-#: ../libvips/foreign/ppmsave.c:137 ../libvips/foreign/tiffsave.c:239
-msgid "Squash"
-msgstr ""
-
-#: ../libvips/foreign/ppmsave.c:138
-msgid "save as one bit"
-msgstr ""
-
-#. Only a warning, since (for example) exported spreadsheets
-#. * will often have text or date fields.
-#.
-#: ../libvips/foreign/csv.c:198
-#, c-format
-msgid "error parsing number, line %d, column %d"
-msgstr ""
-
-#: ../libvips/foreign/csv.c:256
-msgid "end of file while skipping start"
-msgstr ""
-
-#: ../libvips/foreign/csv.c:265 ../libvips/iofuncs/util.c:1050
-#: ../libvips/iofuncs/util.c:1056
-msgid "unable to seek"
-msgstr ""
-
-#: ../libvips/foreign/csv.c:276
-msgid "empty line"
-msgstr ""
-
-#: ../libvips/foreign/csv.c:316
-#, c-format
-msgid "unexpected EOF, line %d col %d"
-msgstr ""
-
-#: ../libvips/foreign/csv.c:322
-#, c-format
-msgid "unexpected EOL, line %d col %d"
-msgstr ""
-
-#: ../libvips/foreign/csv.c:554
-msgid "no width / height"
-msgstr ""
-
-#: ../libvips/foreign/csv.c:560
-msgid "width / height not int"
-msgstr ""
-
-#: ../libvips/foreign/csv.c:570
-msgid "width / height out of range"
-msgstr ""
-
-#: ../libvips/foreign/csv.c:574
-msgid "extra chars in header"
-msgstr ""
-
-#: ../libvips/foreign/csv.c:578
-msgid "zero scale"
-msgstr ""
-
-#: ../libvips/foreign/csv.c:626
-msgid "line too short"
-msgstr ""
-
-#: ../libvips/foreign/csv.c:670
-#, c-format
-msgid "line %d too short"
-msgstr ""
-
-#: ../libvips/foreign/csvload.c:126
-msgid "load csv from file"
-msgstr ""
-
-#: ../libvips/foreign/csvload.c:148
-msgid "Skip"
-msgstr ""
-
-#: ../libvips/foreign/csvload.c:149
-msgid "Skip this many lines at the start of the file"
-msgstr ""
-
-#: ../libvips/foreign/csvload.c:155
-msgid "Lines"
-msgstr ""
-
-#: ../libvips/foreign/csvload.c:156
-msgid "Read this many lines from the file"
-msgstr ""
-
-#: ../libvips/foreign/csvload.c:162
-msgid "Whitespace"
-msgstr ""
-
-#: ../libvips/foreign/csvload.c:163
-msgid "Set of whitespace characters"
-msgstr ""
-
-#: ../libvips/foreign/csvload.c:170
-msgid "Set of separator characters"
-msgstr ""
-
-#: ../libvips/foreign/vipspng.c:307
-msgid "unsupported color type"
-msgstr "unsupported colour type"
-
-#: ../libvips/foreign/vipspng.c:417
-msgid "unable to read PNG header"
-msgstr ""
-
-#: ../libvips/foreign/vipspng.c:504 ../libvips/foreign/jpeg2vips.c:560
-#, c-format
-msgid "out of order read at line %d"
-msgstr ""
-
-#: ../libvips/foreign/vipspng.c:878
-msgid "compress should be in [0,9]"
-msgstr ""
-
-#: ../libvips/foreign/vipspng.c:900
-#, c-format
-msgid "can't save %d band image as png"
-msgstr ""
-
-#: ../libvips/foreign/vipspng.c:1010
-#, c-format
-msgid "unable to write \"%s\""
-msgstr ""
-
-#: ../libvips/foreign/vipspng.c:1078
-msgid "unable to write to buffer"
-msgstr ""
-
-#: ../libvips/foreign/vips2jpeg.c:148
-#, c-format
-msgid "%s"
-msgstr ""
-
-#: ../libvips/foreign/vips2jpeg.c:254
-#, c-format
-msgid "field \"%s\" is too large for a single JPEG marker, ignoring"
-msgstr ""
-
-#: ../libvips/foreign/ppmload.c:119
-msgid "load ppm from file"
-msgstr ""
-
-#: ../libvips/foreign/magickload.c:105
-msgid "load with ImageMagick"
-msgstr ""
-
-#: ../libvips/foreign/magickload.c:117 ../libvips/foreign/magick7load.c:379
-msgid "all_frames"
-msgstr ""
-
-#: ../libvips/foreign/magickload.c:118 ../libvips/foreign/magick7load.c:380
-msgid "Read all frames from an image"
-msgstr ""
-
-#: ../libvips/foreign/magickload.c:124 ../libvips/foreign/magick7load.c:386
-msgid "Density"
-msgstr ""
-
-#: ../libvips/foreign/magickload.c:125 ../libvips/foreign/magick7load.c:387
-msgid "Canvas resolution for rendering vector formats like SVG"
-msgstr ""
-
-#: ../libvips/foreign/magickload.c:131 ../libvips/foreign/gifload.c:816
-#: ../libvips/foreign/magick7load.c:393 ../libvips/foreign/pdfload.c:468
-#: ../libvips/foreign/tiffload.c:99
-msgid "Page"
-msgstr ""
-
-#: ../libvips/foreign/magickload.c:132 ../libvips/foreign/gifload.c:817
-#: ../libvips/foreign/magick7load.c:394 ../libvips/foreign/pdfload.c:469
-msgid "Load this page from the file"
-msgstr ""
-
-#: ../libvips/foreign/magickload.c:139 ../libvips/foreign/gifload.c:824
-#: ../libvips/foreign/magick7load.c:401 ../libvips/foreign/pdfload.c:476
-#: ../libvips/foreign/tiffload.c:107
-msgid "Load this many pages"
-msgstr ""
-
-#: ../libvips/foreign/magickload.c:216
-msgid "load file with ImageMagick"
-msgstr ""
-
-#: ../libvips/foreign/magickload.c:300
-msgid "load buffer with ImageMagick"
-msgstr ""
-
-#: ../libvips/foreign/openexr2vips.c:121
-#, c-format
-msgid "EXR error: %s"
-msgstr ""
-
-#: ../libvips/foreign/gifload.c:145
-msgid "Failed to open given file"
-msgstr ""
-
-#: ../libvips/foreign/gifload.c:148
-msgid "Failed to read from given file"
-msgstr ""
-
-#: ../libvips/foreign/gifload.c:151
-msgid "Data is not a GIF file"
-msgstr ""
-
-#: ../libvips/foreign/gifload.c:154
-msgid "No screen descriptor detected"
-msgstr ""
-
-#: ../libvips/foreign/gifload.c:157
-msgid "No image descriptor detected"
-msgstr ""
-
-#: ../libvips/foreign/gifload.c:160
-msgid "Neither global nor local color map"
-msgstr "Neither global nor local colour map"
-
-#: ../libvips/foreign/gifload.c:163
-msgid "Wrong record type detected"
-msgstr ""
-
-#: ../libvips/foreign/gifload.c:166
-msgid "Number of pixels bigger than width * height"
-msgstr ""
-
-#: ../libvips/foreign/gifload.c:169
-msgid "Failed to allocate required memory"
-msgstr ""
-
-#: ../libvips/foreign/gifload.c:172
-msgid "Failed to close given file"
-msgstr ""
-
-#: ../libvips/foreign/gifload.c:175
-msgid "Given file was not opened for read"
-msgstr ""
-
-#: ../libvips/foreign/gifload.c:178
-msgid "Image is defective, decoding aborted"
-msgstr ""
-
-#: ../libvips/foreign/gifload.c:181
-msgid "Image EOF detected, before image complete"
-msgstr ""
-
-#: ../libvips/foreign/gifload.c:184
-msgid "Unknown error"
-msgstr ""
-
-#: ../libvips/foreign/gifload.c:371
-msgid "pixel value out of range"
-msgstr ""
-
-#: ../libvips/foreign/gifload.c:411
-msgid "frame is outside image area"
-msgstr ""
-
-#: ../libvips/foreign/gifload.c:662 ../libvips/foreign/gifload.c:711
-msgid "too few frames in GIF file"
-msgstr ""
-
-#: ../libvips/foreign/gifload.c:809 ../libvips/foreign/gifload.c:884
-#: ../libvips/foreign/gifload.c:971
-msgid "load GIF with giflib"
-msgstr ""
-
-#: ../libvips/foreign/magick7load.c:366
-msgid "load with ImageMagick7"
-msgstr ""
-
-#: ../libvips/foreign/magick7load.c:419
-#, c-format
-msgid "Magick: %s %s"
-msgstr ""
-
-#: ../libvips/foreign/magick7load.c:474
-#, c-format
-msgid "unsupported bit depth %zd"
-msgstr ""
-
-#: ../libvips/foreign/magick7load.c:506 ../libvips/foreign/magick2vips.c:387
-#, c-format
-msgid "unsupported colorspace %d"
-msgstr "unsupported colourspace %d"
-
-#: ../libvips/foreign/magick7load.c:797
-msgid "load file with ImageMagick7"
-msgstr ""
-
-#: ../libvips/foreign/magick7load.c:894
-msgid "load buffer with ImageMagick7"
-msgstr ""
-
-#: ../libvips/foreign/openslide2vips.c:195
-msgid "invalid associated image name"
-msgstr ""
-
-#: ../libvips/foreign/openslide2vips.c:239
-msgid "specify only one of level or associated image"
-msgstr ""
-
-#: ../libvips/foreign/openslide2vips.c:275
-msgid "unsupported slide format"
-msgstr ""
-
-#: ../libvips/foreign/openslide2vips.c:282
-#, c-format
-msgid "opening slide: %s"
-msgstr ""
-
-#: ../libvips/foreign/openslide2vips.c:289
-msgid "invalid slide level"
-msgstr ""
-
-#: ../libvips/foreign/openslide2vips.c:371
-#, c-format
-msgid "getting dimensions: %s"
-msgstr ""
-
-#: ../libvips/foreign/openslide2vips.c:378
-msgid "image dimensions overflow int"
-msgstr ""
-
-#: ../libvips/foreign/openslide2vips.c:505
-#, c-format
-msgid "reading region: %s"
-msgstr ""
-
-#: ../libvips/foreign/openslide2vips.c:587
-#, c-format
-msgid "reading associated image: %s"
-msgstr ""
-
-#: ../libvips/foreign/exif.c:158
-msgid "unable to init exif"
-msgstr ""
-
-#: ../libvips/foreign/exif.c:918 ../libvips/foreign/exif.c:928
-#: ../libvips/foreign/exif.c:933
-#, c-format
-msgid "bad exif meta \"%s\""
-msgstr ""
-
-#: ../libvips/foreign/exif.c:1097
-msgid "error saving EXIF"
-msgstr ""
-
-#: ../libvips/foreign/fitssave.c:129
-msgid "save image to fits file"
-msgstr ""
-
-#: ../libvips/foreign/pdfload.c:189
-#, c-format
-msgid "unable to load page %d"
-msgstr ""
-
-#: ../libvips/foreign/pdfload.c:281
-msgid "pages out of range"
-msgstr ""
-
-#: ../libvips/foreign/pdfload.c:459
-msgid "load PDF with libpoppler"
-msgstr ""
-
-#: ../libvips/foreign/pdfload.c:483 ../libvips/foreign/svgload.c:284
-msgid "Render at this DPI"
-msgstr ""
-
-#: ../libvips/foreign/pdfload.c:490 ../libvips/foreign/svgload.c:291
-msgid "Scale output by this factor"
-msgstr ""
-
-#: ../libvips/foreign/magick2vips.c:293
-#, c-format
-msgid "unsupported image type %d"
-msgstr ""
-
-#: ../libvips/foreign/magick2vips.c:355
-#, c-format
-msgid "unsupported bit depth %d"
-msgstr ""
-
-#: ../libvips/foreign/magick2vips.c:753
-#, c-format
-msgid ""
-"unable to read file \"%s\"\n"
-"libMagick error: %s %s"
-msgstr ""
-
-#: ../libvips/foreign/magick2vips.c:792
-#, c-format
-msgid ""
-"unable to ping file \"%s\"\n"
-"libMagick error: %s %s"
-msgstr ""
-
-#: ../libvips/foreign/magick2vips.c:804 ../libvips/foreign/magick2vips.c:880
-msgid "bad image size"
-msgstr ""
-
-#: ../libvips/foreign/magick2vips.c:835
-#, c-format
-msgid ""
-"unable to read buffer\n"
-"libMagick error: %s %s"
-msgstr ""
-
-#: ../libvips/foreign/magick2vips.c:869
-#, c-format
-msgid ""
-"unable to ping blob\n"
-"libMagick error: %s %s"
-msgstr ""
-
-#: ../libvips/foreign/fits.c:263
-msgid "dimensions above 3 must be size 1"
-msgstr ""
-
-#: ../libvips/foreign/fits.c:279
-#, c-format
-msgid "bad number of axis %d"
-msgstr ""
-
-#: ../libvips/foreign/fits.c:295
-#, c-format
-msgid "unsupported bitpix %d\n"
-msgstr ""
-
-#: ../libvips/foreign/fits.c:612 ../libvips/iofuncs/vips.c:191
-#, c-format
-msgid "unable to write to \"%s\""
-msgstr ""
-
-#: ../libvips/foreign/fits.c:673
-#, c-format
-msgid "unsupported BandFmt %d\n"
-msgstr ""
-
-#: ../libvips/foreign/openslideload.c:167
-msgid "load file with OpenSlide"
-msgstr ""
-
-#: ../libvips/foreign/openslideload.c:194
-msgid "Level"
-msgstr ""
-
-#: ../libvips/foreign/openslideload.c:195
-msgid "Load this level from the file"
-msgstr ""
-
-#: ../libvips/foreign/openslideload.c:201
-msgid "Autocrop"
-msgstr ""
-
-#: ../libvips/foreign/openslideload.c:202
-msgid "Crop to image bounds"
-msgstr ""
-
-#: ../libvips/foreign/openslideload.c:208
-msgid "Associated"
-msgstr ""
-
-#: ../libvips/foreign/openslideload.c:209
-msgid "Load this associated image"
-msgstr ""
-
-#: ../libvips/foreign/rawload.c:108
-msgid "load raw data from a file"
-msgstr ""
-
-#: ../libvips/foreign/rawload.c:144 ../libvips/iofuncs/image.c:1228
-msgid "Size of header"
-msgstr ""
-
-#: ../libvips/foreign/rawload.c:145 ../libvips/iofuncs/image.c:1229
-msgid "Offset in bytes from start of file"
-msgstr ""
-
-#: ../libvips/foreign/jpeg2vips.c:187
-#, c-format
-msgid "read gave %ld warnings"
-msgstr ""
-
-#: ../libvips/foreign/tiffsave.c:172 ../libvips/foreign/tiffsave.c:358
-msgid "save image to tiff file"
-msgstr ""
-
-#: ../libvips/foreign/tiffsave.c:182
-msgid "Compression for this file"
-msgstr ""
-
-#: ../libvips/foreign/tiffsave.c:189 ../libvips/foreign/webpsave.c:115
-#: ../libvips/foreign/jpegsave.c:149
-msgid "Q"
-msgstr ""
-
-#: ../libvips/foreign/tiffsave.c:190 ../libvips/foreign/webpsave.c:116
-#: ../libvips/foreign/jpegsave.c:150
-msgid "Q factor"
-msgstr ""
-
-#: ../libvips/foreign/tiffsave.c:196
-msgid "predictor"
-msgstr ""
-
-#: ../libvips/foreign/tiffsave.c:197
-msgid "Compression prediction"
-msgstr ""
-
-#: ../libvips/foreign/tiffsave.c:204
-msgid "profile"
-msgstr ""
-
-#: ../libvips/foreign/tiffsave.c:211
-msgid "Tile"
-msgstr ""
-
-#: ../libvips/foreign/tiffsave.c:212
-msgid "Write a tiled tiff"
-msgstr ""
-
-#: ../libvips/foreign/tiffsave.c:232
-msgid "Pyramid"
-msgstr ""
-
-#: ../libvips/foreign/tiffsave.c:233
-msgid "Write a pyramidal tiff"
-msgstr ""
-
-#: ../libvips/foreign/tiffsave.c:240
-msgid "Squash images down to 1 bit"
-msgstr ""
-
-#: ../libvips/foreign/tiffsave.c:246
-msgid "Miniswhite"
-msgstr ""
-
-#: ../libvips/foreign/tiffsave.c:247
-msgid "Use 0 for white in 1-bit images"
-msgstr ""
-
-#: ../libvips/foreign/tiffsave.c:253 ../libvips/foreign/tiffsave.c:254
-msgid "Resolution unit"
-msgstr ""
-
-#: ../libvips/foreign/tiffsave.c:274
-msgid "Bigtiff"
-msgstr ""
-
-#: ../libvips/foreign/tiffsave.c:275
-msgid "Write a bigtiff image"
-msgstr ""
-
-#: ../libvips/foreign/tiffsave.c:281
-msgid "RGB JPEG"
-msgstr ""
-
-#: ../libvips/foreign/tiffsave.c:282
-msgid "Output RGB JPEG rather than YCbCr"
-msgstr ""
-
-#: ../libvips/foreign/tiffsave.c:288 ../libvips/foreign/dzsave.c:2193
-msgid "Properties"
-msgstr ""
-
-#: ../libvips/foreign/tiffsave.c:289
-msgid "Write a properties document to IMAGEDESCRIPTION"
-msgstr ""
-
-#: ../libvips/foreign/tiffsave.c:433
-msgid "save image to tiff buffer"
-msgstr ""
-
-#: ../libvips/foreign/svgload.c:207
-msgid "SVG rendering failed"
-msgstr ""
-
-#: ../libvips/foreign/svgload.c:274
-msgid "load SVG with rsvg"
-msgstr ""
-
-#: ../libvips/foreign/radsave.c:97
-msgid "save Radiance"
-msgstr ""
-
-#: ../libvips/foreign/radsave.c:150
-msgid "save image to Radiance file"
-msgstr ""
-
-#: ../libvips/foreign/radsave.c:213
-msgid "save image to Radiance buffer"
-msgstr ""
-
-#: ../libvips/foreign/dzsave.c:181 ../libvips/iofuncs/vips.c:712
-#, c-format
-msgid "unable to set property \"%s\" to value \"%s\"."
-msgstr ""
-
-#: ../libvips/foreign/dzsave.c:196
-#, c-format
-msgid "unable to set create node \"%s\""
-msgstr ""
-
-#: ../libvips/foreign/dzsave.c:252 ../libvips/foreign/dzsave.c:257
-#: ../libvips/foreign/dzsave.c:284 ../libvips/iofuncs/vips.c:849
-#: ../libvips/iofuncs/vips.c:856
-msgid "xml save error"
-msgstr ""
-
-#: ../libvips/foreign/dzsave.c:351 ../libvips/foreign/dzsave.c:357
-msgid "unable to close stream"
-msgstr ""
-
-#: ../libvips/foreign/dzsave.c:1395
-msgid "too many files in zip"
-msgstr ""
-
-#: ../libvips/foreign/dzsave.c:1405
-msgid "output file too large"
-msgstr ""
-
-#: ../libvips/foreign/dzsave.c:1762
-msgid "overlap too large"
-msgstr ""
-
-#: ../libvips/foreign/dzsave.c:1904
-#, c-format
-msgid "output directory %s/%s_files exists"
-msgstr ""
-
-#: ../libvips/foreign/dzsave.c:1932 ../libvips/iofuncs/util.c:1625
-#, c-format
-msgid "unable to make temporary file %s"
-msgstr ""
-
-#: ../libvips/foreign/dzsave.c:2002
-msgid "deflate-level not supported by libgsf, using default compression"
-msgstr ""
-
-#: ../libvips/foreign/dzsave.c:2117
-msgid "save image to deep zoom format"
-msgstr ""
-
-#: ../libvips/foreign/dzsave.c:2127
-msgid "Base name"
-msgstr ""
-
-#: ../libvips/foreign/dzsave.c:2128
-msgid "Base name to save to"
-msgstr ""
-
-#: ../libvips/foreign/dzsave.c:2134
-msgid "Layout"
-msgstr ""
-
-#: ../libvips/foreign/dzsave.c:2135
-msgid "Directory layout"
-msgstr ""
-
-#: ../libvips/foreign/dzsave.c:2142
-msgid "suffix"
-msgstr ""
-
-#: ../libvips/foreign/dzsave.c:2143
-msgid "Filename suffix for tiles"
-msgstr ""
-
-#: ../libvips/foreign/dzsave.c:2149
-msgid "Overlap"
-msgstr ""
-
-#: ../libvips/foreign/dzsave.c:2150
-msgid "Tile overlap in pixels"
-msgstr ""
-
-#: ../libvips/foreign/dzsave.c:2156
-msgid "Tile size"
-msgstr ""
-
-#: ../libvips/foreign/dzsave.c:2157
-msgid "Tile size in pixels"
-msgstr ""
-
-#: ../libvips/foreign/dzsave.c:2164
-msgid "Pyramid depth"
-msgstr ""
-
-#: ../libvips/foreign/dzsave.c:2171
-msgid "Center"
-msgstr ""
-
-#: ../libvips/foreign/dzsave.c:2172
-msgid "Center image in tile"
-msgstr ""
-
-#: ../libvips/foreign/dzsave.c:2179
-msgid "Rotate image during save"
-msgstr ""
-
-#: ../libvips/foreign/dzsave.c:2185
-msgid "Container"
-msgstr ""
-
-#: ../libvips/foreign/dzsave.c:2186
-msgid "Pyramid container type"
-msgstr ""
-
-#: ../libvips/foreign/dzsave.c:2194
-msgid "Write a properties file to the output directory"
-msgstr ""
-
-#: ../libvips/foreign/dzsave.c:2201
-msgid "ZIP deflate compression level"
-msgstr ""
-
-#: ../libvips/foreign/dzsave.c:2210
-msgid "Directory name"
-msgstr ""
-
-#: ../libvips/foreign/dzsave.c:2211
-msgid "Directory name to save to"
-msgstr ""
-
-#: ../libvips/foreign/dzsave.c:2315
-msgid "save image to deepzoom file"
-msgstr ""
-
-#: ../libvips/foreign/dzsave.c:2377 ../libvips/iofuncs/image.c:2590
-#: ../libvips/iofuncs/image.c:2592 ../libvips/iofuncs/memory.c:309
-#: ../libvips/iofuncs/memory.c:311
-#, c-format
-msgid "out of memory --- size == %dMB"
-msgstr ""
-
-#: ../libvips/foreign/dzsave.c:2402
-msgid "save image to dz buffer"
-msgstr ""
-
-#: ../libvips/foreign/radload.c:122
-msgid "load a Radiance image from a file"
-msgstr ""
-
-#: ../libvips/foreign/openexrload.c:128
-msgid "load an OpenEXR image"
-msgstr ""
-
-#: ../libvips/foreign/vipssave.c:104
-msgid "save image to vips file"
-msgstr ""
-
-#: ../libvips/foreign/webpsave.c:107
-msgid "save webp"
-msgstr ""
-
-#: ../libvips/foreign/webpsave.c:122
-msgid "lossless"
-msgstr ""
-
-#: ../libvips/foreign/webpsave.c:123
-msgid "enable lossless compression"
-msgstr ""
-
-#: ../libvips/foreign/webpsave.c:129
-msgid "preset"
-msgstr ""
-
-#: ../libvips/foreign/webpsave.c:130
-msgid "Preset for lossy compression"
-msgstr ""
-
-#: ../libvips/foreign/webpsave.c:137
-msgid "Smart subsampling"
-msgstr ""
-
-#: ../libvips/foreign/webpsave.c:138
-msgid "Enable high quality chroma subsampling"
-msgstr ""
-
-#: ../libvips/foreign/webpsave.c:144
-msgid "Near lossless"
-msgstr ""
-
-#: ../libvips/foreign/webpsave.c:145
-msgid "Enable preprocessing in lossless mode (uses Q)"
-msgstr ""
-
-#: ../libvips/foreign/webpsave.c:151
-msgid "Alpha quality"
-msgstr ""
-
-#: ../libvips/foreign/webpsave.c:152
-msgid "Change alpha plane fidelity for lossy compression"
-msgstr ""
-
-#: ../libvips/foreign/webpsave.c:210
-msgid "save image to webp file"
-msgstr ""
-
-#: ../libvips/foreign/webpsave.c:281
-msgid "save image to webp buffer"
-msgstr ""
-
-#: ../libvips/foreign/webpsave.c:330 ../libvips/foreign/jpegsave.c:386
-msgid "error writing output"
-msgstr ""
-
-#: ../libvips/foreign/webpsave.c:346
-msgid "save image to webp mime"
-msgstr ""
-
-#: ../libvips/foreign/radiance.c:685
-msgid "end of file"
-msgstr ""
-
-#: ../libvips/foreign/radiance.c:773
-msgid "scanline length mismatch"
-msgstr ""
-
-#: ../libvips/foreign/radiance.c:790
-msgid "overrun"
-msgstr ""
-
-#: ../libvips/foreign/radiance.c:1040
-msgid "error reading radiance header"
-msgstr ""
-
-#: ../libvips/foreign/radiance.c:1057
-msgid "image size out of bounds"
-msgstr ""
-
-#: ../libvips/foreign/radiance.c:1125
-#, c-format
-msgid "read error line %d"
-msgstr ""
-
-#: ../libvips/foreign/rawsave.c:139
-msgid "save image to raw file"
-msgstr ""
-
-#: ../libvips/foreign/rawsave.c:245
-msgid "write raw image to file descriptor"
-msgstr ""
-
-#: ../libvips/foreign/rawsave.c:251
-msgid "File descriptor"
-msgstr ""
-
-#: ../libvips/foreign/rawsave.c:252
-msgid "File descriptor to write to"
-msgstr ""
-
-#: ../libvips/foreign/jpegsave.c:139
-msgid "save jpeg"
-msgstr ""
-
-#: ../libvips/foreign/jpegsave.c:163
-msgid "Optimize_coding"
-msgstr ""
-
-#: ../libvips/foreign/jpegsave.c:164
-msgid "Compute optimal Huffman coding tables"
-msgstr ""
-
-#: ../libvips/foreign/jpegsave.c:171
-msgid "Generate an interlaced (progressive) jpeg"
-msgstr ""
-
-#: ../libvips/foreign/jpegsave.c:177
-msgid "No subsample"
-msgstr ""
-
-#: ../libvips/foreign/jpegsave.c:178
-msgid "Disable chroma subsample"
-msgstr ""
-
-#: ../libvips/foreign/jpegsave.c:184
-msgid "Trellis quantisation"
-msgstr ""
-
-#: ../libvips/foreign/jpegsave.c:185
-msgid "Apply trellis quantisation to each 8x8 block"
-msgstr ""
-
-#: ../libvips/foreign/jpegsave.c:191
-msgid "Overshoot de-ringing"
-msgstr ""
-
-#: ../libvips/foreign/jpegsave.c:192
-msgid "Apply overshooting to samples with extreme values"
-msgstr ""
-
-#: ../libvips/foreign/jpegsave.c:198
-msgid "Optimize scans"
-msgstr ""
-
-#: ../libvips/foreign/jpegsave.c:199
-msgid "Split the spectrum of DCT coefficients into separate scans"
-msgstr ""
-
-#: ../libvips/foreign/jpegsave.c:205
-msgid "Quantization table"
-msgstr ""
-
-#: ../libvips/foreign/jpegsave.c:206
-msgid "Use predefined quantization table with given index"
-msgstr ""
-
-#: ../libvips/foreign/jpegsave.c:264
-msgid "save image to jpeg file"
-msgstr ""
-
-#: ../libvips/foreign/jpegsave.c:336
-msgid "save image to jpeg buffer"
-msgstr ""
-
-#: ../libvips/foreign/jpegsave.c:402
-msgid "save image to jpeg mime"
-msgstr ""
-
-#: ../libvips/foreign/analyze2vips.c:311
+#: libvips/foreign/analyze2vips.c:308
 msgid "header file size incorrect"
 msgstr ""
 
-#: ../libvips/foreign/analyze2vips.c:356
+#: libvips/foreign/analyze2vips.c:352
 msgid "header size incorrect"
 msgstr ""
 
-#: ../libvips/foreign/analyze2vips.c:374
+#: libvips/foreign/analyze2vips.c:370 libvips/foreign/niftiload.c:399
 #, c-format
 msgid "%d-dimensional images not supported"
 msgstr ""
 
-#: ../libvips/foreign/analyze2vips.c:427
+#: libvips/foreign/analyze2vips.c:423 libvips/foreign/niftiload.c:442
 #, c-format
 msgid "datatype %d not supported"
 msgstr ""
 
-#: ../libvips/foreign/matrixload.c:137
-msgid "load matrix from file"
-msgstr ""
-
-#: ../libvips/foreign/jpegload.c:109
-#, c-format
-msgid "bad shrink factor %d"
-msgstr ""
-
-#: ../libvips/foreign/jpegload.c:131
-msgid "load jpeg"
-msgstr ""
-
-#: ../libvips/foreign/jpegload.c:144 ../libvips/foreign/tiffload.c:113
-msgid "Autorotate"
-msgstr ""
-
-#: ../libvips/foreign/jpegload.c:145
-msgid "Rotate image using exif orientation"
-msgstr ""
-
-#: ../libvips/foreign/jpegload.c:219
-msgid "load jpeg from file"
-msgstr ""
-
-#: ../libvips/foreign/jpegload.c:304
-msgid "load jpeg from buffer"
-msgstr ""
-
-#: ../libvips/foreign/analyzeload.c:119
+#: libvips/foreign/analyzeload.c:120
 msgid "load an Analyze6 image"
 msgstr ""
 
-#: ../libvips/foreign/vips2tiff.c:470
-msgid "rounding up IPCT data length"
-msgstr ""
-
-#: ../libvips/foreign/vips2tiff.c:948
-#, c-format
-msgid "image height %d is not a factor of page-height %d"
-msgstr ""
-
-#: ../libvips/foreign/vips2tiff.c:964
-msgid "can't pyramid multi page images --- disabling pyramid"
-msgstr ""
-
-#: ../libvips/foreign/vips2tiff.c:977
-msgid "tile size not a multiple of 16"
-msgstr ""
-
-#: ../libvips/foreign/vips2tiff.c:988
-msgid "can only pyramid LABQ and non-complex images"
-msgstr ""
-
-#: ../libvips/foreign/vips2tiff.c:1043
-msgid "image over 4gb, enabling bigtiff"
-msgstr ""
-
-#: ../libvips/foreign/vips2tiff.c:1295
-msgid "TIFF write tile failed"
-msgstr ""
-
-#: ../libvips/foreign/matload.c:121
-msgid "load mat from file"
-msgstr ""
-
-#: ../libvips/foreign/vipsload.c:122
-msgid "load vips from file"
-msgstr ""
-
-#: ../libvips/foreign/tiffload.c:96
-msgid "load tiff"
-msgstr ""
-
-#: ../libvips/foreign/tiffload.c:100
-msgid "Load this page from the image"
-msgstr ""
-
-#: ../libvips/foreign/tiffload.c:114
-msgid "Rotate image using orientation tag"
-msgstr ""
-
-#: ../libvips/foreign/tiffload.c:207
-msgid "load tiff from file"
-msgstr ""
-
-#: ../libvips/foreign/tiffload.c:306
-msgid "load tiff from buffer"
-msgstr ""
-
-#: ../libvips/freqfilt/spectrum.c:101
-msgid "make displayable power spectrum"
-msgstr ""
-
-#: ../libvips/freqfilt/phasecor.c:108
-msgid "calculate phase correlation"
-msgstr ""
-
-#: ../libvips/freqfilt/fwfft.c:137 ../libvips/freqfilt/fwfft.c:252
-#: ../libvips/freqfilt/invfft.c:120 ../libvips/freqfilt/invfft.c:194
-msgid "unable to create transform plan"
-msgstr ""
-
-#: ../libvips/freqfilt/fwfft.c:335
-msgid "forward FFT"
-msgstr ""
-
-#: ../libvips/freqfilt/freqmult.c:127
-msgid "frequency-domain filtering"
-msgstr ""
-
-#: ../libvips/freqfilt/freqmult.c:131
-msgid "mask"
-msgstr ""
-
-#: ../libvips/freqfilt/freqmult.c:132
-msgid "Input mask image"
-msgstr ""
-
-#: ../libvips/freqfilt/freqfilt.c:94
-msgid "frequency-domain filter operations"
-msgstr ""
-
-#: ../libvips/freqfilt/invfft.c:252
-msgid "inverse FFT"
-msgstr ""
-
-#: ../libvips/freqfilt/invfft.c:256
-msgid "Real"
-msgstr ""
-
-#: ../libvips/freqfilt/invfft.c:257
-msgid "Output only the real part of the transform"
-msgstr ""
-
-#: ../libvips/histogram/hist_match.c:154
-msgid "match two histograms"
-msgstr ""
-
-#: ../libvips/histogram/hist_match.c:162
-msgid "Input histogram"
-msgstr ""
-
-#: ../libvips/histogram/hist_match.c:167 ../libvips/mosaicing/merge.c:109
-#: ../libvips/mosaicing/mosaic.c:180 ../libvips/mosaicing/match.c:204
-#: ../libvips/mosaicing/mosaic1.c:489
-msgid "Reference"
-msgstr ""
-
-#: ../libvips/histogram/hist_match.c:168
-msgid "Reference histogram"
-msgstr ""
-
-#: ../libvips/histogram/hist_cum.c:148
-msgid "form cumulative histogram"
-msgstr ""
-
-#: ../libvips/histogram/hist_equal.c:104
-msgid "histogram equalisation"
-msgstr ""
-
-#: ../libvips/histogram/hist_equal.c:121
-msgid "Equalise with this band"
-msgstr ""
-
-#: ../libvips/histogram/stdif.c:236 ../libvips/histogram/hist_local.c:304
-#: ../libvips/morphology/rank.c:354
-msgid "window too large"
-msgstr ""
-
-#: ../libvips/histogram/stdif.c:240
-msgid "too many bands"
-msgstr ""
-
-#: ../libvips/histogram/stdif.c:290
-msgid "statistical difference"
-msgstr ""
-
-#: ../libvips/histogram/stdif.c:309 ../libvips/histogram/hist_local.c:371
-#: ../libvips/morphology/rank.c:420
-msgid "Window width in pixels"
-msgstr ""
-
-#: ../libvips/histogram/stdif.c:316 ../libvips/histogram/hist_local.c:378
-#: ../libvips/morphology/rank.c:427
-msgid "Window height in pixels"
-msgstr ""
-
-#: ../libvips/histogram/stdif.c:322
-msgid "Mean weight"
-msgstr ""
-
-#: ../libvips/histogram/stdif.c:323
-msgid "Weight of new mean"
-msgstr ""
-
-#: ../libvips/histogram/stdif.c:330
-msgid "New mean"
-msgstr ""
-
-#: ../libvips/histogram/stdif.c:336
-msgid "Deviation weight"
-msgstr ""
-
-#: ../libvips/histogram/stdif.c:337
-msgid "Weight of new deviation"
-msgstr ""
-
-#: ../libvips/histogram/stdif.c:343
-msgid "Deviation"
-msgstr ""
-
-#: ../libvips/histogram/stdif.c:344
-msgid "New deviation"
-msgstr ""
-
-#: ../libvips/histogram/histogram.c:223
-msgid "histogram operations"
-msgstr ""
-
-#: ../libvips/histogram/hist_entropy.c:109
-msgid "estimate image entropy"
-msgstr ""
-
-#: ../libvips/histogram/hist_entropy.c:114
-#: ../libvips/histogram/hist_ismonotonic.c:118
-msgid "Input histogram image"
-msgstr ""
-
-#: ../libvips/histogram/hist_ismonotonic.c:113
-msgid "test for monotonicity"
-msgstr ""
-
-#: ../libvips/histogram/hist_ismonotonic.c:123
-msgid "Monotonic"
-msgstr ""
-
-#: ../libvips/histogram/hist_ismonotonic.c:124
-msgid "true if in is monotonic"
-msgstr ""
-
-#: ../libvips/histogram/hist_norm.c:137
-msgid "normalise histogram"
-msgstr ""
-
-#: ../libvips/histogram/hist_plot.c:338
-msgid "plot histogram"
-msgstr ""
-
-#: ../libvips/histogram/hist_unary.c:85
-msgid "hist_unary operations"
-msgstr ""
-
-#: ../libvips/histogram/hist_local.c:354
-msgid "local histogram equalisation"
-msgstr ""
-
-#: ../libvips/histogram/hist_local.c:384
-msgid "Max slope"
-msgstr ""
-
-#: ../libvips/histogram/hist_local.c:385
-msgid "Maximum slope (CLAHE)"
-msgstr ""
-
-#: ../libvips/histogram/percent.c:106
-msgid "find threshold for percent of pixels"
-msgstr ""
-
-#: ../libvips/histogram/percent.c:116
-msgid "Percent"
-msgstr ""
-
-#: ../libvips/histogram/percent.c:117
-msgid "Percent of pixels"
-msgstr ""
-
-#: ../libvips/histogram/percent.c:123
-msgid "Threshold"
-msgstr ""
-
-#: ../libvips/histogram/percent.c:124
-msgid "Threshold above which lie percent of pixels"
-msgstr ""
-
-#: ../libvips/histogram/maplut.c:110
-#, c-format
-msgid "%d overflows detected"
-msgstr ""
-
-#: ../libvips/histogram/maplut.c:688
-msgid "map an image though a lut"
-msgstr ""
-
-#: ../libvips/histogram/maplut.c:706
-msgid "LUT"
-msgstr ""
-
-#: ../libvips/histogram/maplut.c:707
-msgid "Look-up table image"
-msgstr ""
-
-#: ../libvips/histogram/maplut.c:712
-msgid "band"
-msgstr ""
-
-#: ../libvips/histogram/maplut.c:713
-msgid "apply one-band lut to this band of in"
-msgstr ""
-
-#: ../libvips/introspect.c:54
-msgid "dump introspection data"
-msgstr ""
-
-#: ../libvips/introspect.c:71
-msgid "- introspect"
-msgstr ""
-
-#: ../libvips/iofuncs/sink.c:106
-#, c-format
-msgid "stop function failed for image \"%s\""
-msgstr ""
-
-#: ../libvips/iofuncs/sink.c:143
-#, c-format
-msgid "start function failed for image \"%s\""
-msgstr ""
-
-#: ../libvips/iofuncs/sink.c:176
-msgid "per-thread state for sink"
-msgstr ""
-
-#: ../libvips/iofuncs/type.c:854
-#, c-format
-msgid "unable to convert \"%s\" to int"
-msgstr ""
-
-#: ../libvips/iofuncs/type.c:1046
-#, c-format
-msgid "unable to convert \"%s\" to float"
-msgstr ""
-
-#: ../libvips/iofuncs/image.c:536
-msgid "unable to close fd"
-msgstr ""
-
-#: ../libvips/iofuncs/image.c:617
-#, c-format
-msgid "%dx%d %s, %d band, %s"
-msgid_plural "%dx%d %s, %d bands, %s"
-msgstr[0] ""
-msgstr[1] ""
-
-#: ../libvips/iofuncs/image.c:651
-#, c-format
-msgid " %s, %d band, %s"
-msgid_plural " %s, %d bands, %s"
-msgstr[0] ""
-msgstr[1] ""
-
-#: ../libvips/iofuncs/image.c:784
-#, c-format
-msgid "%s %s: %d x %d pixels, %d threads, %d x %d tiles, %d lines in buffer"
-msgstr ""
-
-#: ../libvips/iofuncs/image.c:797
-#, c-format
-msgid "%s %s: %d%% complete"
-msgstr ""
-
-#. Spaces at end help to erase the %complete message we overwrite.
-#.
-#: ../libvips/iofuncs/image.c:816
-#, c-format
-msgid "%s %s: done in %.3gs          \n"
-msgstr ""
-
-#: ../libvips/iofuncs/image.c:1000
-#, c-format
-msgid "unable to open \"%s\", file too short"
-msgstr ""
-
-#: ../libvips/iofuncs/image.c:1009
-#, c-format
-msgid "%s is longer than expected"
-msgstr ""
-
-#: ../libvips/iofuncs/image.c:1027
-#, c-format
-msgid "bad mode \"%s\""
-msgstr ""
-
-#: ../libvips/iofuncs/image.c:1103
-msgid "image class"
-msgstr ""
-
-#: ../libvips/iofuncs/image.c:1201
-msgid "Image filename"
-msgstr ""
-
-#: ../libvips/iofuncs/image.c:1208
-msgid "Open mode"
-msgstr ""
-
-#: ../libvips/iofuncs/image.c:1214
-msgid "Kill"
-msgstr ""
-
-#: ../libvips/iofuncs/image.c:1215
-msgid "Block evaluation on this image"
-msgstr ""
-
-#: ../libvips/iofuncs/image.c:1221
-msgid "Demand style"
-msgstr ""
-
-#: ../libvips/iofuncs/image.c:1222
-msgid "Preferred demand style for this image"
-msgstr ""
-
-#: ../libvips/iofuncs/image.c:1235
-msgid "Foreign buffer"
-msgstr ""
-
-#: ../libvips/iofuncs/image.c:1236
-msgid "Pointer to foreign pixels"
-msgstr ""
-
-#: ../libvips/iofuncs/image.c:1647
-#, c-format
-msgid "killed for image \"%s\""
-msgstr ""
-
-#: ../libvips/iofuncs/image.c:2049
-#, c-format
-msgid "memory area too small --- should be %zd bytes, you passed %zd"
-msgstr ""
-
-#: ../libvips/iofuncs/image.c:2264
-#, c-format
-msgid "bad array length --- should be %d, you passed %d"
-msgstr ""
-
-#: ../libvips/iofuncs/image.c:2854
-msgid "bad image descriptor"
-msgstr ""
-
-#: ../libvips/iofuncs/image.c:2912 ../libvips/iofuncs/generate.c:779
-#, c-format
-msgid "unable to output to a %s image"
-msgstr ""
-
-#: ../libvips/iofuncs/image.c:2976
-#, c-format
-msgid "auto-rewind for %s failed"
-msgstr ""
-
-#: ../libvips/iofuncs/image.c:3045 ../libvips/iofuncs/image.c:3175
-#: ../libvips/iofuncs/image.c:3354
-msgid "image not readable"
-msgstr ""
-
-#: ../libvips/iofuncs/image.c:3090 ../libvips/iofuncs/image.c:3314
-#: ../libvips/iofuncs/image.c:3331
-msgid "no image data"
-msgstr ""
-
-#: ../libvips/iofuncs/image.c:3196 ../libvips/iofuncs/image.c:3384
-#: ../libvips/iofuncs/image.c:3393
-msgid "image already written"
-msgstr ""
-
-#: ../libvips/iofuncs/image.c:3220 ../libvips/iofuncs/image.c:3405
-msgid "image not writeable"
-msgstr ""
-
-#: ../libvips/iofuncs/image.c:3272
-msgid "bad file type"
-msgstr ""
-
-#: ../libvips/iofuncs/threadpool.c:247
-msgid "unable to create thread"
-msgstr ""
-
-#: ../libvips/iofuncs/threadpool.c:410
-#, c-format
-msgid "threads clipped to %d"
-msgstr ""
-
-#: ../libvips/iofuncs/threadpool.c:456
-msgid "per-thread state for vipsthreadpool"
-msgstr ""
-
-#: ../libvips/iofuncs/mapfile.c:131 ../libvips/iofuncs/mapfile.c:298
-msgid "unable to CreateFileMapping"
-msgstr ""
-
-#: ../libvips/iofuncs/mapfile.c:139 ../libvips/iofuncs/mapfile.c:310
-msgid "unable to MapViewOfFile"
-msgstr ""
-
-#: ../libvips/iofuncs/mapfile.c:179
-msgid "unable to mmap"
-msgstr ""
-
-#: ../libvips/iofuncs/mapfile.c:180
-#, c-format
-msgid ""
-"map failed (%s), running very low on system resources, expect a crash soon"
-msgstr ""
-
-#: ../libvips/iofuncs/mapfile.c:197 ../libvips/iofuncs/mapfile.c:304
-msgid "unable to UnmapViewOfFile"
-msgstr ""
-
-#: ../libvips/iofuncs/mapfile.c:203
-msgid "unable to munmap file"
-msgstr ""
-
-#: ../libvips/iofuncs/mapfile.c:225
-msgid "file is less than 64 bytes"
-msgstr ""
-
-#: ../libvips/iofuncs/mapfile.c:230 ../libvips/iofuncs/mapfile.c:264
-msgid "unable to get file status"
-msgstr ""
-
-#: ../libvips/iofuncs/mapfile.c:236
-msgid "not a regular file"
-msgstr ""
-
-#: ../libvips/iofuncs/mapfile.c:270
-msgid "unable to read data"
-msgstr ""
-
-#: ../libvips/iofuncs/mapfile.c:330
-#, c-format
-msgid "unable to mmap: \"%s\" - %s"
-msgstr ""
-
-#: ../libvips/iofuncs/mapfile.c:340
-#, c-format
-msgid "unable to mmap \"%s\" to same address"
-msgstr ""
-
-#: ../libvips/iofuncs/sinkdisc.c:122
-msgid "per-thread state for sinkdisc"
-msgstr ""
-
-#: ../libvips/iofuncs/sinkdisc.c:261 ../libvips/iofuncs/util.c:535
-msgid "write failed"
-msgstr ""
-
-#: ../libvips/iofuncs/operation.c:225
-#, c-format
-msgid "%d pixels calculated"
-msgstr ""
-
-#: ../libvips/iofuncs/operation.c:309 ../libvips/iofuncs/operation.c:330
-#: ../libvips/iofuncs/operation.c:338 ../libvips/iofuncs/operation.c:350
-msgid "default"
-msgstr ""
-
-#: ../libvips/iofuncs/operation.c:313
-msgid "allowed"
-msgstr ""
-
-#: ../libvips/iofuncs/operation.c:341 ../libvips/iofuncs/operation.c:353
-msgid "min"
-msgstr ""
-
-#: ../libvips/iofuncs/operation.c:343 ../libvips/iofuncs/operation.c:355
-msgid "max"
-msgstr ""
-
-#: ../libvips/iofuncs/operation.c:571
-msgid "operations"
-msgstr ""
-
-#: ../libvips/iofuncs/operation.c:659 ../libvips/iofuncs/object.c:1511
-#: ../libvips/resample/interpolate.c:637
-#, c-format
-msgid "class \"%s\" not found"
-msgstr ""
-
-#: ../libvips/iofuncs/operation.c:665
-#, c-format
-msgid "\"%s\" is not an instantiable class"
-msgstr ""
-
-#: ../libvips/iofuncs/operation.c:1129
-#, c-format
-msgid "unknown argument '%s'"
-msgstr ""
-
-#: ../libvips/iofuncs/operation.c:1253
-msgid "too few arguments"
-msgstr ""
-
-#: ../libvips/iofuncs/operation.c:1374
-msgid "too many arguments"
-msgstr ""
-
-#: ../libvips/iofuncs/sinkmemory.c:109
-msgid "per-thread state for sinkmemory"
-msgstr ""
-
-#: ../libvips/iofuncs/generate.c:690
-msgid "demand hint not set"
-msgstr ""
-
-#: ../libvips/iofuncs/generate.c:709 ../libvips/iofuncs/generate.c:737
-msgid "generate() called twice"
-msgstr ""
-
-#: ../libvips/iofuncs/window.c:237 ../libvips/iofuncs/vips.c:918
-#, c-format
-msgid "unable to read data for \"%s\", %s"
-msgstr ""
-
-#: ../libvips/iofuncs/window.c:238 ../libvips/iofuncs/vips.c:808
-#: ../libvips/iofuncs/vips.c:919
-msgid "file has been truncated"
-msgstr ""
-
-#: ../libvips/iofuncs/system.c:184
-msgid "unable to substitute input filename"
-msgstr ""
-
-#: ../libvips/iofuncs/system.c:191
-msgid "unable to substitute output filename"
-msgstr ""
-
-#: ../libvips/iofuncs/system.c:226
-#, c-format
-msgid "command \"%s\" failed"
-msgstr ""
-
-#: ../libvips/iofuncs/system.c:234
-#, c-format
-msgid "stderr output: %s"
-msgstr ""
-
-#: ../libvips/iofuncs/system.c:269
-msgid "run an external command"
-msgstr ""
-
-#: ../libvips/iofuncs/system.c:290
-msgid "Command"
-msgstr ""
-
-#: ../libvips/iofuncs/system.c:291
-msgid "Command to run"
-msgstr ""
-
-#: ../libvips/iofuncs/system.c:297
-msgid "Input format"
-msgstr ""
-
-#: ../libvips/iofuncs/system.c:298
-msgid "Format for input filename"
-msgstr ""
-
-#: ../libvips/iofuncs/system.c:304
-msgid "Output format"
-msgstr ""
-
-#: ../libvips/iofuncs/system.c:305
-msgid "Format for output filename"
-msgstr ""
-
-#: ../libvips/iofuncs/system.c:312
-msgid "Command log"
-msgstr ""
-
-#: ../libvips/iofuncs/header.c:1067
-#, c-format
-msgid "field \"%s\" not found"
-msgstr ""
-
-#: ../libvips/iofuncs/header.c:1269
-#, c-format
-msgid "field \"%s\" is of type %s, not %s"
-msgstr ""
-
-#: ../libvips/iofuncs/header.c:1498
-#, c-format
-msgid "field \"%s\" is of type %s, not VipsRefString"
-msgstr ""
-
-#: ../libvips/iofuncs/init.c:234
-#, c-format
-msgid "unable to load \"%s\" -- %s"
-msgstr ""
-
-#: ../libvips/iofuncs/init.c:655
-msgid "show informative messages"
-msgstr ""
-
-#: ../libvips/iofuncs/init.c:658
-msgid "abort on first error or warning"
-msgstr ""
-
-#: ../libvips/iofuncs/init.c:661
-msgid "evaluate with N concurrent threads"
-msgstr ""
-
-#: ../libvips/iofuncs/init.c:664
-msgid "set tile width to N (DEBUG)"
-msgstr ""
-
-#: ../libvips/iofuncs/init.c:667
-msgid "set tile height to N (DEBUG)"
-msgstr ""
-
-#: ../libvips/iofuncs/init.c:670
-msgid "set thinstrip height to N (DEBUG)"
-msgstr ""
-
-#: ../libvips/iofuncs/init.c:673
-msgid "set fatstrip height to N (DEBUG)"
-msgstr ""
-
-#: ../libvips/iofuncs/init.c:676
-msgid "show progress feedback"
-msgstr ""
-
-#: ../libvips/iofuncs/init.c:679
-msgid "leak-check on exit"
-msgstr ""
-
-#: ../libvips/iofuncs/init.c:682
-msgid "profile and dump timing on exit"
-msgstr ""
-
-#: ../libvips/iofuncs/init.c:685
-msgid "images larger than N are decompressed to disc"
-msgstr ""
-
-#: ../libvips/iofuncs/init.c:688
-msgid "disable vectorised versions of operations"
-msgstr ""
-
-#: ../libvips/iofuncs/init.c:691
-msgid "cache at most N operations"
-msgstr ""
-
-#: ../libvips/iofuncs/init.c:694
-msgid "cache at most N bytes in memory"
-msgstr ""
-
-#: ../libvips/iofuncs/init.c:697
-msgid "allow at most N open files"
-msgstr ""
-
-#: ../libvips/iofuncs/init.c:700
-msgid "trace operation cache"
-msgstr ""
-
-#: ../libvips/iofuncs/init.c:703
-msgid "dump operation cache on exit"
-msgstr ""
-
-#: ../libvips/iofuncs/init.c:706
-msgid "print libvips version"
-msgstr ""
-
-#: ../libvips/iofuncs/init.c:1091
-msgid "flag not in [0, 5]"
-msgstr ""
-
-#: ../libvips/iofuncs/region.c:585 ../libvips/iofuncs/region.c:657
-#: ../libvips/iofuncs/region.c:805 ../libvips/iofuncs/region.c:1516
-msgid "valid clipped to nothing"
-msgstr ""
-
-#: ../libvips/iofuncs/region.c:702
-msgid "bad image type"
-msgstr ""
-
-#: ../libvips/iofuncs/region.c:747
-msgid "no pixel data on attached image"
-msgstr ""
-
-#: ../libvips/iofuncs/region.c:753
-msgid "images do not match in pixel size"
-msgstr ""
-
-#: ../libvips/iofuncs/region.c:786 ../libvips/iofuncs/region.c:1498
-msgid "dest too small"
-msgstr ""
-
-#: ../libvips/iofuncs/region.c:875
-msgid "bad position"
-msgstr ""
-
-#: ../libvips/iofuncs/region.c:1291
-msgid "stop requested"
-msgstr ""
-
-#: ../libvips/iofuncs/region.c:1376 ../libvips/iofuncs/region.c:1569
-#, c-format
-msgid "unable to input from a %s image"
-msgstr ""
-
-#: ../libvips/iofuncs/region.c:1400
-msgid "incomplete header"
-msgstr ""
-
-#: ../libvips/iofuncs/region.c:1472
-msgid "inappropriate region type"
-msgstr ""
-
-#: ../libvips/iofuncs/vips.c:306
-#, c-format
-msgid "\"%s\" is not a VIPS image"
-msgstr ""
-
-#: ../libvips/iofuncs/vips.c:406
-msgid "unable to read history"
-msgstr ""
-
-#: ../libvips/iofuncs/vips.c:439
-msgid "more than a 10 megabytes of XML? sufferin' succotash!"
-msgstr ""
-
-#: ../libvips/iofuncs/vips.c:487
-msgid "incorrect namespace in XML"
-msgstr ""
-
-#: ../libvips/iofuncs/vips.c:611
-msgid "error transforming from save format"
-msgstr ""
-
-#: ../libvips/iofuncs/vips.c:760
-msgid "error transforming to save format"
-msgstr ""
-
-#: ../libvips/iofuncs/vips.c:904
-#, c-format
-msgid "unable to read header for \"%s\""
-msgstr ""
-
-#: ../libvips/iofuncs/vips.c:930
-#, c-format
-msgid "error reading XML: %s"
-msgstr ""
-
-#: ../libvips/iofuncs/error.c:287
-msgid "windows error"
-msgstr ""
-
-#: ../libvips/iofuncs/error.c:296
-msgid "unix error"
-msgstr ""
-
-#: ../libvips/iofuncs/error.c:447
-msgid "image must be uncoded"
-msgstr ""
-
-#: ../libvips/iofuncs/error.c:475
-msgid "image coding must be 'none' or 'labq'"
-msgstr ""
-
-#: ../libvips/iofuncs/error.c:503
-msgid "unknown image coding"
-msgstr ""
-
-#: ../libvips/iofuncs/error.c:528
-#, c-format
-msgid "coding '%s' only"
-msgstr ""
-
-#: ../libvips/iofuncs/error.c:553
-msgid "image must one band"
-msgstr ""
-
-#: ../libvips/iofuncs/error.c:578
-#, c-format
-msgid "image must have %d bands"
-msgstr ""
-
-#: ../libvips/iofuncs/error.c:603
-msgid "image must have one or three bands"
-msgstr ""
-
-#: ../libvips/iofuncs/error.c:629
-#, c-format
-msgid "image must have at least %d bands"
-msgstr ""
-
-#: ../libvips/iofuncs/error.c:657
-msgid "images must have the same number of bands, or one must be single-band"
-msgstr ""
-
-#: ../libvips/iofuncs/error.c:684
-#, c-format
-msgid "image must have 1 or %d bands"
-msgstr ""
-
-#: ../libvips/iofuncs/error.c:708
-msgid "image must be non-complex"
-msgstr ""
-
-#: ../libvips/iofuncs/error.c:732
-msgid "image must be complex"
-msgstr ""
-
-#: ../libvips/iofuncs/error.c:759
-msgid "image must be two-band or complex"
-msgstr ""
-
-#: ../libvips/iofuncs/error.c:785
-#, c-format
-msgid "image must be %s"
-msgstr ""
-
-#: ../libvips/iofuncs/error.c:810
-msgid "image must be integer"
-msgstr ""
-
-#: ../libvips/iofuncs/error.c:835
-msgid "image must be unsigned integer"
-msgstr ""
-
-#: ../libvips/iofuncs/error.c:863
-msgid "image must be 8- or 16-bit integer, signed or unsigned"
-msgstr ""
-
-#: ../libvips/iofuncs/error.c:890
-msgid "image must be 8- or 16-bit unsigned integer"
-msgstr ""
-
-#: ../libvips/iofuncs/error.c:916
-msgid "image must be 8- or 16-bit unsigned integer, or float"
-msgstr ""
-
-#: ../libvips/iofuncs/error.c:944
-msgid "image must be unsigned int or float"
-msgstr ""
-
-#: ../libvips/iofuncs/error.c:969
-msgid "images must match in size"
-msgstr ""
-
-#: ../libvips/iofuncs/error.c:995
-msgid "images must be odd and square"
-msgstr ""
-
-#: ../libvips/iofuncs/error.c:1021
-msgid "images must have the same number of bands"
-msgstr ""
-
-#: ../libvips/iofuncs/error.c:1075
-msgid "images must have the same band format"
-msgstr ""
-
-#: ../libvips/iofuncs/error.c:1101
-msgid "images must have the same coding"
-msgstr ""
-
-#: ../libvips/iofuncs/error.c:1124
-#, c-format
-msgid "vector must have %d elements"
-msgstr ""
-
-#: ../libvips/iofuncs/error.c:1149
-#, c-format
-msgid "vector must have 1 or %d elements"
-msgstr ""
-
-#: ../libvips/iofuncs/error.c:1174
-msgid "histograms must have width or height 1"
-msgstr ""
-
-#: ../libvips/iofuncs/error.c:1179
-msgid "histograms must have not have more than 65536 elements"
-msgstr ""
-
-#: ../libvips/iofuncs/error.c:1216
-msgid "matrix image too large"
-msgstr ""
-
-#: ../libvips/iofuncs/error.c:1221
-msgid "matrix image must have one band"
-msgstr ""
-
-#: ../libvips/iofuncs/error.c:1255
-msgid "separable matrix images must have width or height 1"
-msgstr ""
-
-#: ../libvips/iofuncs/error.c:1282
-msgid "precision must be int or float"
-msgstr ""
-
-#: ../libvips/iofuncs/util.c:518
-msgid "unable to get file stats"
-msgstr ""
-
-#: ../libvips/iofuncs/util.c:674
-#, c-format
-msgid "unable to open file \"%s\" for reading"
-msgstr ""
-
-#: ../libvips/iofuncs/util.c:696
-#, c-format
-msgid "unable to open file \"%s\" for writing"
-msgstr ""
-
-#: ../libvips/iofuncs/util.c:718
-#, c-format
-msgid "\"%s\" too long"
-msgstr ""
-
-#: ../libvips/iofuncs/util.c:765
-#, c-format
-msgid "error reading from file \"%s\""
-msgstr ""
-
-#: ../libvips/iofuncs/util.c:812
-#, c-format
-msgid "write error (%zd out of %zd blocks written)"
-msgstr ""
-
-#: ../libvips/iofuncs/util.c:1084 ../libvips/iofuncs/util.c:1091
-msgid "unable to truncate"
-msgstr ""
-
-#: ../libvips/iofuncs/util.c:1167
+#: libvips/foreign/analyzeload.c:141 libvips/foreign/cgifsave.c:1058
+#: libvips/foreign/csvload.c:590 libvips/foreign/csvsave.c:274
+#: libvips/foreign/dzsave.c:2597 libvips/foreign/fitsload.c:259
+#: libvips/foreign/fitssave.c:143 libvips/foreign/heifload.c:1271
+#: libvips/foreign/heifsave.c:897 libvips/foreign/jp2kload.c:1309
+#: libvips/foreign/jp2ksave.c:1063 libvips/foreign/jpegload.c:354
+#: libvips/foreign/jpegsave.c:361 libvips/foreign/jxlload.c:1218
+#: libvips/foreign/jxlsave.c:897 libvips/foreign/magick6load.c:238
+#: libvips/foreign/magick7load.c:851 libvips/foreign/matload.c:138
+#: libvips/foreign/matrixload.c:374 libvips/foreign/matrixsave.c:228
+#: libvips/foreign/niftiload.c:713 libvips/foreign/niftisave.c:441
+#: libvips/foreign/nsgifload.c:765 libvips/foreign/openexrload.c:149
+#: libvips/foreign/openslideload.c:1152 libvips/foreign/pdfiumload.c:812
+#: libvips/foreign/pngload.c:318 libvips/foreign/pngsave.c:378
+#: libvips/foreign/popplerload.c:689 libvips/foreign/ppmload.c:829
+#: libvips/foreign/ppmsave.c:592 libvips/foreign/radload.c:281
+#: libvips/foreign/radsave.c:154 libvips/foreign/rawload.c:139
+#: libvips/foreign/rawsave.c:196 libvips/foreign/spngload.c:835
+#: libvips/foreign/spngsave.c:858 libvips/foreign/svgload.c:929
+#: libvips/foreign/tiffload.c:382 libvips/foreign/tiffsave.c:527
+#: libvips/foreign/vips2magick.c:578 libvips/foreign/vipsload.c:236
+#: libvips/foreign/vipssave.c:197 libvips/foreign/webpload.c:346
+#: libvips/foreign/webpsave.c:1038 libvips/iofuncs/connection.c:133
+#: libvips/iofuncs/image.c:1172 libvips/resample/thumbnail.c:1198
+msgid "Filename"
+msgstr ""
+
+#: libvips/foreign/analyzeload.c:142 libvips/foreign/csvload.c:591
+#: libvips/foreign/fitsload.c:260 libvips/foreign/heifload.c:1272
+#: libvips/foreign/jp2kload.c:1310 libvips/foreign/jpegload.c:355
+#: libvips/foreign/jxlload.c:1219 libvips/foreign/magick6load.c:239
+#: libvips/foreign/magick7load.c:852 libvips/foreign/matload.c:139
+#: libvips/foreign/matrixload.c:375 libvips/foreign/niftiload.c:714
+#: libvips/foreign/nsgifload.c:766 libvips/foreign/openexrload.c:150
+#: libvips/foreign/openslideload.c:1153 libvips/foreign/pdfiumload.c:813
+#: libvips/foreign/pngload.c:319 libvips/foreign/popplerload.c:690
+#: libvips/foreign/ppmload.c:830 libvips/foreign/radload.c:282
+#: libvips/foreign/rawload.c:140 libvips/foreign/spngload.c:836
+#: libvips/foreign/svgload.c:930 libvips/foreign/tiffload.c:383
+#: libvips/foreign/vipsload.c:237 libvips/foreign/webpload.c:347
+msgid "Filename to load from"
+msgstr ""
+
+#: libvips/foreign/archive.c:138
+msgid "unable to create archive"
+msgstr ""
+
+#: libvips/foreign/archive.c:146
+msgid "unable to set zip format"
+msgstr ""
+
+#: libvips/foreign/archive.c:163
+msgid "unable to set compression"
+msgstr ""
+
+#: libvips/foreign/archive.c:175
+msgid "unable to set padding"
+msgstr ""
+
+#: libvips/foreign/archive.c:184 libvips/iofuncs/target.c:129
+msgid "unable to open for write"
+msgstr ""
+
+#: libvips/foreign/archive.c:205 libvips/iofuncs/util.c:1097
 #, c-format
 msgid "unable to create directory \"%s\", %s"
 msgstr ""
 
-#: ../libvips/iofuncs/util.c:1191
+#: libvips/foreign/archive.c:240
+msgid "unable to create entry"
+msgstr ""
+
+#: libvips/foreign/archive.c:256
+msgid "unable to write header"
+msgstr ""
+
+#: libvips/foreign/archive.c:265
+msgid "unable to write data"
+msgstr ""
+
+#: libvips/foreign/cgifsave.c:407 libvips/foreign/cgifsave.c:833
+#: libvips/foreign/quantise.c:403 libvips/foreign/quantise.c:423
+msgid "quantisation failed"
+msgstr ""
+
+#: libvips/foreign/cgifsave.c:587
+msgid "dither failed"
+msgstr ""
+
+#: libvips/foreign/cgifsave.c:772
+msgid "frame too large"
+msgstr ""
+
+#: libvips/foreign/cgifsave.c:811
+msgid "gif-palette too large"
+msgstr ""
+
+#: libvips/foreign/cgifsave.c:884
+msgid "save as gif"
+msgstr ""
+
+#: libvips/foreign/cgifsave.c:893 libvips/foreign/pngsave.c:247
+#: libvips/foreign/spngsave.c:725
+msgid "Dithering"
+msgstr ""
+
+#: libvips/foreign/cgifsave.c:894 libvips/foreign/pngsave.c:248
+#: libvips/foreign/spngsave.c:726
+msgid "Amount of dithering"
+msgstr ""
+
+#: libvips/foreign/cgifsave.c:900 libvips/foreign/heifsave.c:803
+#: libvips/foreign/jxlsave.c:824 libvips/foreign/pngsave.c:261
+#: libvips/foreign/spngsave.c:739 libvips/foreign/webpsave.c:890
+msgid "Effort"
+msgstr ""
+
+#: libvips/foreign/cgifsave.c:901
+msgid "Quantisation effort"
+msgstr ""
+
+#: libvips/foreign/cgifsave.c:907 libvips/foreign/heifsave.c:781
+#: libvips/foreign/pngsave.c:254 libvips/foreign/ppmsave.c:521
+#: libvips/foreign/spngsave.c:732 libvips/foreign/tiffsave.c:315
+#: libvips/foreign/vips2magick.c:510
+msgid "Bit depth"
+msgstr ""
+
+#: libvips/foreign/cgifsave.c:908 libvips/foreign/heifsave.c:782
+#: libvips/foreign/vips2magick.c:511
+msgid "Number of bits per pixel"
+msgstr ""
+
+#: libvips/foreign/cgifsave.c:914
+msgid "Maximum inter-frame error"
+msgstr ""
+
+#: libvips/foreign/cgifsave.c:915
+msgid "Maximum inter-frame error for transparency"
+msgstr ""
+
+#: libvips/foreign/cgifsave.c:921
+msgid "Reuse palette"
+msgstr ""
+
+#: libvips/foreign/cgifsave.c:922
+msgid "Reuse palette from input"
+msgstr ""
+
+#: libvips/foreign/cgifsave.c:928
+msgid "Maximum inter-palette error"
+msgstr ""
+
+#: libvips/foreign/cgifsave.c:929
+msgid "Maximum inter-palette error for palette reusage"
+msgstr ""
+
+#: libvips/foreign/cgifsave.c:935
+msgid "Interlaced"
+msgstr ""
+
+#: libvips/foreign/cgifsave.c:936
+msgid "Generate an interlaced (progressive) GIF"
+msgstr ""
+
+#: libvips/foreign/cgifsave.c:945
+msgid "Reoptimise palettes"
+msgstr ""
+
+#: libvips/foreign/cgifsave.c:946
+msgid "Reoptimise colour palettes"
+msgstr ""
+
+#: libvips/foreign/cgifsave.c:952
+msgid "Keep duplicate frames"
+msgstr ""
+
+#: libvips/foreign/cgifsave.c:953
+msgid "Keep duplicate frames in the output instead of combining them"
+msgstr ""
+
+#: libvips/foreign/cgifsave.c:1010 libvips/foreign/csvsave.c:325
+#: libvips/foreign/dzsave.c:2537 libvips/foreign/heifsave.c:1020
+#: libvips/foreign/jp2ksave.c:1182 libvips/foreign/jpegsave.c:292
+#: libvips/foreign/jxlsave.c:1016 libvips/foreign/matrixsave.c:281
+#: libvips/foreign/pngsave.c:326 libvips/foreign/ppmsave.c:648
+#: libvips/foreign/radsave.c:207 libvips/foreign/rawsave.c:252
+#: libvips/foreign/spngsave.c:805 libvips/foreign/tiffsave.c:474
+#: libvips/foreign/vipssave.c:253 libvips/foreign/webpsave.c:987
+#: libvips/iofuncs/target.c:283
+msgid "Target"
+msgstr ""
+
+#: libvips/foreign/cgifsave.c:1011 libvips/foreign/csvsave.c:326
+#: libvips/foreign/dzsave.c:2538 libvips/foreign/heifsave.c:1021
+#: libvips/foreign/jp2ksave.c:1183 libvips/foreign/jpegsave.c:293
+#: libvips/foreign/jxlsave.c:1017 libvips/foreign/matrixsave.c:282
+#: libvips/foreign/pngsave.c:327 libvips/foreign/ppmsave.c:649
+#: libvips/foreign/radsave.c:208 libvips/foreign/rawsave.c:253
+#: libvips/foreign/spngsave.c:806 libvips/foreign/tiffsave.c:475
+#: libvips/foreign/vipssave.c:254 libvips/foreign/webpsave.c:988
+msgid "Target to save to"
+msgstr ""
+
+#: libvips/foreign/cgifsave.c:1059 libvips/foreign/csvsave.c:275
+#: libvips/foreign/dzsave.c:2598 libvips/foreign/fitssave.c:144
+#: libvips/foreign/heifsave.c:898 libvips/foreign/jp2ksave.c:1064
+#: libvips/foreign/jpegsave.c:362 libvips/foreign/jxlsave.c:898
+#: libvips/foreign/matrixsave.c:229 libvips/foreign/niftisave.c:442
+#: libvips/foreign/pngsave.c:379 libvips/foreign/ppmsave.c:593
+#: libvips/foreign/radsave.c:155 libvips/foreign/rawsave.c:197
+#: libvips/foreign/spngsave.c:859 libvips/foreign/tiffsave.c:528
+#: libvips/foreign/vips2magick.c:579 libvips/foreign/vipssave.c:198
+#: libvips/foreign/webpsave.c:1039
+msgid "Filename to save to"
+msgstr ""
+
+#: libvips/foreign/cgifsave.c:1117 libvips/foreign/dzsave.c:2656
+#: libvips/foreign/heifload.c:1340 libvips/foreign/heifsave.c:962
+#: libvips/foreign/jp2kload.c:1385 libvips/foreign/jp2ksave.c:1126
+#: libvips/foreign/jpegload.c:430 libvips/foreign/jpegsave.c:439
+#: libvips/foreign/jxlload.c:1293 libvips/foreign/jxlsave.c:960
+#: libvips/foreign/magick6load.c:313 libvips/foreign/magick7load.c:932
+#: libvips/foreign/nsgifload.c:843 libvips/foreign/pdfiumload.c:872
+#: libvips/foreign/pngload.c:394 libvips/foreign/pngsave.c:437
+#: libvips/foreign/popplerload.c:749 libvips/foreign/radload.c:356
+#: libvips/foreign/radsave.c:273 libvips/foreign/rawsave.c:314
+#: libvips/foreign/spngload.c:911 libvips/foreign/spngsave.c:918
+#: libvips/foreign/svgload.c:997 libvips/foreign/tiffload.c:460
+#: libvips/foreign/tiffsave.c:588 libvips/foreign/vips2magick.c:650
+#: libvips/foreign/webpload.c:424 libvips/foreign/webpsave.c:1096
+#: libvips/resample/thumbnail.c:1445
+msgid "Buffer"
+msgstr ""
+
+#: libvips/foreign/cgifsave.c:1118 libvips/foreign/dzsave.c:2657
+#: libvips/foreign/heifsave.c:963 libvips/foreign/jp2ksave.c:1127
+#: libvips/foreign/jpegsave.c:440 libvips/foreign/jxlsave.c:961
+#: libvips/foreign/pngsave.c:438 libvips/foreign/radsave.c:274
+#: libvips/foreign/rawsave.c:315 libvips/foreign/spngsave.c:919
+#: libvips/foreign/tiffsave.c:589 libvips/foreign/vips2magick.c:651
+#: libvips/foreign/webpsave.c:1097
+msgid "Buffer to save to"
+msgstr ""
+
+#: libvips/foreign/csvload.c:301
 #, c-format
-msgid "unable to remove directory \"%s\", %s"
+msgid "bad number, line %d, column %d"
 msgstr ""
 
-#: ../libvips/iofuncs/util.c:1208
+#: libvips/foreign/csvload.c:341 libvips/foreign/csvload.c:402
+#: libvips/foreign/csvload.c:434
+msgid "unexpected end of file"
+msgstr ""
+
+#: libvips/foreign/csvload.c:440
 #, c-format
-msgid "unable to rename file \"%s\" as \"%s\", %s"
+msgid "line %d has only %d columns"
 msgstr ""
 
-#: ../libvips/iofuncs/util.c:1348
-msgid "unexpected end of string"
+#: libvips/foreign/csvload.c:479
+msgid "load csv"
 msgstr ""
 
-#: ../libvips/iofuncs/util.c:1366 ../libvips/iofuncs/util.c:1436
+#: libvips/foreign/csvload.c:492
+msgid "Skip"
+msgstr ""
+
+#: libvips/foreign/csvload.c:493
+msgid "Skip this many lines at the start of the file"
+msgstr ""
+
+#: libvips/foreign/csvload.c:499
+msgid "Lines"
+msgstr ""
+
+#: libvips/foreign/csvload.c:500
+msgid "Read this many lines from the file"
+msgstr ""
+
+#: libvips/foreign/csvload.c:506
+msgid "Whitespace"
+msgstr ""
+
+#: libvips/foreign/csvload.c:507
+msgid "Set of whitespace characters"
+msgstr ""
+
+#: libvips/foreign/csvload.c:513 libvips/foreign/csvsave.c:223
+msgid "Separator"
+msgstr ""
+
+#: libvips/foreign/csvload.c:514
+msgid "Set of separator characters"
+msgstr ""
+
+#: libvips/foreign/csvload.c:661 libvips/foreign/fitsload.c:338
+#: libvips/foreign/heifload.c:1414 libvips/foreign/jp2kload.c:1448
+#: libvips/foreign/jpegload.c:278 libvips/foreign/jxlload.c:1357
+#: libvips/foreign/matrixload.c:462 libvips/foreign/niftiload.c:792
+#: libvips/foreign/nsgifload.c:909 libvips/foreign/openslideload.c:1230
+#: libvips/foreign/pdfiumload.c:932 libvips/foreign/pngload.c:242
+#: libvips/foreign/popplerload.c:809 libvips/foreign/ppmload.c:890
+#: libvips/foreign/radload.c:205 libvips/foreign/spngload.c:757
+#: libvips/foreign/svgload.c:836 libvips/foreign/tiffload.c:302
+#: libvips/foreign/vipsload.c:312 libvips/foreign/webpload.c:266
+#: libvips/resample/thumbnail.c:1658
+msgid "Source"
+msgstr ""
+
+#: libvips/foreign/csvload.c:662 libvips/foreign/fitsload.c:339
+#: libvips/foreign/heifload.c:1415 libvips/foreign/jp2kload.c:1449
+#: libvips/foreign/jpegload.c:279 libvips/foreign/jxlload.c:1358
+#: libvips/foreign/matrixload.c:463 libvips/foreign/niftiload.c:793
+#: libvips/foreign/nsgifload.c:910 libvips/foreign/openslideload.c:1231
+#: libvips/foreign/pdfiumload.c:933 libvips/foreign/pngload.c:243
+#: libvips/foreign/popplerload.c:810 libvips/foreign/ppmload.c:891
+#: libvips/foreign/radload.c:206 libvips/foreign/spngload.c:758
+#: libvips/foreign/svgload.c:837 libvips/foreign/tiffload.c:303
+#: libvips/foreign/vipsload.c:313 libvips/foreign/webpload.c:267
+#: libvips/iofuncs/sbuf.c:89 libvips/resample/thumbnail.c:1659
+msgid "Source to load from"
+msgstr ""
+
+#: libvips/foreign/csvsave.c:215
+msgid "save image to csv"
+msgstr ""
+
+#: libvips/foreign/csvsave.c:224
+msgid "Separator characters"
+msgstr ""
+
+#: libvips/foreign/dzsave.c:2008
+msgid "overlap too large"
+msgstr ""
+
+#: libvips/foreign/dzsave.c:2319
+msgid "save image to deep zoom format"
+msgstr ""
+
+#: libvips/foreign/dzsave.c:2329 libvips/foreign/dzsave.c:2330
+msgid "Image name"
+msgstr ""
+
+#: libvips/foreign/dzsave.c:2336
+msgid "Layout"
+msgstr ""
+
+#: libvips/foreign/dzsave.c:2337
+msgid "Directory layout"
+msgstr ""
+
+#: libvips/foreign/dzsave.c:2343
+msgid "Suffix"
+msgstr ""
+
+#: libvips/foreign/dzsave.c:2344
+msgid "Filename suffix for tiles"
+msgstr ""
+
+#: libvips/foreign/dzsave.c:2350
+msgid "Overlap"
+msgstr ""
+
+#: libvips/foreign/dzsave.c:2351
+msgid "Tile overlap in pixels"
+msgstr ""
+
+#: libvips/foreign/dzsave.c:2357
+msgid "Tile size"
+msgstr ""
+
+#: libvips/foreign/dzsave.c:2358
+msgid "Tile size in pixels"
+msgstr ""
+
+#: libvips/foreign/dzsave.c:2365 libvips/foreign/tiffsave.c:379
+msgid "Pyramid depth"
+msgstr ""
+
+#: libvips/foreign/dzsave.c:2371
+msgid "Center"
+msgstr ""
+
+#: libvips/foreign/dzsave.c:2372
+msgid "Center image in tile"
+msgstr ""
+
+#: libvips/foreign/dzsave.c:2379
+msgid "Rotate image during save"
+msgstr ""
+
+#: libvips/foreign/dzsave.c:2385
+msgid "Container"
+msgstr ""
+
+#: libvips/foreign/dzsave.c:2386
+msgid "Pyramid container type"
+msgstr ""
+
+#: libvips/foreign/dzsave.c:2392 libvips/foreign/heifsave.c:795
+#: libvips/foreign/pngsave.c:211 libvips/foreign/spngsave.c:689
+#: libvips/foreign/tiffsave.c:257
+msgid "Compression"
+msgstr ""
+
+#: libvips/foreign/dzsave.c:2393
+msgid "ZIP deflate compression level"
+msgstr ""
+
+#: libvips/foreign/dzsave.c:2399 libvips/foreign/tiffsave.c:357
+msgid "Region shrink"
+msgstr ""
+
+#: libvips/foreign/dzsave.c:2400 libvips/foreign/tiffsave.c:358
+msgid "Method to shrink regions"
+msgstr ""
+
+#: libvips/foreign/dzsave.c:2406
+msgid "Skip blanks"
+msgstr ""
+
+#: libvips/foreign/dzsave.c:2407
+msgid "Skip tiles which are nearly equal to the background"
+msgstr ""
+
+#: libvips/foreign/dzsave.c:2413
+msgid "id"
+msgstr ""
+
+#: libvips/foreign/dzsave.c:2414
+msgid "Resource ID"
+msgstr ""
+
+#: libvips/foreign/dzsave.c:2420 libvips/foreign/heifsave.c:774
+#: libvips/foreign/jp2ksave.c:1000 libvips/foreign/jpegsave.c:164
+#: libvips/foreign/jxlsave.c:838 libvips/foreign/tiffsave.c:265
+#: libvips/foreign/webpsave.c:826
+msgid "Q"
+msgstr ""
+
+#: libvips/foreign/dzsave.c:2421 libvips/foreign/heifsave.c:775
+#: libvips/foreign/jp2ksave.c:1001 libvips/foreign/jpegsave.c:165
+#: libvips/foreign/tiffsave.c:266 libvips/foreign/webpsave.c:827
+msgid "Q factor"
+msgstr ""
+
+#: libvips/foreign/dzsave.c:2430
+msgid "No strip"
+msgstr ""
+
+#: libvips/foreign/dzsave.c:2431
+msgid "Don't strip tile metadata"
+msgstr ""
+
+#: libvips/foreign/dzsave.c:2437
+msgid "Base name"
+msgstr ""
+
+#: libvips/foreign/dzsave.c:2438
+msgid "Base name to save to"
+msgstr ""
+
+#: libvips/foreign/dzsave.c:2444
+msgid "Directory name"
+msgstr ""
+
+#: libvips/foreign/dzsave.c:2445
+msgid "Directory name to save to"
+msgstr ""
+
+#: libvips/foreign/dzsave.c:2465 libvips/foreign/tiffsave.c:350
+msgid "Properties"
+msgstr ""
+
+#: libvips/foreign/dzsave.c:2466
+msgid "Write a properties file to the output directory"
+msgstr ""
+
+#: libvips/foreign/dzsave.c:2533
+msgid "save image to deepzoom target"
+msgstr ""
+
+#: libvips/foreign/dzsave.c:2593
+msgid "save image to deepzoom file"
+msgstr ""
+
+#: libvips/foreign/dzsave.c:2652
+msgid "save image to dz buffer"
+msgstr ""
+
+#: libvips/foreign/exif.c:199
+msgid "exif too small"
+msgstr ""
+
+#: libvips/foreign/exif.c:203
+msgid "exif too large"
+msgstr ""
+
+#: libvips/foreign/exif.c:208
+msgid "unable to init exif"
+msgstr ""
+
+#: libvips/foreign/exif.c:1260 libvips/foreign/exif.c:1270
+#: libvips/foreign/exif.c:1279 libvips/foreign/exif.c:1319
 #, c-format
-msgid "expected %s, saw %s"
+msgid "bad exif meta \"%s\""
 msgstr ""
 
-#: ../libvips/iofuncs/util.c:1750
-msgid "no such enum type"
+#: libvips/foreign/exif.c:1496
+msgid "error saving EXIF"
 msgstr ""
 
-#: ../libvips/iofuncs/util.c:1768
+#: libvips/foreign/fits.c:184 libvips/foreign/matlab.c:113
+#: libvips/iofuncs/vips.c:159 libvips/mosaicing/global_balance.c:1240
+#: libvips/mosaicing/global_balance.c:1690
 #, c-format
-msgid "enum '%s' has no member '%s', should be one of: %s"
+msgid "unable to open \"%s\""
 msgstr ""
 
-#: ../libvips/iofuncs/util.c:1786
-msgid "no such flag type"
+#: libvips/foreign/fits.c:237
+msgid "no HDU found with naxes > 0"
 msgstr ""
 
-#: ../libvips/iofuncs/util.c:1802
+#: libvips/foreign/fits.c:275
+msgid "dimensions above 3 must be size 1"
+msgstr ""
+
+#: libvips/foreign/fits.c:290
 #, c-format
-msgid "flags '%s' has no member '%s', should be one of: %s"
+msgid "bad number of axis %d"
 msgstr ""
 
-#: ../libvips/iofuncs/util.c:1889
-msgid "unable to form filename"
-msgstr ""
-
-#: ../libvips/iofuncs/sinkscreen.c:188
-msgid "per-thread state for render"
-msgstr ""
-
-#: ../libvips/iofuncs/sinkscreen.c:1088
-msgid "bad parameters"
-msgstr ""
-
-#: ../libvips/iofuncs/object.c:316
+#: libvips/foreign/fits.c:301
 #, c-format
-msgid "parameter %s not set"
+msgid "unsupported bitpix %d\n"
 msgstr ""
 
-#: ../libvips/iofuncs/object.c:751
+#: libvips/foreign/fits.c:586 libvips/iofuncs/vips.c:222
 #, c-format
-msgid "no property named `%s'"
+msgid "unable to write to \"%s\""
 msgstr ""
 
-#: ../libvips/iofuncs/object.c:759
+#: libvips/foreign/fits.c:729
 #, c-format
-msgid "no vips argument named `%s'"
+msgid "unsupported BandFmt %d\n"
 msgstr ""
 
-#: ../libvips/iofuncs/object.c:765
+#: libvips/foreign/fitsload.c:101 libvips/foreign/niftiload.c:130
+#: libvips/foreign/openslideload.c:916
+msgid "no filename available"
+msgstr ""
+
+#: libvips/foreign/fitsload.c:183
+msgid "FITS loader base class"
+msgstr ""
+
+#: libvips/foreign/fitsload.c:251
+msgid "load a FITS image"
+msgstr ""
+
+#: libvips/foreign/fitsload.c:329
+msgid "load FITS from a source"
+msgstr ""
+
+#: libvips/foreign/fitssave.c:129
+msgid "save image to fits file"
+msgstr ""
+
+#: libvips/foreign/foreign.c:408
+msgid "load and save image files"
+msgstr ""
+
+#: libvips/foreign/foreign.c:607
 #, c-format
-msgid "argument `%s' has no instance"
+msgid "file \"%s\" does not exist"
 msgstr ""
 
-#: ../libvips/iofuncs/object.c:1561
-msgid "base class"
-msgstr ""
-
-#: ../libvips/iofuncs/object.c:1575
-msgid "Nickname"
-msgstr ""
-
-#: ../libvips/iofuncs/object.c:1576
-msgid "Class nickname"
-msgstr ""
-
-#: ../libvips/iofuncs/object.c:1582
-msgid "Description"
-msgstr ""
-
-#: ../libvips/iofuncs/object.c:1583
-msgid "Class description"
-msgstr ""
-
-#: ../libvips/iofuncs/object.c:1781
+#: libvips/foreign/foreign.c:612
 #, c-format
-msgid "no value supplied for argument '%s'"
+msgid "\"%s\" is a directory"
 msgstr ""
 
-#: ../libvips/iofuncs/object.c:1784
+#: libvips/foreign/foreign.c:621 libvips/foreign/foreign.c:2003
 #, c-format
-msgid "no value supplied for argument '%s' ('%s')"
+msgid "\"%s\" is not a known file format"
 msgstr ""
 
-#: ../libvips/iofuncs/object.c:1942 ../libvips/iofuncs/object.c:1961
-#: ../libvips/iofuncs/object.c:2014
+#: libvips/foreign/foreign.c:708
+msgid "buffer is not in a known format"
+msgstr ""
+
+#: libvips/foreign/foreign.c:769
+msgid "source is not in a known format"
+msgstr ""
+
+#: libvips/foreign/foreign.c:979
+msgid "images do not match between header and load"
+msgstr ""
+
+#: libvips/foreign/foreign.c:1210
+msgid "loaders"
+msgstr ""
+
+#: libvips/foreign/foreign.c:1221
+msgid "Flags"
+msgstr ""
+
+#: libvips/foreign/foreign.c:1222
+msgid "Flags for this file"
+msgstr ""
+
+#: libvips/foreign/foreign.c:1228 libvips/iofuncs/target.c:294
+msgid "Memory"
+msgstr ""
+
+#: libvips/foreign/foreign.c:1229
+msgid "Force open via memory"
+msgstr ""
+
+#: libvips/foreign/foreign.c:1236
+msgid "Required access pattern for this file"
+msgstr ""
+
+#: libvips/foreign/foreign.c:1242 libvips/resample/thumbnail.c:1037
+msgid "Fail on"
+msgstr ""
+
+#: libvips/foreign/foreign.c:1243 libvips/resample/thumbnail.c:1038
+msgid "Error level to fail on"
+msgstr ""
+
+#: libvips/foreign/foreign.c:1249
+msgid "Revalidate"
+msgstr ""
+
+#: libvips/foreign/foreign.c:1250
+msgid "Don't use a cached result for this operation"
+msgstr ""
+
+#: libvips/foreign/foreign.c:1256
+msgid "Sequential"
+msgstr ""
+
+#: libvips/foreign/foreign.c:1257
+msgid "Sequential read only"
+msgstr ""
+
+#: libvips/foreign/foreign.c:1263
+msgid "Fail"
+msgstr ""
+
+#: libvips/foreign/foreign.c:1264
+msgid "Fail on first warning"
+msgstr ""
+
+#: libvips/foreign/foreign.c:1270
+msgid "Disc"
+msgstr ""
+
+#: libvips/foreign/foreign.c:1271
+msgid "Open to disc"
+msgstr ""
+
+#: libvips/foreign/foreign.c:1871
+msgid "savers"
+msgstr ""
+
+#: libvips/foreign/foreign.c:1895
+msgid "Image to save"
+msgstr ""
+
+#: libvips/foreign/foreign.c:1900
+msgid "Keep"
+msgstr ""
+
+#: libvips/foreign/foreign.c:1901
+msgid "Which metadata to retain"
+msgstr ""
+
+#: libvips/foreign/foreign.c:1916
+msgid "Set page height for multipage save"
+msgstr ""
+
+#: libvips/foreign/foreign.c:1923
+msgid "Filename of ICC profile to embed"
+msgstr ""
+
+#: libvips/foreign/foreign.c:1929
+msgid "Strip"
+msgstr ""
+
+#: libvips/foreign/foreign.c:1930
+msgid "Strip all metadata from image"
+msgstr ""
+
+#: libvips/foreign/foreign.c:2158
 #, c-format
-msgid "'%s' is not an integer"
+msgid "\"%s\" is not a known target format"
 msgstr ""
 
-#: ../libvips/iofuncs/object.c:1978
+#: libvips/foreign/foreign.c:2216
 #, c-format
-msgid "'%s' is not a double"
+msgid "\"%s\" is not a known buffer format"
 msgstr ""
 
-#: ../libvips/iofuncs/object.c:2293
+#: libvips/foreign/heifload.c:820 libvips/foreign/jxlload.c:753
+#: libvips/foreign/nsgifload.c:448 libvips/foreign/webp2vips.c:501
+msgid "bad page number"
+msgstr ""
+
+#: libvips/foreign/heifload.c:872
+msgid "undefined bits per pixel"
+msgstr ""
+
+#: libvips/foreign/heifload.c:884
+msgid "not all pages are the same size"
+msgstr ""
+
+#: libvips/foreign/heifload.c:983
+msgid "bad image dimensions on decode"
+msgstr ""
+
+#: libvips/foreign/heifload.c:990
+msgid "unable to get image data"
+msgstr ""
+
+#: libvips/foreign/heifload.c:1075
+msgid "load a HEIF image"
+msgstr ""
+
+#: libvips/foreign/heifload.c:1083 libvips/foreign/jp2kload.c:1229
+#: libvips/foreign/jxlload.c:1132 libvips/foreign/magick6load.c:141
+#: libvips/foreign/magick7load.c:382 libvips/foreign/nsgifload.c:620
+#: libvips/foreign/pdfiumload.c:695 libvips/foreign/popplerload.c:545
+#: libvips/foreign/tiffload.c:196 libvips/foreign/webpload.c:178
+msgid "Page"
+msgstr ""
+
+#: libvips/foreign/heifload.c:1084 libvips/foreign/jxlload.c:1133
+#: libvips/foreign/magick6load.c:142 libvips/foreign/magick7load.c:383
+#: libvips/foreign/nsgifload.c:621 libvips/foreign/pdfiumload.c:696
+#: libvips/foreign/popplerload.c:546 libvips/foreign/tiffload.c:197
+#: libvips/foreign/webpload.c:179
+msgid "First page to load"
+msgstr ""
+
+#: libvips/foreign/heifload.c:1091 libvips/foreign/jxlload.c:1140
+#: libvips/foreign/magick6load.c:149 libvips/foreign/magick7load.c:390
+#: libvips/foreign/nsgifload.c:628 libvips/foreign/pdfiumload.c:703
+#: libvips/foreign/popplerload.c:553 libvips/foreign/tiffload.c:204
+#: libvips/foreign/webpload.c:186
+msgid "Number of pages to load, -1 for all"
+msgstr ""
+
+#: libvips/foreign/heifload.c:1097
+msgid "Thumbnail"
+msgstr ""
+
+#: libvips/foreign/heifload.c:1098
+msgid "Fetch thumbnail image"
+msgstr ""
+
+#: libvips/foreign/heifload.c:1104 libvips/foreign/jpegload.c:198
+#: libvips/foreign/tiffload.c:210
+msgid "Autorotate"
+msgstr ""
+
+#: libvips/foreign/heifload.c:1105 libvips/foreign/jpegload.c:199
+msgid "Rotate image using exif orientation"
+msgstr ""
+
+#: libvips/foreign/heifload.c:1112 libvips/foreign/jpegload.c:206
+#: libvips/foreign/pngload.c:171 libvips/foreign/spngload.c:678
+#: libvips/foreign/svgload.c:732 libvips/foreign/tiffload.c:225
+msgid "Unlimited"
+msgstr ""
+
+#: libvips/foreign/heifload.c:1113 libvips/foreign/jpegload.c:207
+#: libvips/foreign/pngload.c:172 libvips/foreign/spngload.c:679
+#: libvips/foreign/tiffload.c:226
+msgid "Remove all denial of service limits"
+msgstr ""
+
+#: libvips/foreign/heifload.c:1341 libvips/foreign/jp2kload.c:1386
+#: libvips/foreign/jpegload.c:431 libvips/foreign/jxlload.c:1294
+#: libvips/foreign/magick6load.c:314 libvips/foreign/magick7load.c:933
+#: libvips/foreign/nsgifload.c:844 libvips/foreign/pdfiumload.c:873
+#: libvips/foreign/pngload.c:395 libvips/foreign/popplerload.c:750
+#: libvips/foreign/radload.c:357 libvips/foreign/spngload.c:912
+#: libvips/foreign/svgload.c:998 libvips/foreign/tiffload.c:461
+#: libvips/foreign/webpload.c:425 libvips/resample/thumbnail.c:1446
+msgid "Buffer to load from"
+msgstr ""
+
+#: libvips/foreign/heifsave.c:441
+#, fuzzy
+msgid "unimplemented format conversion"
+msgstr "unimplemented output colour space 0x%x"
+
+#: libvips/foreign/heifsave.c:550
 #, c-format
-msgid "expected string or ), saw %s"
+msgid "%d-bit colour depth not supported"
 msgstr ""
 
-#: ../libvips/iofuncs/object.c:2336
+#: libvips/foreign/heifsave.c:583
+#, fuzzy
+msgid "Unsupported compression"
+msgstr "unsupported colour type"
+
+#: libvips/foreign/heifsave.c:767
+msgid "save image in HEIF format"
+msgstr ""
+
+#: libvips/foreign/heifsave.c:788 libvips/foreign/jp2ksave.c:985
+#: libvips/foreign/jxlsave.c:831 libvips/foreign/tiffsave.c:371
+#: libvips/foreign/webpsave.c:833
+msgid "Lossless"
+msgstr ""
+
+#: libvips/foreign/heifsave.c:789 libvips/foreign/jp2ksave.c:986
+#: libvips/foreign/jxlsave.c:832 libvips/foreign/webpsave.c:834
+msgid "Enable lossless compression"
+msgstr ""
+
+#: libvips/foreign/heifsave.c:796
+msgid "Compression format"
+msgstr ""
+
+#: libvips/foreign/heifsave.c:804 libvips/foreign/heifsave.c:819
+msgid "CPU effort"
+msgstr ""
+
+#: libvips/foreign/heifsave.c:810 libvips/foreign/jp2ksave.c:992
+#: libvips/foreign/jpegsave.c:220
+msgid "Subsample mode"
+msgstr ""
+
+#: libvips/foreign/heifsave.c:811 libvips/foreign/jp2ksave.c:993
+#: libvips/foreign/jpegsave.c:221
+msgid "Select chroma subsample operation mode"
+msgstr ""
+
+#: libvips/foreign/heifsave.c:818
+msgid "Speed"
+msgstr ""
+
+#: libvips/foreign/heifsave.c:825
+msgid "Encoder"
+msgstr ""
+
+#: libvips/foreign/heifsave.c:826
+msgid "Select encoder to use"
+msgstr ""
+
+#: libvips/foreign/heifsave.c:1047
+msgid "save image in AVIF format"
+msgstr ""
+
+#: libvips/foreign/jp2kload.c:235
+msgid "unable to create jp2k stream"
+msgstr ""
+
+#: libvips/foreign/jp2kload.c:548
+#, fuzzy, c-format
+msgid "unsupported colourspace %d"
+msgstr "unsupported colourspace %d"
+
+#: libvips/foreign/jp2kload.c:597
+msgid "too many image bands"
+msgstr ""
+
+#: libvips/foreign/jp2kload.c:601
+msgid "no image components"
+msgstr ""
+
+#: libvips/foreign/jp2kload.c:618
+msgid "components differ in geometry"
+msgstr ""
+
+#: libvips/foreign/jp2kload.c:625
+msgid "components differ in precision"
+msgstr ""
+
+#: libvips/foreign/jp2kload.c:996 libvips/foreign/jp2kload.c:1093
+msgid "decoded image does not match container"
+msgstr ""
+
+#: libvips/foreign/jp2kload.c:1217
+msgid "load JPEG2000 image"
+msgstr ""
+
+#: libvips/foreign/jp2kload.c:1230
+msgid "Load this page from the image"
+msgstr ""
+
+#: libvips/foreign/jp2kload.c:1600 libvips/foreign/jp2ksave.c:1434
+msgid "libvips built without JPEG2000 support"
+msgstr ""
+
+#: libvips/foreign/jp2ksave.c:818
+msgid "not an integer format"
+msgstr ""
+
+#: libvips/foreign/jp2ksave.c:963
+msgid "save image in JPEG2000 format"
+msgstr ""
+
+#: libvips/foreign/jpeg2vips.c:415
 #, c-format
-msgid "unable to set '%s'"
+msgid "read gave %ld warnings"
 msgstr ""
 
-#: ../libvips/iofuncs/object.c:2349
-msgid "not , or ) after parameter"
+#: libvips/foreign/jpeg2vips.c:886 libvips/foreign/spngload.c:529
+#: libvips/foreign/vipspng.c:723
+#, c-format
+msgid "out of order read at line %d"
 msgstr ""
 
-#: ../libvips/iofuncs/object.c:2356
-msgid "extra tokens after ')'"
+#: libvips/foreign/jpegload.c:116
+#, c-format
+msgid "bad shrink factor %d"
 msgstr ""
 
-#: ../libvips/iofuncs/buf.c:610
+#: libvips/foreign/jpegload.c:177
+msgid "load jpeg"
+msgstr ""
+
+#: libvips/foreign/jpegload.c:191 libvips/foreign/webpload.c:199
+msgid "Shrink"
+msgstr ""
+
+#: libvips/foreign/jpegload.c:192 libvips/foreign/webpload.c:200
+msgid "Shrink factor on load"
+msgstr ""
+
+#: libvips/foreign/jpegload.c:270
+msgid "load image from jpeg source"
+msgstr ""
+
+#: libvips/foreign/jpegload.c:346
+msgid "load jpeg from file"
+msgstr ""
+
+#: libvips/foreign/jpegload.c:424
+msgid "load jpeg from buffer"
+msgstr ""
+
+#: libvips/foreign/jpegsave.c:153
+msgid "save jpeg"
+msgstr ""
+
+#: libvips/foreign/jpegsave.c:171
+msgid "Optimize coding"
+msgstr ""
+
+#: libvips/foreign/jpegsave.c:172
+msgid "Compute optimal Huffman coding tables"
+msgstr ""
+
+#: libvips/foreign/jpegsave.c:178 libvips/foreign/pngsave.c:218
+#: libvips/foreign/spngsave.c:696
+msgid "Interlace"
+msgstr ""
+
+#: libvips/foreign/jpegsave.c:179
+msgid "Generate an interlaced (progressive) jpeg"
+msgstr ""
+
+#: libvips/foreign/jpegsave.c:185
+msgid "No subsample"
+msgstr ""
+
+#: libvips/foreign/jpegsave.c:186
+msgid "Disable chroma subsample"
+msgstr ""
+
+#: libvips/foreign/jpegsave.c:192
+msgid "Trellis quantisation"
+msgstr ""
+
+#: libvips/foreign/jpegsave.c:193
+msgid "Apply trellis quantisation to each 8x8 block"
+msgstr ""
+
+#: libvips/foreign/jpegsave.c:199
+msgid "Overshoot de-ringing"
+msgstr ""
+
+#: libvips/foreign/jpegsave.c:200
+msgid "Apply overshooting to samples with extreme values"
+msgstr ""
+
+#: libvips/foreign/jpegsave.c:206
+msgid "Optimize scans"
+msgstr ""
+
+#: libvips/foreign/jpegsave.c:207
+msgid "Split spectrum of DCT coefficients into separate scans"
+msgstr ""
+
+#: libvips/foreign/jpegsave.c:213
+msgid "Quantization table"
+msgstr ""
+
+#: libvips/foreign/jpegsave.c:214
+msgid "Use predefined quantization table with given index"
+msgstr ""
+
+#: libvips/foreign/jpegsave.c:228
+msgid "Restart interval"
+msgstr ""
+
+#: libvips/foreign/jpegsave.c:229
+msgid "Add restart markers every specified number of mcu"
+msgstr ""
+
+#: libvips/foreign/jpegsave.c:288
+msgid "save image to jpeg target"
+msgstr ""
+
+#: libvips/foreign/jpegsave.c:357
+msgid "save image to jpeg file"
+msgstr ""
+
+#: libvips/foreign/jpegsave.c:435
+msgid "save image to jpeg buffer"
+msgstr ""
+
+#: libvips/foreign/jpegsave.c:511
+msgid "save image to jpeg mime"
+msgstr ""
+
+#: libvips/foreign/jxlload.c:251 libvips/foreign/jxlsave.c:433
+#: libvips/iofuncs/dbuf.c:81 libvips/iofuncs/util.c:684
+msgid "out of memory"
+msgstr ""
+
+#: libvips/foreign/jxlload.c:576
+msgid "bad buffer size"
+msgstr ""
+
+#: libvips/foreign/jxlload.c:602 libvips/foreign/webp2vips.c:724
+msgid "not enough frames"
+msgstr ""
+
+#: libvips/foreign/jxlload.c:683 libvips/foreign/radiance.c:704
+msgid "image size out of bounds"
+msgstr ""
+
+#: libvips/foreign/jxlload.c:1119
+msgid "load JPEG-XL image"
+msgstr ""
+
+#: libvips/foreign/jxlsave.c:748 libvips/foreign/webpsave.c:744
+#, c-format
+msgid "failed to allocate %zu bytes"
+msgstr ""
+
+#: libvips/foreign/jxlsave.c:796
+msgid "save image in JPEG-XL format"
+msgstr ""
+
+#: libvips/foreign/jxlsave.c:810
+msgid "Tier"
+msgstr ""
+
+#: libvips/foreign/jxlsave.c:811
+msgid "Decode speed tier"
+msgstr ""
+
+#: libvips/foreign/jxlsave.c:817 libvips/morphology/nearest.c:315
+msgid "Distance"
+msgstr ""
+
+#: libvips/foreign/jxlsave.c:818
+msgid "Target butteraugli distance"
+msgstr ""
+
+#: libvips/foreign/jxlsave.c:825
+msgid "Encoding effort"
+msgstr ""
+
+#: libvips/foreign/jxlsave.c:839
+msgid "Quality factor"
+msgstr ""
+
+#: libvips/foreign/magick2vips.c:305
+#, c-format
+msgid "unsupported image type %d"
+msgstr ""
+
+#: libvips/foreign/magick2vips.c:354 libvips/foreign/magick7load.c:471
+#, c-format
+msgid "bad image dimensions %d x %d pixels, %d bands"
+msgstr ""
+
+#: libvips/foreign/magick2vips.c:384
+#, c-format
+msgid "unsupported bit depth %d"
+msgstr ""
+
+#: libvips/foreign/magick2vips.c:791 libvips/foreign/webp2vips.c:638
+msgid "unable to read pixels"
+msgstr ""
+
+#: libvips/foreign/magick2vips.c:823 libvips/foreign/magick2vips.c:861
+#, c-format
+msgid "unable to read file \"%s\""
+msgstr ""
+
+#: libvips/foreign/magick2vips.c:870 libvips/foreign/magick2vips.c:949
+msgid "bad image size"
+msgstr ""
+
+#: libvips/foreign/magick2vips.c:902
+msgid "unable to read buffer"
+msgstr ""
+
+#: libvips/foreign/magick2vips.c:940
+msgid "unable to ping blob"
+msgstr ""
+
+#: libvips/foreign/magick6load.c:113
+msgid "load with ImageMagick"
+msgstr ""
+
+#: libvips/foreign/magick6load.c:134 libvips/foreign/magick7load.c:375
+msgid "Density"
+msgstr ""
+
+#: libvips/foreign/magick6load.c:135 libvips/foreign/magick7load.c:376
+msgid "Canvas resolution for rendering vector formats like SVG"
+msgstr ""
+
+#: libvips/foreign/magick6load.c:155 libvips/foreign/magick7load.c:396
+msgid "All frames"
+msgstr ""
+
+#: libvips/foreign/magick6load.c:156 libvips/foreign/magick7load.c:397
+msgid "Read all frames from an image"
+msgstr ""
+
+#: libvips/foreign/magick6load.c:231
+msgid "load file with ImageMagick"
+msgstr ""
+
+#: libvips/foreign/magick6load.c:306
+msgid "load buffer with ImageMagick"
+msgstr ""
+
+#: libvips/foreign/magick7load.c:353
+msgid "load with ImageMagick7"
+msgstr ""
+
+#: libvips/foreign/magick7load.c:414
+#, c-format
+msgid "Magick: %s %s"
+msgstr ""
+
+#: libvips/foreign/magick7load.c:491
+#, c-format
+msgid "unsupported bit depth %zd"
+msgstr ""
+
+#: libvips/foreign/magick7load.c:845
+msgid "load file with ImageMagick7"
+msgstr ""
+
+#: libvips/foreign/magick7load.c:926
+msgid "load buffer with ImageMagick7"
+msgstr ""
+
+#: libvips/foreign/magick.c:804
+#, c-format
+msgid "libMagick error: %s %s"
+msgstr ""
+
+#: libvips/foreign/magick.c:807
+#, c-format
+msgid "libMagick error: %s"
+msgstr ""
+
+#: libvips/foreign/magick.c:810
+msgid "libMagick error:"
+msgstr ""
+
+#: libvips/foreign/matlab.c:121
+#, c-format
+msgid "no matrix variables in \"%s\""
+msgstr ""
+
+#: libvips/foreign/matlab.c:203
+#, c-format
+msgid "unsupported rank %d\n"
+msgstr ""
+
+#: libvips/foreign/matlab.c:211
+#, c-format
+msgid "unsupported class type %d\n"
+msgstr ""
+
+#: libvips/foreign/matlab.c:265
+msgid "Mat_VarReadDataAll failed"
+msgstr ""
+
+#: libvips/foreign/matload.c:122
+msgid "load mat from file"
+msgstr ""
+
+#: libvips/foreign/matrixload.c:128 libvips/foreign/matrixload.c:242
+#, c-format
+msgid "bad number \"%s\""
+msgstr ""
+
+#: libvips/foreign/matrixload.c:137
+msgid "no width / height"
+msgstr ""
+
+#: libvips/foreign/matrixload.c:143
+msgid "width / height not int"
+msgstr ""
+
+#: libvips/foreign/matrixload.c:156
+msgid "width / height out of range"
+msgstr ""
+
+#: libvips/foreign/matrixload.c:160
+msgid "zero scale"
+msgstr ""
+
+#: libvips/foreign/matrixload.c:251
+#, c-format
+msgid "line %d too short"
+msgstr ""
+
+#: libvips/foreign/matrixload.c:273
+msgid "load matrix"
+msgstr ""
+
+#: libvips/foreign/matrixsave.c:175
+msgid "save image to matrix"
+msgstr ""
+
+#: libvips/foreign/matrixsave.c:323
+msgid "print matrix"
+msgstr ""
+
+#: libvips/foreign/niftiload.c:406
+msgid "invalid dimension"
+msgstr ""
+
+#: libvips/foreign/niftiload.c:417
+msgid "invalid resolution"
+msgstr ""
+
+#: libvips/foreign/niftiload.c:431 libvips/foreign/niftiload.c:435
+#: libvips/foreign/niftisave.c:309
+msgid "dimension overflow"
+msgstr ""
+
+#: libvips/foreign/niftiload.c:536
+msgid "unable to read NIFTI header"
+msgstr ""
+
+#: libvips/foreign/niftiload.c:564
+msgid "unable to load NIFTI file"
+msgstr ""
+
+#: libvips/foreign/niftiload.c:594
+msgid "load a NIFTI image"
+msgstr ""
+
+#: libvips/foreign/niftiload.c:705
+msgid "load NIfTI volume"
+msgstr ""
+
+#: libvips/foreign/niftiload.c:783
+msgid "load NIfTI volumes"
+msgstr ""
+
+#: libvips/foreign/niftisave.c:115 libvips/foreign/niftisave.c:322
+#, fuzzy
+msgid "unsupported libvips image type"
+msgstr "unsupported colour type"
+
+#: libvips/foreign/niftisave.c:122
+msgid "8-bit colour images only"
+msgstr ""
+
+#: libvips/foreign/niftisave.c:132
+msgid "3 or 4 band colour images only"
+msgstr ""
+
+#: libvips/foreign/niftisave.c:251
+msgid "bad nifti-ext- field name"
+msgstr ""
+
+#: libvips/foreign/niftisave.c:260
+msgid "unable to attach nifti ext"
+msgstr ""
+
+#: libvips/foreign/niftisave.c:315 libvips/foreign/nsgifload.c:644
+#: libvips/foreign/webp2vips.c:550
+msgid "bad image dimensions"
+msgstr ""
+
+#: libvips/foreign/niftisave.c:375
+msgid "unable to set nifti filename"
+msgstr ""
+
+#: libvips/foreign/niftisave.c:427
+msgid "save image to nifti file"
+msgstr ""
+
+#: libvips/foreign/nsgifload.c:420
+msgid "no frames in GIF"
+msgstr ""
+
+#: libvips/foreign/nsgifload.c:463
+msgid "bad frame"
+msgstr ""
+
+#: libvips/foreign/nsgifload.c:607 libvips/foreign/nsgifload.c:757
+#: libvips/foreign/nsgifload.c:837
+msgid "load GIF with libnsgif"
+msgstr ""
+
+#: libvips/foreign/nsgifload.c:901
+msgid "load gif from source"
+msgstr ""
+
+#: libvips/foreign/openexr2vips.c:123
+#, c-format
+msgid "EXR error: %s"
+msgstr ""
+
+#: libvips/foreign/openexrload.c:129
+msgid "load an OpenEXR image"
+msgstr ""
+
+#: libvips/foreign/openslideload.c:207
+msgid "invalid associated image name"
+msgstr ""
+
+#: libvips/foreign/openslideload.c:252
+msgid "specify only one of level and associated image"
+msgstr ""
+
+#: libvips/foreign/openslideload.c:259
+msgid "specify only one of attach_assicated and associated image"
+msgstr ""
+
+#: libvips/foreign/openslideload.c:376 libvips/foreign/openslideload.c:491
+#: libvips/foreign/openslideload.c:652
+#, c-format
+msgid "opening slide: %s"
+msgstr ""
+
+#: libvips/foreign/openslideload.c:398
+#, c-format
+msgid "reading associated image: %s"
+msgstr ""
+
+#: libvips/foreign/openslideload.c:485
+msgid "unsupported slide format"
+msgstr ""
+
+#: libvips/foreign/openslideload.c:498
+msgid "invalid slide level"
+msgstr ""
+
+#: libvips/foreign/openslideload.c:590
+#, c-format
+msgid "getting dimensions: %s"
+msgstr ""
+
+#: libvips/foreign/openslideload.c:597
+msgid "image dimensions overflow int"
+msgstr ""
+
+#: libvips/foreign/openslideload.c:753
+#, c-format
+msgid "reading region: %s"
+msgstr ""
+
+#: libvips/foreign/openslideload.c:1017
+msgid "load OpenSlide base class"
+msgstr ""
+
+#: libvips/foreign/openslideload.c:1046 libvips/foreign/tiffsave.c:364
+msgid "Level"
+msgstr ""
+
+#: libvips/foreign/openslideload.c:1047
+msgid "Load this level from the file"
+msgstr ""
+
+#: libvips/foreign/openslideload.c:1053
+msgid "Autocrop"
+msgstr ""
+
+#: libvips/foreign/openslideload.c:1054
+msgid "Crop to image bounds"
+msgstr ""
+
+#: libvips/foreign/openslideload.c:1060
+msgid "Associated"
+msgstr ""
+
+#: libvips/foreign/openslideload.c:1061
+msgid "Load this associated image"
+msgstr ""
+
+#: libvips/foreign/openslideload.c:1067
+msgid "Attach associated"
+msgstr ""
+
+#: libvips/foreign/openslideload.c:1068
+msgid "Attach all associated images"
+msgstr ""
+
+#: libvips/foreign/openslideload.c:1074
+msgid "RGB"
+msgstr ""
+
+#: libvips/foreign/openslideload.c:1075
+msgid "Output RGB (not RGBA)"
+msgstr ""
+
+#: libvips/foreign/openslideload.c:1144
+msgid "load file with OpenSlide"
+msgstr ""
+
+#: libvips/foreign/openslideload.c:1223
+msgid "load source with OpenSlide"
+msgstr ""
+
+#: libvips/foreign/pdfiumload.c:196
+msgid "unknown error"
+msgstr ""
+
+#: libvips/foreign/pdfiumload.c:291
+#, c-format
+msgid "%s: too large for pdfium"
+msgstr ""
+
+#: libvips/foreign/pdfiumload.c:307
+#, c-format
+msgid "%s: unable to load"
+msgstr ""
+
+#: libvips/foreign/pdfiumload.c:318
+#, c-format
+msgid "%s: unable to initialize form fill environment"
+msgstr ""
+
+#: libvips/foreign/pdfiumload.c:366 libvips/foreign/popplerload.c:239
+#, c-format
+msgid "unable to load page %d"
+msgstr ""
+
+#: libvips/foreign/pdfiumload.c:478 libvips/foreign/popplerload.c:333
+msgid "pages out of range"
+msgstr ""
+
+#: libvips/foreign/pdfiumload.c:513
+msgid "page size out of range"
+msgstr ""
+
+#: libvips/foreign/pdfiumload.c:685
+msgid "load PDF with PDFium"
+msgstr ""
+
+#: libvips/foreign/pdfiumload.c:717 libvips/foreign/popplerload.c:567
+#: libvips/foreign/webpload.c:193
+msgid "Factor to scale by"
+msgstr ""
+
+#: libvips/foreign/pdfiumload.c:724 libvips/foreign/popplerload.c:574
+msgid "Background colour"
+msgstr ""
+
+#: libvips/foreign/pdfiumload.c:730 libvips/foreign/popplerload.c:580
+msgid "Password"
+msgstr ""
+
+#: libvips/foreign/pdfiumload.c:731 libvips/foreign/popplerload.c:581
+msgid "Password to decrypt with"
+msgstr ""
+
+#: libvips/foreign/pdfiumload.c:803 libvips/foreign/popplerload.c:680
+msgid "load PDF from file"
+msgstr ""
+
+#: libvips/foreign/pdfiumload.c:866 libvips/foreign/popplerload.c:743
+msgid "load PDF from buffer"
+msgstr ""
+
+#: libvips/foreign/pdfiumload.c:924 libvips/foreign/popplerload.c:801
+msgid "load PDF from source"
+msgstr ""
+
+#: libvips/foreign/pngload.c:157 libvips/foreign/spngload.c:664
+msgid "load png base class"
+msgstr ""
+
+#: libvips/foreign/pngload.c:234 libvips/foreign/spngload.c:749
+msgid "load png from source"
+msgstr ""
+
+#: libvips/foreign/pngload.c:310 libvips/foreign/spngload.c:827
+msgid "load png from file"
+msgstr ""
+
+#: libvips/foreign/pngload.c:388 libvips/foreign/spngload.c:905
+msgid "load png from buffer"
+msgstr ""
+
+#: libvips/foreign/pngsave.c:202
+msgid "save png"
+msgstr ""
+
+#: libvips/foreign/pngsave.c:212 libvips/foreign/spngsave.c:690
+msgid "Compression factor"
+msgstr ""
+
+#: libvips/foreign/pngsave.c:219 libvips/foreign/spngsave.c:697
+msgid "Interlace image"
+msgstr ""
+
+#: libvips/foreign/pngsave.c:225 libvips/foreign/spngsave.c:703
+msgid "Filter"
+msgstr ""
+
+#: libvips/foreign/pngsave.c:226
+msgid "libpng row filter flag(s)"
+msgstr ""
+
+#: libvips/foreign/pngsave.c:233 libvips/foreign/spngsave.c:711
+msgid "Palette"
+msgstr ""
+
+#: libvips/foreign/pngsave.c:234 libvips/foreign/spngsave.c:712
+msgid "Quantise to 8bpp palette"
+msgstr ""
+
+#: libvips/foreign/pngsave.c:240 libvips/foreign/spngsave.c:718
+#: libvips/foreign/vips2magick.c:489
+msgid "Quality"
+msgstr ""
+
+#: libvips/foreign/pngsave.c:241 libvips/foreign/spngsave.c:719
+msgid "Quantisation quality"
+msgstr ""
+
+#: libvips/foreign/pngsave.c:255 libvips/foreign/spngsave.c:733
+msgid "Write as a 1, 2, 4, 8 or 16 bit image"
+msgstr ""
+
+#: libvips/foreign/pngsave.c:262 libvips/foreign/spngsave.c:740
+msgid "Quantisation CPU effort"
+msgstr ""
+
+#: libvips/foreign/pngsave.c:268 libvips/foreign/spngsave.c:746
+msgid "Colours"
+msgstr ""
+
+#: libvips/foreign/pngsave.c:269 libvips/foreign/spngsave.c:747
+msgid "Max number of palette colours"
+msgstr ""
+
+#: libvips/foreign/pngsave.c:322 libvips/foreign/spngsave.c:801
+msgid "save image to target as PNG"
+msgstr ""
+
+#: libvips/foreign/pngsave.c:374
+msgid "save image to png file"
+msgstr ""
+
+#: libvips/foreign/pngsave.c:433
+msgid "save image to png buffer"
+msgstr ""
+
+#: libvips/foreign/popplerload.c:531
+msgid "load PDF with libpoppler"
+msgstr ""
+
+#: libvips/foreign/ppmload.c:264
+msgid "bad magic number"
+msgstr ""
+
+#: libvips/foreign/ppmload.c:521
+msgid "file truncated"
+msgstr ""
+
+#: libvips/foreign/ppmload.c:746
+msgid "load ppm base class"
+msgstr ""
+
+#: libvips/foreign/ppmload.c:823
+msgid "load ppm from file"
+msgstr ""
+
+#: libvips/foreign/ppmsave.c:321
+msgid "too few bands for format"
+msgstr ""
+
+#: libvips/foreign/ppmsave.c:499
+msgid "save to ppm"
+msgstr ""
+
+#: libvips/foreign/ppmsave.c:507 libvips/foreign/vips2magick.c:483
+msgid "Format to save in"
+msgstr ""
+
+#: libvips/foreign/ppmsave.c:514
+msgid "ASCII"
+msgstr ""
+
+#: libvips/foreign/ppmsave.c:515
+msgid "Save as ascii"
+msgstr ""
+
+#: libvips/foreign/ppmsave.c:522
+msgid "Set to 1 to write as a 1 bit image"
+msgstr ""
+
+#: libvips/foreign/ppmsave.c:528 libvips/foreign/tiffsave.c:406
+msgid "Squash"
+msgstr ""
+
+#: libvips/foreign/ppmsave.c:529
+msgid "Save as one bit"
+msgstr ""
+
+#: libvips/foreign/ppmsave.c:586
+msgid "save image to ppm file"
+msgstr ""
+
+#: libvips/foreign/ppmsave.c:675
+msgid "save image in pbm format"
+msgstr ""
+
+#: libvips/foreign/ppmsave.c:707
+msgid "save image in pgm format"
+msgstr ""
+
+#: libvips/foreign/ppmsave.c:739
+msgid "save image in pfm format"
+msgstr ""
+
+#: libvips/foreign/ppmsave.c:771
+msgid "save image in pnm format"
+msgstr ""
+
+#: libvips/foreign/quantise.c:469
+msgid "libvips not built with quantisation support"
+msgstr ""
+
+#: libvips/foreign/radiance.c:438
+msgid "scanline length mismatch"
+msgstr ""
+
+#: libvips/foreign/radiance.c:455
+msgid "overrun"
+msgstr ""
+
+#: libvips/foreign/radiance.c:687
+msgid "error reading radiance header"
+msgstr ""
+
+#: libvips/foreign/radiance.c:774
+#, c-format
+msgid "read error line %d"
+msgstr ""
+
+#: libvips/foreign/radload.c:125
+msgid "load rad base class"
+msgstr ""
+
+#: libvips/foreign/radload.c:197
+msgid "load rad from source"
+msgstr ""
+
+#: libvips/foreign/radload.c:273
+msgid "load a Radiance image from a file"
+msgstr ""
+
+#: libvips/foreign/radload.c:350
+msgid "load rad from buffer"
+msgstr ""
+
+#: libvips/foreign/radsave.c:92
+msgid "save Radiance"
+msgstr ""
+
+#: libvips/foreign/radsave.c:150
+msgid "save image to Radiance file"
+msgstr ""
+
+#: libvips/foreign/radsave.c:203
+msgid "save image to Radiance target"
+msgstr ""
+
+#: libvips/foreign/radsave.c:269
+msgid "save image to Radiance buffer"
+msgstr ""
+
+#: libvips/foreign/rawload.c:131
+msgid "load raw data from a file"
+msgstr ""
+
+#: libvips/foreign/rawload.c:167 libvips/iofuncs/image.c:1200
+msgid "Size of header"
+msgstr ""
+
+#: libvips/foreign/rawload.c:168 libvips/iofuncs/image.c:1201
+msgid "Offset in bytes from start of file"
+msgstr ""
+
+#: libvips/foreign/rawsave.c:138
+msgid "save image to raw"
+msgstr ""
+
+#: libvips/foreign/rawsave.c:190
+msgid "save image to raw file"
+msgstr ""
+
+#: libvips/foreign/rawsave.c:246
+msgid "write raw image to target"
+msgstr ""
+
+#: libvips/foreign/rawsave.c:308
+msgid "write raw image to buffer"
+msgstr ""
+
+#: libvips/foreign/spngload.c:252 libvips/foreign/vipspng.c:582
+#, c-format
+msgid "%d text chunks, only %d text chunks will be loaded"
+msgstr ""
+
+#: libvips/foreign/spngload.c:403
+#, fuzzy
+msgid "unknown color type"
+msgstr "unsupported colour type"
+
+#: libvips/foreign/spngload.c:562
+msgid "libspng read error"
+msgstr ""
+
+#: libvips/foreign/spngsave.c:164 libvips/foreign/vipspng.c:1013
+msgid "bad png comment key"
+msgstr ""
+
+#: libvips/foreign/spngsave.c:680
+msgid "save spng"
+msgstr ""
+
+#: libvips/foreign/spngsave.c:704
+msgid "libspng row filter flag(s)"
+msgstr ""
+
+#: libvips/foreign/spngsave.c:854
+msgid "save image to file as PNG"
+msgstr ""
+
+#: libvips/foreign/spngsave.c:914
+msgid "save image to buffer as PNG"
+msgstr ""
+
+#: libvips/foreign/svgload.c:626 libvips/foreign/svgload.c:644
+msgid "SVG rendering failed"
+msgstr ""
+
+#: libvips/foreign/svgload.c:700
+msgid "load SVG with rsvg"
+msgstr ""
+
+#: libvips/foreign/svgload.c:718
+msgid "Render at this DPI"
+msgstr ""
+
+#: libvips/foreign/svgload.c:725
+msgid "Scale output by this factor"
+msgstr ""
+
+#: libvips/foreign/svgload.c:733
+msgid "Allow SVG of any size"
+msgstr ""
+
+#: libvips/foreign/svgload.c:827
+msgid "load svg from source"
+msgstr ""
+
+#: libvips/foreign/tiff2vips.c:480 libvips/foreign/tiff2vips.c:498
+#, c-format
+msgid "required field %d missing"
+msgstr ""
+
+#: libvips/foreign/tiff2vips.c:540
+msgid "unknown resolution unit"
+msgstr ""
+
+#: libvips/foreign/tiff2vips.c:680
+#, c-format
+msgid "bad page number %d"
+msgstr ""
+
+#: libvips/foreign/tiff2vips.c:690
+#, c-format
+msgid "bad number of pages %d"
+msgstr ""
+
+#: libvips/foreign/tiff2vips.c:718 libvips/foreign/tiff2vips.c:760
+#: libvips/iofuncs/source.c:812
+msgid "read error"
+msgstr ""
+
+#: libvips/foreign/tiff2vips.c:802
+#, c-format
+msgid "TIFF does not contain page %d"
+msgstr ""
+
+#: libvips/foreign/tiff2vips.c:812
+msgid "no SUBIFD tag"
+msgstr ""
+
+#: libvips/foreign/tiff2vips.c:818
+#, c-format
+msgid "subifd %d out of range, only 0-%d available"
+msgstr ""
+
+#: libvips/foreign/tiff2vips.c:826
+msgid "subdirectory unreadable"
+msgstr ""
+
+#: libvips/foreign/tiff2vips.c:867
+#, c-format
+msgid "not %d bands"
+msgstr ""
+
+#: libvips/foreign/tiff2vips.c:880
+#, c-format
+msgid "not at least %d samples per pixel"
+msgstr ""
+
+#: libvips/foreign/tiff2vips.c:895
+msgid "samples_per_pixel not a whole number of bytes"
+msgstr ""
+
+#: libvips/foreign/tiff2vips.c:908
+#, c-format
+msgid "not photometric interpretation %d"
+msgstr ""
+
+#: libvips/foreign/tiff2vips.c:920
+#, c-format
+msgid "not %d bits per sample"
+msgstr ""
+
+#: libvips/foreign/tiff2vips.c:936
+#, c-format
+msgid "%d bits per sample palette image not supported"
+msgstr ""
+
+#: libvips/foreign/tiff2vips.c:995
+msgid "unsupported tiff image type\n"
+msgstr ""
+
+#: libvips/foreign/tiff2vips.c:1603
+msgid "bad colormap"
+msgstr "bad colourmap"
+
+#: libvips/foreign/tiff2vips.c:2330
+#, c-format
+msgid "decompress error tile %d x %d"
+msgstr ""
+
+#: libvips/foreign/tiff2vips.c:2608
+msgid "tiled separate planes not supported"
+msgstr ""
+
+#: libvips/foreign/tiff2vips.c:2627 libvips/foreign/tiff2vips.c:2910
+#: libvips/foreign/tiff2vips.c:3034
+msgid "unsupported tiff image type"
+msgstr ""
+
+#: libvips/foreign/tiff2vips.c:2761
+#, c-format
+msgid "out of order read -- at line %d, but line %d requested"
+msgstr ""
+
+#: libvips/foreign/tiff2vips.c:3070
+msgid "subsampled images not supported"
+msgstr ""
+
+#: libvips/foreign/tiff2vips.c:3082
+msgid "not SGI-compressed LOGLUV"
+msgstr ""
+
+#: libvips/foreign/tiff2vips.c:3099
+msgid "width/height out of range"
+msgstr ""
+
+#: libvips/foreign/tiff2vips.c:3108
+msgid "samples out of range"
+msgstr ""
+
+#: libvips/foreign/tiff2vips.c:3194 libvips/foreign/tiff2vips.c:3222
+msgid "tile size out of range"
+msgstr ""
+
+#: libvips/foreign/tiff2vips.c:3414
+#, c-format
+msgid "page %d differs from page %d"
+msgstr ""
+
+#: libvips/foreign/tiff.c:207 libvips/foreign/tiff.c:222
+msgid "unable to open source for input"
+msgstr ""
+
+#: libvips/foreign/tiff.c:330 libvips/foreign/tiff.c:345
+msgid "unable to open target for output"
+msgstr ""
+
+#: libvips/foreign/tiffload.c:183
+msgid "load tiff"
+msgstr ""
+
+#: libvips/foreign/tiffload.c:211
+msgid "Rotate image using orientation tag"
+msgstr ""
+
+#: libvips/foreign/tiffload.c:217
+msgid "subifd"
+msgstr ""
+
+#: libvips/foreign/tiffload.c:218
+msgid "Subifd index"
+msgstr ""
+
+#: libvips/foreign/tiffload.c:294
+msgid "load tiff from source"
+msgstr ""
+
+#: libvips/foreign/tiffload.c:374
+msgid "load tiff from file"
+msgstr ""
+
+#: libvips/foreign/tiffload.c:454
+msgid "load tiff from buffer"
+msgstr ""
+
+#: libvips/foreign/tiffsave.c:248
+msgid "save image as tiff"
+msgstr ""
+
+#: libvips/foreign/tiffsave.c:258
+msgid "Compression for this file"
+msgstr ""
+
+#: libvips/foreign/tiffsave.c:272
+msgid "Predictor"
+msgstr ""
+
+#: libvips/foreign/tiffsave.c:273
+msgid "Compression prediction"
+msgstr ""
+
+#: libvips/foreign/tiffsave.c:280
+msgid "Tile"
+msgstr ""
+
+#: libvips/foreign/tiffsave.c:281
+msgid "Write a tiled tiff"
+msgstr ""
+
+#: libvips/foreign/tiffsave.c:301
+msgid "Pyramid"
+msgstr ""
+
+#: libvips/foreign/tiffsave.c:302
+msgid "Write a pyramidal tiff"
+msgstr ""
+
+#: libvips/foreign/tiffsave.c:308
+msgid "Miniswhite"
+msgstr ""
+
+#: libvips/foreign/tiffsave.c:309
+msgid "Use 0 for white in 1-bit images"
+msgstr ""
+
+#: libvips/foreign/tiffsave.c:316
+msgid "Write as a 1, 2, 4 or 8 bit image"
+msgstr ""
+
+#: libvips/foreign/tiffsave.c:322 libvips/foreign/tiffsave.c:323
+msgid "Resolution unit"
+msgstr ""
+
+#: libvips/foreign/tiffsave.c:343
+msgid "Bigtiff"
+msgstr ""
+
+#: libvips/foreign/tiffsave.c:344
+msgid "Write a bigtiff image"
+msgstr ""
+
+#: libvips/foreign/tiffsave.c:351
+msgid "Write a properties document to IMAGEDESCRIPTION"
+msgstr ""
+
+#: libvips/foreign/tiffsave.c:365
+msgid "Deflate (1-9, default 6) or ZSTD (1-22, default 9) compression level"
+msgstr ""
+
+#: libvips/foreign/tiffsave.c:372
+msgid "Enable WEBP lossless mode"
+msgstr ""
+
+#: libvips/foreign/tiffsave.c:385
+msgid "Sub-IFD"
+msgstr ""
+
+#: libvips/foreign/tiffsave.c:386
+msgid "Save pyr layers as sub-IFDs"
+msgstr ""
+
+#: libvips/foreign/tiffsave.c:392
+msgid "Premultiply"
+msgstr ""
+
+#: libvips/foreign/tiffsave.c:393
+msgid "Save with premultiplied alpha"
+msgstr ""
+
+#: libvips/foreign/tiffsave.c:399
+msgid "RGB JPEG"
+msgstr ""
+
+#: libvips/foreign/tiffsave.c:400
+msgid "Output RGB JPEG rather than YCbCr"
+msgstr ""
+
+#: libvips/foreign/tiffsave.c:407
+msgid "Squash images down to 1 bit"
+msgstr ""
+
+#: libvips/foreign/tiffsave.c:470
+msgid "save image to tiff target"
+msgstr ""
+
+#: libvips/foreign/tiffsave.c:523
+msgid "save image to tiff file"
+msgstr ""
+
+#: libvips/foreign/tiffsave.c:584
+msgid "save image to tiff buffer"
+msgstr ""
+
+#: libvips/foreign/vips2jpeg.c:176
+#, c-format
+msgid "%s"
+msgstr ""
+
+#: libvips/foreign/vips2jpeg.c:273
+#, c-format
+msgid "field \"%s\" is too large for a single JPEG marker, ignoring"
+msgstr ""
+
+#: libvips/foreign/vips2jpeg.c:1059
+msgid "libvips built without JPEG support"
+msgstr ""
+
+#: libvips/foreign/vips2magick.c:319
+#, fuzzy
+msgid "unsupported image format"
+msgstr "unsupported colour type"
+
+#: libvips/foreign/vips2magick.c:349
+msgid "unsupported number of image bands"
+msgstr ""
+
+#: libvips/foreign/vips2magick.c:464
+msgid "save with ImageMagick"
+msgstr ""
+
+#: libvips/foreign/vips2magick.c:490
+msgid "Quality to use"
+msgstr ""
+
+#: libvips/foreign/vips2magick.c:496
+msgid "Optimize_gif_frames"
+msgstr ""
+
+#: libvips/foreign/vips2magick.c:497
+msgid "Apply GIF frames optimization"
+msgstr ""
+
+#: libvips/foreign/vips2magick.c:503
+msgid "Optimize_gif_transparency"
+msgstr ""
+
+#: libvips/foreign/vips2magick.c:504
+msgid "Apply GIF transparency optimization"
+msgstr ""
+
+#: libvips/foreign/vips2magick.c:574
+msgid "save file with ImageMagick"
+msgstr ""
+
+#: libvips/foreign/vips2magick.c:646
+msgid "save image to magick buffer"
+msgstr ""
+
+#: libvips/foreign/vips2magick.c:677
+msgid "save bmp image with ImageMagick"
+msgstr ""
+
+#: libvips/foreign/vips2magick.c:710
+msgid "save bmp image to magick buffer"
+msgstr ""
+
+#: libvips/foreign/vips2magick.c:743
+msgid "save gif image with ImageMagick"
+msgstr ""
+
+#: libvips/foreign/vips2magick.c:776
+msgid "save gif image to magick buffer"
+msgstr ""
+
+#: libvips/foreign/vips2tiff.c:1449
+msgid "can only pyramid LABQ and non-complex images"
+msgstr ""
+
+#: libvips/foreign/vips2tiff.c:1472
+msgid "tile size not a multiple of 16"
+msgstr ""
+
+#: libvips/foreign/vips2tiff.c:1830 libvips/foreign/vips2tiff.c:2019
+msgid "TIFF write tile failed"
+msgstr ""
+
+#: libvips/foreign/vipsload.c:126
+msgid "no filename associated with source"
+msgstr ""
+
+#: libvips/foreign/vipsload.c:157
+msgid "load vips base class"
+msgstr ""
+
+#: libvips/foreign/vipsload.c:228
+msgid "load vips from file"
+msgstr ""
+
+#: libvips/foreign/vipsload.c:303
+msgid "load vips from source"
+msgstr ""
+
+#: libvips/foreign/vipspng.c:450
+msgid "unsupported color type"
+msgstr "unsupported colour type"
+
+#: libvips/foreign/vipspng.c:564
+msgid "unable to read PNG header"
+msgstr ""
+
+#: libvips/foreign/vipspng.c:756
+msgid "libpng read error"
+msgstr ""
+
+#: libvips/foreign/vipspng.c:1113
+msgid "compress should be in [0,9]"
+msgstr ""
+
+#: libvips/foreign/vipspng.c:1141
+#, c-format
+msgid "can't save %d band image as png"
+msgstr ""
+
+#: libvips/foreign/vipspng.c:1349
+#, c-format
+msgid "unable to write to target %s"
+msgstr ""
+
+#: libvips/foreign/vipssave.c:114
+msgid "no filename associated with target"
+msgstr ""
+
+#: libvips/foreign/vipssave.c:141
+msgid "save vips base class"
+msgstr ""
+
+#: libvips/foreign/vipssave.c:193
+msgid "save image to file in vips format"
+msgstr ""
+
+#: libvips/foreign/vipssave.c:249
+msgid "save image to target in vips format"
+msgstr ""
+
+#: libvips/foreign/webp2vips.c:407
+msgid "unable to parse image"
+msgstr ""
+
+#: libvips/foreign/webp2vips.c:595
+msgid "unable to loop through frames"
+msgstr ""
+
+#: libvips/foreign/webpload.c:164
+msgid "load webp"
+msgstr ""
+
+#: libvips/foreign/webpload.c:258
+msgid "load webp from source"
+msgstr ""
+
+#: libvips/foreign/webpload.c:338
+msgid "load webp from file"
+msgstr ""
+
+#: libvips/foreign/webpload.c:418
+msgid "load webp from buffer"
+msgstr ""
+
+#: libvips/foreign/webpsave.c:248
+msgid "picture version error"
+msgstr ""
+
+#: libvips/foreign/webpsave.c:290
+msgid "picture memory error"
+msgstr ""
+
+#: libvips/foreign/webpsave.c:315
+msgid "anim add error"
+msgstr ""
+
+#: libvips/foreign/webpsave.c:332
+msgid "unable to encode"
+msgstr ""
+
+#: libvips/foreign/webpsave.c:428
+msgid "chunk add error"
+msgstr ""
+
+#: libvips/foreign/webpsave.c:534 libvips/foreign/webpsave.c:575
+msgid "mux error"
+msgstr ""
+
+#: libvips/foreign/webpsave.c:595 libvips/foreign/webpsave.c:605
+#: libvips/foreign/webpsave.c:644
+msgid "config version error"
+msgstr ""
+
+#: libvips/foreign/webpsave.c:625
+msgid "invalid configuration"
+msgstr ""
+
+#: libvips/foreign/webpsave.c:655
+msgid "unable to init animation"
+msgstr ""
+
+#: libvips/foreign/webpsave.c:698
+msgid "anim close error"
+msgstr ""
+
+#: libvips/foreign/webpsave.c:703
+msgid "anim build error"
+msgstr ""
+
+#: libvips/foreign/webpsave.c:711 libvips/mosaicing/lrmerge.c:309
+#: libvips/mosaicing/tbmerge.c:187 libvips/mosaicing/tbmerge.c:262
+#: libvips/mosaicing/tbmerge.c:594
+msgid "internal error"
+msgstr ""
+
+#: libvips/foreign/webpsave.c:817
+msgid "save as WebP"
+msgstr ""
+
+#: libvips/foreign/webpsave.c:840
+msgid "Preset"
+msgstr ""
+
+#: libvips/foreign/webpsave.c:841
+msgid "Preset for lossy compression"
+msgstr ""
+
+#: libvips/foreign/webpsave.c:848
+msgid "Smart subsampling"
+msgstr ""
+
+#: libvips/foreign/webpsave.c:849
+msgid "Enable high quality chroma subsampling"
+msgstr ""
+
+#: libvips/foreign/webpsave.c:855
+msgid "Near lossless"
+msgstr ""
+
+#: libvips/foreign/webpsave.c:856
+msgid "Enable preprocessing in lossless mode (uses Q)"
+msgstr ""
+
+#: libvips/foreign/webpsave.c:862
+msgid "Alpha quality"
+msgstr ""
+
+#: libvips/foreign/webpsave.c:863
+msgid "Change alpha plane fidelity for lossy compression"
+msgstr ""
+
+#: libvips/foreign/webpsave.c:869
+msgid "Minimise size"
+msgstr ""
+
+#: libvips/foreign/webpsave.c:870
+msgid "Optimise for minimum size"
+msgstr ""
+
+#: libvips/foreign/webpsave.c:876
+msgid "Minimum keyframe spacing"
+msgstr ""
+
+#: libvips/foreign/webpsave.c:877
+msgid "Minimum number of frames between key frames"
+msgstr ""
+
+#: libvips/foreign/webpsave.c:883
+msgid "Maximum keyframe spacing"
+msgstr ""
+
+#: libvips/foreign/webpsave.c:884
+msgid "Maximum number of frames between key frames"
+msgstr ""
+
+#: libvips/foreign/webpsave.c:891 libvips/foreign/webpsave.c:912
+msgid "Level of CPU effort to reduce file size"
+msgstr ""
+
+#: libvips/foreign/webpsave.c:897
+msgid "Target size"
+msgstr ""
+
+#: libvips/foreign/webpsave.c:898
+msgid "Desired target size in bytes"
+msgstr ""
+
+#: libvips/foreign/webpsave.c:904
+msgid "Passes"
+msgstr ""
+
+#: libvips/foreign/webpsave.c:905
+msgid "Number of entropy-analysis passes (in [1..10])"
+msgstr ""
+
+#: libvips/foreign/webpsave.c:911
+msgid "Reduction effort"
+msgstr ""
+
+#: libvips/foreign/webpsave.c:918
+msgid "Mixed encoding"
+msgstr ""
+
+#: libvips/foreign/webpsave.c:919
+msgid "Allow mixed encoding (might reduce file size)"
+msgstr ""
+
+#: libvips/foreign/webpsave.c:925
+msgid "Smart deblocking"
+msgstr ""
+
+#: libvips/foreign/webpsave.c:926
+msgid "Enable auto-adjusting of the deblocking filter"
+msgstr ""
+
+#: libvips/foreign/webpsave.c:1156
+msgid "save image to webp mime"
+msgstr ""
+
+#: libvips/freqfilt/freqfilt.c:94
+msgid "frequency-domain filter operations"
+msgstr ""
+
+#: libvips/freqfilt/freqmult.c:126
+msgid "frequency-domain filtering"
+msgstr ""
+
+#: libvips/freqfilt/freqmult.c:131
+msgid "Input mask image"
+msgstr ""
+
+#: libvips/freqfilt/fwfft.c:145 libvips/freqfilt/fwfft.c:266
+#: libvips/freqfilt/invfft.c:124 libvips/freqfilt/invfft.c:203
+msgid "unable to create transform plan"
+msgstr ""
+
+#: libvips/freqfilt/fwfft.c:351
+msgid "forward FFT"
+msgstr ""
+
+#: libvips/freqfilt/invfft.c:263
+msgid "inverse FFT"
+msgstr ""
+
+#: libvips/freqfilt/invfft.c:267
+msgid "Real"
+msgstr ""
+
+#: libvips/freqfilt/invfft.c:268
+msgid "Output only the real part of the transform"
+msgstr ""
+
+#: libvips/freqfilt/phasecor.c:107
+msgid "calculate phase correlation"
+msgstr ""
+
+#: libvips/freqfilt/spectrum.c:100
+msgid "make displayable power spectrum"
+msgstr ""
+
+#: libvips/histogram/case.c:164
+msgid "bad number of cases"
+msgstr ""
+
+#: libvips/histogram/case.c:169
+msgid "index image not 1-band"
+msgstr ""
+
+#: libvips/histogram/case.c:233
+msgid "use pixel values to pick cases from an array of images"
+msgstr ""
+
+#: libvips/histogram/case.c:245
+msgid "Cases"
+msgstr ""
+
+#: libvips/histogram/case.c:246
+msgid "Array of case images"
+msgstr ""
+
+#: libvips/histogram/hist_cum.c:158
+msgid "form cumulative histogram"
+msgstr ""
+
+#: libvips/histogram/hist_entropy.c:107
+msgid "estimate image entropy"
+msgstr ""
+
+#: libvips/histogram/hist_entropy.c:112
+#: libvips/histogram/hist_ismonotonic.c:119
+msgid "Input histogram image"
+msgstr ""
+
+#: libvips/histogram/hist_equal.c:110
+msgid "histogram equalisation"
+msgstr ""
+
+#: libvips/histogram/hist_equal.c:127
+msgid "Equalise with this band"
+msgstr ""
+
+#: libvips/histogram/hist_ismonotonic.c:114
+msgid "test for monotonicity"
+msgstr ""
+
+#: libvips/histogram/hist_ismonotonic.c:124
+msgid "Monotonic"
+msgstr ""
+
+#: libvips/histogram/hist_ismonotonic.c:125
+msgid "true if in is monotonic"
+msgstr ""
+
+#: libvips/histogram/hist_local.c:304 libvips/histogram/stdif.c:236
+#: libvips/morphology/rank.c:491
+msgid "window too large"
+msgstr ""
+
+#: libvips/histogram/hist_local.c:355
+msgid "local histogram equalisation"
+msgstr ""
+
+#: libvips/histogram/hist_local.c:374 libvips/histogram/stdif.c:309
+#: libvips/morphology/rank.c:571
+msgid "Window width in pixels"
+msgstr ""
+
+#: libvips/histogram/hist_local.c:381 libvips/histogram/stdif.c:316
+#: libvips/morphology/rank.c:578
+msgid "Window height in pixels"
+msgstr ""
+
+#: libvips/histogram/hist_local.c:387
+msgid "Max slope"
+msgstr ""
+
+#: libvips/histogram/hist_local.c:388
+msgid "Maximum slope (CLAHE)"
+msgstr ""
+
+#: libvips/histogram/hist_match.c:154
+msgid "match two histograms"
+msgstr ""
+
+#: libvips/histogram/hist_match.c:162
+msgid "Input histogram"
+msgstr ""
+
+#: libvips/histogram/hist_match.c:167 libvips/mosaicing/match.c:196
+#: libvips/mosaicing/merge.c:122 libvips/mosaicing/mosaic1.c:498
+#: libvips/mosaicing/mosaic.c:179
+msgid "Reference"
+msgstr ""
+
+#: libvips/histogram/hist_match.c:168
+msgid "Reference histogram"
+msgstr ""
+
+#: libvips/histogram/hist_norm.c:137
+msgid "normalise histogram"
+msgstr ""
+
+#: libvips/histogram/histogram.c:223
+msgid "histogram operations"
+msgstr ""
+
+#: libvips/histogram/hist_plot.c:329
+msgid "plot histogram"
+msgstr ""
+
+#: libvips/histogram/hist_unary.c:84
+msgid "hist_unary operations"
+msgstr ""
+
+#: libvips/histogram/maplut.c:110
+#, c-format
+msgid "%d overflows detected"
+msgstr ""
+
+#: libvips/histogram/maplut.c:738
+msgid "map an image though a lut"
+msgstr ""
+
+#: libvips/histogram/maplut.c:756
+msgid "LUT"
+msgstr ""
+
+#: libvips/histogram/maplut.c:757
+msgid "Look-up table image"
+msgstr ""
+
+#: libvips/histogram/maplut.c:763
+msgid "Apply one-band lut to this band of in"
+msgstr ""
+
+#: libvips/histogram/percent.c:105
+msgid "find threshold for percent of pixels"
+msgstr ""
+
+#: libvips/histogram/percent.c:115
+msgid "Percent"
+msgstr ""
+
+#: libvips/histogram/percent.c:116
+msgid "Percent of pixels"
+msgstr ""
+
+#: libvips/histogram/percent.c:123
+msgid "Threshold above which lie percent of pixels"
+msgstr ""
+
+#: libvips/histogram/stdif.c:240
+msgid "too many bands"
+msgstr ""
+
+#: libvips/histogram/stdif.c:290
+msgid "statistical difference"
+msgstr ""
+
+#: libvips/histogram/stdif.c:322
+msgid "Mean weight"
+msgstr ""
+
+#: libvips/histogram/stdif.c:323
+msgid "Weight of new mean"
+msgstr ""
+
+#: libvips/histogram/stdif.c:330
+msgid "New mean"
+msgstr ""
+
+#: libvips/histogram/stdif.c:336
+msgid "Deviation weight"
+msgstr ""
+
+#: libvips/histogram/stdif.c:337
+msgid "Weight of new deviation"
+msgstr ""
+
+#: libvips/histogram/stdif.c:343
+msgid "Deviation"
+msgstr ""
+
+#: libvips/histogram/stdif.c:344
+msgid "New deviation"
+msgstr ""
+
+#: libvips/iofuncs/buf.c:609
 #, c-format
 msgid "%zd bytes of binary data"
 msgstr ""
 
-#. File length unit.
-#.
-#: ../libvips/iofuncs/buf.c:679
-msgid "bytes"
+#: libvips/iofuncs/connection.c:126
+msgid "Descriptor"
 msgstr ""
 
-#. Kilobyte unit.
-#.
-#: ../libvips/iofuncs/buf.c:683
-msgid "KB"
+#: libvips/iofuncs/connection.c:127
+msgid "File descriptor for read or write"
 msgstr ""
 
-#. Megabyte unit.
-#.
-#: ../libvips/iofuncs/buf.c:687
-msgid "MB"
+#: libvips/iofuncs/connection.c:134
+msgid "Name of file to open"
 msgstr ""
 
-#. Gigabyte unit.
-#.
-#: ../libvips/iofuncs/buf.c:691
-msgid "GB"
+#: libvips/iofuncs/error.c:296
+msgid "system error"
 msgstr ""
 
-#. Terabyte unit.
-#.
-#: ../libvips/iofuncs/buf.c:695
-msgid "TB"
+#: libvips/iofuncs/error.c:443
+msgid "image must be uncoded"
 msgstr ""
 
-#: ../libvips/morphology/morph.c:139
-msgid "morphology operation"
+#: libvips/iofuncs/error.c:471
+msgid "image coding must be 'none' or 'labq'"
 msgstr ""
 
-#: ../libvips/morphology/morph.c:155
-msgid "Morphology"
+#: libvips/iofuncs/error.c:499
+msgid "unknown image coding"
 msgstr ""
 
-#: ../libvips/morphology/morph.c:156
-msgid "Morphological operation to perform"
+#: libvips/iofuncs/error.c:524
+#, c-format
+msgid "coding '%s' only"
 msgstr ""
 
-#: ../libvips/morphology/rank.c:359
-msgid "index out of range"
+#: libvips/iofuncs/error.c:549
+msgid "image must one band"
 msgstr ""
 
-#: ../libvips/morphology/rank.c:409
-msgid "rank filter"
+#: libvips/iofuncs/error.c:574
+#, c-format
+msgid "image must have %d bands"
 msgstr ""
 
-#: ../libvips/morphology/rank.c:433
-msgid "index"
+#: libvips/iofuncs/error.c:599
+msgid "image must have one or three bands"
 msgstr ""
 
-#: ../libvips/morphology/rank.c:434
-msgid "Select pixel at index"
+#: libvips/iofuncs/error.c:625
+#, c-format
+msgid "image must have at least %d bands"
 msgstr ""
 
-#: ../libvips/morphology/countlines.c:131
+#: libvips/iofuncs/error.c:653
+msgid "images must have the same number of bands, or one must be single-band"
+msgstr ""
+
+#: libvips/iofuncs/error.c:680
+#, c-format
+msgid "image must have 1 or %d bands"
+msgstr ""
+
+#: libvips/iofuncs/error.c:704
+msgid "image must be non-complex"
+msgstr ""
+
+#: libvips/iofuncs/error.c:728
+msgid "image must be complex"
+msgstr ""
+
+#: libvips/iofuncs/error.c:755
+msgid "image must be two-band or complex"
+msgstr ""
+
+#: libvips/iofuncs/error.c:781
+#, c-format
+msgid "image must be %s"
+msgstr ""
+
+#: libvips/iofuncs/error.c:806
+msgid "image must be integer"
+msgstr ""
+
+#: libvips/iofuncs/error.c:831
+msgid "image must be unsigned integer"
+msgstr ""
+
+#: libvips/iofuncs/error.c:859
+msgid "image must be 8- or 16-bit integer, signed or unsigned"
+msgstr ""
+
+#: libvips/iofuncs/error.c:885
+msgid "image must be 8- or 16-bit unsigned integer"
+msgstr ""
+
+#: libvips/iofuncs/error.c:911
+msgid "image must be 8- or 16-bit unsigned integer, or float"
+msgstr ""
+
+#: libvips/iofuncs/error.c:938
+msgid "image must be unsigned int or float"
+msgstr ""
+
+#: libvips/iofuncs/error.c:964
+msgid "images must match in size"
+msgstr ""
+
+#: libvips/iofuncs/error.c:990
+msgid "images must be odd and square"
+msgstr ""
+
+#: libvips/iofuncs/error.c:1016
+msgid "images must have the same number of bands"
+msgstr ""
+
+#: libvips/iofuncs/error.c:1070
+msgid "images must have the same band format"
+msgstr ""
+
+#: libvips/iofuncs/error.c:1096
+msgid "images must have the same coding"
+msgstr ""
+
+#: libvips/iofuncs/error.c:1119
+#, c-format
+msgid "vector must have %d elements"
+msgstr ""
+
+#: libvips/iofuncs/error.c:1155
+msgid "vector must have 1 element"
+msgstr ""
+
+#: libvips/iofuncs/error.c:1158
+#, c-format
+msgid "vector must have 1 or %d elements"
+msgstr ""
+
+#: libvips/iofuncs/error.c:1183
+msgid "histograms must have width or height 1"
+msgstr ""
+
+#: libvips/iofuncs/error.c:1188
+msgid "histograms must have not have more than 65536 elements"
+msgstr ""
+
+#: libvips/iofuncs/error.c:1224
+msgid "matrix image too large"
+msgstr ""
+
+#: libvips/iofuncs/error.c:1229
+msgid "matrix image must have one band"
+msgstr ""
+
+#: libvips/iofuncs/error.c:1263
+msgid "separable matrix images must have width or height 1"
+msgstr ""
+
+#: libvips/iofuncs/error.c:1289
+msgid "precision must be int or float"
+msgstr ""
+
+#: libvips/iofuncs/generate.c:696
+msgid "demand hint not set"
+msgstr ""
+
+#: libvips/iofuncs/generate.c:715 libvips/iofuncs/generate.c:743
+msgid "generate() called twice"
+msgstr ""
+
+#: libvips/iofuncs/generate.c:784 libvips/iofuncs/image.c:3235
+#, c-format
+msgid "unable to output to a %s image"
+msgstr ""
+
+#: libvips/iofuncs/ginputsource.c:164 libvips/iofuncs/ginputsource.c:229
+#, c-format
+msgid "Error while seeking: %s"
+msgstr ""
+
+#: libvips/iofuncs/ginputsource.c:185
+msgid "Cannot truncate VipsGInputStream"
+msgstr ""
+
+#: libvips/iofuncs/ginputsource.c:206
+#, c-format
+msgid "Error while reading: %s"
+msgstr ""
+
+#: libvips/iofuncs/ginputsource.c:275
+msgid "Stream to wrap"
+msgstr ""
+
+#: libvips/iofuncs/header.c:1380
+#, c-format
+msgid "field \"%s\" not found"
+msgstr ""
+
+#: libvips/iofuncs/header.c:1614
+#, c-format
+msgid "field \"%s\" is of type %s, not %s"
+msgstr ""
+
+#: libvips/iofuncs/header.c:1888
+#, c-format
+msgid "field \"%s\" is of type %s, not VipsRefString"
+msgstr ""
+
+#: libvips/iofuncs/image.c:539
+msgid "unable to close fd"
+msgstr ""
+
+#: libvips/iofuncs/image.c:762
+#, c-format
+msgid "%s %s: %d x %d pixels, %d threads, %d x %d tiles, %d lines in buffer"
+msgstr ""
+
+#: libvips/iofuncs/image.c:775
+#, c-format
+msgid "%s %s: %d%% complete"
+msgstr ""
+
+#: libvips/iofuncs/image.c:794
+#, c-format
+msgid "%s %s: done in %.3gs          \n"
+msgstr ""
+
+#: libvips/iofuncs/image.c:976
+#, c-format
+msgid "unable to open \"%s\", file too short"
+msgstr ""
+
+#: libvips/iofuncs/image.c:985
+#, c-format
+msgid "%s is longer than expected"
+msgstr ""
+
+#: libvips/iofuncs/image.c:1003
+#, c-format
+msgid "bad mode \"%s\""
+msgstr ""
+
+#: libvips/iofuncs/image.c:1075
+msgid "image class"
+msgstr ""
+
+#: libvips/iofuncs/image.c:1173
+msgid "Image filename"
+msgstr ""
+
+#: libvips/iofuncs/image.c:1180
+msgid "Open mode"
+msgstr ""
+
+#: libvips/iofuncs/image.c:1186
+msgid "Kill"
+msgstr ""
+
+#: libvips/iofuncs/image.c:1187
+msgid "Block evaluation on this image"
+msgstr ""
+
+#: libvips/iofuncs/image.c:1193
+msgid "Demand style"
+msgstr ""
+
+#: libvips/iofuncs/image.c:1194
+msgid "Preferred demand style for this image"
+msgstr ""
+
+#: libvips/iofuncs/image.c:1207
+msgid "Foreign buffer"
+msgstr ""
+
+#: libvips/iofuncs/image.c:1208
+msgid "Pointer to foreign pixels"
+msgstr ""
+
+#: libvips/iofuncs/image.c:1660
+#, c-format
+msgid "killed for image \"%s\""
+msgstr ""
+
+#: libvips/iofuncs/image.c:2069
+msgid "memory area too small --- should be %"
+msgstr ""
+
+#: libvips/iofuncs/image.c:2258
+msgid "unable to load source"
+msgstr ""
+
+#: libvips/iofuncs/image.c:2369
+#, c-format
+msgid "bad array length --- should be %d, you passed %d"
+msgstr ""
+
+#: libvips/iofuncs/image.c:2886 libvips/iofuncs/image.c:2888
+#: libvips/iofuncs/memory.c:336 libvips/iofuncs/memory.c:338
+#: libvips/iofuncs/memory.c:409 libvips/iofuncs/memory.c:411
+#, c-format
+msgid "out of memory --- size == %dMB"
+msgstr ""
+
+#: libvips/iofuncs/image.c:3179
+msgid "bad image descriptor"
+msgstr ""
+
+#: libvips/iofuncs/image.c:3298
+#, c-format
+msgid "auto-rewind for %s failed"
+msgstr ""
+
+#: libvips/iofuncs/image.c:3372 libvips/iofuncs/image.c:3502
+#: libvips/iofuncs/image.c:3679
+msgid "image not readable"
+msgstr ""
+
+#: libvips/iofuncs/image.c:3417 libvips/iofuncs/image.c:3643
+msgid "no image data"
+msgstr ""
+
+#: libvips/iofuncs/image.c:3523 libvips/iofuncs/image.c:3709
+#: libvips/iofuncs/image.c:3718
+msgid "image already written"
+msgstr ""
+
+#: libvips/iofuncs/image.c:3547 libvips/iofuncs/image.c:3730
+msgid "image not writeable"
+msgstr ""
+
+#: libvips/iofuncs/image.c:3602
+msgid "bad file type"
+msgstr ""
+
+#: libvips/iofuncs/init.c:316 tools/vips.c:772
+#, c-format
+msgid "unable to load \"%s\" -- %s"
+msgstr ""
+
+#: libvips/iofuncs/init.c:1270
+msgid "flag not in [0, 5]"
+msgstr ""
+
+#: libvips/iofuncs/mapfile.c:189 libvips/iofuncs/mapfile.c:355
+msgid "unable to CreateFileMapping"
+msgstr ""
+
+#: libvips/iofuncs/mapfile.c:196 libvips/iofuncs/mapfile.c:367
+msgid "unable to MapViewOfFile"
+msgstr ""
+
+#: libvips/iofuncs/mapfile.c:235
+msgid "unable to mmap"
+msgstr ""
+
+#: libvips/iofuncs/mapfile.c:250 libvips/iofuncs/mapfile.c:361
+msgid "unable to UnmapViewOfFile"
+msgstr ""
+
+#: libvips/iofuncs/mapfile.c:256
+msgid "unable to munmap file"
+msgstr ""
+
+#: libvips/iofuncs/mapfile.c:278
+msgid "file is less than 64 bytes"
+msgstr ""
+
+#: libvips/iofuncs/mapfile.c:283 libvips/iofuncs/mapfile.c:317
+msgid "unable to get file status"
+msgstr ""
+
+#: libvips/iofuncs/mapfile.c:289
+msgid "not a regular file"
+msgstr ""
+
+#: libvips/iofuncs/mapfile.c:323
+msgid "unable to read data"
+msgstr ""
+
+#: libvips/iofuncs/mapfile.c:387
+#, c-format
+msgid "unable to mmap: \"%s\" - %s"
+msgstr ""
+
+#: libvips/iofuncs/mapfile.c:398
+#, c-format
+msgid "unable to mmap \"%s\" to same address"
+msgstr ""
+
+#: libvips/iofuncs/object.c:346
+#, c-format
+msgid "parameter %s not set"
+msgstr ""
+
+#: libvips/iofuncs/object.c:781
+#, c-format
+msgid "no property named `%s'"
+msgstr ""
+
+#: libvips/iofuncs/object.c:787
+#, c-format
+msgid "no vips argument named `%s'"
+msgstr ""
+
+#: libvips/iofuncs/object.c:793
+#, c-format
+msgid "argument `%s' has no instance"
+msgstr ""
+
+#: libvips/iofuncs/object.c:1533 libvips/iofuncs/operation.c:749
+#: libvips/resample/interpolate.c:659
+#, c-format
+msgid "class \"%s\" not found"
+msgstr ""
+
+#: libvips/iofuncs/object.c:1584
+msgid "base class"
+msgstr ""
+
+#: libvips/iofuncs/object.c:1598
+msgid "Nickname"
+msgstr ""
+
+#: libvips/iofuncs/object.c:1599
+msgid "Class nickname"
+msgstr ""
+
+#: libvips/iofuncs/object.c:1605
+msgid "Description"
+msgstr ""
+
+#: libvips/iofuncs/object.c:1606
+msgid "Class description"
+msgstr ""
+
+#: libvips/iofuncs/object.c:1844
+#, c-format
+msgid "no value supplied for argument '%s'"
+msgstr ""
+
+#: libvips/iofuncs/object.c:1847
+#, c-format
+msgid "no value supplied for argument '%s' ('%s')"
+msgstr ""
+
+#: libvips/iofuncs/object.c:2039 libvips/iofuncs/object.c:2058
+#, c-format
+msgid "'%s' is not an integer"
+msgstr ""
+
+#: libvips/iofuncs/object.c:2481
+#, c-format
+msgid "expected string or ), saw %s"
+msgstr ""
+
+#: libvips/iofuncs/object.c:2524
+#, c-format
+msgid "unable to set '%s'"
+msgstr ""
+
+#: libvips/iofuncs/object.c:2537
+msgid "not , or ) after parameter"
+msgstr ""
+
+#: libvips/iofuncs/object.c:2544
+msgid "extra tokens after ')'"
+msgstr ""
+
+#: libvips/iofuncs/operation.c:235
+#, c-format
+msgid "%d pixels calculated"
+msgstr ""
+
+#: libvips/iofuncs/operation.c:343
+msgid "default enum"
+msgstr ""
+
+#: libvips/iofuncs/operation.c:347
+msgid "allowed enums"
+msgstr ""
+
+#: libvips/iofuncs/operation.c:375
+msgid "default flags"
+msgstr ""
+
+#: libvips/iofuncs/operation.c:380
+msgid "allowed flags"
+msgstr ""
+
+#: libvips/iofuncs/operation.c:396 libvips/iofuncs/operation.c:404
+#: libvips/iofuncs/operation.c:416
+msgid "default"
+msgstr ""
+
+#: libvips/iofuncs/operation.c:407 libvips/iofuncs/operation.c:419
+msgid "min"
+msgstr ""
+
+#: libvips/iofuncs/operation.c:409 libvips/iofuncs/operation.c:421
+msgid "max"
+msgstr ""
+
+#: libvips/iofuncs/operation.c:618
+msgid "operation is blocked"
+msgstr ""
+
+#: libvips/iofuncs/operation.c:664
+msgid "operations"
+msgstr ""
+
+#: libvips/iofuncs/operation.c:755
+#, c-format
+msgid "\"%s\" is not an instantiable class"
+msgstr ""
+
+#: libvips/iofuncs/operation.c:1225
+#, c-format
+msgid "unknown argument '%s'"
+msgstr ""
+
+#: libvips/iofuncs/operation.c:1350
+msgid "too few arguments"
+msgstr ""
+
+#: libvips/iofuncs/operation.c:1469
+msgid "too many arguments"
+msgstr ""
+
+#: libvips/iofuncs/region.c:565 libvips/iofuncs/region.c:635
+#: libvips/iofuncs/region.c:777 libvips/iofuncs/region.c:1848
+msgid "valid clipped to nothing"
+msgstr ""
+
+#: libvips/iofuncs/region.c:675
+msgid "bad image type"
+msgstr ""
+
+#: libvips/iofuncs/region.c:719
+msgid "no pixel data on attached image"
+msgstr ""
+
+#: libvips/iofuncs/region.c:725
+msgid "images do not match in pixel size"
+msgstr ""
+
+#: libvips/iofuncs/region.c:758 libvips/iofuncs/region.c:1830
+msgid "dest too small"
+msgstr ""
+
+#: libvips/iofuncs/region.c:847
+msgid "bad position"
+msgstr ""
+
+#: libvips/iofuncs/region.c:1628
+msgid "stop requested"
+msgstr ""
+
+#: libvips/iofuncs/region.c:1711 libvips/iofuncs/region.c:1901
+#, c-format
+msgid "unable to input from a %s image"
+msgstr ""
+
+#: libvips/iofuncs/region.c:1735
+msgid "incomplete header"
+msgstr ""
+
+#: libvips/iofuncs/region.c:1804
+msgid "inappropriate region type"
+msgstr ""
+
+#: libvips/iofuncs/sbuf.c:85
+msgid "buffered source"
+msgstr ""
+
+#: libvips/iofuncs/sbuf.c:280
+msgid "end of file"
+msgstr ""
+
+#: libvips/iofuncs/sink.c:262
+#, c-format
+msgid "stop function failed for image \"%s\""
+msgstr ""
+
+#: libvips/iofuncs/sink.c:299
+#, c-format
+msgid "start function failed for image \"%s\""
+msgstr ""
+
+#: libvips/iofuncs/sink.c:331
+msgid "per-thread state for sink"
+msgstr ""
+
+#: libvips/iofuncs/sinkdisc.c:108 libvips/iofuncs/util.c:477
+msgid "write failed"
+msgstr ""
+
+#: libvips/iofuncs/sinkdisc.c:137
+msgid "per-thread state for sinkdisc"
+msgstr ""
+
+#: libvips/iofuncs/sinkmemory.c:109
+msgid "per-thread state for sinkmemory"
+msgstr ""
+
+#: libvips/iofuncs/sinkscreen.c:196
+msgid "per-thread state for render"
+msgstr ""
+
+#: libvips/iofuncs/sinkscreen.c:1122
+msgid "bad parameters"
+msgstr ""
+
+#: libvips/iofuncs/source.c:281 libvips/iofuncs/target.c:114
+msgid "don't set 'filename' and 'descriptor'"
+msgstr ""
+
+#: libvips/iofuncs/source.c:358
+msgid "input source"
+msgstr ""
+
+#: libvips/iofuncs/source.c:366 libvips/iofuncs/target.c:304
+msgid "Blob"
+msgstr ""
+
+#: libvips/iofuncs/source.c:367
+msgid "Blob to load from"
+msgstr ""
+
+#: libvips/iofuncs/source.c:512
+#, fuzzy
+msgid "unimplemented target"
+msgstr "unimplemented input colour space 0x%x"
+
+#: libvips/iofuncs/source.c:649
+msgid "unable to open for read"
+msgstr ""
+
+#: libvips/iofuncs/source.c:890
+msgid "pipe too long"
+msgstr ""
+
+#: libvips/iofuncs/source.c:1165 libvips/iofuncs/source.c:1190
+#: libvips/iofuncs/target.c:206
+msgid "bad 'whence'"
+msgstr ""
+
+#: libvips/iofuncs/source.c:1211
+msgid "bad seek to %"
+msgstr ""
+
+#: libvips/iofuncs/sourcecustom.c:173
+msgid "Custom source"
+msgstr ""
+
+#: libvips/iofuncs/sourceginput.c:219
+msgid "GInputStream source"
+msgstr ""
+
+#: libvips/iofuncs/sourceginput.c:227
+msgid "Stream"
+msgstr ""
+
+#: libvips/iofuncs/sourceginput.c:228
+msgid "GInputStream to read from"
+msgstr ""
+
+#: libvips/iofuncs/system.c:185
+msgid "unable to substitute input filename"
+msgstr ""
+
+#: libvips/iofuncs/system.c:191
+msgid "unable to substitute output filename"
+msgstr ""
+
+#: libvips/iofuncs/system.c:226
+#, c-format
+msgid "command \"%s\" failed"
+msgstr ""
+
+#: libvips/iofuncs/system.c:234
+#, c-format
+msgid "stderr output: %s"
+msgstr ""
+
+#: libvips/iofuncs/system.c:269
+msgid "run an external command"
+msgstr ""
+
+#: libvips/iofuncs/system.c:290
+msgid "Command"
+msgstr ""
+
+#: libvips/iofuncs/system.c:291
+msgid "Command to run"
+msgstr ""
+
+#: libvips/iofuncs/system.c:297
+msgid "Input format"
+msgstr ""
+
+#: libvips/iofuncs/system.c:298
+msgid "Format for input filename"
+msgstr ""
+
+#: libvips/iofuncs/system.c:304
+msgid "Output format"
+msgstr ""
+
+#: libvips/iofuncs/system.c:305
+msgid "Format for output filename"
+msgstr ""
+
+#: libvips/iofuncs/system.c:312
+msgid "Command log"
+msgstr ""
+
+#: libvips/iofuncs/target.c:295
+msgid "File descriptor should output to memory"
+msgstr ""
+
+#: libvips/iofuncs/target.c:305
+msgid "Blob to save to"
+msgstr ""
+
+#: libvips/iofuncs/target.c:474
+msgid "write error"
+msgstr ""
+
+#: libvips/iofuncs/targetcustom.c:235
+msgid "Custom target"
+msgstr ""
+
+#: libvips/iofuncs/thread.c:179
+msgid "unable to create thread"
+msgstr ""
+
+#: libvips/iofuncs/thread.c:214 libvips/iofuncs/thread.c:243
+#, c-format
+msgid "threads clipped to %d"
+msgstr ""
+
+#: libvips/iofuncs/threadpool.c:193
+msgid "per-thread state for vipsthreadpool"
+msgstr ""
+
+#: libvips/iofuncs/type.c:958
+#, c-format
+msgid "unable to convert \"%s\" to int"
+msgstr ""
+
+#: libvips/iofuncs/util.c:455
+msgid "unable to get file stats"
+msgstr ""
+
+#: libvips/iofuncs/util.c:619
+#, c-format
+msgid "unable to open file \"%s\" for reading"
+msgstr ""
+
+#: libvips/iofuncs/util.c:641
+#, c-format
+msgid "unable to open file \"%s\" for writing"
+msgstr ""
+
+#: libvips/iofuncs/util.c:662
+#, c-format
+msgid "\"%s\" too long"
+msgstr ""
+
+#: libvips/iofuncs/util.c:710
+#, c-format
+msgid "error reading from file \"%s\""
+msgstr ""
+
+#: libvips/iofuncs/util.c:756
+#, c-format
+msgid "write error (%zd out of %zd blocks written)"
+msgstr ""
+
+#: libvips/iofuncs/util.c:1003
+msgid "unable to seek"
+msgstr ""
+
+#: libvips/iofuncs/util.c:1028 libvips/iofuncs/util.c:1035
+msgid "unable to truncate"
+msgstr ""
+
+#: libvips/iofuncs/util.c:1121
+#, c-format
+msgid "unable to remove directory \"%s\", %s"
+msgstr ""
+
+#: libvips/iofuncs/util.c:1138
+#, c-format
+msgid "unable to rename file \"%s\" as \"%s\", %s"
+msgstr ""
+
+#: libvips/iofuncs/util.c:1267
+msgid "unexpected end of string"
+msgstr ""
+
+#: libvips/iofuncs/util.c:1285 libvips/iofuncs/util.c:1355
+#, c-format
+msgid "expected %s, saw %s"
+msgstr ""
+
+#: libvips/iofuncs/util.c:1664
+msgid "no such enum type"
+msgstr ""
+
+#: libvips/iofuncs/util.c:1682
+#, c-format
+msgid "enum '%s' has no member '%s', should be one of: %s"
+msgstr ""
+
+#: libvips/iofuncs/util.c:1701
+msgid "no such flag type"
+msgstr ""
+
+#: libvips/iofuncs/util.c:1720
+#, c-format
+msgid "flags '%s' has no member '%s'"
+msgstr ""
+
+#: libvips/iofuncs/vips.c:338
+#, c-format
+msgid "\"%s\" is not a VIPS image"
+msgstr ""
+
+#: libvips/iofuncs/vips.c:395
+msgid "unknown coding"
+msgstr ""
+
+#: libvips/iofuncs/vips.c:405
+msgid "malformed LABQ image"
+msgstr ""
+
+#: libvips/iofuncs/vips.c:414
+msgid "malformed RAD image"
+msgstr ""
+
+#: libvips/iofuncs/vips.c:485
+msgid "unable to read history"
+msgstr ""
+
+#: libvips/iofuncs/vips.c:518
+msgid "more than 100 megabytes of XML? sufferin' succotash!"
+msgstr ""
+
+#: libvips/iofuncs/vips.c:552
+msgid "unable to allocate read buffer"
+msgstr ""
+
+#: libvips/iofuncs/vips.c:558
+msgid "read error while fetching XML"
+msgstr ""
+
+#: libvips/iofuncs/vips.c:570
+msgid "XML parse error"
+msgstr ""
+
+#: libvips/iofuncs/vips.c:635
+msgid "incorrect namespace in XML"
+msgstr ""
+
+#: libvips/iofuncs/vips.c:683
+msgid "error transforming from save format"
+msgstr ""
+
+#: libvips/iofuncs/vips.c:784 libvips/iofuncs/vips.c:1056
+#: libvips/iofuncs/window.c:232
+msgid "file has been truncated"
+msgstr ""
+
+#: libvips/iofuncs/vips.c:836 libvips/iofuncs/vips.c:927
+msgid "error transforming to save format"
+msgstr ""
+
+#: libvips/iofuncs/vips.c:1041
+#, c-format
+msgid "unable to read header for \"%s\""
+msgstr ""
+
+#: libvips/iofuncs/vips.c:1055 libvips/iofuncs/window.c:231
+#, c-format
+msgid "unable to read data for \"%s\", %s"
+msgstr ""
+
+#: libvips/iofuncs/vips.c:1067
+#, c-format
+msgid "error reading vips image metadata: %s"
+msgstr ""
+
+#: libvips/morphology/countlines.c:135
 msgid "count lines in an image"
 msgstr ""
 
-#: ../libvips/morphology/countlines.c:135
+#: libvips/morphology/countlines.c:139
 msgid "Nolines"
 msgstr ""
 
-#: ../libvips/morphology/countlines.c:136
+#: libvips/morphology/countlines.c:140
 msgid "Number of lines"
 msgstr ""
 
-#: ../libvips/morphology/countlines.c:143
+#: libvips/morphology/countlines.c:147
 msgid "Countlines left-right or up-down"
 msgstr ""
 
-#: ../libvips/morphology/labelregions.c:121
+#: libvips/morphology/labelregions.c:120
 msgid "label regions in an image"
 msgstr ""
 
-#: ../libvips/morphology/labelregions.c:126
+#: libvips/morphology/labelregions.c:125
 msgid "Mask of region labels"
 msgstr ""
 
-#: ../libvips/morphology/labelregions.c:131
+#: libvips/morphology/labelregions.c:130
 msgid "Segments"
 msgstr ""
 
-#: ../libvips/morphology/labelregions.c:132
+#: libvips/morphology/labelregions.c:131
 msgid "Number of discrete contiguous regions"
 msgstr ""
 
-#: ../libvips/morphology/morphology.c:111
+#: libvips/morphology/morph.c:885
+#, c-format
+msgid "bad mask element (%f should be 0, 128 or 255)"
+msgstr ""
+
+#: libvips/morphology/morph.c:955
+msgid "morphology operation"
+msgstr ""
+
+#: libvips/morphology/morph.c:971
+msgid "Morphology"
+msgstr ""
+
+#: libvips/morphology/morph.c:972
+msgid "Morphological operation to perform"
+msgstr ""
+
+#: libvips/morphology/morphology.c:115
 msgid "morphological operations"
 msgstr ""
 
-#: ../libvips/morphology/hitmiss.c:321
-#, c-format
-msgid "bad mask element (%d should be 0, 128 or 255)"
+#: libvips/morphology/nearest.c:305
+msgid "fill image zeros with nearest non-zero pixel"
 msgstr ""
 
-#: ../libvips/mosaicing/im_tbmerge.c:164 ../libvips/mosaicing/im_tbmerge.c:218
-#: ../libvips/mosaicing/im_tbmerge.c:536 ../libvips/mosaicing/im_lrmerge.c:216
-#: ../libvips/mosaicing/im_lrmerge.c:265 ../libvips/mosaicing/im_lrmerge.c:606
-msgid "internal error"
+#: libvips/morphology/nearest.c:309
+msgid "Out"
 msgstr ""
 
-#: ../libvips/mosaicing/im_tbmerge.c:635 ../libvips/mosaicing/im_lrmerge.c:806
-msgid "unknown coding type"
+#: libvips/morphology/nearest.c:310
+msgid "Value of nearest non-zero pixel"
 msgstr ""
 
-#: ../libvips/mosaicing/im_tbmerge.c:653 ../libvips/mosaicing/im_lrmerge.c:823
-msgid "too much overlap"
+#: libvips/morphology/nearest.c:316
+msgid "Distance to nearest non-zero pixel"
 msgstr ""
 
-#: ../libvips/mosaicing/im_chkpair.c:201
+#: libvips/morphology/rank.c:496
+msgid "index out of range"
+msgstr ""
+
+#: libvips/morphology/rank.c:560
+msgid "rank filter"
+msgstr ""
+
+#: libvips/morphology/rank.c:585
+msgid "Select pixel at index"
+msgstr ""
+
+#: libvips/mosaicing/chkpair.c:200
 msgid "inputs incompatible"
 msgstr ""
 
-#: ../libvips/mosaicing/im_chkpair.c:205 ../libvips/mosaicing/im_tbcalcon.c:103
+#: libvips/mosaicing/chkpair.c:204 libvips/mosaicing/im_tbcalcon.c:105
 msgid "help!"
 msgstr ""
 
-#: ../libvips/mosaicing/im_lrmosaic.c:114 ../libvips/mosaicing/im_tbmosaic.c:90
-msgid "bad area parameters"
-msgstr ""
-
-#: ../libvips/mosaicing/im_lrmosaic.c:135
-#: ../libvips/mosaicing/im_tbmosaic.c:111
-msgid "overlap too small for search"
-msgstr ""
-
-#: ../libvips/mosaicing/im_lrmosaic.c:168
-#: ../libvips/mosaicing/im_tbmosaic.c:144
-msgid "unknown Coding type"
-msgstr ""
-
-#: ../libvips/mosaicing/im_tbcalcon.c:117
-msgid "overlap too small"
-msgstr ""
-
-#: ../libvips/mosaicing/merge.c:105
-msgid "merge two images"
-msgstr ""
-
-#: ../libvips/mosaicing/merge.c:110 ../libvips/mosaicing/mosaic.c:181
-#: ../libvips/mosaicing/match.c:205 ../libvips/mosaicing/mosaic1.c:490
-msgid "Reference image"
-msgstr ""
-
-#: ../libvips/mosaicing/merge.c:115 ../libvips/mosaicing/mosaic.c:186
-#: ../libvips/mosaicing/match.c:210 ../libvips/mosaicing/mosaic1.c:495
-msgid "Secondary"
-msgstr ""
-
-#: ../libvips/mosaicing/merge.c:116 ../libvips/mosaicing/mosaic.c:187
-#: ../libvips/mosaicing/match.c:211 ../libvips/mosaicing/mosaic1.c:496
-msgid "Secondary image"
-msgstr ""
-
-#: ../libvips/mosaicing/merge.c:128
-msgid "Horizontal or vertcial merge"
-msgstr ""
-
-#: ../libvips/mosaicing/merge.c:134
-msgid "dx"
-msgstr ""
-
-#: ../libvips/mosaicing/merge.c:135
-msgid "Horizontal displacement from sec to ref"
-msgstr ""
-
-#: ../libvips/mosaicing/merge.c:141
-msgid "dy"
-msgstr ""
-
-#: ../libvips/mosaicing/merge.c:142
-msgid "Vertical displacement from sec to ref"
-msgstr ""
-
-#: ../libvips/mosaicing/merge.c:148 ../libvips/mosaicing/mosaic.c:247
-#: ../libvips/mosaicing/mosaic1.c:597
-msgid "Max blend"
-msgstr ""
-
-#: ../libvips/mosaicing/merge.c:149 ../libvips/mosaicing/mosaic.c:248
-#: ../libvips/mosaicing/mosaic1.c:598
-msgid "Maximum blend size"
-msgstr ""
-
-#: ../libvips/mosaicing/im_remosaic.c:115
-#, c-format
-msgid "substitute image \"%s\" is not the same size as \"%s\""
-msgstr ""
-
-#: ../libvips/mosaicing/im_remosaic.c:160
-#: ../libvips/mosaicing/global_balance.c:1767
-msgid "global balance an image mosaic"
-msgstr ""
-
-#: ../libvips/mosaicing/im_remosaic.c:176
-msgid "old_str"
-msgstr ""
-
-#: ../libvips/mosaicing/im_remosaic.c:177
-msgid "Search for this string"
-msgstr ""
-
-#: ../libvips/mosaicing/im_remosaic.c:183
-msgid "new_str"
-msgstr ""
-
-#: ../libvips/mosaicing/im_remosaic.c:184
-msgid "And swap for this string"
-msgstr ""
-
-#: ../libvips/mosaicing/im_lrcalcon.c:204
-msgid "overlap too small for your search size"
-msgstr ""
-
-#: ../libvips/mosaicing/im_lrcalcon.c:243
-#, c-format
-msgid "found %d tie-points, need at least %d"
-msgstr ""
-
-#: ../libvips/mosaicing/im_lrcalcon.c:288
-msgid "not 1-band uchar image"
-msgstr ""
-
-#: ../libvips/mosaicing/global_balance.c:148
+#: libvips/mosaicing/global_balance.c:151
 msgid "no matching '>'"
 msgstr ""
 
-#: ../libvips/mosaicing/global_balance.c:157
+#: libvips/mosaicing/global_balance.c:160
 msgid "too many items"
 msgstr ""
 
-#: ../libvips/mosaicing/global_balance.c:451
+#: libvips/mosaicing/global_balance.c:463
 msgid "circularity detected"
 msgstr ""
 
-#: ../libvips/mosaicing/global_balance.c:485
-#: ../libvips/mosaicing/global_balance.c:545
+#: libvips/mosaicing/global_balance.c:497
+#: libvips/mosaicing/global_balance.c:557
 #, c-format
 msgid "image \"%s\" used twice as output"
 msgstr ""
 
-#: ../libvips/mosaicing/global_balance.c:594
+#: libvips/mosaicing/global_balance.c:606
 msgid "bad number of args in join line"
 msgstr ""
 
-#: ../libvips/mosaicing/global_balance.c:636
+#: libvips/mosaicing/global_balance.c:648
 msgid "bad number of args in join1 line"
 msgstr ""
 
-#: ../libvips/mosaicing/global_balance.c:672
+#: libvips/mosaicing/global_balance.c:684
 msgid "bad number of args in copy line"
 msgstr ""
 
-#: ../libvips/mosaicing/global_balance.c:730
+#: libvips/mosaicing/global_balance.c:742
 msgid ""
 "mosaic root not found in desc file\n"
 "is this really a mosaiced image?"
 msgstr ""
 
-#: ../libvips/mosaicing/global_balance.c:741
+#: libvips/mosaicing/global_balance.c:753
 msgid "more than one root"
 msgstr ""
 
-#: ../libvips/mosaicing/global_balance.c:1783
-msgid "gamma"
+#: libvips/mosaicing/global_balance.c:1525
+msgid "bad sizes"
 msgstr ""
 
-#: ../libvips/mosaicing/global_balance.c:1784
+#: libvips/mosaicing/global_balance.c:1920
+msgid "global balance an image mosaic"
+msgstr ""
+
+#: libvips/mosaicing/global_balance.c:1936
+msgid "Gamma"
+msgstr ""
+
+#: libvips/mosaicing/global_balance.c:1937
 msgid "Image gamma"
 msgstr ""
 
-#: ../libvips/mosaicing/global_balance.c:1790
+#: libvips/mosaicing/global_balance.c:1943
 msgid "Int output"
 msgstr ""
 
-#: ../libvips/mosaicing/global_balance.c:1791
+#: libvips/mosaicing/global_balance.c:1944
 msgid "Integer output"
 msgstr ""
 
-#: ../libvips/mosaicing/im_avgdxdy.c:65
+#: libvips/mosaicing/im_avgdxdy.c:65
 msgid "no points to average"
 msgstr ""
 
-#: ../libvips/mosaicing/im_lrmerge.c:706
+#: libvips/mosaicing/im_clinear.c:138
+msgid "vips_invmat failed"
+msgstr ""
+
+#: libvips/mosaicing/im_lrcalcon.c:206
+msgid "overlap too small for your search size"
+msgstr ""
+
+#: libvips/mosaicing/im_lrcalcon.c:245
+#, c-format
+msgid "found %d tie-points, need at least %d"
+msgstr ""
+
+#: libvips/mosaicing/im_lrcalcon.c:290
+msgid "not 1-band uchar image"
+msgstr ""
+
+#: libvips/mosaicing/im_tbcalcon.c:119
+msgid "overlap too small"
+msgstr ""
+
+#: libvips/mosaicing/lrmerge.c:786
 msgid "mwidth must be -1 or >= 0"
 msgstr ""
 
-#: ../libvips/mosaicing/im_lrmerge.c:735
+#: libvips/mosaicing/lrmerge.c:818
 msgid "no overlap"
 msgstr ""
 
-#: ../libvips/mosaicing/mosaic.c:176
-msgid "mosaic two images"
+#: libvips/mosaicing/lrmerge.c:888 libvips/mosaicing/tbmerge.c:693
+msgid "unknown coding type"
 msgstr ""
 
-#: ../libvips/mosaicing/mosaic.c:199 ../libvips/mosaicing/mosaic1.c:508
-msgid "Horizontal or vertcial mosaic"
+#: libvips/mosaicing/lrmerge.c:906 libvips/mosaicing/tbmerge.c:711
+msgid "too much overlap"
 msgstr ""
 
-#: ../libvips/mosaicing/mosaic.c:205
-msgid "xref"
+#: libvips/mosaicing/lrmosaic.c:122 libvips/mosaicing/tbmosaic.c:93
+msgid "bad area parameters"
 msgstr ""
 
-#: ../libvips/mosaicing/mosaic.c:206 ../libvips/mosaicing/mosaic.c:213
-msgid "Position of reference tie-point"
+#: libvips/mosaicing/lrmosaic.c:143 libvips/mosaicing/tbmosaic.c:114
+msgid "overlap too small for search"
 msgstr ""
 
-#: ../libvips/mosaicing/mosaic.c:212
-msgid "yref"
+#: libvips/mosaicing/lrmosaic.c:171 libvips/mosaicing/tbmosaic.c:142
+msgid "unknown Coding type"
 msgstr ""
 
-#: ../libvips/mosaicing/mosaic.c:219
-msgid "xsec"
-msgstr ""
-
-#: ../libvips/mosaicing/mosaic.c:220 ../libvips/mosaicing/mosaic.c:227
-msgid "Position of secondary tie-point"
-msgstr ""
-
-#: ../libvips/mosaicing/mosaic.c:226
-msgid "ysec"
-msgstr ""
-
-#: ../libvips/mosaicing/mosaic.c:233 ../libvips/mosaicing/match.c:278
-#: ../libvips/mosaicing/mosaic1.c:570
-msgid "hwindow"
-msgstr ""
-
-#: ../libvips/mosaicing/mosaic.c:234 ../libvips/mosaicing/match.c:279
-#: ../libvips/mosaicing/mosaic1.c:571
-msgid "Half window size"
-msgstr ""
-
-#: ../libvips/mosaicing/mosaic.c:240 ../libvips/mosaicing/match.c:285
-#: ../libvips/mosaicing/mosaic1.c:577
-msgid "harea"
-msgstr ""
-
-#: ../libvips/mosaicing/mosaic.c:241 ../libvips/mosaicing/match.c:286
-#: ../libvips/mosaicing/mosaic1.c:578
-msgid "Half area size"
-msgstr ""
-
-#: ../libvips/mosaicing/mosaic.c:254 ../libvips/mosaicing/mosaic1.c:604
-msgid "Search band"
-msgstr ""
-
-#: ../libvips/mosaicing/mosaic.c:255 ../libvips/mosaicing/mosaic1.c:605
-msgid "Band to search for features on"
-msgstr ""
-
-#: ../libvips/mosaicing/mosaic.c:261 ../libvips/mosaicing/mosaic.c:268
-msgid "Integer offset"
-msgstr ""
-
-#: ../libvips/mosaicing/mosaic.c:262 ../libvips/mosaicing/mosaic.c:269
-msgid "Detected integer offset"
-msgstr ""
-
-#: ../libvips/mosaicing/mosaic.c:276
-msgid "Detected scale"
-msgstr ""
-
-#: ../libvips/mosaicing/mosaic.c:283
-msgid "Detected rotation"
-msgstr ""
-
-#: ../libvips/mosaicing/mosaic.c:289 ../libvips/mosaicing/mosaic.c:296
-msgid "First-order displacement"
-msgstr ""
-
-#: ../libvips/mosaicing/mosaic.c:290 ../libvips/mosaicing/mosaic.c:297
-msgid "Detected first-order displacement"
-msgstr ""
-
-#: ../libvips/mosaicing/im_clinear.c:137
-msgid "im_invmat failed"
-msgstr ""
-
-#: ../libvips/mosaicing/match.c:200
+#: libvips/mosaicing/match.c:192
 msgid "first-order match of two images"
 msgstr ""
 
-#: ../libvips/mosaicing/match.c:222 ../libvips/mosaicing/mosaic1.c:514
+#: libvips/mosaicing/match.c:197 libvips/mosaicing/merge.c:123
+#: libvips/mosaicing/mosaic1.c:499 libvips/mosaicing/mosaic.c:180
+msgid "Reference image"
+msgstr ""
+
+#: libvips/mosaicing/match.c:202 libvips/mosaicing/merge.c:128
+#: libvips/mosaicing/mosaic1.c:504 libvips/mosaicing/mosaic.c:185
+msgid "Secondary"
+msgstr ""
+
+#: libvips/mosaicing/match.c:203 libvips/mosaicing/merge.c:129
+#: libvips/mosaicing/mosaic1.c:505 libvips/mosaicing/mosaic.c:186
+msgid "Secondary image"
+msgstr ""
+
+#: libvips/mosaicing/match.c:214 libvips/mosaicing/mosaic1.c:523
 msgid "xr1"
 msgstr ""
 
-#: ../libvips/mosaicing/match.c:223 ../libvips/mosaicing/match.c:230
-#: ../libvips/mosaicing/mosaic1.c:515 ../libvips/mosaicing/mosaic1.c:522
+#: libvips/mosaicing/match.c:215 libvips/mosaicing/match.c:222
+#: libvips/mosaicing/mosaic1.c:524 libvips/mosaicing/mosaic1.c:531
 msgid "Position of first reference tie-point"
 msgstr ""
 
-#: ../libvips/mosaicing/match.c:229 ../libvips/mosaicing/mosaic1.c:521
+#: libvips/mosaicing/match.c:221 libvips/mosaicing/mosaic1.c:530
 msgid "yr1"
 msgstr ""
 
-#: ../libvips/mosaicing/match.c:236 ../libvips/mosaicing/mosaic1.c:528
+#: libvips/mosaicing/match.c:228 libvips/mosaicing/mosaic1.c:537
 msgid "xs1"
 msgstr ""
 
-#: ../libvips/mosaicing/match.c:237 ../libvips/mosaicing/match.c:244
-#: ../libvips/mosaicing/mosaic1.c:529 ../libvips/mosaicing/mosaic1.c:536
+#: libvips/mosaicing/match.c:229 libvips/mosaicing/match.c:236
+#: libvips/mosaicing/mosaic1.c:538 libvips/mosaicing/mosaic1.c:545
 msgid "Position of first secondary tie-point"
 msgstr ""
 
-#: ../libvips/mosaicing/match.c:243 ../libvips/mosaicing/mosaic1.c:535
+#: libvips/mosaicing/match.c:235 libvips/mosaicing/mosaic1.c:544
 msgid "ys1"
 msgstr ""
 
-#: ../libvips/mosaicing/match.c:250 ../libvips/mosaicing/mosaic1.c:542
+#: libvips/mosaicing/match.c:242 libvips/mosaicing/mosaic1.c:551
 msgid "xr2"
 msgstr ""
 
-#: ../libvips/mosaicing/match.c:251 ../libvips/mosaicing/match.c:258
-#: ../libvips/mosaicing/mosaic1.c:543 ../libvips/mosaicing/mosaic1.c:550
+#: libvips/mosaicing/match.c:243 libvips/mosaicing/match.c:250
+#: libvips/mosaicing/mosaic1.c:552 libvips/mosaicing/mosaic1.c:559
 msgid "Position of second reference tie-point"
 msgstr ""
 
-#: ../libvips/mosaicing/match.c:257 ../libvips/mosaicing/mosaic1.c:549
+#: libvips/mosaicing/match.c:249 libvips/mosaicing/mosaic1.c:558
 msgid "yr2"
 msgstr ""
 
-#: ../libvips/mosaicing/match.c:264 ../libvips/mosaicing/mosaic1.c:556
+#: libvips/mosaicing/match.c:256 libvips/mosaicing/mosaic1.c:565
 msgid "xs2"
 msgstr ""
 
-#: ../libvips/mosaicing/match.c:265 ../libvips/mosaicing/match.c:272
-#: ../libvips/mosaicing/mosaic1.c:557 ../libvips/mosaicing/mosaic1.c:564
+#: libvips/mosaicing/match.c:257 libvips/mosaicing/match.c:264
+#: libvips/mosaicing/mosaic1.c:566 libvips/mosaicing/mosaic1.c:573
 msgid "Position of second secondary tie-point"
 msgstr ""
 
-#: ../libvips/mosaicing/match.c:271 ../libvips/mosaicing/mosaic1.c:563
+#: libvips/mosaicing/match.c:263 libvips/mosaicing/mosaic1.c:572
 msgid "ys2"
 msgstr ""
 
-#: ../libvips/mosaicing/match.c:292 ../libvips/mosaicing/mosaic1.c:584
-msgid "search"
+#: libvips/mosaicing/match.c:270 libvips/mosaicing/mosaic1.c:579
+#: libvips/mosaicing/mosaic.c:232
+msgid "hwindow"
 msgstr ""
 
-#: ../libvips/mosaicing/match.c:293 ../libvips/mosaicing/mosaic1.c:585
+#: libvips/mosaicing/match.c:271 libvips/mosaicing/mosaic1.c:580
+#: libvips/mosaicing/mosaic.c:233
+msgid "Half window size"
+msgstr ""
+
+#: libvips/mosaicing/match.c:277 libvips/mosaicing/mosaic1.c:586
+#: libvips/mosaicing/mosaic.c:239
+msgid "harea"
+msgstr ""
+
+#: libvips/mosaicing/match.c:278 libvips/mosaicing/mosaic1.c:587
+#: libvips/mosaicing/mosaic.c:240
+msgid "Half area size"
+msgstr ""
+
+#: libvips/mosaicing/match.c:284 libvips/mosaicing/mosaic1.c:593
+msgid "Search"
+msgstr ""
+
+#: libvips/mosaicing/match.c:285 libvips/mosaicing/mosaic1.c:594
 msgid "Search to improve tie-points"
 msgstr ""
 
-#: ../libvips/mosaicing/match.c:299 ../libvips/mosaicing/mosaic1.c:591
-#: ../libvips/resample/affine.c:568 ../libvips/resample/mapim.c:418
-#: ../libvips/resample/resize.c:384 ../libvips/resample/quadratic.c:354
-#: ../libvips/resample/similarity.c:185
+#: libvips/mosaicing/match.c:291 libvips/mosaicing/mosaic1.c:600
+#: libvips/resample/affine.c:651 libvips/resample/mapim.c:561
+#: libvips/resample/quadratic.c:351 libvips/resample/resize.c:376
+#: libvips/resample/similarity.c:127
 msgid "Interpolate"
 msgstr ""
 
-#: ../libvips/mosaicing/match.c:300 ../libvips/mosaicing/mosaic1.c:592
-#: ../libvips/resample/affine.c:569 ../libvips/resample/mapim.c:419
-#: ../libvips/resample/resize.c:385 ../libvips/resample/similarity.c:186
+#: libvips/mosaicing/match.c:292 libvips/mosaicing/mosaic1.c:601
+#: libvips/resample/affine.c:652 libvips/resample/mapim.c:562
+#: libvips/resample/resize.c:377 libvips/resample/similarity.c:128
 msgid "Interpolate pixels with this"
 msgstr ""
 
-#: ../libvips/mosaicing/mosaic1.c:485
+#: libvips/mosaicing/matrixinvert.c:312 libvips/mosaicing/matrixinvert.c:328
+#: libvips/mosaicing/matrixinvert.c:353 libvips/resample/transform.c:60
+msgid "singular or near-singular matrix"
+msgstr ""
+
+#: libvips/mosaicing/matrixinvert.c:406
+msgid "non-square matrix"
+msgstr ""
+
+#: libvips/mosaicing/matrixinvert.c:439
+msgid "invert an matrix"
+msgstr ""
+
+#: libvips/mosaicing/matrixinvert.c:444
+msgid "An square matrix"
+msgstr ""
+
+#: libvips/mosaicing/matrixinvert.c:450
+msgid "Output matrix"
+msgstr ""
+
+#: libvips/mosaicing/merge.c:116
+msgid "merge two images"
+msgstr ""
+
+#: libvips/mosaicing/merge.c:141
+msgid "Horizontal or vertical merge"
+msgstr ""
+
+#: libvips/mosaicing/merge.c:147
+msgid "dx"
+msgstr ""
+
+#: libvips/mosaicing/merge.c:148
+msgid "Horizontal displacement from sec to ref"
+msgstr ""
+
+#: libvips/mosaicing/merge.c:154
+msgid "dy"
+msgstr ""
+
+#: libvips/mosaicing/merge.c:155
+msgid "Vertical displacement from sec to ref"
+msgstr ""
+
+#: libvips/mosaicing/merge.c:161 libvips/mosaicing/mosaic1.c:606
+#: libvips/mosaicing/mosaic.c:246
+msgid "Max blend"
+msgstr ""
+
+#: libvips/mosaicing/merge.c:162 libvips/mosaicing/mosaic1.c:607
+#: libvips/mosaicing/mosaic.c:247
+msgid "Maximum blend size"
+msgstr ""
+
+#: libvips/mosaicing/mosaic1.c:494
 msgid "first-order mosaic of two images"
 msgstr ""
 
-#: ../libvips/resample/affine.c:486
+#: libvips/mosaicing/mosaic1.c:517 libvips/mosaicing/mosaic.c:198
+msgid "Horizontal or vertical mosaic"
+msgstr ""
+
+#: libvips/mosaicing/mosaic1.c:613 libvips/mosaicing/mosaic.c:253
+msgid "Search band"
+msgstr ""
+
+#: libvips/mosaicing/mosaic1.c:614 libvips/mosaicing/mosaic.c:254
+msgid "Band to search for features on"
+msgstr ""
+
+#: libvips/mosaicing/mosaic.c:175
+msgid "mosaic two images"
+msgstr ""
+
+#: libvips/mosaicing/mosaic.c:204
+msgid "xref"
+msgstr ""
+
+#: libvips/mosaicing/mosaic.c:205 libvips/mosaicing/mosaic.c:212
+msgid "Position of reference tie-point"
+msgstr ""
+
+#: libvips/mosaicing/mosaic.c:211
+msgid "yref"
+msgstr ""
+
+#: libvips/mosaicing/mosaic.c:218
+msgid "xsec"
+msgstr ""
+
+#: libvips/mosaicing/mosaic.c:219 libvips/mosaicing/mosaic.c:226
+msgid "Position of secondary tie-point"
+msgstr ""
+
+#: libvips/mosaicing/mosaic.c:225
+msgid "ysec"
+msgstr ""
+
+#: libvips/mosaicing/mosaic.c:260 libvips/mosaicing/mosaic.c:267
+msgid "Integer offset"
+msgstr ""
+
+#: libvips/mosaicing/mosaic.c:261 libvips/mosaicing/mosaic.c:268
+msgid "Detected integer offset"
+msgstr ""
+
+#: libvips/mosaicing/mosaic.c:275
+msgid "Detected scale"
+msgstr ""
+
+#: libvips/mosaicing/mosaic.c:282
+msgid "Detected rotation"
+msgstr ""
+
+#: libvips/mosaicing/mosaic.c:288 libvips/mosaicing/mosaic.c:295
+msgid "First-order displacement"
+msgstr ""
+
+#: libvips/mosaicing/mosaic.c:289 libvips/mosaicing/mosaic.c:296
+msgid "Detected first-order displacement"
+msgstr ""
+
+#: libvips/mosaicing/remosaic.c:89
+#, c-format
+msgid "file \"%s\" not found"
+msgstr ""
+
+#: libvips/mosaicing/remosaic.c:117
+#, c-format
+msgid "substitute image \"%s\" is not the same size as \"%s\""
+msgstr ""
+
+#: libvips/mosaicing/remosaic.c:160
+msgid "rebuild an mosaiced image"
+msgstr ""
+
+#: libvips/mosaicing/remosaic.c:176
+msgid "old_str"
+msgstr ""
+
+#: libvips/mosaicing/remosaic.c:177
+msgid "Search for this string"
+msgstr ""
+
+#: libvips/mosaicing/remosaic.c:183
+msgid "new_str"
+msgstr ""
+
+#: libvips/mosaicing/remosaic.c:184
+msgid "And swap for this string"
+msgstr ""
+
+#: libvips/resample/affine.c:516
 msgid "output coordinates out of range"
 msgstr ""
 
-#: ../libvips/resample/affine.c:557
+#: libvips/resample/affine.c:640
 msgid "affine transform of an image"
 msgstr ""
 
-#: ../libvips/resample/affine.c:561
+#: libvips/resample/affine.c:644
 msgid "Matrix"
 msgstr ""
 
-#: ../libvips/resample/affine.c:562
+#: libvips/resample/affine.c:645
 msgid "Transformation matrix"
 msgstr ""
 
-#: ../libvips/resample/affine.c:574
+#: libvips/resample/affine.c:657
 msgid "Output rect"
 msgstr ""
 
-#: ../libvips/resample/affine.c:575
+#: libvips/resample/affine.c:658
 msgid "Area of output to generate"
 msgstr ""
 
-#: ../libvips/resample/affine.c:581 ../libvips/resample/affine.c:588
-#: ../libvips/resample/similarity.c:191 ../libvips/resample/similarity.c:198
+#: libvips/resample/affine.c:664 libvips/resample/affine.c:671
+#: libvips/resample/similarity.c:140 libvips/resample/similarity.c:147
 msgid "Output offset"
 msgstr ""
 
-#: ../libvips/resample/affine.c:582 ../libvips/resample/similarity.c:192
+#: libvips/resample/affine.c:665 libvips/resample/similarity.c:141
 msgid "Horizontal output displacement"
 msgstr ""
 
-#: ../libvips/resample/affine.c:589 ../libvips/resample/similarity.c:199
+#: libvips/resample/affine.c:672 libvips/resample/similarity.c:148
 msgid "Vertical output displacement"
 msgstr ""
 
-#: ../libvips/resample/affine.c:595 ../libvips/resample/affine.c:602
-#: ../libvips/resample/resize.c:368 ../libvips/resample/resize.c:375
-#: ../libvips/resample/similarity.c:205 ../libvips/resample/similarity.c:212
+#: libvips/resample/affine.c:678 libvips/resample/affine.c:685
+#: libvips/resample/resize.c:360 libvips/resample/resize.c:367
+#: libvips/resample/similarity.c:154 libvips/resample/similarity.c:161
 msgid "Input offset"
 msgstr ""
 
-#: ../libvips/resample/affine.c:596 ../libvips/resample/resize.c:369
-#: ../libvips/resample/similarity.c:206
+#: libvips/resample/affine.c:679 libvips/resample/resize.c:361
+#: libvips/resample/similarity.c:155
 msgid "Horizontal input displacement"
 msgstr ""
 
-#: ../libvips/resample/affine.c:603 ../libvips/resample/resize.c:376
-#: ../libvips/resample/similarity.c:213
+#: libvips/resample/affine.c:686 libvips/resample/resize.c:368
+#: libvips/resample/similarity.c:162
 msgid "Vertical input displacement"
 msgstr ""
 
-#: ../libvips/resample/shrinkv.c:344 ../libvips/resample/shrinkh.c:246
-msgid "shrink factors should be >= 1"
+#: libvips/resample/bicubic.cpp:629
+msgid "bicubic interpolation (Catmull-Rom)"
 msgstr ""
 
-#: ../libvips/resample/shrinkv.c:424 ../libvips/resample/reducev.cpp:895
-msgid "shrink an image vertically"
-msgstr ""
-
-#: ../libvips/resample/shrinkv.c:430 ../libvips/resample/reduce.c:141
-#: ../libvips/resample/shrink.c:137 ../libvips/resample/reducev.cpp:901
-msgid "Vshrink"
-msgstr ""
-
-#: ../libvips/resample/shrinkv.c:431 ../libvips/resample/shrinkv.c:440
-#: ../libvips/resample/reduce.c:142 ../libvips/resample/reduce.c:172
-#: ../libvips/resample/shrink.c:138 ../libvips/resample/shrink.c:161
-#: ../libvips/resample/reducev.cpp:902 ../libvips/resample/reducev.cpp:925
-msgid "Vertical shrink factor"
-msgstr ""
-
-#: ../libvips/resample/shrinkv.c:439 ../libvips/resample/reduce.c:171
-#: ../libvips/resample/shrink.c:160 ../libvips/resample/reducev.cpp:924
-msgid "Yshrink"
-msgstr ""
-
-#: ../libvips/resample/mapim.c:408
-msgid "resample with an mapim image"
-msgstr ""
-
-#: ../libvips/resample/mapim.c:413
-msgid "Index pixels with this"
-msgstr ""
-
-#: ../libvips/resample/resize.c:331
-msgid "resize an image"
-msgstr ""
-
-#: ../libvips/resample/resize.c:337
-msgid "Scale factor"
-msgstr ""
-
-#: ../libvips/resample/resize.c:338
-msgid "Scale image by this factor"
-msgstr ""
-
-#: ../libvips/resample/resize.c:344
-msgid "Vertical scale factor"
-msgstr ""
-
-#: ../libvips/resample/resize.c:345
-msgid "Vertical scale image by this factor"
-msgstr ""
-
-#: ../libvips/resample/resize.c:351 ../libvips/resample/reduce.c:148
-#: ../libvips/resample/reduceh.cpp:575 ../libvips/resample/reducev.cpp:908
-msgid "Kernel"
-msgstr ""
-
-#: ../libvips/resample/resize.c:352 ../libvips/resample/reduce.c:149
-#: ../libvips/resample/reduceh.cpp:576 ../libvips/resample/reducev.cpp:909
-msgid "Resampling kernel"
-msgstr ""
-
-#: ../libvips/resample/resize.c:358 ../libvips/resample/reduce.c:155
-#: ../libvips/resample/reduceh.cpp:582 ../libvips/resample/reducev.cpp:915
-msgid "Centre"
-msgstr ""
-
-#: ../libvips/resample/resize.c:359 ../libvips/resample/reduce.c:156
-#: ../libvips/resample/reduceh.cpp:583 ../libvips/resample/reducev.cpp:916
-msgid "Use centre sampling convention"
-msgstr ""
-
-#: ../libvips/resample/reduce.c:128
-msgid "reduce an image"
-msgstr ""
-
-#: ../libvips/resample/reduce.c:134 ../libvips/resample/shrinkh.c:326
-#: ../libvips/resample/shrink.c:144 ../libvips/resample/reduceh.cpp:568
-msgid "Hshrink"
-msgstr ""
-
-#: ../libvips/resample/reduce.c:135 ../libvips/resample/reduce.c:165
-#: ../libvips/resample/shrinkh.c:327 ../libvips/resample/shrinkh.c:336
-#: ../libvips/resample/shrink.c:145 ../libvips/resample/shrink.c:154
-#: ../libvips/resample/reduceh.cpp:569 ../libvips/resample/reduceh.cpp:592
-msgid "Horizontal shrink factor"
-msgstr ""
-
-#: ../libvips/resample/reduce.c:164 ../libvips/resample/shrinkh.c:335
-#: ../libvips/resample/shrink.c:153 ../libvips/resample/reduceh.cpp:591
-msgid "Xshrink"
-msgstr ""
-
-#: ../libvips/resample/shrinkh.c:320 ../libvips/resample/reduceh.cpp:562
-msgid "shrink an image horizontally"
-msgstr ""
-
-#: ../libvips/resample/resample.c:128
-msgid "resample operations"
-msgstr ""
-
-#: ../libvips/resample/quadratic.c:270
-msgid "coefficient matrix must have width 2"
-msgstr ""
-
-#: ../libvips/resample/quadratic.c:292
-msgid "coefficient matrix must have height 1, 3, 4 or 6"
-msgstr ""
-
-#: ../libvips/resample/quadratic.c:344
-msgid "resample an image with a quadratic transform"
-msgstr ""
-
-#: ../libvips/resample/quadratic.c:348
-msgid "Coeff"
-msgstr ""
-
-#: ../libvips/resample/quadratic.c:349
-msgid "Coefficient matrix"
-msgstr ""
-
-#: ../libvips/resample/quadratic.c:355
-msgid "Interpolate values with this"
-msgstr ""
-
-#: ../libvips/resample/thumbnail.c:436
-#, c-format
-msgid "unable to import with embedded profile: %s"
-msgstr ""
-
-#: ../libvips/resample/thumbnail.c:516
-msgid "thumbnail generation"
-msgstr ""
-
-#: ../libvips/resample/thumbnail.c:526
-msgid "Target width"
-msgstr ""
-
-#: ../libvips/resample/thumbnail.c:527
-msgid "Size to this width"
-msgstr ""
-
-#: ../libvips/resample/thumbnail.c:533
-msgid "Target height"
-msgstr ""
-
-#: ../libvips/resample/thumbnail.c:534
-msgid "Size to this height"
-msgstr ""
-
-#: ../libvips/resample/thumbnail.c:540
-msgid "size"
-msgstr ""
-
-#: ../libvips/resample/thumbnail.c:541
-msgid "Only upsize, only downsize, or both"
-msgstr ""
-
-#: ../libvips/resample/thumbnail.c:547
-msgid "Auto rotate"
-msgstr ""
-
-#: ../libvips/resample/thumbnail.c:548
-msgid "Use orientation tags to rotate image upright"
-msgstr ""
-
-#: ../libvips/resample/thumbnail.c:554
-msgid "Crop"
-msgstr ""
-
-#: ../libvips/resample/thumbnail.c:555
-msgid "Reduce to fill target rectangle, then crop"
-msgstr ""
-
-#: ../libvips/resample/thumbnail.c:561
-msgid "Linear"
-msgstr ""
-
-#: ../libvips/resample/thumbnail.c:562
-msgid "Reduce in linear light"
-msgstr ""
-
-#: ../libvips/resample/thumbnail.c:568
-msgid "Import profile"
-msgstr ""
-
-#: ../libvips/resample/thumbnail.c:569
-msgid "Fallback import profile"
-msgstr ""
-
-#: ../libvips/resample/thumbnail.c:575
-msgid "Export profile"
-msgstr ""
-
-#: ../libvips/resample/thumbnail.c:576
-msgid "Fallback export profile"
-msgstr ""
-
-#: ../libvips/resample/thumbnail.c:663
-msgid "generate thumbnail from file"
-msgstr ""
-
-#: ../libvips/resample/thumbnail.c:670
-msgid "Filename to read from"
-msgstr ""
-
-#: ../libvips/resample/thumbnail.c:830
-msgid "generate thumbnail from buffer"
-msgstr ""
-
-#: ../libvips/resample/shrink.c:128
-msgid "shrink an image"
-msgstr ""
-
-#: ../libvips/resample/similarity.c:167
-msgid "similarity transform of an image"
-msgstr ""
-
-#: ../libvips/resample/similarity.c:172
-msgid "Scale by this factor"
-msgstr ""
-
-#: ../libvips/resample/similarity.c:179
-msgid "Rotate anticlockwise by this many degrees"
-msgstr ""
-
-#: ../libvips/resample/interpolate.c:183
+#: libvips/resample/interpolate.c:185
 msgid "VIPS interpolators"
 msgstr ""
 
-#: ../libvips/resample/interpolate.c:359
+#: libvips/resample/interpolate.c:361
 msgid "nearest-neighbour interpolation"
 msgstr ""
 
-#: ../libvips/resample/interpolate.c:556
+#: libvips/resample/interpolate.c:579
 msgid "bilinear interpolation"
 msgstr ""
 
-#: ../libvips/video/im_video_test.c:52
-msgid "error requested"
+#: libvips/resample/lbb.cpp:872
+msgid "reduced halo bicubic"
 msgstr ""
 
-#: ../tools/vips.c:154
+#: libvips/resample/mapim.c:551
+msgid "resample with a map image"
+msgstr ""
+
+#: libvips/resample/mapim.c:556
+msgid "Index pixels with this"
+msgstr ""
+
+#: libvips/resample/nohalo.cpp:1551
+msgid "edge sharpening resampler with halo reduction"
+msgstr ""
+
+#: libvips/resample/quadratic.c:269
+msgid "coefficient matrix must have width 2"
+msgstr ""
+
+#: libvips/resample/quadratic.c:291
+msgid "coefficient matrix must have height 1, 3, 4 or 6"
+msgstr ""
+
+#: libvips/resample/quadratic.c:341
+msgid "resample an image with a quadratic transform"
+msgstr ""
+
+#: libvips/resample/quadratic.c:345
+msgid "Coeff"
+msgstr ""
+
+#: libvips/resample/quadratic.c:346
+msgid "Coefficient matrix"
+msgstr ""
+
+#: libvips/resample/quadratic.c:352
+msgid "Interpolate values with this"
+msgstr ""
+
+#: libvips/resample/reduce.c:199
+msgid "reduce an image"
+msgstr ""
+
+#: libvips/resample/reduce.c:205 libvips/resample/reduceh.cpp:586
+#: libvips/resample/shrink.c:149 libvips/resample/shrinkh.c:353
+msgid "Hshrink"
+msgstr ""
+
+#: libvips/resample/reduce.c:206 libvips/resample/reduce.c:236
+#: libvips/resample/reduceh.cpp:587 libvips/resample/reduceh.cpp:610
+#: libvips/resample/shrink.c:150 libvips/resample/shrink.c:166
+#: libvips/resample/shrinkh.c:354 libvips/resample/shrinkh.c:370
+msgid "Horizontal shrink factor"
+msgstr ""
+
+#: libvips/resample/reduce.c:212 libvips/resample/reducev.cpp:1070
+#: libvips/resample/shrink.c:142 libvips/resample/shrinkv.c:427
+msgid "Vshrink"
+msgstr ""
+
+#: libvips/resample/reduce.c:213 libvips/resample/reduce.c:243
+#: libvips/resample/reducev.cpp:1071 libvips/resample/reducev.cpp:1094
+#: libvips/resample/shrink.c:143 libvips/resample/shrink.c:173
+#: libvips/resample/shrinkv.c:428 libvips/resample/shrinkv.c:444
+msgid "Vertical shrink factor"
+msgstr ""
+
+#: libvips/resample/reduce.c:219 libvips/resample/reduceh.cpp:593
+#: libvips/resample/reducev.cpp:1077 libvips/resample/resize.c:343
+msgid "Kernel"
+msgstr ""
+
+#: libvips/resample/reduce.c:220 libvips/resample/reduceh.cpp:594
+#: libvips/resample/reducev.cpp:1078 libvips/resample/resize.c:344
+msgid "Resampling kernel"
+msgstr ""
+
+#: libvips/resample/reduce.c:226 libvips/resample/reduceh.cpp:600
+#: libvips/resample/reducev.cpp:1084 libvips/resample/resize.c:350
+msgid "Gap"
+msgstr ""
+
+#: libvips/resample/reduce.c:227 libvips/resample/reduceh.cpp:601
+#: libvips/resample/reducev.cpp:1085 libvips/resample/resize.c:351
+msgid "Reducing gap"
+msgstr ""
+
+#: libvips/resample/reduce.c:235 libvips/resample/reduceh.cpp:609
+#: libvips/resample/shrink.c:165 libvips/resample/shrinkh.c:369
+msgid "Xshrink"
+msgstr ""
+
+#: libvips/resample/reduce.c:242 libvips/resample/reducev.cpp:1093
+#: libvips/resample/shrink.c:172 libvips/resample/shrinkv.c:443
+msgid "Yshrink"
+msgstr ""
+
+#: libvips/resample/reduce.c:251 libvips/resample/reduceh.cpp:618
+#: libvips/resample/reducev.cpp:1102 libvips/resample/resize.c:384
+msgid "Centre"
+msgstr ""
+
+#: libvips/resample/reduce.c:252 libvips/resample/reduceh.cpp:619
+#: libvips/resample/reducev.cpp:1103 libvips/resample/resize.c:385
+msgid "Use centre sampling convention"
+msgstr ""
+
+#: libvips/resample/reduceh.cpp:414 libvips/resample/reducev.cpp:848
+msgid "reduce factor should be >= 1.0"
+msgstr ""
+
+#: libvips/resample/reduceh.cpp:437 libvips/resample/reducev.cpp:870
+msgid "reduce gap should be >= 1.0"
+msgstr ""
+
+#: libvips/resample/reduceh.cpp:467 libvips/resample/reducev.cpp:900
+msgid "reduce factor too large"
+msgstr ""
+
+#: libvips/resample/reduceh.cpp:580 libvips/resample/shrinkh.c:347
+msgid "shrink an image horizontally"
+msgstr ""
+
+#: libvips/resample/reducev.cpp:1064 libvips/resample/shrinkv.c:421
+msgid "shrink an image vertically"
+msgstr ""
+
+#: libvips/resample/resample.c:136
+msgid "resample operations"
+msgstr ""
+
+#: libvips/resample/resize.c:323
+msgid "resize an image"
+msgstr ""
+
+#: libvips/resample/resize.c:329
+msgid "Scale factor"
+msgstr ""
+
+#: libvips/resample/resize.c:330
+msgid "Scale image by this factor"
+msgstr ""
+
+#: libvips/resample/resize.c:336
+msgid "Vertical scale factor"
+msgstr ""
+
+#: libvips/resample/resize.c:337
+msgid "Vertical scale image by this factor"
+msgstr ""
+
+#: libvips/resample/shrink.c:133
+msgid "shrink an image"
+msgstr ""
+
+#: libvips/resample/shrink.c:156 libvips/resample/shrinkh.c:360
+#: libvips/resample/shrinkv.c:434
+msgid "Ceil"
+msgstr ""
+
+#: libvips/resample/shrink.c:157 libvips/resample/shrinkh.c:361
+#: libvips/resample/shrinkv.c:435
+msgid "Round-up output dimensions"
+msgstr ""
+
+#: libvips/resample/shrinkh.c:283 libvips/resample/shrinkv.c:327
+msgid "shrink factors should be >= 1"
+msgstr ""
+
+#: libvips/resample/similarity.c:123
+msgid "base similarity transform"
+msgstr ""
+
+#: libvips/resample/similarity.c:197
+msgid "similarity transform of an image"
+msgstr ""
+
+#: libvips/resample/similarity.c:201
+msgid "Scale by this factor"
+msgstr ""
+
+#: libvips/resample/similarity.c:208 libvips/resample/similarity.c:277
+msgid "Rotate clockwise by this many degrees"
+msgstr ""
+
+#: libvips/resample/similarity.c:273
+msgid "rotate an image by a number of degrees"
+msgstr ""
+
+#: libvips/resample/thumbnail.c:959
+msgid "thumbnail generation"
+msgstr ""
+
+#: libvips/resample/thumbnail.c:974
+msgid "Target width"
+msgstr ""
+
+#: libvips/resample/thumbnail.c:975
+msgid "Size to this width"
+msgstr ""
+
+#: libvips/resample/thumbnail.c:981
+msgid "Target height"
+msgstr ""
+
+#: libvips/resample/thumbnail.c:982
+msgid "Size to this height"
+msgstr ""
+
+#: libvips/resample/thumbnail.c:989
+msgid "Only upsize, only downsize, or both"
+msgstr ""
+
+#: libvips/resample/thumbnail.c:995
+msgid "No rotate"
+msgstr ""
+
+#: libvips/resample/thumbnail.c:996
+msgid "Don't use orientation tags to rotate image upright"
+msgstr ""
+
+#: libvips/resample/thumbnail.c:1002
+msgid "Crop"
+msgstr ""
+
+#: libvips/resample/thumbnail.c:1003
+msgid "Reduce to fill target rectangle, then crop"
+msgstr ""
+
+#: libvips/resample/thumbnail.c:1009
+msgid "Linear"
+msgstr ""
+
+#: libvips/resample/thumbnail.c:1010
+msgid "Reduce in linear light"
+msgstr ""
+
+#: libvips/resample/thumbnail.c:1016
+msgid "Import profile"
+msgstr ""
+
+#: libvips/resample/thumbnail.c:1017
+msgid "Fallback import profile"
+msgstr ""
+
+#: libvips/resample/thumbnail.c:1023
+msgid "Export profile"
+msgstr ""
+
+#: libvips/resample/thumbnail.c:1024
+msgid "Fallback export profile"
+msgstr ""
+
+#: libvips/resample/thumbnail.c:1050
+msgid "Auto rotate"
+msgstr ""
+
+#: libvips/resample/thumbnail.c:1051
+msgid "Use orientation tags to rotate image upright"
+msgstr ""
+
+#: libvips/resample/thumbnail.c:1192
+msgid "generate thumbnail from file"
+msgstr ""
+
+#: libvips/resample/thumbnail.c:1199
+msgid "Filename to read from"
+msgstr ""
+
+#: libvips/resample/thumbnail.c:1439
+msgid "generate thumbnail from buffer"
+msgstr ""
+
+#: libvips/resample/thumbnail.c:1452 libvips/resample/thumbnail.c:1665
+#, fuzzy
+msgid "Extra options"
+msgstr "colour operations"
+
+#: libvips/resample/thumbnail.c:1453 libvips/resample/thumbnail.c:1666
+msgid "Options that are passed on to the underlying loader"
+msgstr ""
+
+#: libvips/resample/thumbnail.c:1652
+msgid "generate thumbnail from source"
+msgstr ""
+
+#: libvips/resample/thumbnail.c:1776
+msgid "generate thumbnail from image"
+msgstr ""
+
+#: libvips/resample/vsqbs.cpp:378
+msgid "B-Splines with antialiasing smoothing"
+msgstr ""
+
+#: tools/vips.c:166
 #, c-format
 msgid "'%s' is not the name of a vips class"
 msgstr ""
 
-#: ../tools/vips.c:170
-msgid "list objects"
+#: tools/vips.c:282
+#, c-format
+msgid "'%s' is not the name of a vips operation"
 msgstr ""
 
-#: ../tools/vips.c:171
-msgid "BASE-NAME"
-msgstr ""
-
-#: ../tools/vips.c:173
-msgid "load PLUGIN"
-msgstr ""
-
-#: ../tools/vips.c:174
-msgid "PLUGIN"
-msgstr ""
-
-#: ../tools/vips.c:176
-msgid "print version"
-msgstr ""
-
-#: ../tools/vips.c:219
+#: tools/vips.c:355
 #, c-format
 msgid "no package or function \"%s\""
 msgstr ""
 
-#: ../tools/vips.c:1000
-msgid "list classes|packages|all|package-name|operation-name"
-msgstr ""
-
-#: ../tools/vips.c:1002
-msgid "generate headers for C++ binding"
-msgstr ""
-
-#: ../tools/vips.c:1004
-msgid "generate bodies for C++ binding"
-msgstr ""
-
-#: ../tools/vips.c:1006
-msgid "generate links for vips/bin"
-msgstr ""
-
-#: ../tools/vips.c:1008
-msgid "list possible actions"
-msgstr ""
-
-#: ../tools/vips.c:1027
+#: tools/vips.c:584
 msgid "execute vips operation OPER"
 msgstr ""
 
-#: ../tools/vips.c:1070
+#: tools/vips.c:627
 msgid "Operation help"
 msgstr ""
 
-#: ../tools/vips.c:1116
+#: tools/vips.c:706
 msgid "[ACTION] [OPTIONS] [PARAMETERS] - VIPS driver program"
 msgstr ""
 
-#: ../tools/vips.c:1300
+#: tools/vips.c:916
 #, c-format
 msgid "unknown action \"%s\""
 msgstr ""
 
-#: ../tools/vipsedit.c:83
-msgid "tag file as big or little-endian"
-msgstr ""
-
-#: ../tools/vipsedit.c:85
-msgid "set width to N pixels"
-msgstr ""
-
-#: ../tools/vipsedit.c:87
-msgid "set height to N pixels"
-msgstr ""
-
-#: ../tools/vipsedit.c:89
-msgid "set Bands to N"
-msgstr ""
-
-#: ../tools/vipsedit.c:91
-msgid "set BandFmt to F (eg. uchar, float)"
-msgstr ""
-
-#: ../tools/vipsedit.c:93
-msgid "set interpretation to I (eg. xyz)"
-msgstr ""
-
-#: ../tools/vipsedit.c:95
-msgid "set Coding to C (eg. labq)"
-msgstr ""
-
-#: ../tools/vipsedit.c:97
-msgid "set Xres to R pixels/mm"
-msgstr ""
-
-#: ../tools/vipsedit.c:99
-msgid "set Yres to R pixels/mm"
-msgstr ""
-
-#: ../tools/vipsedit.c:101
-msgid "set Xoffset to N pixels"
-msgstr ""
-
-#: ../tools/vipsedit.c:103
-msgid "set Yoffset to N pixels"
-msgstr ""
-
-#: ../tools/vipsedit.c:105
-msgid "replace extension block with stdin"
-msgstr ""
-
-#: ../tools/vipsedit.c:107
-msgid "set Xsize to N (deprecated, use width)"
-msgstr ""
-
-#: ../tools/vipsedit.c:109
-msgid "set Ysize to N (deprecated, use height)"
-msgstr ""
-
-#: ../tools/vipsedit.c:111
-msgid "set Type to T (deprecated, use interpretation)"
-msgstr ""
-
-#: ../tools/vipsedit.c:122
+#: tools/vipsedit.c:129
 #, c-format
 msgid "'%s' is not a positive integer"
 msgstr ""
 
-#: ../tools/vipsedit.c:135
+#: tools/vipsedit.c:142
 msgid "unable to start VIPS"
 msgstr ""
 
-#: ../tools/vipsedit.c:147
+#: tools/vipsedit.c:165
 msgid "vipsedit - edit vips file header"
 msgstr ""
 
-#: ../tools/vipsedit.c:175
+#: tools/vipsedit.c:193
 #, c-format
 msgid "usage: %s [OPTION...] vips-file\n"
 msgstr ""
 
-#: ../tools/vipsedit.c:182
+#: tools/vipsedit.c:200
 #, c-format
 msgid "could not open image %s"
 msgstr ""
 
-#: ../tools/vipsedit.c:185
+#: tools/vipsedit.c:206
 #, c-format
 msgid "could not read VIPS header for %s"
 msgstr ""
 
-#: ../tools/vipsedit.c:194
+#: tools/vipsedit.c:216
 #, c-format
 msgid "bad endian-ness %s, should be 'big' or 'little'"
 msgstr ""
 
-#: ../tools/vipsedit.c:207
+#: tools/vipsedit.c:230
 #, c-format
 msgid "bad format %s"
 msgstr ""
 
-#: ../tools/vipsedit.c:215
+#: tools/vipsedit.c:244
 #, c-format
 msgid "bad interpretation %s"
 msgstr ""
 
-#: ../tools/vipsedit.c:223
+#: tools/vipsedit.c:254
 #, c-format
 msgid "bad coding %s"
 msgstr ""
 
-#: ../tools/vipsedit.c:236
+#: tools/vipsedit.c:268
 #, c-format
 msgid "could not seek on %s"
 msgstr ""
 
-#: ../tools/vipsedit.c:239
+#: tools/vipsedit.c:271
 #, c-format
 msgid "could not write to %s"
 msgstr ""
 
-#: ../tools/vipsedit.c:246
+#: tools/vipsedit.c:278
 msgid "could not get ext data"
 msgstr ""
 
-#: ../tools/vipsedit.c:255
+#: tools/vipsedit.c:287
 msgid "could not set extension"
 msgstr ""
 
-#: ../tools/vipsheader.c:88
-msgid "show all fields"
-msgstr ""
-
-#: ../tools/vipsheader.c:90
-msgid ""
-"print value of FIELD (\"getext\" reads extension block, \"Hist\" reads image "
-"history)"
-msgstr ""
-
-#: ../tools/vipsheader.c:181
+#: tools/vipsheader.c:221
 msgid "- print image header"
 msgstr ""
 
-#: ../tools/vipsthumbnail.c:136
-msgid "shrink to SIZE or to WIDTHxHEIGHT"
+#: tools/vipsthumbnail.c:447
+msgid "bad geometry spec"
 msgstr ""
 
-#: ../tools/vipsthumbnail.c:137
-msgid "SIZE"
-msgstr ""
-
-#: ../tools/vipsthumbnail.c:140
-msgid "set output to FORMAT"
-msgstr ""
-
-#: ../tools/vipsthumbnail.c:141 ../tools/vipsthumbnail.c:145
-msgid "FORMAT"
-msgstr ""
-
-#: ../tools/vipsthumbnail.c:144
-msgid "set output format string to FORMAT"
-msgstr ""
-
-#: ../tools/vipsthumbnail.c:148
-msgid "export with PROFILE"
-msgstr ""
-
-#: ../tools/vipsthumbnail.c:149 ../tools/vipsthumbnail.c:153
-msgid "PROFILE"
-msgstr ""
-
-#: ../tools/vipsthumbnail.c:152
-msgid "import untagged images with PROFILE"
-msgstr ""
-
-#: ../tools/vipsthumbnail.c:156
-msgid "process in linear space"
-msgstr ""
-
-#: ../tools/vipsthumbnail.c:159
-msgid "crop exactly to SIZE"
-msgstr ""
-
-#: ../tools/vipsthumbnail.c:162
-msgid "auto-rotate"
-msgstr ""
-
-#: ../tools/vipsthumbnail.c:165
-msgid "delete profile from exported image"
-msgstr ""
-
-#: ../tools/vipsthumbnail.c:169 ../tools/vipsthumbnail.c:172
-#: ../tools/vipsthumbnail.c:175 ../tools/vipsthumbnail.c:178
-#: ../tools/vipsthumbnail.c:181
-msgid "(deprecated, does nothing)"
-msgstr ""
-
-#: ../tools/vipsthumbnail.c:375
+#: tools/vipsthumbnail.c:516
 msgid "- thumbnail generator"
 msgstr ""
 
-#: ../libvips/resample/reduceh.cpp:457
-msgid "reduce factors should be >= 1"
-msgstr ""
-
-#: ../libvips/resample/reduceh.cpp:471 ../libvips/resample/reducev.cpp:850
-msgid "reduce factor too large"
-msgstr ""
-
-#: ../libvips/resample/bicubic.cpp:639
-msgid "bicubic interpolation (Catmull-Rom)"
-msgstr ""
-
-#: ../libvips/resample/vsqbs.cpp:405
-msgid "B-Splines with antialiasing smoothing"
-msgstr ""
-
-#: ../libvips/resample/nohalo.cpp:1586
-msgid "edge sharpening resampler with halo reduction"
-msgstr ""
-
-#: ../libvips/resample/lbb.cpp:865
-msgid "reduced halo bicubic"
-msgstr ""
-
-#: ../libvips/resample/reducev.cpp:839
-msgid "reduce factor should be >= 1"
-msgstr ""
+#~ msgid "Neither global nor local color map"
+#~ msgstr "Neither global nor local colour map"

--- a/tools/vips.c
+++ b/tools/vips.c
@@ -775,7 +775,7 @@ main(int argc, char **argv)
 #endif /*ENABLE_DEPRECATED*/
 #else  /*!ENABLE_MODULES*/
 		g_warning("plugin load disabled: "
-			  "libvips built without modules support");
+				  "libvips built without modules support");
 #endif /*ENABLE_MODULES*/
 	}
 

--- a/tools/vipsthumbnail.c
+++ b/tools/vipsthumbnail.c
@@ -547,7 +547,7 @@ main(int argc, char **argv)
 #ifndef HAVE_EXIF
 	if (rotate_image)
 		g_warning("auto-rotate disabled: "
-			  "libvips built without exif support");
+				  "libvips built without exif support");
 #endif /*!HAVE_EXIF*/
 
 	result = 0;


### PR DESCRIPTION
Mostly-automated:

- Apply `git clang-format` to commit da5803e
- Remove empty/outdated/non-automated headers from translation files
- Run `meson compile vips8.17-update-po` to automagically update translation files