### PR TITLE
svgload: add support for custom CSS via stylesheet option

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -8,6 +8,7 @@
 - much more reliable operation caching
 - colour: add support for auto-selecting the rendering intent [kleisauke]
 - add matrixmultiply
+- svgload: add support for custom CSS via stylesheet option [lovell]
 
 8.16.1
 

--- a/libvips/foreign/svgload.c
+++ b/libvips/foreign/svgload.c
@@ -119,6 +119,10 @@ typedef struct _VipsForeignLoadSvg {
 	 */
 	gboolean unlimited;
 
+	/* Custom CSS.
+	 */
+	const char *stylesheet;
+
 	RsvgHandle *page;
 
 } VipsForeignLoadSvg;
@@ -601,6 +605,21 @@ vips_foreign_load_svg_generate(VipsRegion *out_region,
 	cr = cairo_create(surface);
 	cairo_surface_destroy(surface);
 
+#ifdef HAVE_RSVG_HANDLE_SET_STYLESHEET
+	if (svg->stylesheet && g_utf8_validate(svg->stylesheet, -1, NULL)) {
+		GError *error = NULL;
+		if (!rsvg_handle_set_stylesheet(svg->page,
+				(const guint8 *) svg->stylesheet,
+				g_utf8_strlen(svg->stylesheet, -1), &error)) {
+			cairo_destroy(cr);
+			vips_operation_invalidate(VIPS_OPERATION(svg));
+			vips_error(class->nickname, "Invalid custom CSS");
+			vips_g_error(&error);
+			return -1;
+		}
+	}
+#endif
+
 	/* rsvg is single-threaded, but we don't need to lock since we're
 	 * running inside a non-threaded tilecache.
 	 */
@@ -735,6 +754,13 @@ vips_foreign_load_svg_class_init(VipsForeignLoadSvgClass *class)
 		G_STRUCT_OFFSET(VipsForeignLoadSvg, unlimited),
 		FALSE);
 #endif
+
+	VIPS_ARG_STRING(class, "stylesheet", 24,
+		_("Stylesheet"),
+		_("Custom CSS"),
+		VIPS_ARGUMENT_OPTIONAL_INPUT,
+		G_STRUCT_OFFSET(VipsForeignLoadSvg, stylesheet),
+		NULL);
 }
 
 static void
@@ -1019,6 +1045,7 @@ vips_foreign_load_svg_buffer_init(VipsForeignLoadSvgBuffer *buffer)
  * * @dpi: %gdouble, render at this DPI
  * * @scale: %gdouble, scale render by this factor
  * * @unlimited: %gboolean, allow SVGs of any size
+ * * @stylesheet: %gchararray, custom CSS
  *
  * Render a SVG file into a VIPS image.  Rendering uses the librsvg library
  * and should be fast.
@@ -1031,6 +1058,10 @@ vips_foreign_load_svg_buffer_init(VipsForeignLoadSvgBuffer *buffer)
  *
  * SVGs larger than 10MB are normally blocked for security. Set @unlimited to
  * allow SVGs of any size.
+ *
+ * A UTF-8 string containing custom CSS can be provided via @stylesheet.
+ * During the CSS cascade, the specified stylesheet will be applied with a
+ * User Origin. This feature requires librsvg 2.48.0 or later.
  *
  * See also: vips_image_new_from_file().
  *
@@ -1061,6 +1092,7 @@ vips_svgload(const char *filename, VipsImage **out, ...)
  * * @dpi: %gdouble, render at this DPI
  * * @scale: %gdouble, scale render by this factor
  * * @unlimited: %gboolean, allow SVGs of any size
+ * * @stylesheet: %gchararray, custom CSS
  *
  * Read a SVG-formatted memory block into a VIPS image. Exactly as
  * vips_svgload(), but read from a memory buffer.
@@ -1103,6 +1135,7 @@ vips_svgload_buffer(void *buf, size_t len, VipsImage **out, ...)
  * * @dpi: %gdouble, render at this DPI
  * * @scale: %gdouble, scale render by this factor
  * * @unlimited: %gboolean, allow SVGs of any size
+ * * @stylesheet: %gchararray, custom CSS
  *
  * Exactly as vips_svgload(), but read from a string. This function takes a
  * copy of the string.

--- a/meson.build
+++ b/meson.build
@@ -388,6 +388,8 @@ if librsvg_found
     external_deps += librsvg_dep
     external_deps += cairo_dep
     cfg_var.set('HAVE_RSVG', true)
+    # rsvg_handle_set_stylesheet added in librsvg 2.48.0
+    cfg_var.set('HAVE_RSVG_HANDLE_SET_STYLESHEET', cc.has_function('rsvg_handle_set_stylesheet', dependencies: librsvg_dep))
 endif
 
 openslide_dep = dependency('openslide', version: '>=3.3.0', required: get_option('openslide'))

--- a/test/test-suite/test_foreign.py
+++ b/test/test-suite/test_foreign.py
@@ -1200,6 +1200,12 @@ class TestForeign:
         assert im.width == 10
         assert im.height == 10
 
+        # Custom CSS stylesheet
+        im = pyvips.Image.new_from_file(SVG_FILE)
+        assert im.avg() < 5
+        im = pyvips.Image.new_from_file(SVG_FILE, stylesheet=b'path{stroke:#f00;stroke-width:1em;}')
+        assert im.avg() > 5
+
     def test_csv(self):
         self.save_load("%s.csv", self.mono)
 


### PR DESCRIPTION
This PR exposes a new `stylesheet` option for custom User Origin CSS to apply when rendering SVG images. This feature requires librsvg version 2.48.0 or later.

The underlying `rsvg_handle_set_stylesheet` method will accept strings of CSS containing `NULL` but doing so is probably a bad idea and isn't supported by this PR. More importantly, by not allowing this, we can use `g_utf8_validate` and friends to sanitise the input.

Closes https://github.com/libvips/libvips/discussions/4333 and https://github.com/libvips/libvips/issues/4334