### PR TITLE
Fix two compiler warnings

### DIFF
--- a/libvips/create/text.c
+++ b/libvips/create/text.c
@@ -92,6 +92,11 @@
 #include <pango/pangocairo.h>
 
 #ifdef HAVE_FONTCONFIG
+/* ftconfig.h also appears to define HAVE_UNISTD_H.
+ */
+#ifdef HAVE_UNISTD_H
+#undef HAVE_UNISTD_H
+#endif
 #include <pango/pangofc-fontmap.h>
 #include <fontconfig/fontconfig.h>
 #endif

--- a/libvips/foreign/jxlload.c
+++ b/libvips/foreign/jxlload.c
@@ -636,8 +636,6 @@ vips_foreign_load_jxl_generate(VipsRegion *out_region,
 static int
 vips_foreign_load_jxl_fix_exif(VipsForeignLoadJxl *jxl)
 {
-	VipsObjectClass *class = VIPS_OBJECT_GET_CLASS(jxl);
-
 	if (!jxl->exif_data ||
 		vips_isprefix("Exif", (char *) jxl->exif_data))
 		return 0;


### PR DESCRIPTION
```console
[350/452] Compiling C object libvips/create/libcreate.a.p/text.c.o
In file included from /usr/include/freetype2/freetype/config/ftconfig.h:9,
                 from /usr/include/freetype2/freetype/freetype.h:24,
                 from /usr/include/pango-1.0/pango/pangofc-font.h:36,
                 from /usr/include/pango-1.0/pango/pangofc-decoder.h:25,
                 from /usr/include/pango-1.0/pango/pangofc-fontmap.h:27,
                 from ../libvips/create/text.c:95:
/usr/include/freetype2/freetype/config/ftconfig-64.h:43:9: warning: "HAVE_UNISTD_H" redefined
   43 | #define HAVE_UNISTD_H 1
      |         ^~~~~~~~~~~~~
In file included from ../libvips/create/text.c:78:
./config.h:146:9: note: this is the location of the previous definition
  146 | #define HAVE_UNISTD_H
      |         ^~~~~~~~~~~~~
[362/452] Compiling C object libvips/vips-jxl.so.p/foreign_jxlload.c.o
../libvips/foreign/jxlload.c: In function ‘vips_foreign_load_jxl_fix_exif’:
../libvips/foreign/jxlload.c:639:26: warning: unused variable ‘class’ [-Wunused-variable]
  639 |         VipsObjectClass *class = VIPS_OBJECT_GET_CLASS(jxl);
      |                          ^~~~~
```