### PR TITLE
heifload: ensure unlimited flag removes all security limits where possible

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -10,6 +10,7 @@
 - add matrixmultiply
 - improve performance of vips_shrink() [kleisauke]
 - svgload: add support for custom CSS via stylesheet option [lovell]
+- heifload: `unlimited` flag removes all limits (requires libheif 1.19.0+) [lovell]
 
 8.16.1
 

--- a/libvips/foreign/heifload.c
+++ b/libvips/foreign/heifload.c
@@ -354,6 +354,13 @@ vips_foreign_load_heif_build(VipsObject *object)
 		heif_context_set_maximum_image_size_limit(heif->ctx,
 			heif->unlimited ? USHRT_MAX : 0x4000);
 #endif /* HAVE_HEIF_SET_MAX_IMAGE_SIZE_LIMIT */
+#ifdef HAVE_HEIF_GET_DISABLED_SECURITY_LIMITS
+		if (heif->unlimited) {
+			const struct heif_security_limits *unlimited =
+				heif_get_disabled_security_limits();
+			heif_context_set_security_limits(heif->ctx, unlimited);
+		}
+#endif /* HAVE_HEIF_GET_DISABLED_SECURITY_LIMITS */
 		error = heif_context_read_from_reader(heif->ctx,
 			heif->reader, heif, NULL);
 		if (error.code) {

--- a/meson.build
+++ b/meson.build
@@ -510,6 +510,8 @@ if libheif_dep.found()
     cfg_var.set('HAVE_HEIF_ENCODING_OPTIONS_IMAGE_ORIENTATION', cpp.has_member('struct heif_encoding_options', 'image_orientation', prefix: '#include <libheif/heif.h>', dependencies: libheif_dep))
     # heif_error_success added in 1.17.0
     cfg_var.set('HAVE_HEIF_ERROR_SUCCESS', libheif_dep.version().version_compare('>=1.17.0'))
+    # heif_get_disabled_security_limits added in 1.19.0
+    cfg_var.set('HAVE_HEIF_GET_DISABLED_SECURITY_LIMITS', cpp.has_function('heif_get_disabled_security_limits', prefix: '#include <libheif/heif.h>', dependencies: libheif_dep))
 endif
 
 libjxl_dep = dependency('libjxl', version: '>=0.6', required: get_option('jpeg-xl'))


### PR DESCRIPTION
libheif v1.19.0 added new `heif_get_disabled_security_limits` API to remove *all* security limits.

I discovered this whilst investigating https://github.com/lovell/sharp/issues/4335 and removing all limits appears to provide a solution to it.