### PR TITLE
Prevent possible use-after-free when debugging via --vips-leak flag

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -25,6 +25,7 @@
 - heifsave: reject multiband images [lovell]
 - heifload: prevent possible int overflow for large images [kleisauke]
 - tiffload: add missing read loop [kleisauke]
+- prevent possible use-after-free when debugging via `--vips-leak` flag [lovell]
 
 10/10/24 8.16.0
 

--- a/libvips/iofuncs/type.c
+++ b/libvips/iofuncs/type.c
@@ -198,13 +198,13 @@ vips_area_unref(VipsArea *area)
 
 		VIPS_FREEF(vips_g_mutex_free, area->lock);
 
-		g_free(area);
-
 		if (vips__leak) {
 			g_mutex_lock(vips__global_lock);
 			vips_area_all = g_slist_remove(vips_area_all, area);
 			g_mutex_unlock(vips__global_lock);
 		}
+
+		g_free(area);
 
 #ifdef DEBUG
 		g_mutex_lock(vips__global_lock);


### PR DESCRIPTION
Nothing serious as this is was in debugging logic, but worth moving all the same.