### PR TITLE
heifload: improve detection of seek beyond EOF

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -14,6 +14,7 @@
 - heifsave: improve alpha channel detection [lovell]
 - convi: ensure double sum precision for floats [lovell]
 - improve guard against corrupt ICC profiles with older lcms2 versions [kleisauke]
+- heifload: improve detection of seek beyond EOF [lovell]
 
 8.16.1
 

--- a/libvips/foreign/heifload.c
+++ b/libvips/foreign/heifload.c
@@ -1185,7 +1185,7 @@ vips_foreign_load_heif_wait_for_file_size(gint64 target_size, void *userdata)
 	result = vips_source_seek(heif->source, target_size, SEEK_SET);
 	vips_source_seek(heif->source, old_position, SEEK_SET);
 
-	if (result < 0)
+	if (result < 0 || old_position < 0)
 		/* Unable to seek to this point, so it's beyond EOF.
 		 */
 		status = heif_reader_grow_status_size_beyond_eof;


### PR DESCRIPTION
Ensures we check both the `old_position` and `result` for a possible error when seeking.

Fixes https://issues.oss-fuzz.com/issues/404288018