### PR TITLE
fix invertlut in some cases

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -19,6 +19,7 @@
 - fill_nearest: fix a leak
 - colour: use suggested rendering intent as fallback [kleisauke]
 - morph: fix Orc path with large masks [kleisauke]
+- invertlut: fix final value in some cases
 
 10/10/24 8.16.0
 

--- a/libvips/create/invertlut.c
+++ b/libvips/create/invertlut.c
@@ -212,7 +212,7 @@ vips_invertlut_build_create(VipsInvertlut *lut)
 
 		/* Interpolate the data sections.
 		 */
-		for (k = first; k < last; k++) {
+		for (k = first; k <= last; k++) {
 			/* Where we're at in the [0,1] range.
 			 */
 			double ki = (double) k / (lut->size - 1);


### PR DESCRIPTION
If the measurements filled the entire x range, we were not writing the final value.

For example:

```
2 2
0 0
1 1
```

```
$ vips invertlut linear.mat x2.v
$ vips getpoint x2.v 255 0
-nan
```

With this PR you get 1, as expected.