### PR TITLE
Remove redundant `#undef` for `HAVE_STDLIB_H`

### DIFF
--- a/libvips/foreign/jpeg.h
+++ b/libvips/foreign/jpeg.h
@@ -35,13 +35,6 @@
 extern "C" {
 #endif /*__cplusplus*/
 
-/* jpeglib includes jconfig.h, which can define HAVE_STDLIB_H ... which we
- * also define. Make sure it's turned off.
- */
-#ifdef HAVE_STDLIB_H
-#undef HAVE_STDLIB_H
-#endif /*HAVE_STDLIB_H*/
-
 /* jpeglib defines its own boolean type as an enum which then clashes with
  * everyone elses. Rename it as jboolean.
  */


### PR DESCRIPTION
Aside from the `HAVE_MAGICK` marco that will be fixed via PR #4433, this was the only `HAVE_*` macro we never defined but were still checking for. Found using:
<details>
  <summary>Script</summary>

```console
$ find .  \( -name '*.[hc]'  -o -name '*.cc' -o -name '*.cpp'  \) -exec awk '/^#if/ {print $0}' {} \; | sort | uniq > expressions.txt
$ grep -vFf <(awk '/^#define|^#undef/ {print $2}' build/config.h) expressions.txt | grep 'HAVE_'
#ifdef HAVE_ACQUIREEXCEPTIONINFO
#ifdef HAVE_ACQUIREIMAGE
#ifdef HAVE_BLOBTOSTRINGINFO
#ifdef HAVE_CMYCOLORSPACE
#ifdef HAVE_CONFIG_H
#ifdef HAVE_GETIMAGEMAGICK3
#ifdef HAVE_GETVIRTUALPIXELS
#ifdef HAVE_HCLPCOLORSPACE
#ifdef HAVE_INHERITEXCEPTION
#ifdef HAVE_MAGICK6
#ifdef HAVE_NUMBER_SCENES
#ifdef HAVE_OPTIMIZEIMAGETRANSPARENCY
#ifdef HAVE_OPTIMIZEPLUSIMAGELAYERS
#ifdef HAVE_ORC
#ifdef HAVE_PDFIUM
#ifdef HAVE_PNG
#ifdef HAVE_PNG_SET_CHUNK_MALLOC_MAX
#ifdef HAVE_QUANTIZATION
#ifdef HAVE_RESETIMAGEPROFILEITERATOR
#ifdef HAVE_RESETIMAGEPROPERTYITERATOR
#ifdef HAVE_SETIMAGEEXTENT
#ifdef HAVE_SETIMAGEOPTION
#ifdef HAVE_SETIMAGEPROPERTY
#ifdef HAVE_STDLIB_H
#if defined(HAVE_PNG)
#ifndef HAVE_ORC
#ifndef HAVE_ORC_CF_PROTECTION
```
</details>

Though, that script also prints `HAVE_*` definitions that we define in code (like `#define HAVE_QUANTIZATION`), pass as compile args (like `-DHAVE_CONFIG`) or from alternative dependencies not compiled on my machine, such as liborc (instead of Highway), PDFium (instead of Poppler), libpng (instead of spng), and GraphicsMagick/ImageMagick6 (instead of ImageMagick7).