### PR TITLE
fix linear resize of 16-bit rgba

### DIFF
--- a/libvips/colour/XYZ2scRGB.c
+++ b/libvips/colour/XYZ2scRGB.c
@@ -47,20 +47,10 @@
 
 #include "pcolour.h"
 
-/* We can't use VipsColourCode as our parent class. We want to handle
- * alpha ourselves.
- */
+typedef VipsColourTransform VipsXYZ2scRGB;
+typedef VipsColourTransformClass VipsXYZ2scRGBClass;
 
-typedef struct _VipsXYZ2scRGB {
-	VipsOperation parent_instance;
-
-	VipsImage *in;
-	VipsImage *out;
-} VipsXYZ2scRGB;
-
-typedef VipsOperationClass VipsXYZ2scRGBClass;
-
-G_DEFINE_TYPE(VipsXYZ2scRGB, vips_XYZ2scRGB, VIPS_TYPE_OPERATION);
+G_DEFINE_TYPE(VipsXYZ2scRGB, vips_XYZ2scRGB, VIPS_TYPE_COLOUR_TRANSFORM);
 
 /* We used to have the comment:
 
@@ -79,12 +69,12 @@ G_DEFINE_TYPE(VipsXYZ2scRGB, vips_XYZ2scRGB, VIPS_TYPE_OPERATION);
  */
 
 static void
-vips_XYZ2scRGB_line(float *restrict q, float *restrict p,
-	int extra_bands, int width)
+vips_XYZ2scRGB_line(VipsColour *colour, VipsPel *out, VipsPel **in, int width)
 {
-	int i, j;
+	float *restrict p = (float *) in[0];
+	float *restrict q = (float *) out;
 
-	for (i = 0; i < width; i++) {
+	for (int i = 0; i < width; i++) {
 		const float X = p[0];
 		const float Y = p[1];
 		const float Z = p[2];
@@ -100,118 +90,27 @@ vips_XYZ2scRGB_line(float *restrict q, float *restrict p,
 		q[2] = B;
 
 		q += 3;
-
-		for (j = 0; j < extra_bands; j++)
-			q[j] = VIPS_CLIP(0, p[j] / 255.0, 1.0);
-		p += extra_bands;
-		q += extra_bands;
 	}
-}
-
-static int
-vips_XYZ2scRGB_gen(VipsRegion *out_region,
-	void *seq, void *a, void *b, gboolean *stop)
-{
-	VipsRegion *ir = (VipsRegion *) seq;
-	VipsRect *r = &out_region->valid;
-	VipsImage *in = ir->im;
-
-	int y;
-
-	if (vips_region_prepare(ir, r))
-		return -1;
-
-	VIPS_GATE_START("vips_XYZ2scRGB: work");
-
-	for (y = 0; y < r->height; y++) {
-		float *p = (float *)
-			VIPS_REGION_ADDR(ir, r->left, r->top + y);
-		float *q = (float *)
-			VIPS_REGION_ADDR(out_region, r->left, r->top + y);
-
-		vips_XYZ2scRGB_line(q, p, in->Bands - 3, r->width);
-	}
-
-	VIPS_GATE_STOP("vips_XYZ2scRGB: work");
-
-	return 0;
-}
-
-static int
-vips_XYZ2scRGB_build(VipsObject *object)
-{
-	VipsObjectClass *class = VIPS_OBJECT_GET_CLASS(object);
-	VipsXYZ2scRGB *XYZ2scRGB = (VipsXYZ2scRGB *) object;
-
-	VipsImage **t = (VipsImage **) vips_object_local_array(object, 2);
-
-	VipsImage *in;
-	VipsImage *out;
-
-	if (VIPS_OBJECT_CLASS(vips_XYZ2scRGB_parent_class)->build(object))
-		return -1;
-
-	in = XYZ2scRGB->in;
-	if (vips_check_bands_atleast(class->nickname, in, 3))
-		return -1;
-
-	if (vips_cast_float(in, &t[0], NULL))
-		return -1;
-	in = t[0];
-
-	out = vips_image_new();
-	if (vips_image_pipelinev(out,
-			VIPS_DEMAND_STYLE_THINSTRIP, in, NULL)) {
-		g_object_unref(out);
-		return -1;
-	}
-	out->Type = VIPS_INTERPRETATION_scRGB;
-	out->BandFmt = VIPS_FORMAT_FLOAT;
-
-	if (vips_image_generate(out,
-			vips_start_one, vips_XYZ2scRGB_gen, vips_stop_one,
-			in, XYZ2scRGB)) {
-		g_object_unref(out);
-		return -1;
-	}
-
-	g_object_set(object, "out", out, NULL);
-
-	return 0;
 }
 
 static void
 vips_XYZ2scRGB_class_init(VipsXYZ2scRGBClass *class)
 {
-	GObjectClass *gobject_class = G_OBJECT_CLASS(class);
 	VipsObjectClass *object_class = (VipsObjectClass *) class;
-	VipsOperationClass *operation_class = VIPS_OPERATION_CLASS(class);
-
-	gobject_class->set_property = vips_object_set_property;
-	gobject_class->get_property = vips_object_get_property;
+	VipsColourClass *colour_class = VIPS_COLOUR_CLASS(class);
 
 	object_class->nickname = "XYZ2scRGB";
 	object_class->description = _("transform XYZ to scRGB");
-	object_class->build = vips_XYZ2scRGB_build;
 
-	operation_class->flags = VIPS_OPERATION_SEQUENTIAL;
-
-	VIPS_ARG_IMAGE(class, "in", 1,
-		_("Input"),
-		_("Input image"),
-		VIPS_ARGUMENT_REQUIRED_INPUT,
-		G_STRUCT_OFFSET(VipsXYZ2scRGB, in));
-
-	VIPS_ARG_IMAGE(class, "out", 100,
-		_("Output"),
-		_("Output image"),
-		VIPS_ARGUMENT_REQUIRED_OUTPUT,
-		G_STRUCT_OFFSET(VipsXYZ2scRGB, out));
+	colour_class->process_line = vips_XYZ2scRGB_line;
 }
 
 static void
 vips_XYZ2scRGB_init(VipsXYZ2scRGB *XYZ2scRGB)
 {
+	VipsColour *colour = VIPS_COLOUR(XYZ2scRGB);
+
+	colour->interpretation = VIPS_INTERPRETATION_scRGB;
 }
 
 /**

--- a/libvips/colour/scRGB2XYZ.c
+++ b/libvips/colour/scRGB2XYZ.c
@@ -49,28 +49,18 @@
 
 #include "pcolour.h"
 
-/* We can't use VipsColourCode as our parent class. We want to handle
- * alpha ourselves.
- */
+typedef VipsColourTransform VipsscRGB2XYZ;
+typedef VipsColourTransformClass VipsscRGB2XYZClass;
 
-typedef struct _VipsscRGB2XYZ {
-	VipsOperation parent_instance;
-
-	VipsImage *in;
-	VipsImage *out;
-} VipsscRGB2XYZ;
-
-typedef VipsOperationClass VipsscRGB2XYZClass;
-
-G_DEFINE_TYPE(VipsscRGB2XYZ, vips_scRGB2XYZ, VIPS_TYPE_OPERATION);
+G_DEFINE_TYPE(VipsscRGB2XYZ, vips_scRGB2XYZ, VIPS_TYPE_COLOUR_TRANSFORM);
 
 static void
-vips_scRGB2XYZ_line(float *restrict q, float *restrict p,
-	int extra_bands, int width)
+vips_scRGB2XYZ_line(VipsColour *colour, VipsPel *out, VipsPel **in, int width)
 {
-	int i, j;
+	float *restrict p = (float *) in[0];
+	float *restrict q = (float *) out;
 
-	for (i = 0; i < width; i++) {
+	for (int i = 0; i < width; i++) {
 		const float R = p[0] * VIPS_D65_Y0;
 		const float G = p[1] * VIPS_D65_Y0;
 		const float B = p[2] * VIPS_D65_Y0;
@@ -79,130 +69,33 @@ vips_scRGB2XYZ_line(float *restrict q, float *restrict p,
 		 * as the original is defined in a separate file and is part of
 		 * the public API so a compiler will not inline.
 		 */
-		q[0] = 0.4124F * R +
-			0.3576F * G +
-			0.1805F * B;
-		q[1] = 0.2126F * R +
-			0.7152F * G +
-			0.0722F * B;
-		q[2] = 0.0193F * R +
-			0.1192F * G +
-			0.9505F * B;
+		q[0] = 0.4124F * R + 0.3576F * G + 0.1805F * B;
+		q[1] = 0.2126F * R + 0.7152F * G + 0.0722F * B;
+		q[2] = 0.0193F * R + 0.1192F * G + 0.9505F * B;
 
 		p += 3;
 		q += 3;
-
-		for (j = 0; j < extra_bands; j++)
-			q[j] = VIPS_FCLIP(0, p[j] * 255.0, 255.0);
-		p += extra_bands;
-		q += extra_bands;
 	}
-}
-
-static int
-vips_scRGB2XYZ_gen(VipsRegion *out_region,
-	void *seq, void *a, void *b, gboolean *stop)
-{
-	VipsRegion *ir = (VipsRegion *) seq;
-	VipsRect *r = &out_region->valid;
-	VipsImage *in = ir->im;
-
-	int y;
-
-	if (vips_region_prepare(ir, r))
-		return -1;
-
-	VIPS_GATE_START("vips_scRGB2XYZ_gen: work");
-
-	for (y = 0; y < r->height; y++) {
-		float *p = (float *)
-			VIPS_REGION_ADDR(ir, r->left, r->top + y);
-		float *q = (float *)
-			VIPS_REGION_ADDR(out_region, r->left, r->top + y);
-
-		vips_scRGB2XYZ_line(q, p, in->Bands - 3, r->width);
-	}
-
-	VIPS_GATE_STOP("vips_scRGB2XYZ_gen: work");
-
-	return 0;
-}
-
-static int
-vips_scRGB2XYZ_build(VipsObject *object)
-{
-	VipsObjectClass *class = VIPS_OBJECT_GET_CLASS(object);
-	VipsscRGB2XYZ *scRGB2XYZ = (VipsscRGB2XYZ *) object;
-
-	VipsImage **t = (VipsImage **) vips_object_local_array(object, 2);
-
-	VipsImage *in;
-	VipsImage *out;
-
-	if (VIPS_OBJECT_CLASS(vips_scRGB2XYZ_parent_class)->build(object))
-		return -1;
-
-	in = scRGB2XYZ->in;
-	if (vips_check_bands_atleast(class->nickname, in, 3))
-		return -1;
-
-	if (vips_cast_float(in, &t[0], NULL))
-		return -1;
-	in = t[0];
-
-	out = vips_image_new();
-	if (vips_image_pipelinev(out,
-			VIPS_DEMAND_STYLE_THINSTRIP, in, NULL)) {
-		g_object_unref(out);
-		return -1;
-	}
-	out->Type = VIPS_INTERPRETATION_XYZ;
-	out->BandFmt = VIPS_FORMAT_FLOAT;
-
-	if (vips_image_generate(out,
-			vips_start_one, vips_scRGB2XYZ_gen, vips_stop_one,
-			in, scRGB2XYZ)) {
-		g_object_unref(out);
-		return -1;
-	}
-
-	g_object_set(object, "out", out, NULL);
-
-	return 0;
 }
 
 static void
 vips_scRGB2XYZ_class_init(VipsscRGB2XYZClass *class)
 {
-	GObjectClass *gobject_class = G_OBJECT_CLASS(class);
 	VipsObjectClass *object_class = (VipsObjectClass *) class;
-	VipsOperationClass *operation_class = VIPS_OPERATION_CLASS(class);
-
-	gobject_class->set_property = vips_object_set_property;
-	gobject_class->get_property = vips_object_get_property;
+	VipsColourClass *colour_class = VIPS_COLOUR_CLASS(class);
 
 	object_class->nickname = "scRGB2XYZ";
 	object_class->description = _("transform scRGB to XYZ");
-	object_class->build = vips_scRGB2XYZ_build;
 
-	operation_class->flags = VIPS_OPERATION_SEQUENTIAL;
-
-	VIPS_ARG_IMAGE(class, "in", 1,
-		_("Input"),
-		_("Input image"),
-		VIPS_ARGUMENT_REQUIRED_INPUT,
-		G_STRUCT_OFFSET(VipsscRGB2XYZ, in));
-
-	VIPS_ARG_IMAGE(class, "out", 100,
-		_("Output"),
-		_("Output image"),
-		VIPS_ARGUMENT_REQUIRED_OUTPUT,
-		G_STRUCT_OFFSET(VipsscRGB2XYZ, out));
+	colour_class->process_line = vips_scRGB2XYZ_line;
 }
 
 static void
 vips_scRGB2XYZ_init(VipsscRGB2XYZ *scRGB2XYZ)
 {
+	VipsColour *colour = VIPS_COLOUR(scRGB2XYZ);
+
+	colour->interpretation = VIPS_INTERPRETATION_XYZ;
 }
 
 /**


### PR DESCRIPTION
We were changing the interpretation in icc_import and icc_export, but we were not rescaling the alpha. As a result, 16-bit RGBA images had a alpha of 65535 in PCS, not 255.

This PR moves alpha channel scaling into the base VipsColour class, so we get correct scaling automatically, and moves XYZ <-> scRGB conversion back on top of VipsColourCode, partially reverting #3627

see https://github.com/libvips/libvips/issues/4343