### PR TITLE
openslideload: drop support for OpenSlide 3.3.x

### DIFF
--- a/libvips/foreign/openslideload.c
+++ b/libvips/foreign/openslideload.c
@@ -143,7 +143,6 @@ typedef struct {
 static int
 vips__openslide_isslide(const char *filename)
 {
-#ifdef HAVE_OPENSLIDE_3_4
 	const char *vendor;
 	int ok;
 
@@ -159,36 +158,6 @@ vips__openslide_isslide(const char *filename)
 	VIPS_DEBUG_MSG("vips__openslide_isslide: %s - %d\n", filename, ok);
 
 	return ok;
-#else
-	openslide_t *osr;
-	int ok;
-
-	ok = 0;
-	osr = vips__openslideconnection_open(filename, FALSE);
-
-	if (osr) {
-		const char *vendor;
-
-		/* Generic tiled tiff images can be opened by openslide as
-		 * well. Only offer to load this file if it's not a generic
-		 * tiff since we want vips_tiffload() to handle these.
-		 */
-		vendor = openslide_get_property_value(osr,
-			OPENSLIDE_PROPERTY_NAME_VENDOR);
-
-		/* vendor will be NULL if osr is in error state.
-		 */
-		if (vendor &&
-			strcmp(vendor, "generic-tiff") != 0)
-			ok = 1;
-
-		vips__openslideconnection_close(filename);
-	}
-
-	VIPS_DEBUG_MSG("vips__openslide_isslide: %s - %d\n", filename, ok);
-
-	return ok;
-#endif
 }
 
 static void

--- a/meson.build
+++ b/meson.build
@@ -392,7 +392,7 @@ if librsvg_found
     cfg_var.set('HAVE_RSVG_HANDLE_SET_STYLESHEET', cc.has_function('rsvg_handle_set_stylesheet', dependencies: librsvg_dep))
 endif
 
-openslide_dep = dependency('openslide', version: '>=3.3.0', required: get_option('openslide'))
+openslide_dep = dependency('openslide', version: '>=3.4.0', required: get_option('openslide'))
 openslide_module = false
 if openslide_dep.found()
     openslide_module = modules_enabled and not get_option('openslide-module').disabled()
@@ -403,7 +403,6 @@ if openslide_dep.found()
         external_deps += openslide_dep
     endif
     cfg_var.set('HAVE_OPENSLIDE', true)
-    cfg_var.set('HAVE_OPENSLIDE_3_4', openslide_dep.version().version_compare('>=3.4.0'))
     cfg_var.set('HAVE_OPENSLIDE_ICC', cc.has_function('openslide_get_icc_profile_size', dependencies: openslide_dep))
     cfg_var.set('HAVE_OPENSLIDE_CACHE_CREATE', cc.has_function('openslide_cache_create', dependencies: openslide_dep))
 endif


### PR DESCRIPTION
OpenSlide 3.4.0 was released in January 2014.