### PR TITLE
heifload: prevent possible int overflow for large images

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -23,6 +23,7 @@
 - matrixload: fix file format detect for some matrix types
 - radload: improve sanity check of colour-related headers [lovell]
 - heifsave: reject multiband images [lovell]
+- heifload: prevent possible int overflow for large images [kleisauke]
 
 10/10/24 8.16.0
 

--- a/libvips/foreign/heifload.c
+++ b/libvips/foreign/heifload.c
@@ -351,6 +351,9 @@ vips_foreign_load_heif_build(VipsObject *object)
 
 		heif->ctx = heif_context_alloc();
 #ifdef HAVE_HEIF_SET_MAX_IMAGE_SIZE_LIMIT
+		/* heifsave is limited to a maximum image size of 16384x16384,
+		 * so align the heifload defaults accordingly.
+		 */
 		heif_context_set_maximum_image_size_limit(heif->ctx,
 			heif->unlimited ? USHRT_MAX : 0x4000);
 #endif /* HAVE_HEIF_SET_MAX_IMAGE_SIZE_LIMIT */
@@ -993,7 +996,7 @@ vips_foreign_load_heif_generate(VipsRegion *out_region,
 	}
 
 	memcpy(VIPS_REGION_ADDR(out_region, 0, r->top),
-		heif->data + heif->stride * line,
+		heif->data + (size_t) heif->stride * line,
 		VIPS_IMAGE_SIZEOF_LINE(out_region->im));
 
 	/* We may need to swap bytes and shift to fill 16 bits.

--- a/libvips/foreign/heifsave.c
+++ b/libvips/foreign/heifsave.c
@@ -471,7 +471,7 @@ vips_foreign_save_heif_write_block(VipsRegion *region, VipsRect *area,
 		int page = (area->top + y) / heif->page_height;
 		int line = (area->top + y) % heif->page_height;
 		VipsPel *p = VIPS_REGION_ADDR(region, 0, area->top + y);
-		VipsPel *q = heif->data + line * heif->stride;
+		VipsPel *q = heif->data + (size_t) heif->stride * line;
 
 		if (vips_foreign_save_heif_pack(heif,
 				q, p, VIPS_REGION_N_ELEMENTS(region)))


### PR DESCRIPTION
i.e. when the `unlimited` flag is set (> 16384x16384).

See: https://github.com/libvips/libvips/pull/4266#discussion_r1856394879.

Targets the 8.16 branch.