### PR TITLE
dzsave: ensure IIIF scaleFactors includes all levels

### DIFF
--- a/libvips/foreign/dzsave.c
+++ b/libvips/foreign/dzsave.c
@@ -776,11 +776,11 @@ write_json(VipsForeignSaveDz *dz)
 		"    {\n"
 		"      \"scaleFactors\": [\n");
 
-	for (i = 0; i < dz->level->n; i++) {
+	for (i = 0; i <= dz->level->n; i++) {
 		vips_dbuf_writef(&dbuf,
 			"        %d",
 			1 << i);
-		if (i != dz->level->n - 1)
+		if (i != dz->level->n)
 			vips_dbuf_writef(&dbuf, ",");
 		vips_dbuf_writef(&dbuf, "\n");
 	}


### PR DESCRIPTION
Originally reported at https://github.com/lovell/sharp/issues/4346 - the sample image of 39125x34708 split into 1024x1024 tiles correctly generated 7 levels in the IIIF pyramid but it looks like the `scaleFactors` calculation was only considering the first 6.