### PR TITLE
Deprecate math macros

### DIFF
--- a/libvips/arithmetic/abs.c
+++ b/libvips/arithmetic/abs.c
@@ -116,7 +116,7 @@ vips_abs_build(VipsObject *object)
 		int x; \
 \
 		for (x = 0; x < sz; x++) \
-			q[x] = VIPS_FABS(p[x]); \
+			q[x] = fabs(p[x]); \
 	}
 
 /* Complex abs operation: calculate modulus.

--- a/libvips/arithmetic/deviate.c
+++ b/libvips/arithmetic/deviate.c
@@ -120,7 +120,7 @@ vips_deviate_build(VipsObject *object)
 	s2 = deviate->sum2;
 
 	g_object_set(object,
-		"out", sqrt(VIPS_FABS(s2 - (s * s / vals)) / (vals - 1)),
+		"out", sqrt(fabs(s2 - (s * s / vals)) / (vals - 1)),
 		NULL);
 
 	return 0;

--- a/libvips/arithmetic/divide.c
+++ b/libvips/arithmetic/divide.c
@@ -97,7 +97,7 @@ G_DEFINE_TYPE(VipsDivide, vips_divide, VIPS_TYPE_BINARY);
 				q[0] = 0.0; \
 				q[1] = 0.0; \
 			} \
-			else if (VIPS_FABS(right[0]) > VIPS_FABS(right[1])) { \
+			else if (fabs(right[0]) > fabs(right[1])) { \
 				double a = right[1] / right[0]; \
 				double b = right[0] + right[1] * a; \
 \

--- a/libvips/arithmetic/max.c
+++ b/libvips/arithmetic/max.c
@@ -337,7 +337,7 @@ vips_max_stop(VipsStatistic *statistic, void *seq)
 		TYPE m; \
 \
 		for (i = 0; i < sz && values->n < values->size; i++) \
-			if (!VIPS_ISNAN(p[i])) \
+			if (!isnan(p[i])) \
 				vips_values_add(values, p[i], x + i / bands, y); \
 		m = values->value[0]; \
 \
@@ -358,7 +358,7 @@ vips_max_stop(VipsStatistic *statistic, void *seq)
 		for (i = 0; i < sz && values->n < values->size; i++) { \
 			TYPE mod2 = p[0] * p[0] + p[1] * p[1]; \
 \
-			if (!VIPS_ISNAN(mod2)) \
+			if (!isnan(mod2)) \
 				vips_values_add(values, p[i], x + i / bands, y); \
 \
 			p += 2; \

--- a/libvips/arithmetic/maxpair.c
+++ b/libvips/arithmetic/maxpair.c
@@ -70,7 +70,7 @@ G_DEFINE_TYPE(VipsMaxpair, vips_maxpair, VIPS_TYPE_BINARY);
 		TYPE *restrict q = (TYPE *) out; \
 \
 		for (int x = 0; x < sz; x++) \
-			q[x] = VIPS_FMAX(left[x], right[x]); \
+			q[x] = fmax(left[x], right[x]); \
 	}
 
 static void

--- a/libvips/arithmetic/measure.c
+++ b/libvips/arithmetic/measure.c
@@ -159,8 +159,8 @@ vips_measure_build(VipsObject *object)
 				 * averages near zero (can get these if use
 				 * measure on IM_TYPE_LAB images).
 				 */
-				if (dev * 5 > VIPS_FABS(avg) &&
-					VIPS_FABS(avg) > 3)
+				if (dev * 5 > fabs(avg) &&
+					fabs(avg) > 3)
 					g_warning(_("%s: "
 								"patch %d x %d, "
 								"band %d: "

--- a/libvips/arithmetic/min.c
+++ b/libvips/arithmetic/min.c
@@ -337,7 +337,7 @@ vips_min_stop(VipsStatistic *statistic, void *seq)
 		TYPE m; \
 \
 		for (i = 0; i < sz && values->n < values->size; i++) \
-			if (!VIPS_ISNAN(p[i])) \
+			if (!isnan(p[i])) \
 				vips_values_add(values, p[i], x + i / bands, y); \
 		m = values->value[0]; \
 \
@@ -358,7 +358,7 @@ vips_min_stop(VipsStatistic *statistic, void *seq)
 		for (i = 0; i < sz && values->n < values->size; i++) { \
 			TYPE mod2 = p[0] * p[0] + p[1] * p[1]; \
 \
-			if (!VIPS_ISNAN(mod2)) \
+			if (!isnan(mod2)) \
 				vips_values_add(values, p[i], x + i / bands, y); \
 \
 			p += 2; \

--- a/libvips/arithmetic/minpair.c
+++ b/libvips/arithmetic/minpair.c
@@ -70,7 +70,7 @@ G_DEFINE_TYPE(VipsMinpair, vips_minpair, VIPS_TYPE_BINARY);
 		TYPE *restrict q = (TYPE *) out; \
 \
 		for (int x = 0; x < sz; x++) \
-			q[x] = VIPS_FMIN(left[x], right[x]); \
+			q[x] = fmin(left[x], right[x]); \
 	}
 
 static void

--- a/libvips/arithmetic/remainder.c
+++ b/libvips/arithmetic/remainder.c
@@ -113,7 +113,7 @@ vips_remainder_build(VipsObject *object)
 			double a = p1[x]; \
 			double b = p2[x]; \
 \
-			q[x] = b ? a - b * VIPS_FLOOR(a / b) : -1; \
+			q[x] = b ? a - b * floor(a / b) : -1; \
 		} \
 	}
 

--- a/libvips/arithmetic/round.c
+++ b/libvips/arithmetic/round.c
@@ -127,13 +127,13 @@ vips_round_buffer(VipsArithmetic *arithmetic,
 
 	switch (round->round) {
 	case VIPS_OPERATION_ROUND_RINT:
-		SWITCH(VIPS_RINT);
+		SWITCH(rint);
 		break;
 	case VIPS_OPERATION_ROUND_CEIL:
-		SWITCH(VIPS_CEIL);
+		SWITCH(ceil);
 		break;
 	case VIPS_OPERATION_ROUND_FLOOR:
-		SWITCH(VIPS_FLOOR);
+		SWITCH(floor);
 		break;
 
 	default:

--- a/libvips/arithmetic/stats.c
+++ b/libvips/arithmetic/stats.c
@@ -160,14 +160,14 @@ vips_stats_build(VipsObject *object)
 
 		row[COL_AVG] = row[COL_SUM] / pels;
 		row[COL_SD] = sqrt(
-			VIPS_FABS(row[COL_SUM2] -
+			fabs(row[COL_SUM2] -
 				(row[COL_SUM] * row[COL_SUM] / pels)) /
 			(pels - 1));
 	}
 
 	row0[COL_AVG] = row0[COL_SUM] / vals;
 	row0[COL_SD] = sqrt(
-		VIPS_FABS(row0[COL_SUM2] -
+		fabs(row0[COL_SUM2] -
 			(row0[COL_SUM] * row0[COL_SUM] / vals)) /
 		(vals - 1));
 

--- a/libvips/colour/HSV2sRGB.c
+++ b/libvips/colour/HSV2sRGB.c
@@ -63,7 +63,7 @@ vips_HSV2sRGB_line(VipsColour *colour, VipsPel *out, VipsPel **in, int width)
 		float c, x, m;
 
 		c = p[2] * p[1] / 255.0;
-		x = c * (1 - VIPS_FABS(fmod(p[0] / SIXTH_OF_CHAR, 2) - 1));
+		x = c * (1 - fabs(fmod(p[0] / SIXTH_OF_CHAR, 2) - 1));
 		m = p[2] - c;
 
 		if (p[0] < (int) SIXTH_OF_CHAR) {

--- a/libvips/colour/LCh2UCS.c
+++ b/libvips/colour/LCh2UCS.c
@@ -165,7 +165,7 @@ vips_col_Ch2hcmc(float C, float h)
 	}
 
 	P = cos(VIPS_RAD(k7 * h + k8));
-	D = k4 + k5 * P * pow(VIPS_FABS(P), k6);
+	D = k4 + k5 * P * pow(fabs(P), k6);
 	g = C * C * C * C;
 	f = sqrt(g / (g + 1900.0));
 	hcmc = h + D * f;

--- a/libvips/colour/Lab2LabQ.c
+++ b/libvips/colour/Lab2LabQ.c
@@ -103,13 +103,13 @@ vips_Lab2LabQ_line(VipsColour *colour, VipsPel *out, VipsPel **in, int width)
 		q[0] = intv >> 2;		  /* drop bot 2 bits and store */
 
 		fval = 8.0 * p[1]; /* do a */
-		intv = VIPS_RINT(fval);
+		intv = rint(fval);
 		intv = VIPS_CLIP(-1024, intv, 1023);
 		lsbs |= (intv & 0x7) << 3; /* 00000111 -> 00111000 */
 		q[1] = intv >> 3;		   /* drop bot 3 bits & store */
 
 		fval = 8.0 * p[2]; /* do b */
-		intv = VIPS_RINT(fval);
+		intv = rint(fval);
 		intv = VIPS_CLIP(-1024, intv, 1023);
 		lsbs |= (intv & 0x7);
 		q[2] = intv >> 3;

--- a/libvips/colour/LabQ2sRGB.c
+++ b/libvips/colour/LabQ2sRGB.c
@@ -140,7 +140,7 @@ calcul_tables(int range, int *Y2v, float *v2Y)
 		else
 			v = (1.0 + 0.055) * pow(f, 1.0 / 2.4) - 0.055;
 
-		Y2v[i] = VIPS_RINT((range - 1) * v);
+		Y2v[i] = rint((range - 1) * v);
 	}
 
 	/* Copy the final element. This is used in the piecewise linear
@@ -303,7 +303,7 @@ vips_col_scRGB2sRGB(int range, int *lut,
 	 * Don't use isnormal(), it is false for 0.0 and for subnormal
 	 * numbers.
 	 */
-	if (VIPS_ISNAN(R) || VIPS_ISNAN(G) || VIPS_ISNAN(B)) {
+	if (isnan(R) || isnan(G) || isnan(B)) {
 		*r = 0;
 		*g = 0;
 		*b = 0;
@@ -337,19 +337,19 @@ vips_col_scRGB2sRGB(int range, int *lut,
 	CLIP(0, Yf, maxval);
 	Yi = (int) Yf;
 	v = lut[Yi] + (lut[Yi + 1] - lut[Yi]) * (Yf - Yi);
-	*r = VIPS_RINT(v);
+	*r = rint(v);
 
 	Yf = G * maxval;
 	CLIP(0, Yf, maxval);
 	Yi = (int) Yf;
 	v = lut[Yi] + (lut[Yi + 1] - lut[Yi]) * (Yf - Yi);
-	*g = VIPS_RINT(v);
+	*g = rint(v);
 
 	Yf = B * maxval;
 	CLIP(0, Yf, maxval);
 	Yi = (int) Yf;
 	v = lut[Yi] + (lut[Yi + 1] - lut[Yi]) * (Yf - Yi);
-	*b = VIPS_RINT(v);
+	*b = rint(v);
 
 	if (og_ret)
 		*og_ret = og;
@@ -399,7 +399,7 @@ vips_col_scRGB2BW(int range, int *lut, float R, float G, float B,
 	/* Y can be Nan. Throw those values out, they will break
 	 * our clipping.
 	 */
-	if (VIPS_ISNAN(Y)) {
+	if (isnan(Y)) {
 		*g = 0;
 
 		return -1;
@@ -417,7 +417,7 @@ vips_col_scRGB2BW(int range, int *lut, float R, float G, float B,
 	CLIP(0, Yf, maxval);
 	Yi = (int) Yf;
 	v = lut[Yi] + (lut[Yi + 1] - lut[Yi]) * (Yf - Yi);
-	*g = VIPS_RINT(v);
+	*g = rint(v);
 
 	if (og_ret)
 		*og_ret = og;

--- a/libvips/colour/UCS2LCh.c
+++ b/libvips/colour/UCS2LCh.c
@@ -151,7 +151,7 @@ vips_col_Lcmc2L(float Lcmc)
 {
 	int known;
 
-	known = VIPS_FLOOR(Lcmc * 10.0);
+	known = floor(Lcmc * 10.0);
 	known = VIPS_CLIP(0, known, 999);
 
 	return LI[known] +
@@ -173,7 +173,7 @@ vips_col_Ccmc2C(float Ccmc)
 {
 	int known;
 
-	known = VIPS_FLOOR(Ccmc * 10.0);
+	known = floor(Ccmc * 10.0);
 	known = VIPS_CLIP(0, known, 2999);
 
 	return CI[known] +
@@ -202,7 +202,7 @@ vips_col_Chcmc2h(float C, float hcmc)
 	r = (int) ((C + 1.0) / 2.0);
 	r = VIPS_CLIP(0, r, 99);
 
-	known = VIPS_FLOOR(hcmc);
+	known = floor(hcmc);
 	known = VIPS_CLIP(0, known, 359);
 
 	return hI[r][known] +

--- a/libvips/colour/dE00.c
+++ b/libvips/colour/dE00.c
@@ -133,9 +133,9 @@ vips_col_dE00(float L1, float a1, float b1,
 	 */
 	double Ldb = (L1d + L2d) / 2;
 	double Cdb = (C1d + C2d) / 2;
-	double hdb = VIPS_FABS(h1d - h2d) < 180
+	double hdb = fabs(h1d - h2d) < 180
 		? (h1d + h2d) / 2
-		: VIPS_FABS(h1d + h2d - 360) / 2;
+		: fabs(h1d + h2d - 360) / 2;
 
 	/* dtheta, RC
 	 */
@@ -162,7 +162,7 @@ vips_col_dE00(float L1, float a1, float b1,
 
 	/* hue difference ... careful!
 	 */
-	double dhd = VIPS_FABS(h1d - h2d) < 180
+	double dhd = fabs(h1d - h2d) < 180
 		? h1d - h2d
 		: 360 - (h1d - h2d);
 

--- a/libvips/conversion/unpremultiply.c
+++ b/libvips/conversion/unpremultiply.c
@@ -138,7 +138,7 @@ G_DEFINE_TYPE(VipsUnpremultiply, vips_unpremultiply, VIPS_TYPE_CONVERSION);
 \
 		for (x = 0; x < width; x++) { \
 			IN alpha = p[alpha_band]; \
-			OUT factor = VIPS_ABS(alpha) < 0.01 ? 0 : max_alpha / alpha; \
+			OUT factor = fabs(alpha) < 0.01 ? 0 : max_alpha / alpha; \
 \
 			for (i = 0; i < alpha_band; i++) \
 				q[i] = factor * p[i]; \
@@ -158,7 +158,7 @@ G_DEFINE_TYPE(VipsUnpremultiply, vips_unpremultiply, VIPS_TYPE_CONVERSION);
 \
 		for (x = 0; x < width; x++) { \
 			IN alpha = p[3]; \
-			OUT factor = VIPS_ABS(alpha) < 0.01 ? 0 : max_alpha / alpha; \
+			OUT factor = fabs(alpha) < 0.01 ? 0 : max_alpha / alpha; \
 \
 			q[0] = factor * p[0]; \
 			q[1] = factor * p[1]; \

--- a/libvips/convolution/conva.c
+++ b/libvips/convolution/conva.c
@@ -331,9 +331,9 @@ vips_conva_decompose_hlines(VipsConva *conva)
 	 * fixed n-lines which includes any negative parts.
 	 */
 	depth = (max - min) / conva->layers;
-	layers_above = VIPS_CEIL(max / depth);
+	layers_above = ceil(max / depth);
 	depth = max / layers_above;
-	layers_below = VIPS_FLOOR(min / depth);
+	layers_below = floor(min / depth);
 	conva->layers = layers_above - layers_below; // FIXME: Invalidates operation cache
 
 	VIPS_DEBUG_MSG("vips_conva_decompose_hlines: depth = %g, layers = %d\n",
@@ -744,7 +744,7 @@ vips_conva_decompose_boxes(VipsConva *conva)
 	for (z = 0; z < size; z++)
 		sum += fabs(coeff[z]);
 
-	conva->divisor = VIPS_RINT(area * scale / sum);
+	conva->divisor = rint(area * scale / sum);
 	conva->rounding = (conva->divisor + 1) / 2;
 	conva->offset = offset;
 

--- a/libvips/convolution/convasep.c
+++ b/libvips/convolution/convasep.c
@@ -303,7 +303,7 @@ vips_convasep_decompose(VipsConvasep *convasep)
 	for (z = 0; z < convasep->width; z++)
 		sum += coeff[z];
 
-	convasep->divisor = VIPS_RINT(sum * area / scale);
+	convasep->divisor = rint(sum * area / scale);
 	if (convasep->divisor == 0)
 		convasep->divisor = 1;
 	convasep->rounding = (convasep->divisor + 1) / 2;

--- a/libvips/convolution/convi.c
+++ b/libvips/convolution/convi.c
@@ -309,7 +309,7 @@ vips_convi_uchar_vector_gen(VipsRegion *out_region,
 	VipsConvi *convi = (VipsConvi *) b;
 	VipsConvolution *convolution = (VipsConvolution *) convi;
 	VipsImage *M = convolution->M;
-	int offset = VIPS_RINT(vips_image_get_offset(M));
+	int offset = rint(vips_image_get_offset(M));
 	VipsImage *in = (VipsImage *) a;
 	VipsRegion *ir = seq->ir;
 	const int nnz = convi->nnz;
@@ -521,7 +521,7 @@ vips_convi_compile_clip(VipsConvi *convi)
 {
 	VipsConvolution *convolution = (VipsConvolution *) convi;
 	VipsImage *M = convolution->M;
-	int offset = VIPS_RINT(vips_image_get_offset(M));
+	int offset = rint(vips_image_get_offset(M));
 
 	OrcProgram *p;
 	OrcCompileResult result;
@@ -755,9 +755,9 @@ vips_convi_gen(VipsRegion *out_region,
 	VipsConvi *convi = (VipsConvi *) b;
 	VipsConvolution *convolution = (VipsConvolution *) convi;
 	VipsImage *M = convolution->M;
-	int scale = VIPS_RINT(vips_image_get_scale(M));
+	int scale = rint(vips_image_get_scale(M));
 	int rounding = scale / 2;
-	int offset = VIPS_RINT(vips_image_get_offset(M));
+	int offset = rint(vips_image_get_offset(M));
 	VipsImage *in = (VipsImage *) a;
 	VipsRegion *ir = seq->ir;
 	int *restrict t = convi->coeff;
@@ -890,12 +890,12 @@ vips__image_intize(VipsImage *in, VipsImage **out)
 	for (y = 0; y < t->Ysize; y++)
 		for (x = 0; x < t->Xsize; x++)
 			*VIPS_MATRIX(*out, x, y) =
-				VIPS_RINT(*VIPS_MATRIX(t, x, y));
+				rint(*VIPS_MATRIX(t, x, y));
 
-	out_scale = VIPS_RINT(vips_image_get_scale(t));
+	out_scale = rint(vips_image_get_scale(t));
 	if (out_scale == 0)
 		out_scale = 1;
-	out_offset = VIPS_RINT(vips_image_get_offset(t));
+	out_offset = rint(vips_image_get_offset(t));
 
 	/* Now convolve a 1 everywhere image with the int version we've made,
 	 * what do we get?
@@ -908,7 +908,7 @@ vips__image_intize(VipsImage *in, VipsImage **out)
 
 	/* And adjust the scale to get as close to a match as we can.
 	 */
-	out_scale = VIPS_RINT(out_scale + (int_result - double_result));
+	out_scale = rint(out_scale + (int_result - double_result));
 	if (out_scale == 0)
 		out_scale = 1;
 
@@ -1023,7 +1023,7 @@ vips_convi_intize(VipsConvi *convi, VipsImage *M)
 	for (i = 0; i < convi->n_point; i++) {
 		/* 128 since this is signed.
 		 */
-		convi->mant[i] = VIPS_RINT(128 * scaled[i] * pow(2, -shift));
+		convi->mant[i] = rint(128 * scaled[i] * pow(2, -shift));
 
 		if (convi->mant[i] < -128 ||
 			convi->mant[i] > 127) {
@@ -1106,7 +1106,7 @@ vips_convi_intize(VipsConvi *convi, VipsImage *M)
 			int_value = VIPS_LSHIFT_INT(int_sum, convi->exp);
 		int_value = VIPS_CLIP(0, int_value, 255);
 
-		if (VIPS_ABS(true_value - int_value) > 2) {
+		if (abs(true_value - int_value) > 2) {
 			g_info("vips_convi_intize: too inaccurate");
 			return -1;
 		}

--- a/libvips/convolution/edge.c
+++ b/libvips/convolution/edge.c
@@ -98,7 +98,7 @@ vips_edge_uchar_gen(VipsRegion *out_region,
 			int v2 = 2 * (p2[x] - 128);
 			/* Avoid the sqrt() for uchar.
 			 */
-			int v = VIPS_ABS(v1) + VIPS_ABS(v2);
+			int v = abs(v1) + abs(v2);
 
 			q[x] = v > 255 ? 255 : v;
 		}

--- a/libvips/convolution/sharpen.c
+++ b/libvips/convolution/sharpen.c
@@ -253,7 +253,7 @@ vips_sharpen_build(VipsObject *object)
 		if (y > sharpen->y2)
 			y = sharpen->y2;
 
-		sharpen->lut[i] = VIPS_RINT(y * 327.67);
+		sharpen->lut[i] = rint(y * 327.67);
 	}
 
 #ifdef DEBUG

--- a/libvips/create/buildlut.c
+++ b/libvips/create/buildlut.c
@@ -129,13 +129,13 @@ vips_buildlut_build_init(VipsBuildlut *lut)
 
 		/* Allow for being a bit off.
 		 */
-		if (VIPS_FABS(v - VIPS_RINT(v)) > 0.001) {
+		if (fabs(v - rint(v)) > 0.001) {
 			vips_error(class->nickname,
 				_("x value row %d not an int"), y);
 			return -1;
 		}
 
-		v = VIPS_RINT(v);
+		v = rint(v);
 
 		if (v < xlow)
 			xlow = v;
@@ -197,8 +197,8 @@ vips_buildlut_build_create(VipsBuildlut *lut)
 	 */
 	for (b = 0; b < bands; b++) {
 		for (i = 0; i < ysize - 1; i++) {
-			const int x1 = VIPS_RINT(lut->data[i][0]);
-			const int x2 = VIPS_RINT(lut->data[i + 1][0]);
+			const int x1 = rint(lut->data[i][0]);
+			const int x2 = rint(lut->data[i + 1][0]);
 			const int dx = x2 - x1;
 			const double y1 = lut->data[i][b + 1];
 			const double y2 = lut->data[i + 1][b + 1];

--- a/libvips/create/gaussmat.c
+++ b/libvips/create/gaussmat.c
@@ -150,7 +150,7 @@ vips_gaussmat_build(VipsObject *object)
 			double v = exp(-distance / sig2);
 
 			if (gaussmat->precision != VIPS_PRECISION_FLOAT)
-				v = VIPS_RINT(20 * v);
+				v = rint(20 * v);
 
 			*VIPS_MATRIX(create->out, x, y) = v;
 			sum += v;

--- a/libvips/create/logmat.c
+++ b/libvips/create/logmat.c
@@ -138,7 +138,7 @@ vips_logmat_build(VipsObject *object)
 		 * is less than the min.
 		 */
 		if (val - last >= 0 &&
-			VIPS_FABS(val) < logmat->min_ampl)
+			fabs(val) < logmat->min_ampl)
 			break;
 
 		last = val;
@@ -171,7 +171,7 @@ vips_logmat_build(VipsObject *object)
 				exp(-distance / (2.0 * sig2));
 
 			if (logmat->precision == VIPS_PRECISION_INTEGER)
-				v = VIPS_RINT(20 * v);
+				v = rint(20 * v);
 
 			*VIPS_MATRIX(create->out, x, y) = v;
 			sum += v;

--- a/libvips/deprecated/im_vips2mask.c
+++ b/libvips/deprecated/im_vips2mask.c
@@ -216,15 +216,15 @@ im_vips2imask(IMAGE *in, const char *filename)
 				 * we need RRRGGGBBB.
 				 */
 				out->coeff[x + y * width] =
-					VIPS_RINT(data[x * height + y]);
+					rint(data[x * height + y]);
 			else
 				out->coeff[x + y * width] =
-					VIPS_RINT(data[x + y * width]);
+					rint(data[x + y * width]);
 
-	out->scale = VIPS_RINT(vips_image_get_scale(in));
+	out->scale = rint(vips_image_get_scale(in));
 	if (out->scale == 0)
 		out->scale = 1;
-	out->offset = VIPS_RINT(vips_image_get_offset(in));
+	out->offset = rint(vips_image_get_offset(in));
 
 	/* Now convolve a 1 everywhere image with the int version we've made,
 	 * what do we get?
@@ -237,7 +237,7 @@ im_vips2imask(IMAGE *in, const char *filename)
 
 	/* And adjust the scale to get as close to a match as we can.
 	 */
-	out->scale = VIPS_RINT(out->scale + (int_result - double_result));
+	out->scale = rint(out->scale + (int_result - double_result));
 	if (out->scale == 0)
 		out->scale = 1;
 

--- a/libvips/foreign/cgifsave.c
+++ b/libvips/foreign/cgifsave.c
@@ -667,7 +667,7 @@ vips_foreign_save_cgif_write_frame(VipsForeignSaveCgif *cgif)
 	if (cgif->delay &&
 		cgif->page_number < cgif->delay_length)
 		frame_config.delay =
-			VIPS_RINT(cgif->delay[cgif->page_number] / 10.0);
+			rint(cgif->delay[cgif->page_number] / 10.0);
 
 	/* Attach a local palette, if we need one.
 	 */

--- a/libvips/foreign/dzsave.c
+++ b/libvips/foreign/dzsave.c
@@ -1288,7 +1288,7 @@ region_tile_equal(VipsRegion *region, VipsRect *rect,
 
 		for (x = 0; x < rect->width; x++) {
 			for (b = 0; b < bytes; b++)
-				if (VIPS_ABS(p[b] - ink[b]) > threshold)
+				if (abs(p[b] - ink[b]) > threshold)
 					return FALSE;
 
 			p += bytes;

--- a/libvips/foreign/exif.c
+++ b/libvips/foreign/exif.c
@@ -748,7 +748,7 @@ vips_exif_set_double(ExifData *ed,
 		else
 			old_value = (double) rv.numerator / rv.denominator;
 
-		if (VIPS_FABS(old_value - value) > 0.0001) {
+		if (fabs(old_value - value) > 0.0001) {
 			vips_exif_double_to_rational(value, &rv);
 
 			VIPS_DEBUG_MSG("vips_exif_set_double: %u / %u\n",
@@ -767,7 +767,7 @@ vips_exif_set_double(ExifData *ed,
 		else
 			old_value = (double) srv.numerator / srv.denominator;
 
-		if (VIPS_FABS(old_value - value) > 0.0001) {
+		if (fabs(old_value - value) > 0.0001) {
 			vips_exif_double_to_srational(value, &srv);
 
 			VIPS_DEBUG_MSG("vips_exif_set_double: %d / %d\n",

--- a/libvips/foreign/jxlload.c
+++ b/libvips/foreign/jxlload.c
@@ -764,7 +764,7 @@ vips_foreign_load_jxl_set_header(VipsForeignLoadJxl *jxl, VipsImage *out)
 
 			/* gif uses centiseconds for delays
 			 */
-			vips_image_set_int(out, "gif-delay", VIPS_RINT(delay[0] / 10.0));
+			vips_image_set_int(out, "gif-delay", rint(delay[0] / 10.0));
 
 			vips_image_set_int(out, "loop", jxl->info.animation.num_loops);
 		}
@@ -993,7 +993,7 @@ vips_foreign_load_jxl_header(VipsForeignLoad *load)
 				double tick = (double) jxl->info.animation.tps_denominator /
 					jxl->info.animation.tps_numerator;
 				// this duration in ms
-				int ms = VIPS_RINT(1000.0 * h.duration * tick);
+				int ms = rint(1000.0 * h.duration * tick);
 				// h.duration of 0xffffffff is used for multipage JXL ... map
 				// this to -1 in delay
 				int duration = h.duration == 0xffffffff ? -1 : ms;

--- a/libvips/foreign/matrixload.c
+++ b/libvips/foreign/matrixload.c
@@ -140,8 +140,8 @@ parse_matrix_header(char *line,
 		return -1;
 	}
 
-	if (VIPS_FLOOR(header[0]) != header[0] ||
-		VIPS_FLOOR(header[1]) != header[1]) {
+	if (floor(header[0]) != header[0] ||
+		floor(header[1]) != header[1]) {
 		vips_error("mask2vips", "%s", _("width / height not int"));
 		return -1;
 	}

--- a/libvips/foreign/pdfiumload.c
+++ b/libvips/foreign/pdfiumload.c
@@ -498,9 +498,9 @@ vips_foreign_load_pdf_header(VipsForeignLoad *load)
 		 * does round to nearest. Without this, things like
 		 * shrink-on-load will break.
 		 */
-		pdf->pages[i].width = VIPS_RINT(
+		pdf->pages[i].width = rint(
 			FPDF_GetPageWidth(pdf->page) * pdf->scale);
-		pdf->pages[i].height = VIPS_RINT(
+		pdf->pages[i].height = rint(
 			FPDF_GetPageHeight(pdf->page) * pdf->scale);
 
 		/* PDFium allows page width or height to be less than 1 (!!).

--- a/libvips/foreign/popplerload.c
+++ b/libvips/foreign/popplerload.c
@@ -357,8 +357,8 @@ vips_foreign_load_pdf_header(VipsForeignLoad *load)
 		 * does round to nearest. Without this, things like
 		 * shrink-on-load will break.
 		 */
-		pdf->pages[i].width = VIPS_RINT(width * pdf->total_scale);
-		pdf->pages[i].height = VIPS_RINT(height * pdf->total_scale);
+		pdf->pages[i].width = rint(width * pdf->total_scale);
+		pdf->pages[i].height = rint(height * pdf->total_scale);
 
 		if (pdf->pages[i].width > pdf->image.width)
 			pdf->image.width = pdf->pages[i].width;

--- a/libvips/foreign/ppmload.c
+++ b/libvips/foreign/ppmload.c
@@ -412,10 +412,10 @@ vips_foreign_load_ppm_set_image_metadata(VipsForeignLoadPpm *ppm,
 	if (ppm->index == 6 ||
 		ppm->index == 7)
 		vips_image_set_double(image,
-			"pfm-scale", VIPS_FABS(ppm->scale));
+			"pfm-scale", fabs(ppm->scale));
 	else
 		vips_image_set_double(image,
-			"ppm-max-value", VIPS_ABS(ppm->max_value));
+			"ppm-max-value", abs(ppm->max_value));
 
 	VIPS_SETSTR(image->filename,
 		vips_connection_filename(VIPS_CONNECTION(ppm->sbuf->source)));

--- a/libvips/foreign/spngsave.c
+++ b/libvips/foreign/spngsave.c
@@ -452,8 +452,8 @@ vips_foreign_save_spng_write(VipsForeignSaveSpng *spng, VipsImage *in)
 	/* Set resolution. spng uses pixels per meter.
 	 */
 	phys.unit_specifier = 1;
-	phys.ppu_x = VIPS_RINT(in->Xres * 1000.0);
-	phys.ppu_y = VIPS_RINT(in->Xres * 1000.0);
+	phys.ppu_x = rint(in->Xres * 1000.0);
+	phys.ppu_y = rint(in->Xres * 1000.0);
 	spng_set_phys(spng->ctx, &phys);
 
 	/* Metadata.

--- a/libvips/foreign/vips2jpeg.c
+++ b/libvips/foreign/vips2jpeg.c
@@ -435,18 +435,18 @@ vips_jfif_resolution_from_image(struct jpeg_compress_struct *cinfo,
 
 	switch (unit) {
 	case 0:
-		xres = VIPS_RINT(image->Xres);
-		yres = VIPS_RINT(image->Yres);
+		xres = rint(image->Xres);
+		yres = rint(image->Yres);
 		break;
 
 	case 1:
-		xres = VIPS_RINT(image->Xres * 25.4);
-		yres = VIPS_RINT(image->Yres * 25.4);
+		xres = rint(image->Xres * 25.4);
+		yres = rint(image->Yres * 25.4);
 		break;
 
 	case 2:
-		xres = VIPS_RINT(image->Xres * 10.0);
-		yres = VIPS_RINT(image->Yres * 10.0);
+		xres = rint(image->Xres * 10.0);
+		yres = rint(image->Yres * 10.0);
 		break;
 
 	default:

--- a/libvips/foreign/vips2magick.c
+++ b/libvips/foreign/vips2magick.c
@@ -166,7 +166,7 @@ vips_foreign_save_magick_next_image(VipsForeignSaveMagick *magick)
 		page_index = magick->position.top / magick->page_height;
 		if (page_index < magick->delays_length)
 			image->delay =
-				VIPS_RINT(magick->delays[page_index] / 10.0);
+				rint(magick->delays[page_index] / 10.0);
 	}
 
 	/* ImageMagick uses iterations like this (at least in gif save):

--- a/libvips/foreign/vipspng.c
+++ b/libvips/foreign/vipspng.c
@@ -1165,7 +1165,7 @@ write_vips(Write *write,
 	/* Set resolution. libpng uses pixels per meter.
 	 */
 	png_set_pHYs(write->pPng, write->pInfo,
-		VIPS_RINT(in->Xres * 1000), VIPS_RINT(in->Yres * 1000),
+		rint(in->Xres * 1000), rint(in->Yres * 1000),
 		PNG_RESOLUTION_METER);
 
 	/* Metadata

--- a/libvips/foreign/webp2vips.c
+++ b/libvips/foreign/webp2vips.c
@@ -486,7 +486,7 @@ read_header(Read *read, VipsImage *out)
 			/* webp uses ms for delays, gif uses centiseconds.
 			 */
 			vips_image_set_int(out, "gif-delay",
-				VIPS_RINT(read->delays[0] / 10.0));
+				rint(read->delays[0] / 10.0));
 		}
 
 		WebPDemuxReleaseIterator(&iter);
@@ -510,8 +510,8 @@ read_header(Read *read, VipsImage *out)
 
 	/* We round-to-nearest cf. pdfload etc.
 	 */
-	read->frame_width = VIPS_RINT(read->canvas_width * read->scale);
-	read->frame_height = VIPS_RINT(read->canvas_height * read->scale);
+	read->frame_width = rint(read->canvas_width * read->scale);
+	read->frame_height = rint(read->canvas_height * read->scale);
 
 #ifdef DEBUG
 	printf("webp2vips: canvas_width = %d\n", read->canvas_width);
@@ -656,10 +656,10 @@ read_next_frame(Read *read)
 	 * since we need the same rules as the overall image scale, or we'll
 	 * sometimes have missing pixels on edges.
 	 */
-	area.left = VIPS_RINT(read->iter.x_offset * read->scale);
-	area.top = VIPS_RINT(read->iter.y_offset * read->scale);
-	area.width = VIPS_RINT(read->iter.width * read->scale);
-	area.height = VIPS_RINT(read->iter.height * read->scale);
+	area.left = rint(read->iter.x_offset * read->scale);
+	area.top = rint(read->iter.y_offset * read->scale);
+	area.width = rint(read->iter.width * read->scale);
+	area.height = rint(read->iter.height * read->scale);
 
 	/* Dispose from the previous frame.
 	 */

--- a/libvips/histogram/hist_plot.c
+++ b/libvips/histogram/hist_plot.c
@@ -280,7 +280,7 @@ vips_hist_plot_build(VipsObject *object)
 	if (in->BandFmt == VIPS_FORMAT_UCHAR)
 		tsize = 256;
 	else
-		tsize = VIPS_CEIL(max);
+		tsize = ceil(max);
 
 	/* Make sure we don't make a zero height image.
 	 */

--- a/libvips/include/vips/basic.h
+++ b/libvips/include/vips/basic.h
@@ -56,6 +56,18 @@
 #define VIPS_DEPRECATED_FOR(f) G_DEPRECATED_FOR(f) VIPS_API
 #endif
 
+#if !defined(VIPS_DISABLE_DEPRECATION_WARNINGS) && \
+	(G_GNUC_CHECK_VERSION(4, 6) || \
+		__clang_major__ > 3 || (__clang_major__ == 3 && __clang_minor__ >= 4))
+#define _VIPS_GNUC_DO_PRAGMA(x) _Pragma(G_STRINGIFY(x))
+#define VIPS_DEPRECATED_MACRO _VIPS_GNUC_DO_PRAGMA(GCC warning "Deprecated pre-processor symbol")
+#define VIPS_DEPRECATED_MACRO_FOR(f) \
+	_VIPS_GNUC_DO_PRAGMA(GCC warning G_STRINGIFY(Deprecated pre-processor symbol: replace with #f))
+#else
+#define VIPS_DEPRECATED_MACRO
+#define VIPS_DEPRECATED_MACRO_FOR(f)
+#endif
+
 #ifdef __cplusplus
 extern "C" {
 #endif /*__cplusplus*/

--- a/libvips/include/vips/util.h
+++ b/libvips/include/vips/util.h
@@ -62,7 +62,7 @@ extern "C" {
 
 #define VIPS_NUMBER(R) ((int) (sizeof(R) / sizeof(R[0])))
 
-#define VIPS_ABS(V) abs((V)) VIPS_DEPRECATED_MACRO_FOR(abs)
+#define VIPS_ABS(V) (((V) >= 0) ? (V) : -(V))
 #define VIPS_FABS(V) fabs((V)) VIPS_DEPRECATED_MACRO_FOR(fabs)
 
 // is something (eg. a pointer) N aligned

--- a/libvips/include/vips/util.h
+++ b/libvips/include/vips/util.h
@@ -54,38 +54,25 @@ extern "C" {
 #define VIPS_MAX(A, B) ((A) > (B) ? (A) : (B))
 #define VIPS_MIN(A, B) ((A) < (B) ? (A) : (B))
 
+#define VIPS_FMAX(A, B) fmax((A), (B)) VIPS_DEPRECATED_MACRO_FOR(fmax)
+#define VIPS_FMIN(A, B) fmin((A), (B)) VIPS_DEPRECATED_MACRO_FOR(fmin)
+
 #define VIPS_CLIP(A, V, B) VIPS_MAX((A), VIPS_MIN((B), (V)))
-#define VIPS_FCLIP(A, V, B) VIPS_FMAX((A), VIPS_FMIN((B), (V)))
+#define VIPS_FCLIP(A, V, B) fmax((A), fmin((B), (V)))
 
 #define VIPS_NUMBER(R) ((int) (sizeof(R) / sizeof(R[0])))
 
-#define VIPS_ABS(X) (((X) >= 0) ? (X) : -(X))
+#define VIPS_ABS(V) abs((V)) VIPS_DEPRECATED_MACRO_FOR(abs)
+#define VIPS_FABS(V) fabs((V)) VIPS_DEPRECATED_MACRO_FOR(fabs)
 
 // is something (eg. a pointer) N aligned
 #define VIPS_ALIGNED(P, N) ((((guint64) (P)) & ((N) - 1)) == 0)
 
-/* The built-in isnan and isinf functions provided by gcc 4+ and clang are
- * up to 7x faster than their libc equivalent included from <math.h>.
- */
-#if defined(__clang__) || (__GNUC__ >= 4)
-#define VIPS_ISNAN(V) __builtin_isnan(V)
-#define VIPS_FLOOR(V) __builtin_floor(V)
-#define VIPS_CEIL(V) __builtin_ceil(V)
-#define VIPS_RINT(V) __builtin_rint(V)
-#define VIPS_ROUND(V) __builtin_round(V)
-#define VIPS_FABS(V) __builtin_fabs(V)
-#define VIPS_FMAX(A, B) __builtin_fmax(A, B)
-#define VIPS_FMIN(A, B) __builtin_fmin(A, B)
-#else
-#define VIPS_ISNAN(V) isnan(V)
-#define VIPS_FLOOR(V) floor(V)
-#define VIPS_CEIL(V) ceil(V)
-#define VIPS_RINT(V) rint(V)
-#define VIPS_ROUND(V) round(V)
-#define VIPS_FABS(V) VIPS_ABS(V)
-#define VIPS_FMAX(A, B) VIPS_MAX(A, B)
-#define VIPS_FMIN(A, B) VIPS_MIN(A, B)
-#endif
+#define VIPS_ISNAN(V) isnan(V) VIPS_DEPRECATED_MACRO_FOR(isnan)
+#define VIPS_FLOOR(V) floor(V) VIPS_DEPRECATED_MACRO_FOR(floor)
+#define VIPS_CEIL(V) ceil(V) VIPS_DEPRECATED_MACRO_FOR(ceil)
+#define VIPS_RINT(V) rint(V) VIPS_DEPRECATED_MACRO_FOR(rint)
+#define VIPS_ROUND(V) round(V) VIPS_DEPRECATED_MACRO_FOR(round)
 
 /* Testing status before the function call saves a lot of time.
  */
@@ -97,7 +84,7 @@ extern "C" {
 	} \
 	G_STMT_END
 
-/* VIPS_RINT() does "bankers rounding", it rounds to the nearest even integer.
+/* rint() does "bankers rounding", it rounds to the nearest even integer.
  * For things like image geometry, we want strict nearest int.
  *
  * If you know it's unsigned, _UINT is a little faster.

--- a/libvips/mosaicing/im_avgdxdy.c
+++ b/libvips/mosaicing/im_avgdxdy.c
@@ -75,8 +75,8 @@ vips__avgdxdy(TiePoints *points, int *dx, int *dy)
 		sumdy += points->y_secondary[i] - points->y_reference[i];
 	}
 
-	*dx = VIPS_RINT((double) sumdx / (double) points->nopoints);
-	*dy = VIPS_RINT((double) sumdy / (double) points->nopoints);
+	*dx = rint((double) sumdx / (double) points->nopoints);
+	*dy = rint((double) sumdy / (double) points->nopoints);
 
 	return 0;
 }

--- a/libvips/resample/affine.c
+++ b/libvips/resample/affine.c
@@ -366,8 +366,8 @@ vips_affine_gen(VipsRegion *out_region,
 		for (x = le; x < ri; x++) {
 			int fx, fy;
 
-			fx = VIPS_FLOOR(ix);
-			fy = VIPS_FLOOR(iy);
+			fx = floor(ix);
+			fy = floor(iy);
 
 			/* Clip against iarea.
 			 */

--- a/libvips/resample/mapim.c
+++ b/libvips/resample/mapim.c
@@ -285,8 +285,8 @@ vips_mapim_region_minmax(VipsRegion *region, VipsRect *r, VipsRect *bounds)
 			TYPE px = p1[0]; \
 			TYPE py = p1[1]; \
 \
-			if (VIPS_ISNAN(px) || \
-				VIPS_ISNAN(py) || \
+			if (isnan(px) || \
+				isnan(py) || \
 				px < -1 || \
 				px >= clip_width || \
 				py < -1 || \

--- a/libvips/resample/reduceh.cpp
+++ b/libvips/resample/reduceh.cpp
@@ -441,7 +441,7 @@ vips_reduceh_build(VipsObject *object)
 		/* The int part of our reduce.
 		 */
 		int_hshrink = VIPS_MAX(1,
-			VIPS_FLOOR((double) in->Xsize / width / reduceh->gap));
+			floor((double) in->Xsize / width / reduceh->gap));
 
 		if (int_hshrink > 1) {
 			g_info("shrinkh by %d", int_hshrink);
@@ -510,7 +510,7 @@ vips_reduceh_build(VipsObject *object)
 	/* Add new pixels around the input so we can interpolate at the edges.
 	 */
 	if (vips_embed(in, &t[2],
-			VIPS_CEIL(reduceh->n_point / 2.0) - 1, 0,
+			ceil(reduceh->n_point / 2.0) - 1, 0,
 			in->Xsize + reduceh->n_point, in->Ysize,
 			"extend", VIPS_EXTEND_COPY,
 			nullptr))

--- a/libvips/resample/reducev.cpp
+++ b/libvips/resample/reducev.cpp
@@ -762,7 +762,7 @@ vips_reducev_vector_to_fixed_point(double *in, int *out, int n, int scale)
 	fsum = 0.0;
 	for (i = 0; i < n; i++)
 		fsum += in[i];
-	target = VIPS_RINT(fsum * scale);
+	target = rint(fsum * scale);
 
 	/* As we rint() each scale element, we can get up to 0.5 error.
 	 * Therefore, by the end of the mask, we can be off by up to n/2. Our
@@ -776,7 +776,7 @@ vips_reducev_vector_to_fixed_point(double *in, int *out, int n, int scale)
 		guess = (high + low) / 2.0;
 
 		for (i = 0; i < n; i++)
-			out[i] = VIPS_RINT(in[i] * guess);
+			out[i] = rint(in[i] * guess);
 
 		sum = 0;
 		for (i = 0; i < n; i++)
@@ -812,7 +812,7 @@ vips_reducev_vector_to_fixed_point(double *in, int *out, int n, int scale)
 		 * first abs(extra_error) elements.
 		 */
 		int direction = extra_error > 0 ? 1 : -1;
-		int n_elements = VIPS_ABS(extra_error);
+		int n_elements = abs(extra_error);
 
 		for (i = 0; i < n; i++)
 			out[i] += each_error;
@@ -874,7 +874,7 @@ vips_reducev_build(VipsObject *object)
 		/* The int part of our reduce.
 		 */
 		int_vshrink = VIPS_MAX(1,
-			VIPS_FLOOR((double) in->Ysize / height / reducev->gap));
+			floor((double) in->Ysize / height / reducev->gap));
 
 		if (int_vshrink > 1) {
 			g_info("shrinkv by %d", int_vshrink);
@@ -941,7 +941,7 @@ vips_reducev_build(VipsObject *object)
 	/* Add new pixels around the input so we can interpolate at the edges.
 	 */
 	if (vips_embed(in, &t[2],
-			0, VIPS_CEIL(reducev->n_point / 2.0) - 1,
+			0, ceil(reducev->n_point / 2.0) - 1,
 			in->Xsize, in->Ysize + reducev->n_point,
 			"extend", VIPS_EXTEND_COPY,
 			nullptr))

--- a/libvips/resample/resize.c
+++ b/libvips/resample/resize.c
@@ -171,17 +171,17 @@ vips_resize_build(VipsObject *object)
 		/* The int part of our scale.
 		 */
 		if (resize->gap < 1.0) {
-			int_hshrink = VIPS_FLOOR(1.0 / hscale);
-			int_vshrink = VIPS_FLOOR(1.0 / vscale);
+			int_hshrink = floor(1.0 / hscale);
+			int_vshrink = floor(1.0 / vscale);
 		}
 		else {
 			target_width = VIPS_ROUND_UINT(in->Xsize * hscale);
 			target_height = VIPS_ROUND_UINT(in->Ysize * vscale);
 
-			int_hshrink = VIPS_FLOOR(
+			int_hshrink = floor(
 				(double) in->Xsize / target_width /
 				resize->gap);
-			int_vshrink = VIPS_FLOOR(
+			int_vshrink = floor(
 				(double) in->Ysize / target_height /
 				resize->gap);
 		}
@@ -252,12 +252,12 @@ vips_resize_build(VipsObject *object)
 		vips_object_local(object, interpolate);
 
 		if (resize->kernel == VIPS_KERNEL_NEAREST &&
-			hscale == VIPS_FLOOR(hscale) &&
-			vscale == VIPS_FLOOR(vscale)) {
+			hscale == floor(hscale) &&
+			vscale == floor(vscale)) {
 			/* Fast, integral nearest neighbour enlargement
 			 */
-			if (vips_zoom(in, &t[4], VIPS_FLOOR(hscale),
-					VIPS_FLOOR(vscale), NULL))
+			if (vips_zoom(in, &t[4], floor(hscale),
+					floor(vscale), NULL))
 				return -1;
 			in = t[4];
 		}

--- a/libvips/resample/shrinkh.c
+++ b/libvips/resample/shrinkh.c
@@ -392,7 +392,7 @@ vips_shrinkh_build(VipsObject *object)
 	 * fractional part), we just see the integer part here.
 	 */
 	resample->out->Xsize = shrink->ceil
-		? VIPS_CEIL((double) resample->in->Xsize / shrink->hshrink)
+		? ceil((double) resample->in->Xsize / shrink->hshrink)
 		: VIPS_ROUND_UINT((double) resample->in->Xsize / shrink->hshrink);
 	if (resample->out->Xsize <= 0) {
 		vips_error(class->nickname,

--- a/libvips/resample/shrinkv.c
+++ b/libvips/resample/shrinkv.c
@@ -443,7 +443,7 @@ vips_shrinkv_build(VipsObject *object)
 	 * fractional part), we just see the integer part here.
 	 */
 	t[2]->Ysize = shrink->ceil
-		? VIPS_CEIL((double) resample->in->Ysize / shrink->vshrink)
+		? ceil((double) resample->in->Ysize / shrink->vshrink)
 		: VIPS_ROUND_UINT((double) resample->in->Ysize / shrink->vshrink);
 	if (t[2]->Ysize <= 0) {
 		vips_error(class->nickname,

--- a/libvips/resample/templates.h
+++ b/libvips/resample/templates.h
@@ -323,7 +323,7 @@ static void inline calculate_coefficients_catmull(double c[4], const double x)
  */
 static double inline cubic_filter(double x, double B, double C)
 {
-	const double ax = VIPS_FABS(x);
+	const double ax = fabs(x);
 	const double ax2 = ax * ax;
 	const double ax3 = ax2 * ax;
 
@@ -361,7 +361,7 @@ static double inline filter(double x);
 template <>
 double inline filter<VIPS_KERNEL_LINEAR>(double x)
 {
-	x = VIPS_FABS(x);
+	x = fabs(x);
 
 	if (x < 1.0)
 		return 1.0 - x;
@@ -404,7 +404,7 @@ double inline filter<VIPS_KERNEL_LANCZOS3>(double x)
 template <>
 double inline filter<VIPS_KERNEL_MKS2013>(double x)
 {
-	x = VIPS_FABS(x);
+	x = fabs(x);
 
 	if (x >= 2.5)
 		return 0.0;
@@ -421,7 +421,7 @@ double inline filter<VIPS_KERNEL_MKS2013>(double x)
 template <>
 double inline filter<VIPS_KERNEL_MKS2021>(double x)
 {
-	x = VIPS_FABS(x);
+	x = fabs(x);
 
 	if (x >= 4.5)
 		return 0.0;

--- a/libvips/resample/thumbnail.c
+++ b/libvips/resample/thumbnail.c
@@ -783,7 +783,7 @@ vips_thumbnail_build(VipsObject *object)
 	 * page_height or we'll have pixels straddling page boundaries.
 	 */
 	if (in->Ysize > preshrunk_page_height) {
-		int target_page_height = VIPS_RINT(preshrunk_page_height / vshrink);
+		int target_page_height = rint(preshrunk_page_height / vshrink);
 		int target_image_height =
 			target_page_height * thumbnail->n_loaded_pages;
 
@@ -827,7 +827,7 @@ vips_thumbnail_build(VipsObject *object)
 	 * accidentally turn into an animated image later.
 	 */
 	if (thumbnail->n_loaded_pages > 1) {
-		int output_page_height = VIPS_RINT(preshrunk_page_height / vshrink);
+		int output_page_height = rint(preshrunk_page_height / vshrink);
 
 		if (vips_copy(in, &t[8], NULL))
 			return -1;


### PR DESCRIPTION
We can simply use the functions from `<math.h>` instead of conditionally relying on GCC and Clang's `__builtin_*` functions.

The likely reason for commit 90c1fb9a9444dde41e3db8fd18c41f83c31c7e5f was due to https://sourceware.org/bugzilla/show_bug.cgi?id=17441, which was resolved in glibc 2.23.

Context: https://github.com/libvips/libvips/pull/4412#discussion_r1986142253.