### PR TITLE
radload: improve sanity check of colour-related headers

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -21,6 +21,7 @@
 - morph: fix Orc path with large masks [kleisauke]
 - invertlut: fix final value in some cases
 - matrixload: fix file format detect for some matrix types
+- radload: improve sanity check of colour-related headers [lovell]
 
 10/10/24 8.16.0
 

--- a/libvips/foreign/radiance.c
+++ b/libvips/foreign/radiance.c
@@ -229,8 +229,8 @@ typedef float RGBPRIMS[4][2]; /* (x,y) chromaticities for RGBW */
 #define COLCORSTR "COLORCORR="
 #define LCOLCORSTR 10
 #define iscolcor(hl) (!strncmp(hl, COLCORSTR, LCOLCORSTR))
-#define colcorval(cc, hl) sscanf((hl) + LCOLCORSTR, "%f %f %f", \
-	&(cc)[RED], &(cc)[GRN], &(cc)[BLU])
+#define colcorval(cc, hl) (sscanf((hl) + LCOLCORSTR, "%f %f %f", \
+							   &(cc)[RED], &(cc)[GRN], &(cc)[BLU]) == 3)
 
 #define MINELEN 8	   /* minimum scanline length for encoding */
 #define MAXELEN 0x7fff /* maximum scanline length for encoding */
@@ -643,7 +643,8 @@ rad2vips_process_line(char *line, Read *read)
 		COLOR cc;
 		int i;
 
-		(void) colcorval(cc, line);
+		if (!colcorval(cc, line))
+			return -1;
 		for (i = 0; i < 3; i++)
 			read->colcor[i] *= cc[i];
 	}
@@ -651,7 +652,8 @@ rad2vips_process_line(char *line, Read *read)
 		read->aspect *= aspectval(line);
 	}
 	else if (isprims(line)) {
-		(void) primsval(read->prims, line);
+		if (!primsval(read->prims, line))
+			return -1;
 	}
 
 	return 0;


### PR DESCRIPTION
Ensure PRIMARIES and COLORCORR have expected number of components.