### PR TITLE
convi: ensure double sum precision for floats

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -12,6 +12,7 @@
 - svgload: add support for custom CSS via stylesheet option [lovell]
 - heifload: `unlimited` flag removes all limits (requires libheif 1.19.0+) [lovell]
 - heifsave: improve alpha channel detection [lovell]
+- convi: ensure double sum precision for floats [lovell]
 
 8.16.1
 

--- a/libvips/convolution/convi.c
+++ b/libvips/convolution/convi.c
@@ -728,7 +728,7 @@ vips_convi_gen_vector(VipsRegion *out_region,
 \
 			sum = 0; \
 			for (i = 0; i < nnz; i++) \
-				sum += t[i] * p[offsets[i]]; \
+				sum += (double) t[i] * p[offsets[i]]; \
 \
 			sum = (sum / scale) + offset; \
 \


### PR DESCRIPTION
The `CONV_FLOAT` inner loop macro is used for both `float` and `double` images so the type of `sum` should probably match.

I've not had a chance to performance test this change but it has the possibility of making integer convolution of float images a tiny bit faster.