### PR TITLE
Improve guard against corrupt ICC profiles

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -13,6 +13,7 @@
 - heifload: `unlimited` flag removes all limits (requires libheif 1.19.0+) [lovell]
 - heifsave: improve alpha channel detection [lovell]
 - convi: ensure double sum precision for floats [lovell]
+- improve guard against corrupt ICC profiles with older lcms2 versions [kleisauke]
 
 8.16.1
 


### PR DESCRIPTION
Some LCMS versions (i.e. before commit https://github.com/mm2/Little-CMS/commit/f3f6b7bceb629bc4b6f1dea3e45b44dc3f8674af or https://github.com/mm2/Little-CMS/commit/6223d3d3c8339eadba2230a0112cdeaca72c080e) would fail on corrupted ICC profiles.

<details>
  <summary>Test case</summary>

```c
/* Compile with:
 * gcc -g -Wall test-lcms2.c `pkg-config lcms2 --cflags --libs`
 */

#include <lcms2.h>

int main(int argc, char *argv[]) {
	if (argc != 2) {
		printf("usage: %s input\n", argv[0]);
		return 1;
	}

	printf("LittleCMS %2.2f\n", cmsGetEncodedCMMversion() / 1000.0);

	cmsHPROFILE profile;
	if (!(profile = cmsOpenProfileFromFile(argv[1], "r"))) {
		printf("corrupt profile\n");
		return 1;
	}

	cmsUInt32Number intent = cmsGetHeaderRenderingIntent(profile);
	printf("cmsGetHeaderRenderingIntent = %u\n", intent);

	cmsCloseProfile(profile);

	return 0;
}
```

LCMS 2.12:
```console
$ exiftool -icc_profile -b -w icc x.jpg
Warning: Bad length ICC_Profile (length 1735682121) - x.jpg
    1 output files created
$ gcc -g -Wall test-lcms2.c `pkg-config lcms2 --cflags --libs`
$ ./a.out x.icc
LittleCMS 2.12
cmsGetHeaderRenderingIntent = 3775608382
$ vipsthumbnail x.jpg -e srgb

(vipsthumbnail:3297278): VIPS-WARNING **: 11:40:41.713: fallback to suggested (null) intent, as profile does not support relative input intent
Segmentation fault (core dumped)
```

LCMS 2.16:
```console
$ ./a.out x.icc
LittleCMS 2.16
corrupt profile
$ vipsthumbnail x.jpg -e srgb

(vipsthumbnail:19721): VIPS-WARNING **: 12:40:51.953: corrupt profile
```
</details>
