### PR TITLE
tiffload: add missing read loop

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -24,6 +24,7 @@
 - radload: improve sanity check of colour-related headers [lovell]
 - heifsave: reject multiband images [lovell]
 - heifload: prevent possible int overflow for large images [kleisauke]
+- tiffload: add missing read loop [kleisauke]
 
 10/10/24 8.16.0
 

--- a/libvips/foreign/tiff.c
+++ b/libvips/foreign/tiff.c
@@ -98,7 +98,24 @@ openin_source_read(thandle_t st, tdata_t data, tsize_t size)
 {
 	VipsSource *source = VIPS_SOURCE(st);
 
-	return vips_source_read(source, data, size);
+	gint64 total_read;
+
+	total_read = 0;
+
+	while (total_read < size) {
+		gint64 bytes_read;
+
+		bytes_read = vips_source_read(source, data, size - total_read);
+		if (bytes_read == -1)
+			return -1;
+		if (bytes_read == 0)
+			break;
+
+		total_read += bytes_read;
+		data = (char *) data + bytes_read;
+	}
+
+	return total_read;
 }
 
 static tsize_t


### PR DESCRIPTION
We weren't looping on `vips_source_read()` in tiffload, which could cause failures when reading from pipes.

Resolves: #4400.

Targets the 8.16 branch.

Note that I couldn't find any documentation for this callback, but I noticed that `TIFFOpen*()` behaves similarly, see:
https://gitlab.com/libtiff/libtiff/-/blob/v4.7.0/libtiff/tif_unix.c#L68-95