### PR TITLE
openslideconnection: fix link failure with modules enabled

### DIFF
--- a/libvips/include/vips/internal.h
+++ b/libvips/include/vips/internal.h
@@ -171,6 +171,10 @@ int vips__print_renders(void);
 int vips__type_leak(void);
 int vips__object_leak(void);
 
+#ifdef HAVE_OPENSLIDE
+int vips__openslideconnection_leak(void);
+#endif /*HAVE_OPENSLIDE*/
+
 /* iofuncs
  */
 int vips__open_image_read(const char *filename);

--- a/libvips/iofuncs/init.c
+++ b/libvips/iofuncs/init.c
@@ -136,10 +136,6 @@ GQuark vips__image_pixels_quark = 0;
  */
 static char *vips__max_coord_arg = NULL;
 
-#ifdef HAVE_OPENSLIDE
-int vips__openslideconnection_leak(void);
-#endif /*HAVE_OPENSLIDE*/
-
 /**
  * vips_max_coord_get:
  *
@@ -395,9 +391,9 @@ vips_leak(void)
 	n_leaks += vips_tracked_get_allocs();
 	n_leaks += vips_tracked_get_mem();
 	n_leaks += vips_tracked_get_files();
-#ifdef HAVE_OPENSLIDE
+#if defined(HAVE_OPENSLIDE) && !defined(OPENSLIDE_MODULE)
 	n_leaks += vips__openslideconnection_leak();
-#endif /*HAVE_OPENSLIDE*/
+#endif /*defined(HAVE_OPENSLIDE) && !defined(OPENSLIDE_MODULE)*/
 
 	if (vips_tracked_get_allocs() ||
 		vips_tracked_get_mem() ||


### PR DESCRIPTION
Alternatively, we could make `vips__openslideconnection_leak()` always available, just like:
https://github.com/libvips/libvips/blob/dbc3b86054208b2d9915e5ebdf7a0c3d022013e0/libvips/include/vips/internal.h#L102-L105

But I'm not sure if that's worth it, since this logic is only for `VIPS_LEAK`.