### PR TITLE
clang-tidy: avoid narrowing conversions

### DIFF
--- a/libvips/colour/HSV2sRGB.c
+++ b/libvips/colour/HSV2sRGB.c
@@ -63,7 +63,7 @@ vips_HSV2sRGB_line(VipsColour *colour, VipsPel *out, VipsPel **in, int width)
 		float c, x, m;
 
 		c = p[2] * p[1] / 255.0;
-		x = c * (1 - fabs(fmod(p[0] / SIXTH_OF_CHAR, 2) - 1));
+		x = c * (1 - fabsf(fmodf(p[0] / SIXTH_OF_CHAR, 2) - 1));
 		m = p[2] - c;
 
 		if (p[0] < (int) SIXTH_OF_CHAR) {

--- a/libvips/colour/LCh2Lab.c
+++ b/libvips/colour/LCh2Lab.c
@@ -69,8 +69,8 @@ G_DEFINE_TYPE(VipsLCh2Lab, vips_LCh2Lab, VIPS_TYPE_COLOUR_TRANSFORM);
 void
 vips_col_Ch2ab(float C, float h, float *a, float *b)
 {
-	*a = C * cos(VIPS_RAD(h));
-	*b = C * sin(VIPS_RAD(h));
+	*a = C * cosf(VIPS_RAD(h));
+	*b = C * sinf(VIPS_RAD(h));
 }
 
 /* Process a buffer of data.

--- a/libvips/colour/LCh2UCS.c
+++ b/libvips/colour/LCh2UCS.c
@@ -92,9 +92,9 @@ vips_col_L2Lcmc(float L)
 	float Lcmc;
 
 	if (L < 16.0)
-		Lcmc = 1.744 * L;
+		Lcmc = 1.744F * L;
 	else
-		Lcmc = 21.75 * log(L) + 0.3838 * L - 38.54;
+		Lcmc = 21.75F * logf(L) + 0.3838F * L - 38.54F;
 
 	return Lcmc;
 }
@@ -112,7 +112,7 @@ vips_col_C2Ccmc(float C)
 {
 	float Ccmc;
 
-	Ccmc = 0.162 * C + 10.92 * log(0.638 + 0.07216 * C) + 4.907;
+	Ccmc = 0.162F * C + 10.92F * logf(0.638F + 0.07216F * C) + 4.907F;
 	if (Ccmc < 0)
 		Ccmc = 0;
 
@@ -136,35 +136,35 @@ vips_col_Ch2hcmc(float C, float h)
 	float hcmc;
 
 	if (h < 49.1) {
-		k4 = 133.87;
-		k5 = -134.5;
-		k6 = -.924;
-		k7 = 1.727;
-		k8 = 340.0;
+		k4 = 133.87F;
+		k5 = -134.5F;
+		k6 = -.924F;
+		k7 = 1.727F;
+		k8 = 340.0F;
 	}
 	else if (h < 110.1) {
-		k4 = 11.78;
-		k5 = -12.7;
-		k6 = -.218;
-		k7 = 2.12;
-		k8 = 333.0;
+		k4 = 11.78F;
+		k5 = -12.7F;
+		k6 = -.218F;
+		k7 = 2.12F;
+		k8 = 333.0F;
 	}
 	else if (h < 269.6) {
-		k4 = 13.87;
-		k5 = 10.93;
-		k6 = 0.14;
-		k7 = 1.0;
-		k8 = -83.0;
+		k4 = 13.87F;
+		k5 = 10.93F;
+		k6 = 0.14F;
+		k7 = 1.0F;
+		k8 = -83.0F;
 	}
 	else {
-		k4 = .14;
-		k5 = 5.23;
-		k6 = .17;
-		k7 = 1.61;
-		k8 = 233.0;
+		k4 = .14F;
+		k5 = 5.23F;
+		k6 = .17F;
+		k7 = 1.61F;
+		k8 = 233.0F;
 	}
 
-	P = cos(VIPS_RAD(k7 * h + k8));
+	P = cosf(VIPS_RAD(k7 * h + k8));
 	D = k4 + k5 * P * powf(fabsf(P), k6);
 	g = C * C * C * C;
 	f = sqrtf(g / (g + 1900.0F));

--- a/libvips/colour/Lab2LCh.c
+++ b/libvips/colour/Lab2LCh.c
@@ -92,7 +92,7 @@ void
 vips_col_ab2Ch(float a, float b, float *C, float *h)
 {
 	*h = vips_col_ab2h(a, b);
-	*C = hypot(a, b);
+	*C = hypotf(a, b);
 }
 
 static void
@@ -111,7 +111,7 @@ vips_Lab2LCh_line(VipsColour *colour, VipsPel *out, VipsPel **in, int width)
 
 		p += 3;
 
-		C = sqrt(a * a + b * b);
+		C = sqrtf(a * a + b * b);
 		h = vips_col_ab2h(a, b);
 
 		q[0] = L;

--- a/libvips/colour/Lab2LabQ.c
+++ b/libvips/colour/Lab2LabQ.c
@@ -102,14 +102,14 @@ vips_Lab2LabQ_line(VipsColour *colour, VipsPel *out, VipsPel **in, int width)
 		lsbs = (intv & 0x3) << 6; /* 00000011 -> 11000000 */
 		q[0] = intv >> 2;		  /* drop bot 2 bits and store */
 
-		fval = 8.0 * p[1]; /* do a */
-		intv = rint(fval);
+		fval = 8.0F * p[1]; /* do a */
+		intv = rintf(fval);
 		intv = VIPS_CLIP(-1024, intv, 1023);
 		lsbs |= (intv & 0x7) << 3; /* 00000111 -> 00111000 */
 		q[1] = intv >> 3;		   /* drop bot 3 bits & store */
 
-		fval = 8.0 * p[2]; /* do b */
-		intv = rint(fval);
+		fval = 8.0F * p[2]; /* do b */
+		intv = rintf(fval);
 		intv = VIPS_CLIP(-1024, intv, 1023);
 		lsbs |= (intv & 0x7);
 		q[2] = intv >> 3;

--- a/libvips/colour/LabQ2Lab.c
+++ b/libvips/colour/LabQ2Lab.c
@@ -92,17 +92,17 @@ vips_LabQ2Lab_line(VipsColour *colour, VipsPel *out, VipsPel **in, int width)
 		 */
 		l = ((unsigned char *) p)[0];
 		l = (l << 2) | (lsbs >> 6);
-		q[0] = (float) l * (100.0 / 1023.0);
+		q[0] = (float) l * (100.0F / 1023.0F);
 
 		/* Build a.
 		 */
 		l = VIPS_LSHIFT_INT(p[1], 3) | ((lsbs >> 3) & 0x7);
-		q[1] = (float) l * 0.125;
+		q[1] = (float) l * 0.125F;
 
 		/* And b.
 		 */
 		l = VIPS_LSHIFT_INT(p[2], 3) | (lsbs & 0x7);
-		q[2] = (float) l * 0.125;
+		q[2] = (float) l * 0.125F;
 
 		p += 4;
 		q += 3;

--- a/libvips/colour/LabQ2sRGB.c
+++ b/libvips/colour/LabQ2sRGB.c
@@ -136,11 +136,11 @@ calcul_tables(int range, int *Y2v, float *v2Y)
 		float v;
 
 		if (f <= 0.0031308)
-			v = 12.92 * f;
+			v = 12.92F * f;
 		else
-			v = (1.0 + 0.055) * pow(f, 1.0 / 2.4) - 0.055;
+			v = (1.0F + 0.055F) * powf(f, 1.0F / 2.4F) - 0.055F;
 
-		Y2v[i] = rint((range - 1) * v);
+		Y2v[i] = rintf((range - 1) * v);
 	}
 
 	/* Copy the final element. This is used in the piecewise linear
@@ -152,9 +152,9 @@ calcul_tables(int range, int *Y2v, float *v2Y)
 		float f = (float) i / (range - 1);
 
 		if (f <= 0.04045)
-			v2Y[i] = f / 12.92;
+			v2Y[i] = f / 12.92F;
 		else
-			v2Y[i] = pow((f + 0.055) / (1 + 0.055), 2.4);
+			v2Y[i] = powf((f + 0.055F) / (1 + 0.055F), 2.4F);
 	}
 }
 
@@ -231,15 +231,15 @@ vips_col_scRGB2XYZ(float R, float G, float B, float *X, float *Y, float *Z)
 	G *= SCALE;
 	B *= SCALE;
 
-	*X = 0.4124 * R +
-		0.3576 * G +
-		0.1805 * B;
-	*Y = 0.2126 * R +
-		0.7152 * G +
-		0.0722 * B;
-	*Z = 0.0193 * R +
-		0.1192 * G +
-		0.9505 * B;
+	*X = 0.4124F * R +
+		0.3576F * G +
+		0.1805F * B;
+	*Y = 0.2126F * R +
+		0.7152F * G +
+		0.0722F * B;
+	*Z = 0.0193F * R +
+		0.1192F * G +
+		0.9505F * B;
 
 	return 0;
 }
@@ -266,15 +266,15 @@ vips_col_XYZ2scRGB(float X, float Y, float Z, float *R, float *G, float *B)
 
 	/* Use 6 decimal places of precision for the inverse matrix.
 	 */
-	*R = 3.240625 * X +
-		-1.537208 * Y +
-		-0.498629 * Z;
-	*G = -0.968931 * X +
-		1.875756 * Y +
-		0.041518 * Z;
-	*B = 0.055710 * X +
-		-0.204021 * Y +
-		1.056996 * Z;
+	*R = 3.240625F * X +
+		-1.537208F * Y +
+		-0.498629F * Z;
+	*G = -0.968931F * X +
+		1.875756F * Y +
+		0.041518F * Z;
+	*B = 0.055710F * X +
+		-0.204021F * Y +
+		1.056996F * Z;
 
 	return 0;
 }
@@ -337,19 +337,19 @@ vips_col_scRGB2sRGB(int range, int *lut,
 	CLIP(0, Yf, maxval);
 	Yi = (int) Yf;
 	v = lut[Yi] + (lut[Yi + 1] - lut[Yi]) * (Yf - Yi);
-	*r = rint(v);
+	*r = rintf(v);
 
 	Yf = G * maxval;
 	CLIP(0, Yf, maxval);
 	Yi = (int) Yf;
 	v = lut[Yi] + (lut[Yi + 1] - lut[Yi]) * (Yf - Yi);
-	*g = rint(v);
+	*g = rintf(v);
 
 	Yf = B * maxval;
 	CLIP(0, Yf, maxval);
 	Yi = (int) Yf;
 	v = lut[Yi] + (lut[Yi + 1] - lut[Yi]) * (Yf - Yi);
-	*b = rint(v);
+	*b = rintf(v);
 
 	if (og_ret)
 		*og_ret = og;
@@ -394,7 +394,7 @@ vips_col_scRGB2BW(int range, int *lut, float R, float G, float B,
 
 	/* CIE linear luminance function, see https://en.wikipedia.org/wiki/Grayscale#Colorimetric_(perceptual_luminance-preserving)_conversion_to_grayscale
 	 */
-	Y = 0.2126 * R + 0.7152 * G + 0.0722 * B;
+	Y = 0.2126F * R + 0.7152F * G + 0.0722F * B;
 
 	/* Y can be Nan. Throw those values out, they will break
 	 * our clipping.
@@ -417,7 +417,7 @@ vips_col_scRGB2BW(int range, int *lut, float R, float G, float B,
 	CLIP(0, Yf, maxval);
 	Yi = (int) Yf;
 	v = lut[Yi] + (lut[Yi + 1] - lut[Yi]) * (Yf - Yi);
-	*g = rint(v);
+	*g = rintf(v);
 
 	if (og_ret)
 		*og_ret = og;
@@ -454,7 +454,7 @@ build_tables(void *client)
 			for (b = 0; b < 64; b++) {
 				/* Scale to lab space.
 				 */
-				float L = (l << 2) * (100.0 / 256.0);
+				float L = (l << 2) * (100.0F / 256.0F);
 				float A = (signed char) (a << 2);
 				float B = (signed char) (b << 2);
 				float X, Y, Z;

--- a/libvips/colour/UCS2LCh.c
+++ b/libvips/colour/UCS2LCh.c
@@ -155,7 +155,7 @@ vips_col_Lcmc2L(float Lcmc)
 	known = VIPS_CLIP(0, known, 999);
 
 	return LI[known] +
-		(LI[known + 1] - LI[known]) * (Lcmc * 10.0 - known);
+		(LI[known + 1] - LI[known]) * (Lcmc * 10.0F - known);
 }
 
 /**
@@ -177,7 +177,7 @@ vips_col_Ccmc2C(float Ccmc)
 	known = VIPS_CLIP(0, known, 2999);
 
 	return CI[known] +
-		(CI[known + 1] - CI[known]) * (Ccmc * 10.0 - known);
+		(CI[known + 1] - CI[known]) * (Ccmc * 10.0F - known);
 }
 
 /**

--- a/libvips/colour/XYZ2Lab.c
+++ b/libvips/colour/XYZ2Lab.c
@@ -97,9 +97,9 @@ table_init(void *client)
 		float Y = (double) i / QUANT_ELEMENTS;
 
 		if (Y < 0.008856)
-			cbrt_table[i] = 7.787 * Y + (16.0 / 116.0);
+			cbrt_table[i] = 7.787F * Y + (16.0F / 116.0F);
 		else
-			cbrt_table[i] = cbrt(Y);
+			cbrt_table[i] = cbrtf(Y);
 	}
 
 	return NULL;
@@ -132,9 +132,9 @@ vips_col_XYZ2Lab_helper(VipsXYZ2Lab *XYZ2Lab,
 	f = nZ - i;
 	cbz = cbrt_table[i] + f * (cbrt_table[i + 1] - cbrt_table[i]);
 
-	*L = 116.0 * cby - 16.0;
-	*a = 500.0 * (cbx - cby);
-	*b = 200.0 * (cby - cbz);
+	*L = 116.0F * cby - 16.0F;
+	*a = 500.0F * (cbx - cby);
+	*b = 200.0F * (cby - cbz);
 }
 
 /* Process a buffer of data.

--- a/libvips/colour/Yxy2XYZ.c
+++ b/libvips/colour/Yxy2XYZ.c
@@ -73,11 +73,11 @@ vips_Yxy2XYZ_line(VipsColour *colour, VipsPel *out, VipsPel **in, int width)
 
 		if (x == 0.0 ||
 			y == 0.0) {
-			X = 0.0;
-			Z = 0.0;
+			X = 0.0F;
+			Z = 0.0F;
 		}
 		else {
-			double total;
+			float total;
 
 			total = Y / y;
 			X = x * total;

--- a/libvips/colour/dE76.c
+++ b/libvips/colour/dE76.c
@@ -76,7 +76,7 @@ vips_pythagoras(float L1, float a1, float b1, float L2, float a2, float b2)
 	float da = a1 - a2;
 	float db = b1 - b2;
 
-	return sqrt(dL * dL + da * da + db * db);
+	return sqrtf(dL * dL + da * da + db * db);
 }
 
 /* Find the difference between two buffers of LAB data.
@@ -96,7 +96,7 @@ vips__pythagoras_line(VipsColour *colour,
 		float da = p1[1] - p2[1];
 		float db = p1[2] - p2[2];
 
-		q[x] = sqrt(dL * dL + da * da + db * db);
+		q[x] = sqrtf(dL * dL + da * da + db * db);
 
 		p1 += 3;
 		p2 += 3;

--- a/libvips/colour/icc_transform.c
+++ b/libvips/colour/icc_transform.c
@@ -903,15 +903,15 @@ decode_xyz(guint16 *fixed, float *xyz, int n)
 		 * Bradford transformation.
 		 * See: https://fujiwaratko.sakura.ne.jp/infosci/colorspace/bradford_e.html
 		 */
-		xyz[0] = 0.955513 * X +
-			-0.023073 * Y +
-			0.063309 * Z;
-		xyz[1] = -0.028325 * X +
-			1.009942 * Y +
-			0.021055 * Z;
-		xyz[2] = 0.012329 * X +
-			-0.020536 * Y +
-			1.330714 * Z;
+		xyz[0] = 0.955513F * X +
+			-0.023073F * Y +
+			0.063309F * Z;
+		xyz[1] = -0.028325F * X +
+			1.009942F * Y +
+			0.021055F * Z;
+		xyz[2] = 0.012329F * X +
+			-0.020536F * Y +
+			1.330714F * Z;
 
 		xyz += 3;
 		fixed += 3;
@@ -1067,15 +1067,15 @@ encode_xyz(float *in, float *out, int n)
 		 * Bradford transformation.
 		 * See: https://fujiwaratko.sakura.ne.jp/infosci/colorspace/bradford_e.html
 		 */
-		out[0] = 1.047886 * X +
-			0.022919 * Y +
-			-0.050216 * Z;
-		out[1] = 0.029582 * X +
-			0.990484 * Y +
-			-0.017079 * Z;
-		out[2] = -0.009252 * X +
-			0.015073 * Y +
-			0.751678 * Z;
+		out[0] = 1.047886F * X +
+			0.022919F * Y +
+			-0.050216F * Z;
+		out[1] = 0.029582F * X +
+			0.990484F * Y +
+			-0.017079F * Z;
+		out[2] = -0.009252F * X +
+			0.015073F * Y +
+			0.751678F * Z;
 
 		in += 3;
 		out += 3;

--- a/libvips/colour/sRGB2HSV.c
+++ b/libvips/colour/sRGB2HSV.c
@@ -68,7 +68,7 @@ vips_sRGB2HSV_line(VipsColour *colour, VipsPel *out, VipsPel **in, int width)
 				c_max = p[0];
 				c_min = p[1];
 				secondary_diff = p[1] - p[2];
-				wrap_around_hue = 255.0;
+				wrap_around_hue = 255.0F;
 			}
 			else {
 				/* Center blue.
@@ -76,7 +76,7 @@ vips_sRGB2HSV_line(VipsColour *colour, VipsPel *out, VipsPel **in, int width)
 				c_max = p[2];
 				c_min = VIPS_MIN(p[1], p[0]);
 				secondary_diff = p[0] - p[1];
-				wrap_around_hue = 170.0;
+				wrap_around_hue = 170.0F;
 			}
 		}
 		else {
@@ -86,7 +86,7 @@ vips_sRGB2HSV_line(VipsColour *colour, VipsPel *out, VipsPel **in, int width)
 				c_max = p[0];
 				c_min = p[2];
 				secondary_diff = p[1] - p[2];
-				wrap_around_hue = 0.0;
+				wrap_around_hue = 0.0F;
 			}
 			else {
 				/* Center green
@@ -94,7 +94,7 @@ vips_sRGB2HSV_line(VipsColour *colour, VipsPel *out, VipsPel **in, int width)
 				c_max = p[1];
 				c_min = VIPS_MIN(p[2], p[0]);
 				secondary_diff = p[2] - p[0];
-				wrap_around_hue = 85.0;
+				wrap_around_hue = 85.0F;
 			}
 		}
 

--- a/libvips/colour/scRGB2XYZ.c
+++ b/libvips/colour/scRGB2XYZ.c
@@ -79,21 +79,21 @@ vips_scRGB2XYZ_line(float *restrict q, float *restrict p,
 		 * as the original is defined in a separate file and is part of
 		 * the public API so a compiler will not inline.
 		 */
-		q[0] = 0.4124 * R +
-			0.3576 * G +
-			0.1805 * B;
-		q[1] = 0.2126 * R +
-			0.7152 * G +
-			0.0722 * B;
-		q[2] = 0.0193 * R +
-			0.1192 * G +
-			0.9505 * B;
+		q[0] = 0.4124F * R +
+			0.3576F * G +
+			0.1805F * B;
+		q[1] = 0.2126F * R +
+			0.7152F * G +
+			0.0722F * B;
+		q[2] = 0.0193F * R +
+			0.1192F * G +
+			0.9505F * B;
 
 		p += 3;
 		q += 3;
 
 		for (j = 0; j < extra_bands; j++)
-			q[j] = VIPS_CLIP(0, p[j] * 255.0, 255.0);
+			q[j] = VIPS_FCLIP(0, p[j] * 255.0, 255.0);
 		p += extra_bands;
 		q += extra_bands;
 	}

--- a/libvips/create/eye.c
+++ b/libvips/create/eye.c
@@ -82,10 +82,10 @@ vips_eye_point(VipsPoint *point, int x, int y)
 	int max_x = VIPS_MAX(point->width - 1, 1);
 	int max_y = VIPS_MAX(point->height - 1, 1);
 
-	double c = eye->factor * VIPS_PI / (2 * max_x);
-	double h = max_y * max_y;
+	float c = eye->factor * VIPS_PI / (2 * max_x);
+	float h = max_y * max_y;
 
-	return y * y * cos(c * x * x) / h;
+	return y * y * cosf(c * x * x) / h;
 }
 
 static void

--- a/libvips/create/grey.c
+++ b/libvips/create/grey.c
@@ -89,8 +89,8 @@ vips_grey_class_init(VipsGreyClass *class)
 	vobject_class->description = _("make a grey ramp image");
 
 	point_class->point = vips_grey_point;
-	point_class->min = 0.0;
-	point_class->max = 1.0;
+	point_class->min = 0.0F;
+	point_class->max = 1.0F;
 }
 
 static void

--- a/libvips/create/mask.c
+++ b/libvips/create/mask.c
@@ -114,8 +114,8 @@ vips_mask_class_init(VipsMaskClass *class)
 	vobject_class->description = _("base class for frequency filters");
 
 	point_class->point = vips_mask_point;
-	point_class->min = 0.0;
-	point_class->max = 1.0;
+	point_class->min = 0.0F;
+	point_class->max = 1.0F;
 	point_class->interpretation = VIPS_INTERPRETATION_FOURIER;
 
 	VIPS_ARG_BOOL(class, "optical", 5,

--- a/libvips/create/perlin.c
+++ b/libvips/create/perlin.c
@@ -264,10 +264,10 @@ vips_perlin_make_tables(void *client)
 	int i;
 
 	for (i = 0; i < 256; i++) {
-		double angle = 2 * VIPS_PI * i / 256.0;
+		float angle = 2.0F * VIPS_PI * i / 256.0F;
 
-		vips_perlin_cos[i] = cos(angle);
-		vips_perlin_sin[i] = sin(angle);
+		vips_perlin_cos[i] = cosf(angle);
+		vips_perlin_sin[i] = sinf(angle);
 	}
 
 	return NULL;

--- a/libvips/create/point.c
+++ b/libvips/create/point.c
@@ -133,8 +133,8 @@ vips_point_class_init(VipsPointClass *class)
 	vobject_class->build = vips_point_build;
 
 	class->point = NULL;
-	class->min = -1.0;
-	class->max = 1.0;
+	class->min = -1.0F;
+	class->max = 1.0F;
 	class->interpretation = VIPS_INTERPRETATION_MULTIBAND;
 
 	VIPS_ARG_INT(class, "width", 2,

--- a/libvips/create/sdf.c
+++ b/libvips/create/sdf.c
@@ -92,7 +92,7 @@ G_DEFINE_TYPE(VipsSdf, vips_sdf, VIPS_TYPE_CREATE);
 static float
 vips_sdf_circle(VipsSdf *sdf, int x, int y)
 {
-	return hypot(x - sdf->a[0], y - sdf->a[1]) - sdf->r;
+	return hypotf(x - sdf->a[0], y - sdf->a[1]) - sdf->r;
 }
 
 static float
@@ -101,10 +101,10 @@ vips_sdf_box(VipsSdf *sdf, int x, int y)
 	float px = x - sdf->cx;
 	float py = y - sdf->cy;
 
-	float dx = fabs(px) - sdf->sx;
-	float dy = fabs(py) - sdf->sy;
+	float dx = fabsf(px) - sdf->sx;
+	float dy = fabsf(py) - sdf->sy;
 
-	return hypot(VIPS_MAX(dx, 0), VIPS_MAX(dy, 0)) +
+	return hypotf(VIPS_MAX(dx, 0), VIPS_MAX(dy, 0)) +
 		VIPS_MIN(VIPS_MAX(dx, dy), 0);
 }
 
@@ -119,10 +119,10 @@ vips_sdf_rounded_box(VipsSdf *sdf, int x, int y)
 	float r_bottom = px > 0 ? sdf->corners[1] : sdf->corners[3];
 	float r = py > 0 ? r_top : r_bottom;
 
-	float qx = fabs(px) - sdf->sx + r;
-	float qy = fabs(py) - sdf->sy + r;
+	float qx = fabsf(px) - sdf->sx + r;
+	float qy = fabsf(py) - sdf->sy + r;
 
-	return hypot(VIPS_MAX(qx, 0), VIPS_MAX(qy, 0)) +
+	return hypotf(VIPS_MAX(qx, 0), VIPS_MAX(qy, 0)) +
 		VIPS_MIN(VIPS_MAX(qx, qy), 0) - r;
 }
 
@@ -134,12 +134,12 @@ vips_sdf_line(VipsSdf *sdf, int px, int py)
 
 	float dot_paba = pax * sdf->dx + pay * sdf->dy;
 	float dot_baba = sdf->dx * sdf->dx + sdf->dy * sdf->dy;
-	float h = VIPS_CLIP(0, dot_paba / dot_baba, 1);
+	float h = VIPS_FCLIP(0, dot_paba / dot_baba, 1);
 
 	float dx = pax - h * sdf->dx;
 	float dy = pay - h * sdf->dy;
 
-	return hypot(dx, dy);
+	return hypotf(dx, dy);
 }
 
 static int

--- a/libvips/create/sines.c
+++ b/libvips/create/sines.c
@@ -81,7 +81,7 @@ vips_sines_point(VipsPoint *point, int x, int y)
 {
 	VipsSines *sines = (VipsSines *) point;
 
-	return cos(sines->c * (x * sines->costheta - y * sines->sintheta));
+	return cosf(sines->c * (x * sines->costheta - y * sines->sintheta));
 }
 
 static int

--- a/libvips/create/worley.c
+++ b/libvips/create/worley.c
@@ -197,9 +197,9 @@ vips_worley_start(VipsImage *out, void *a, void *b)
 static float
 vips_int_hypot(int x, int y)
 {
-	/* Faster than hypot() for int args.
+	/* Faster than hypotf() for int args.
 	 */
-	return sqrt(x * x + y * y);
+	return sqrtf(x * x + y * y);
 }
 
 static float

--- a/libvips/create/zone.c
+++ b/libvips/create/zone.c
@@ -75,9 +75,9 @@ vips_zone_point(VipsPoint *point, int x, int y)
 	int hheight = point->height / 2;
 	int h2 = (x - hwidth) * (x - hwidth);
 	int v2 = (y - hheight) * (y - hheight);
-	double c = VIPS_PI / zone->width;
+	float c = VIPS_PI / zone->width;
 
-	return cos(c * (v2 + h2));
+	return cosf(c * (v2 + h2));
 }
 
 static void

--- a/libvips/foreign/ppmload.c
+++ b/libvips/foreign/ppmload.c
@@ -764,7 +764,7 @@ vips_foreign_load_ppm_class_init(VipsForeignLoadPpmClass *class)
 static void
 vips_foreign_load_ppm_init(VipsForeignLoadPpm *ppm)
 {
-	ppm->scale = 1.0;
+	ppm->scale = 1.0F;
 }
 
 typedef struct _VipsForeignLoadPpmFile {

--- a/libvips/foreign/radiance.c
+++ b/libvips/foreign/radiance.c
@@ -610,7 +610,7 @@ read_new(VipsSource *source, VipsImage *out)
 	strcpy(read->format, COLRFMT);
 	read->expos = 1.0;
 	for (i = 0; i < 3; i++)
-		read->colcor[i] = 1.0;
+		read->colcor[i] = 1.0F;
 	read->aspect = 1.0;
 	read->prims[0][0] = CIE_x_r;
 	read->prims[0][1] = CIE_y_r;
@@ -858,7 +858,7 @@ write_new(VipsImage *in, VipsTarget *target)
 	strcpy(write->format, COLRFMT);
 	write->expos = 1.0;
 	for (i = 0; i < 3; i++)
-		write->colcor[i] = 1.0;
+		write->colcor[i] = 1.0F;
 	write->aspect = 1.0;
 	write->prims[0][0] = CIE_x_r;
 	write->prims[0][1] = CIE_y_r;

--- a/libvips/foreign/tiff2vips.c
+++ b/libvips/foreign/tiff2vips.c
@@ -447,11 +447,11 @@ half_2_float(gushort h)
 	case 16:
 		return INFINITY * sign;
 	case -15:
-		return sign / (float) (1 << 14) * (prec / 1024.0);
+		return sign / (float) (1 << 14) * (prec / 1024.0F);
 	default:
 		return exp > 0
-			? sign * (float) (1 << exp) * (1.0 + prec / 1024.0)
-			: sign / (float) (1 << -exp) * (1.0 + prec / 1024.0);
+			? sign * (float) (1 << exp) * (1.0F + prec / 1024.0F)
+			: sign / (float) (1 << -exp) * (1.0F + prec / 1024.0F);
 	}
 }
 
@@ -520,8 +520,8 @@ get_resolution(TIFF *tiff, VipsImage *out)
 		case RESUNIT_INCH:
 			/* In pixels-per-inch ... convert to mm.
 			 */
-			x /= 10.0 * 2.54;
-			y /= 10.0 * 2.54;
+			x /= 10.0F * 2.54F;
+			y /= 10.0F * 2.54F;
 			vips_image_set_string(out,
 				VIPS_META_RESOLUTION_UNIT, "in");
 			break;
@@ -529,8 +529,8 @@ get_resolution(TIFF *tiff, VipsImage *out)
 		case RESUNIT_CENTIMETER:
 			/* In pixels-per-centimetre ... convert to mm.
 			 */
-			x /= 10.0;
-			y /= 10.0;
+			x /= 10.0F;
+			y /= 10.0F;
 			vips_image_set_string(out,
 				VIPS_META_RESOLUTION_UNIT, "cm");
 			break;
@@ -545,8 +545,8 @@ get_resolution(TIFF *tiff, VipsImage *out)
 		/* We used to warn about missing res data, but it happens so
 		 * often and is so harmless, why bother.
 		 */
-		x = 1.0;
-		y = 1.0;
+		x = 1.0F;
+		y = 1.0F;
 	}
 
 	out->Xres = x;

--- a/libvips/morphology/nearest.c
+++ b/libvips/morphology/nearest.c
@@ -116,7 +116,7 @@ vips_fill_nearest_pixel(Circle *circle, int x, int y, int octant)
 	p = (float *) VIPS_IMAGE_ADDR(circle->nearest->distance, x, y);
 	dx = x - circle->seed->x;
 	dy = y - circle->seed->y;
-	radius = sqrt(dx * dx + dy * dy);
+	radius = sqrtf(dx * dx + dy * dy);
 
 	if (p[0] == 0 ||
 		p[0] > radius) {


### PR DESCRIPTION
Found with clang-tidy 19.1.7, see:
https://gist.github.com/kleisauke/9025c3564d3aec17496bd21d675908fb

Context: https://github.com/libvips/libvips/pull/3935#issuecomment-2081489038.