### PR TITLE
threadset: prevent possible thread oversubscription on Wasm

### DIFF
--- a/libvips/iofuncs/threadset.c
+++ b/libvips/iofuncs/threadset.c
@@ -311,7 +311,9 @@ vips_threadset_run(VipsThreadset *set,
 
 	g_async_queue_lock(set->queue);
 
-	/* Create a new thread if there are no waiting threads in the queue.
+	/* Create or reuse an idle thread if there are at least as many tasks
+	 * in the queue as waiting threads. The guard comparison prevents
+	 * oversubscription by threads that haven't started yet.
 	 */
 	if (g_async_queue_length_unlocked(set->queue) >= set->queue_guard)
 		if (!vips_threadset_add_thread(set)) {

--- a/libvips/iofuncs/threadset.c
+++ b/libvips/iofuncs/threadset.c
@@ -74,6 +74,10 @@ struct _VipsThreadset {
 	 */
 	VipsSemaphore idle;
 
+	/* The number of threads that haven't reached their entry point.
+	 */
+	int queue_guard;
+
 	/* The current number of (idle-)threads, the highwater mark,
 	 * and the max we allow before blocking thread creation.
 	 */
@@ -136,6 +140,8 @@ vips_threadset_work(void *pointer)
 	VIPS_DEBUG_MSG("vips_threadset_work: starting %p\n", g_thread_self());
 
 	g_async_queue_lock(set->queue);
+
+	set->queue_guard--;
 
 	for (;;) {
 		/* Pop a task from the queue. If the number of threads is limited,
@@ -238,6 +244,7 @@ vips_threadset_add_thread(VipsThreadset *set)
 		g_thread_unref(thread);
 
 		set->n_threads++;
+		set->queue_guard++;
 		set->n_threads_highwater =
 			VIPS_MAX(set->n_threads_highwater, set->n_threads);
 	}
@@ -306,7 +313,7 @@ vips_threadset_run(VipsThreadset *set,
 
 	/* Create a new thread if there are no waiting threads in the queue.
 	 */
-	if (g_async_queue_length_unlocked(set->queue) >= 0)
+	if (g_async_queue_length_unlocked(set->queue) >= set->queue_guard)
 		if (!vips_threadset_add_thread(set)) {
 			g_async_queue_unlock(set->queue);
 


### PR DESCRIPTION
Track the number of threads that haven't reached their entry point to prevent thread oversubscription, which could occur on Wasm.

This issue likely did not affect other environments, where thread spawning is usually instant.

See: https://github.com/kleisauke/wasm-vips/issues/92.