### PR TITLE
test: reduce severity of `gifsave_timeout`

### DIFF
--- a/test/test_timeout_gifsave.c
+++ b/test/test_timeout_gifsave.c
@@ -18,7 +18,6 @@ main(int argc, char **argv)
 	void *buf;
 	size_t len;
 	gboolean is_killed = FALSE;
-	int ret;
 
 	if (VIPS_INIT(argv[0]))
 		vips_error_exit(NULL);
@@ -36,14 +35,13 @@ main(int argc, char **argv)
 		G_CALLBACK(eval_callback), &is_killed);
 
 	buf = NULL;
-	ret = vips_gifsave_buffer(im, &buf, &len, NULL);
-	if (!ret)
-		printf("expected error return from vips_gifsave_buffer()\n");
+	if (vips_gifsave_buffer(im, &buf, &len, NULL))
+		printf("error return from vips_gifsave_buffer()\n");
 
 	g_object_unref(im);
 	if (buf)
 		g_free(buf);
 	g_assert(is_killed);
 
-	return !ret;
+	return 0;
 }


### PR DESCRIPTION
On my AMD Ryzen 9 7900 workstation, the `gifsave_timeout` test consistently fails with:
```console
$ meson test -C build --print-errorlogs
...
 8/12 gifsave_timeout          FAIL             2.46s   exit status 1
――― ✀ ―――
expected error return from vips_gifsave_buffer()
――――――――――
```

I suspect the image gets quantized/remapped within 2 seconds, so we can't guarantee that it always returns an error. The best we could do is `g_assert(is_killed)`, which is a no-op in release builds.

Targets the 8.16 branch.