### PR TITLE
update conversion docs

### DIFF
--- a/doc/rename.sed
+++ b/doc/rename.sed
@@ -121,6 +121,7 @@ s/vips_\(cos\)()/[method@Image.\1]/g
 s/vips_\(countlines\)()/[method@Image.\1]/g
 s/vips_\(crop\)()/[method@Image.\1]/g
 s/vips_\(cross_phase\)()/[method@Image.\1]/g
+s/vips_\(csvload\)()/[ctor@Image.\1]/g
 s/vips_\(csvsave\)()/[method@Image.\1]/g
 s/vips_\(csvsave_target\)()/[method@Image.\1]/g
 s/vips_\(dE00\)()/[method@Image.\1]/g
@@ -199,6 +200,7 @@ s/vips_\(HSV2sRGB\)()/[method@Image.\1]/g
 s/vips_\(icc_export\)()/[method@Image.\1]/g
 s/vips_\(icc_import\)()/[method@Image.\1]/g
 s/vips_\(icc_transform\)()/[method@Image.\1]/g
+s/vips_\(identity\)()/[ctor@Image.\1]/g
 s/vips_\(ifthenelse\)()/[method@Image.\1]/g
 s/vips_image_\(get_typeof\)()/[method@Image.\1]/g
 s/vips_\(imag\)()/[method@Image.\1]/g
@@ -210,6 +212,7 @@ s/vips_\(join\)()/[method@Image.\1]/g
 s/vips_\(jp2ksave_buffer\)()/[method@Image.\1]/g
 s/vips_\(jp2ksave\)()/[method@Image.\1]/g
 s/vips_\(jp2ksave_target\)()/[method@Image.\1]/g
+s/vips_\(jpegload\)()/[ctor@Image.\1]/g
 s/vips_\(jpegsave_buffer\)()/[method@Image.\1]/g
 s/vips_\(jpegsave\)()/[method@Image.\1]/g
 s/vips_\(jpegsave_mime\)()/[method@Image.\1]/g
@@ -285,10 +288,13 @@ s/vips_\(orimage_const\)()/[method@Image.\1]/g
 s/vips_\(orimage\)()/[method@Image.\1]/g
 s/vips_\(percent\)()/[method@Image.\1]/g
 s/vips_\(phasecor\)()/[method@Image.\1]/g
+s/vips_\(pngload\)()/[ctor@Image.\1]/g
 s/vips_\(pngsave_buffer\)()/[method@Image.\1]/g
 s/vips_\(pngsave\)()/[method@Image.\1]/g
 s/vips_\(pngsave_target\)()/[method@Image.\1]/g
 s/vips_\(polar\)()/[method@Image.\1]/g
+s/vips_\(pow_const1\)()/[method@Image.\1]/g
+s/vips_\(pow_const\)()/[method@Image.\1]/g
 s/vips_\(pow\)()/[method@Image.\1]/g
 s/vips_\(ppmsave\)()/[method@Image.\1]/g
 s/vips_\(ppmsave_target\)()/[method@Image.\1]/g
@@ -302,6 +308,7 @@ s/vips_\(radsave_buffer\)()/[method@Image.\1]/g
 s/vips_\(radsave\)()/[method@Image.\1]/g
 s/vips_\(radsave_target\)()/[method@Image.\1]/g
 s/vips_\(rank\)()/[method@Image.\1]/g
+s/vips_\(rawload\)()/[ctor@Image.\1]/g
 s/vips_\(rawsave_buffer\)()/[method@Image.\1]/g
 s/vips_\(rawsave_fd\)()/[method@Image.\1]/g
 s/vips_\(rawsave\)()/[method@Image.\1]/g
@@ -381,15 +388,29 @@ s/vips_\(XYZ2Yxy\)()/[method@Image.\1]/g
 s/vips_\(Yxy2XYZ\)()/[method@Image.\1]/g
 s/vips_\(zoom\)()/[method@Image.\1]/g
 
+s/vips_\(arrayjoin\)()/[func@Image.\1]/g
+s/vips_\(bandjoin\)()/[func@Image.\1]/g
+s/vips_\(bandrank\)()/[func@Image.\1]/g
+s/vips_\(composite\)()/[func@Image.\1]/g
+s/vips_\(sum\)()/[func@Image.\1]/g
+s/vips_\(switch\)()/[func@Image.\1]/g
+
 s/vips_\([^(]*\)()/[func@\1]/g
 
+s/#Vips\(Extend\)/[enum@\1]/g
+s/#Vips\(Angle45\)/[enum@\1]/g
+s/#Vips\(Interesting\)/[enum@\1]/g
 s/#Vips\(Access\)/[enum@\1]/g
+s/#Vips\(Align\)/[enum@\1]/g
+s/#Vips\(Angle\)/[enum@\1]/g
+s/#Vips\(ArgumentFlags\)/[flags@\1]/g
 s/#Vips\(BandFormat\)/[enum@\1]/g
-s/#Vips\(Interpretation\)/[enum@\1]/g
 s/#Vips\(Coding\)/[enum@\1]/g
 s/#Vips\(DemandStyle\)/[enum@\1]/g
+s/#Vips\(Intent\)/[enum@\1]/g
+s/#Vips\(Interpretation\)/[enum@\1]/g
+s/#Vips\(PCS\)/[enum@\1]/g
 s/#Vips\(Precision\)/[enum@\1]/g
-s/#Vips\(ArgumentFlags\)/[flags@\1]/g
 
 s/#Vips\(Rect\)/[struct@\1]/g
 s/#Vips\(Progress\)/[struct@\1]/g
@@ -420,6 +441,7 @@ s/#Vips\(ThreadpoolWorkFn\)/[callback@\1]/g
 s/#Vips\(ThreadpoolProgressFn\)/[callback@\1]/g
 
 s/#VIPS_OPERATION_MATH_\([^ ,.]*\)/[enum@Vips.OperationMath.\1]/g
+s/#VIPS_PCS_\([^ ,.]*\)/[enum@Vips.PCS.\1]/g
 s/#VIPS_OPERATION_MATH2_\([^ ,.]*\)/[enum@Vips.OperationMath2.\1]/g
 s/#VIPS_OPERATION_RELATIONAL_\([^ ,.]*\)/[enum@Vips.OperationRelational.\1]/g
 s/#VIPS_OPERATION_BOOLEAN_\([^ ,.]*\)/[enum@Vips.OperationBoolean.\1]/g
@@ -435,6 +457,8 @@ s/#VIPS_INTERPRETATION_\([^ ,.]*\)/[enum@Vips.Interpretation.\1]/g
 s/#VIPS_ACCESS_\([^ ,.]*\)/[enum@Vips.Access.\1]/g
 s/#VIPS_CODING_\([^ ,.]*\)/[enum@Vips.Coding.\1]/g
 
+s/g_\(assert_not_reached\)/banana_\1_banana/g
+
 s/g_thread_\([^(]*new\)()/[ctor@GLib.Thread.\1]/g
 s/g_object_\(new\)()/[ctor@GObject.Object.\1]/g
 s/g_object_\([^(]*\)()/[method@GObject.Object.\1]/g
@@ -446,3 +470,5 @@ s/%GInput/[class@Gio.Input]/g
 s/%GSList/[struct@GLib.SList]/g
 
 s/g_\([^(]*\)()/[func@GLib.\1]/g
+
+s/banana_\(.*\)_banana/g_\1/g

--- a/libvips/arithmetic/clamp.c
+++ b/libvips/arithmetic/clamp.c
@@ -186,13 +186,13 @@ vips_clamp_init(VipsClamp *clamp)
  * @out: (out): output [class@Image]
  * @...: %NULL-terminated list of optional named arguments
  *
- * ::: note "Optional arguments"
- *     * @min: %gdouble, minimum value
- *     * @max: %gdouble, maximum value
- *
  * This operation clamps pixel values to a range, by default 0 - 1.
  *
  * Use @min and @max to change the range.
+ *
+ * ::: tip "Optional arguments"
+ *     * @min: %gdouble, minimum value
+ *     * @max: %gdouble, maximum value
  *
  * ::: seealso
  *     [method@Image.sign], [method@Image.abs], [ctor@Image.sdf].

--- a/libvips/arithmetic/find_trim.c
+++ b/libvips/arithmetic/find_trim.c
@@ -256,11 +256,6 @@ vips_find_trim_init(VipsFindTrim *find_trim)
  * @height: (out): output height
  * @...: %NULL-terminated list of optional named arguments
  *
- * ::: note "Optional arguments"
- *     * @threshold: %gdouble, background / object threshold
- *     * @background: [struct@ArrayDouble], background colour
- *     * @line_art: %gboolean, enable line art mode
- *
  * Search @in for the bounding box of the non-background area.
  *
  * Any alpha is flattened out, then the image is median-filtered (unless
@@ -269,12 +264,12 @@ vips_find_trim_init(VipsFindTrim *find_trim)
  * the absolute difference are calculated from this binary image and searched
  * for the first row or column in each direction to obtain the bounding box.
  *
- * If the image is entirely background, [method@Image.find_trim] returns @width == 0
- * and @height == 0.
+ * If the image is entirely background, [method@Image.find_trim] returns
+ * @width == 0 and @height == 0.
  *
  * @background defaults to 255, or 65535 for 16-bit images. Set another value,
- * or use [method@Image.getpoint] to pick a value from an edge. You'll need to flatten
- * before [method@Image.getpoint] to get a correct background value.
+ * or use [method@Image.getpoint] to pick a value from an edge. You'll need
+ * to flatten before [method@Image.getpoint] to get a correct background value.
  *
  * @threshold defaults to 10.
  *
@@ -284,6 +279,11 @@ vips_find_trim_init(VipsFindTrim *find_trim)
  * filtering.
  *
  * The image needs to be at least 3x3 pixels in size.
+ *
+ * ::: tip "Optional arguments"
+ *     * @threshold: %gdouble, background / object threshold
+ *     * @background: [struct@ArrayDouble], background colour
+ *     * @line_art: %gboolean, enable line art mode
  *
  * ::: seealso
  *     [method@Image.getpoint], [method@Image.extract_area], [method@Image.smartcrop].

--- a/libvips/arithmetic/hist_find.c
+++ b/libvips/arithmetic/hist_find.c
@@ -453,15 +453,15 @@ vips_hist_find_init(VipsHistFind *hist_find)
  * @out: (out): output image
  * @...: %NULL-terminated list of optional named arguments
  *
- * ::: note "Optional arguments"
- *     * @band: band to equalise
- *
  * Find the histogram of @in. Find the histogram for band @band (producing a
  * one-band histogram), or for all bands (producing an n-band histogram) if
  * @band is -1.
  *
  * char and uchar images are cast to uchar before histogramming, all other
  * image types are cast to ushort.
+ *
+ * ::: tip "Optional arguments"
+ *     * @band: band to equalise
  *
  * ::: seealso
  *     [method@Image.hist_find_ndim], [method@Image.hist_find_indexed].

--- a/libvips/arithmetic/hist_find_indexed.c
+++ b/libvips/arithmetic/hist_find_indexed.c
@@ -498,8 +498,6 @@ vips_hist_find_indexed_init(VipsHistFindIndexed *indexed)
  * @out: (out): output image
  * @...: %NULL-terminated list of optional named arguments
  *
- * ::: note "Optional arguments"
- *     * @combine: #VipsCombine, combine bins like this
  *
  * Make a histogram of @in, but use image @index to pick the bins. In other
  * words, element zero in @out contains the combination of all the pixels in @in
@@ -515,8 +513,12 @@ vips_hist_find_indexed_init(VipsHistFindIndexed *indexed)
  * Normally, bins are summed, but you can use @combine to set other combine
  * modes.
  *
- * This operation is useful in conjunction with [method@Image.labelregions]. You can
- * use it to find the centre of gravity of blobs in an image, for example.
+ * This operation is useful in conjunction with [method@Image.labelregions].
+ * You can use it to find the centre of gravity of blobs in an image, for
+ * example.
+ *
+ * ::: tip "Optional arguments"
+ *     * @combine: #VipsCombine, combine bins like this
  *
  * ::: seealso
  *     [method@Image.hist_find], [method@Image.labelregions].

--- a/libvips/arithmetic/hist_find_ndim.c
+++ b/libvips/arithmetic/hist_find_ndim.c
@@ -335,9 +335,6 @@ vips_hist_find_ndim_init(VipsHistFindNDim *ndim)
  * @out: (out): output image
  * @...: %NULL-terminated list of optional named arguments
  *
- * ::: note "Optional arguments"
- *     * @bins: number of bins to make on each axis
- *
  * Make a one, two or three dimensional histogram of a 1, 2 or
  * 3 band image. Divide each axis into @bins bins .. ie.
  * output is 1 x bins, bins x bins, or bins x bins x bins bands.
@@ -345,6 +342,9 @@ vips_hist_find_ndim_init(VipsHistFindNDim *ndim)
  *
  * char and uchar images are cast to uchar before histogramming, all other
  * image types are cast to ushort.
+ *
+ * ::: tip "Optional arguments"
+ *     * @bins: number of bins to make on each axis
  *
  * ::: seealso
  *     [method@Image.hist_find], [method@Image.hist_find_indexed].

--- a/libvips/arithmetic/hough_circle.c
+++ b/libvips/arithmetic/hough_circle.c
@@ -265,11 +265,6 @@ vips_hough_circle_init(VipsHoughCircle *hough_circle)
  * @out: (out): output image
  * @...: %NULL-terminated list of optional named arguments
  *
- * ::: note "Optional arguments"
- *     * @scale: scale down dimensions by this much
- *     * @min_radius: smallest radius to search for
- *     * @max_radius: largest radius to search for
- *
  * Find the circular Hough transform of an image. @in must be one band, with
  * non-zero pixels for image edges. @out is three-band, with the third channel
  * representing the detected circle radius. The operation scales the number of
@@ -285,6 +280,11 @@ vips_hough_circle_init(VipsHoughCircle *hough_circle)
  * @scale of 3, for example, will make @out 1/3rd of the width and height of
  * @in, and reduce the number of radii tested (and hence the number of bands
  * int @out) by a factor of three as well.
+ *
+ * ::: tip "Optional arguments"
+ *     * @scale: scale down dimensions by this much
+ *     * @min_radius: smallest radius to search for
+ *     * @max_radius: largest radius to search for
  *
  * ::: seealso
  *     [method@Image.hough_line].

--- a/libvips/arithmetic/hough_line.c
+++ b/libvips/arithmetic/hough_line.c
@@ -171,10 +171,6 @@ vips_hough_line_init(VipsHoughLine *hough_line)
  * @out: (out): output image
  * @...: %NULL-terminated list of optional named arguments
  *
- * ::: note "Optional arguments"
- *     * @width: horizontal size of parameter space
- *     * @height: vertical size of parameter space
- *
  * Find the line Hough transform for @in. @in must have one band. @out has one
  * band, with pixels being the number of votes for that line. The X dimension
  * of @out is the line angle in 0 - 180 degrees, the Y dimension is the
@@ -182,6 +178,10 @@ vips_hough_line_init(VipsHoughLine *hough_line)
  *
  * Use @width @height to set the size of the parameter space image (@out),
  * that is, how accurate the line determination should be.
+ *
+ * ::: tip "Optional arguments"
+ *     * @width: horizontal size of parameter space
+ *     * @height: vertical size of parameter space
  *
  * ::: seealso
  *     [method@Image.hough_circle].

--- a/libvips/arithmetic/linear.c
+++ b/libvips/arithmetic/linear.c
@@ -505,9 +505,6 @@ vips_linearv(VipsImage *in, VipsImage **out,
  * @n: length of constant arrays
  * @...: %NULL-terminated list of optional named arguments
  *
- * ::: note "Optional arguments"
- *     * @uchar: output uchar pixels
- *
  * Pass an image through a linear transform, ie. (@out = @in * @a + @b). Output
  * is float for integer input, double for double input, complex for
  * complex input and double complex for double complex input. Set @uchar to
@@ -519,6 +516,9 @@ vips_linearv(VipsImage *in, VipsImage **out,
  * one array element is used for each band. If the arrays have more than one
  * element and the image only has a single band, the result is a many-band
  * image where each band corresponds to one array element.
+ *
+ * ::: tip "Optional arguments"
+ *     * @uchar: output uchar pixels
  *
  * ::: seealso
  *     [method@Image.linear1], [method@Image.add].
@@ -547,11 +547,10 @@ vips_linear(VipsImage *in, VipsImage **out,
  * @b: constant for addition
  * @...: %NULL-terminated list of optional named arguments
  *
- * Optional arguments:
- *
- * * @uchar: output uchar pixels
- *
  * Run [method@Image.linear] with a single constant.
+ *
+ * ::: tip "Optional arguments"
+ *	   * @uchar: output uchar pixels
  *
  * ::: seealso
  *     [method@Image.linear].

--- a/libvips/arithmetic/max.c
+++ b/libvips/arithmetic/max.c
@@ -510,14 +510,6 @@ vips_max_init(VipsMax *max)
  * @out: (out): output pixel maximum
  * @...: %NULL-terminated list of optional named arguments
  *
- * ::: note "Optional arguments"
- *     * @x: horizontal position of maximum
- *     * @y: vertical position of maximum
- *     * @size: number of maxima to find
- *     * @out_array: return array of maximum values
- *     * @x_array: corresponding horizontal positions
- *     * @y_array: corresponding vertical positions
- *
  * This operation finds the maximum value in an image.
  *
  * By default it finds the single largest value. If @size is set >1, it will
@@ -538,6 +530,14 @@ vips_max_init(VipsMax *max)
  *
  * If there are more than @size maxima, the maxima returned will be a random
  * selection of the maxima in the image.
+ *
+ * ::: tip "Optional arguments"
+ *     * @x: horizontal position of maximum
+ *     * @y: vertical position of maximum
+ *     * @size: number of maxima to find
+ *     * @out_array: return array of maximum values
+ *     * @x_array: corresponding horizontal positions
+ *     * @y_array: corresponding vertical positions
  *
  * ::: seealso
  *     [method@Image.min], [method@Image.stats].

--- a/libvips/arithmetic/measure.c
+++ b/libvips/arithmetic/measure.c
@@ -259,12 +259,6 @@ vips_measure_init(VipsMeasure *measure)
  * @v: patches down chart
  * @...: %NULL-terminated list of optional named arguments
  *
- * ::: note "Optional arguments"
- *     * @left: area of image containing chart
- *     * @top: area of image containing chart
- *     * @width: area of image containing chart
- *     * @height: area of image containing chart
- *
  * Analyse a grid of colour patches, producing an array of patch averages.
  * The mask has a row for each measured patch and a column for each image
  * band. The operations issues a warning if any patch has a deviation more
@@ -274,6 +268,12 @@ vips_measure_init(VipsMeasure *measure)
  * If the chart does not fill the whole image, use the optional @left, @top,
  * @width, @height arguments to indicate the
  * position of the chart.
+ *
+ * ::: tip "Optional arguments"
+ *     * @left: area of image containing chart
+ *     * @top: area of image containing chart
+ *     * @width: area of image containing chart
+ *     * @height: area of image containing chart
  *
  * ::: seealso
  *     [method@Image.avg], [method@Image.deviate].

--- a/libvips/arithmetic/min.c
+++ b/libvips/arithmetic/min.c
@@ -510,14 +510,6 @@ vips_min_init(VipsMin *min)
  * @out: (out): output pixel minimum
  * @...: %NULL-terminated list of optional named arguments
  *
- * ::: note "Optional arguments"
- *     * @x: horizontal position of minimum
- *     * @y: vertical position of minimum
- *     * @size: number of minima to find
- *     * @out_array: return array of minimum values
- *     * @x_array: corresponding horizontal positions
- *     * @y_array: corresponding vertical positions
- *
  * This operation finds the minimum value in an image.
  *
  * By default it finds the single smallest value. If @size is set >1, it will
@@ -539,6 +531,14 @@ vips_min_init(VipsMin *min)
  *
  * If there are more than @size minima, the minima returned will be a random
  * selection of the minima in the image.
+ *
+ * ::: tip "Optional arguments"
+ *     * @x: horizontal position of minimum
+ *     * @y: vertical position of minimum
+ *     * @size: number of minima to find
+ *     * @out_array: return array of minimum values
+ *     * @x_array: corresponding horizontal positions
+ *     * @y_array: corresponding vertical positions
  *
  * ::: seealso
  *     [method@Image.min], [method@Image.stats].

--- a/libvips/colour/Lab2XYZ.c
+++ b/libvips/colour/Lab2XYZ.c
@@ -205,12 +205,11 @@ vips_Lab2XYZ_init(VipsLab2XYZ *Lab2XYZ)
  * @out: (out): output image
  * @...: %NULL-terminated list of optional named arguments
  *
- * Optional arguments:
- *
- * * @temp: [struct@ArrayDouble], colour temperature
- *
  * Turn Lab to XYZ. The colour temperature defaults to D65, but can be
  * specified with @temp.
+ *
+ * ::: tip "Optional arguments"
+ *		* @temp: [struct@ArrayDouble], colour temperature
  *
  * Returns: 0 on success, -1 on error
  */

--- a/libvips/colour/XYZ2Lab.c
+++ b/libvips/colour/XYZ2Lab.c
@@ -259,12 +259,11 @@ vips_XYZ2Lab_init(VipsXYZ2Lab *XYZ2Lab)
  * @out: (out): output image
  * @...: %NULL-terminated list of optional named arguments
  *
- * Optional arguments:
- *
- * * @temp: [struct@ArrayDouble], colour temperature
- *
  * Turn XYZ to Lab, optionally specifying the colour temperature. @temp
  * defaults to D65.
+ *
+ * ::: tip "Optional arguments"
+ *		* @temp: [struct@ArrayDouble], colour temperature
  *
  * Returns: 0 on success, -1 on error.
  */

--- a/libvips/colour/colourspace.c
+++ b/libvips/colour/colourspace.c
@@ -593,17 +593,17 @@ vips_colourspace_init(VipsColourspace *colourspace)
  * @space: convert to this colour space
  * @...: %NULL-terminated list of optional named arguments
  *
- * Optional arguments:
- *
- * * @source_space: input colour space
- *
  * This operation looks at the interpretation field of @in (or uses
  * @source_space, if set) and runs
  * a set of colourspace conversion functions to move it to @space.
  *
  * For example, given an image tagged as [enum@Vips.Interpretation.YXY], running
- * [method@Image.colourspace] with @space set to [enum@Vips.Interpretation.LAB] will
- * convert with [method@Image.Yxy2XYZ] and [method@Image.XYZ2Lab].
+ * [method@Image.colourspace] with @space set to
+ * [enum@Vips.Interpretation.LAB] will convert with [method@Image.Yxy2XYZ]
+ * and [method@Image.XYZ2Lab].
+ *
+ * ::: tip "Optional arguments"
+ *		* @source_space: input colour space
  *
  * ::: seealso
  *     [method@Image.colourspace_issupported],

--- a/libvips/colour/icc_transform.c
+++ b/libvips/colour/icc_transform.c
@@ -1440,16 +1440,8 @@ vips_icc_is_compatible_profile(VipsImage *image,
  * @out: (out): output image
  * @...: %NULL-terminated list of optional named arguments
  *
- * Optional arguments:
- *
- * * @pcs: #VipsPCS,  use XYZ or LAB PCS
- * * @intent: #VipsIntent, transform with this intent
- * * @black_point_compensation: %gboolean, enable black point compensation
- * * @embedded: %gboolean, use profile embedded in input image
- * * @input_profile: %gchararray, get the input profile from here
- *
  * Import an image from device space to D65 LAB with an ICC profile. If @pcs is
- * set to #VIPS_PCS_XYZ, use CIE XYZ PCS instead.
+ * set to [enum@Vips.PCS.XYZ], use CIE XYZ PCS instead.
  *
  * The input profile is searched for in three places:
  *
@@ -1459,7 +1451,7 @@ vips_icc_is_compatible_profile(VipsImage *image,
  *	  argument. This will return %GType 0 if there is no profile.
  *
  *	  2. Otherwise, if @input_profile is set, libvips will try to load a
- *	  profile from the named file. This can aslso be the name of one of the
+ *	  profile from the named file. This can also be the name of one of the
  *	  built-in profiles.
  *
  *	  3. Otherwise, libvips will try to pick a compatible profile from the set
@@ -1467,6 +1459,13 @@ vips_icc_is_compatible_profile(VipsImage *image,
  *
  * If @black_point_compensation is set, LCMS black point compensation is
  * enabled.
+ *
+ * ::: tip "Optional arguments"
+ *		* @pcs: [enum@PCS], use XYZ or LAB PCS
+ *		* @intent: [enum@Intent], transform with this intent
+ *		* @black_point_compensation: %gboolean, enable black point compensation
+ *		* @embedded: %gboolean, use profile embedded in input image
+ *		* @input_profile: %gchararray, get the input profile from here
  *
  * Returns: 0 on success, -1 on error.
  */

--- a/libvips/colour/scRGB2BW.c
+++ b/libvips/colour/scRGB2BW.c
@@ -265,17 +265,14 @@ vips_scRGB2BW_init(VipsscRGB2BW *scRGB2BW)
  * @out: (out): output image
  * @...: %NULL-terminated list of optional named arguments
  *
- * Optional arguments:
- *
- * * @depth: depth of output image in bits
- *
  * Convert an scRGB image to greyscale. Set @depth to 16 to get 16-bit output.
  *
- * If @depth is 16, any extra channels after RGB are
- * multiplied by 256.
+ * ::: tip "Optional arguments"
+ *     * @depth: depth of output image in bits
  *
  * ::: seealso
- *     [method@Image.LabS2LabQ], [method@Image.sRGB2scRGB], [method@Image.rad2float].
+ *     [method@Image.LabS2LabQ], [method@Image.sRGB2scRGB],
+ *     [method@Image.rad2float].
  *
  * Returns: 0 on success, -1 on error.
  */

--- a/libvips/colour/scRGB2sRGB.c
+++ b/libvips/colour/scRGB2sRGB.c
@@ -298,17 +298,14 @@ vips_scRGB2sRGB_init(VipsscRGB2sRGB *scRGB2sRGB)
  * @out: (out): output image
  * @...: %NULL-terminated list of optional named arguments
  *
- * Optional arguments:
- *
- * * @depth: depth of output image in bits
- *
  * Convert an scRGB image to sRGB. Set @depth to 16 to get 16-bit output.
  *
- * If @depth is 16, any extra channels after RGB are
- * multiplied by 256.
+ * ::: tip "Optional arguments"
+ *     * @depth: depth of output image in bits
  *
  * ::: seealso
- *     [method@Image.LabS2LabQ], [method@Image.sRGB2scRGB], [method@Image.rad2float].
+ *     [method@Image.LabS2LabQ], [method@Image.sRGB2scRGB],
+ *     [method@Image.rad2float].
  *
  * Returns: 0 on success, -1 on error.
  */

--- a/libvips/conversion/addalpha.c
+++ b/libvips/conversion/addalpha.c
@@ -106,7 +106,8 @@ vips_addalpha_init(VipsAddAlpha *addalpha)
  *
  * Append an alpha channel.
  *
- * See also: vips_image_hasalpha().
+ * ::: seealso
+ *     [method@Image.hasalpha].
  *
  * Returns: 0 on success, -1 on error
  */

--- a/libvips/conversion/arrayjoin.c
+++ b/libvips/conversion/arrayjoin.c
@@ -475,16 +475,6 @@ vips_arrayjoinv(VipsImage **in, VipsImage **out, int n, va_list ap)
  * @n: number of input images
  * @...: %NULL-terminated list of optional named arguments
  *
- * Optional arguments:
- *
- * * @across: %gint, number of images per row
- * * @shim: %gint, space between images, in pixels
- * * @background: #VipsArrayDouble, background ink colour
- * * @halign: #VipsAlign, low, centre or high alignment
- * * @valign: #VipsAlign, low, centre or high alignment
- * * @hspacing: %gint, horizontal distance between images
- * * @vspacing: %gint, vertical distance between images
- *
  * Lay out the images in @in in a grid. The grid is @across images across and
  * however high is necessary to use up all of @in. Images are set down
  * left-to-right and top-to-bottom. @across defaults to @n.
@@ -511,10 +501,20 @@ vips_arrayjoinv(VipsImage **in, VipsImage **out, int n, va_list ap)
  * Smallest common format in
  * <link linkend="libvips-arithmetic">arithmetic</link>).
  *
- * vips_colourspace() can be useful for moving the images to a common
+ * [method@Image.colourspace] can be useful for moving the images to a common
  * colourspace for compositing.
  *
- * See also: vips_join(), vips_insert(), vips_colourspace().
+ * ::: tip "Optional arguments"
+ *     * @across: %gint, number of images per row
+ *     * @shim: %gint, space between images, in pixels
+ *     * @background: [struct@ArrayDouble], background ink colour
+ *     * @halign: [enum@Align], low, centre or high alignment
+ *     * @valign: [enum@Align], low, centre or high alignment
+ *     * @hspacing: %gint, horizontal distance between images
+ *     * @vspacing: %gint, vertical distance between images
+ *
+ * ::: seealso
+ *     [method@Image.join], [method@Image.insert], [method@Image.colourspace].
  *
  * Returns: 0 on success, -1 on error
  */

--- a/libvips/conversion/autorot.c
+++ b/libvips/conversion/autorot.c
@@ -90,7 +90,7 @@ vips_autorot_remove_angle_sub(VipsImage *image,
  * @image: image to remove orientation from
  *
  * Remove the orientation tag on @image. Also remove any exif orientation tags.
- * You must vips_copy() the image before calling this function since it
+ * You must [method@Image.copy] the image before calling this function since it
  * modifies metadata.
  */
 void
@@ -237,17 +237,16 @@ vips_autorot_init(VipsAutorot *autorot)
  * @out: (out): output image
  * @...: %NULL-terminated list of optional named arguments
  *
- * Optional arguments:
- *
- * * @angle: output #VipsAngle the image was rotated by
- * * @flip: output %gboolean whether the image was flipped
- *
  * Look at the image metadata and rotate and flip the image to make it
  * upright. The #VIPS_META_ORIENTATION tag is removed from @out to prevent
  * accidental double rotation.
  *
  * Read @angle to find the amount the image was rotated by. Read @flip to
  * see if the image was also flipped.
+ *
+ * ::: tip "Optional arguments"
+ *     * @angle: output [enum@Angle] the image was rotated by
+ *     * @flip: output %gboolean whether the image was flipped
  *
  * Returns: 0 on success, -1 on error
  */

--- a/libvips/conversion/bandbool.c
+++ b/libvips/conversion/bandbool.c
@@ -258,14 +258,14 @@ vips_bandboolv(VipsImage *in, VipsImage **out,
 
 /**
  * vips_bandbool: (method)
- * @in: left-hand input #VipsImage
- * @out: (out): output #VipsImage
+ * @in: left-hand input [class@Image]
+ * @out: (out): output [class@Image]
  * @boolean: boolean operation to perform
  * @...: %NULL-terminated list of optional named arguments
  *
  * Perform various boolean operations across the bands of an image. For
  * example, a three-band uchar image operated on with
- * #VIPS_OPERATION_BOOLEAN_AND will produce a one-band uchar image where each
+ * [enum@Vips.OperationBoolean.AND] will produce a one-band uchar image where each
  * pixel is the bitwise and of the band elements of the corresponding pixel in
  * the input image.
  *
@@ -275,10 +275,11 @@ vips_bandboolv(VipsImage *in, VipsImage **out,
  *
  * The output image always has one band.
  *
- * This operation is useful in conjunction with vips_relational(). You can use
+ * This operation is useful in conjunction with [method@Image.relational]. You can use
  * it to see if all image bands match exactly.
  *
- * See also: vips_boolean_const().
+ * ::: seealso
+ *     [method@Image.boolean_const].
  *
  * Returns: 0 on success, -1 on error
  */
@@ -298,12 +299,12 @@ vips_bandbool(VipsImage *in, VipsImage **out,
 
 /**
  * vips_bandand: (method)
- * @in: left-hand input #VipsImage
- * @out: (out): output #VipsImage
+ * @in: left-hand input [class@Image]
+ * @out: (out): output [class@Image]
  * @...: %NULL-terminated list of optional named arguments
  *
- * Perform #VIPS_OPERATION_BOOLEAN_AND on an image. See
- * vips_bandbool().
+ * Perform [enum@Vips.OperationBoolean.AND] on an image. See
+ * [method@Image.bandbool].
  *
  * Returns: 0 on success, -1 on error
  */
@@ -322,12 +323,12 @@ vips_bandand(VipsImage *in, VipsImage **out, ...)
 
 /**
  * vips_bandor: (method)
- * @in: left-hand input #VipsImage
- * @out: (out): output #VipsImage
+ * @in: left-hand input [class@Image]
+ * @out: (out): output [class@Image]
  * @...: %NULL-terminated list of optional named arguments
  *
- * Perform #VIPS_OPERATION_BOOLEAN_OR on an image. See
- * vips_bandbool().
+ * Perform [enum@Vips.OperationBoolean.OR] on an image. See
+ * [method@Image.bandbool].
  *
  * Returns: 0 on success, -1 on error
  */
@@ -346,12 +347,12 @@ vips_bandor(VipsImage *in, VipsImage **out, ...)
 
 /**
  * vips_bandeor: (method)
- * @in: left-hand input #VipsImage
- * @out: (out): output #VipsImage
+ * @in: left-hand input [class@Image]
+ * @out: (out): output [class@Image]
  * @...: %NULL-terminated list of optional named arguments
  *
- * Perform #VIPS_OPERATION_BOOLEAN_EOR on an image. See
- * vips_bandbool().
+ * Perform [enum@Vips.OperationBoolean.EOR] on an image. See
+ * [method@Image.bandbool].
  *
  * Returns: 0 on success, -1 on error
  */

--- a/libvips/conversion/bandfold.c
+++ b/libvips/conversion/bandfold.c
@@ -185,16 +185,16 @@ vips_bandfold_init(VipsBandfold *bandfold)
  * @out: (out): output image
  * @...: %NULL-terminated list of optional named arguments
  *
- * Optional arguments:
- *
- * * @factor: fold by this factor
- *
  * Fold up an image horizontally: width is collapsed into bands.
  * Use @factor to set how much to fold by: @factor 3, for example, will make
  * the output image three times narrower than the input, and with three times
  * as many bands. By default the whole of the input width is folded up.
  *
- * See also: vips_csvload(), vips_bandunfold().
+ * ::: tip "Optional arguments"
+ *		* @factor: %gint, fold by this factor
+ *
+ * ::: seealso
+ *     [ctor@Image.csvload], [method@Image.bandunfold].
  *
  * Returns: 0 on success, -1 on error.
  */

--- a/libvips/conversion/bandjoin.c
+++ b/libvips/conversion/bandjoin.c
@@ -246,7 +246,8 @@ vips_bandjoinv(VipsImage **in, VipsImage **out, int n, va_list ap)
  * Smallest common format in
  * <link linkend="libvips-arithmetic">arithmetic</link>).
  *
- * See also: vips_insert().
+ * ::: seealso
+ *     [method@Image.insert].
  *
  * Returns: 0 on success, -1 on error
  */
@@ -270,7 +271,7 @@ vips_bandjoin(VipsImage **in, VipsImage **out, int n, ...)
  * @out: (out): output image
  * @...: %NULL-terminated list of optional named arguments
  *
- * Join a pair of images together, bandwise. See vips_bandjoin().
+ * Join a pair of images together, bandwise. See [func@Image.bandjoin].
  *
  * Returns: 0 on success, -1 on error
  */
@@ -477,7 +478,8 @@ vips_bandjoin_constv(VipsImage *in, VipsImage **out,
  *
  * Append a set of constant bands to an image.
  *
- * See also: vips_bandjoin().
+ * ::: seealso
+ *     [func@Image.bandjoin].
  *
  * Returns: 0 on success, -1 on error
  */

--- a/libvips/conversion/bandmean.c
+++ b/libvips/conversion/bandmean.c
@@ -231,7 +231,8 @@ vips_bandmean_init(VipsBandmean *bandmean)
  * the same as the input band format. Integer types use round-to-nearest
  * averaging.
  *
- * See also: vips_add(), vips_avg(), vips_recomb()
+ * ::: seealso
+ *     [method@Image.add], [method@Image.avg], [method@Image.recomb]
  *
  * Returns: 0 on success, -1 on error
  */

--- a/libvips/conversion/bandrank.c
+++ b/libvips/conversion/bandrank.c
@@ -293,10 +293,6 @@ vips_bandrankv(VipsImage **in, VipsImage **out, int n, va_list ap)
  * @n: number of input images
  * @...: %NULL-terminated list of optional named arguments
  *
- * Optional arguments:
- *
- * * @index: pick this index from list of sorted values
- *
  * Sorts the images @in band-element-wise, then outputs an
  * image in which each band element is selected from the sorted list by the
  * @index parameter. For example, if @index
@@ -314,7 +310,11 @@ vips_bandrankv(VipsImage **in, VipsImage **out, int n, va_list ap)
  *
  * Smaller input images are expanded by adding black pixels.
  *
- * See also: vips_rank().
+ * ::: tip "Optional arguments"
+ *     * @index: %gint, pick this index from list of sorted values
+ *
+ * ::: seealso
+ *     [method@Image.rank].
  *
  * Returns: 0 on success, -1 on error
  */

--- a/libvips/conversion/bandunfold.c
+++ b/libvips/conversion/bandunfold.c
@@ -188,16 +188,16 @@ vips_bandunfold_init(VipsBandunfold *bandunfold)
  * @out: (out): output image
  * @...: %NULL-terminated list of optional named arguments
  *
- * Optional arguments:
- *
- * * @factor: unfold by this factor
- *
  * Unfold image bands into x axis.
  * Use @factor to set how much to unfold by: @factor 3, for example, will make
  * the output image three times wider than the input, and with one third
  * as many bands. By default, all bands are unfolded.
  *
- * See also: vips_csvload(), vips_bandfold().
+ * ::: tip "Optional arguments"
+ *     * @factor: unfold by this factor
+ *
+ * ::: seealso
+ *     [ctor@Image.csvload], [method@Image.bandfold].
  *
  * Returns: 0 on success, -1 on error.
  */

--- a/libvips/conversion/byteswap.c
+++ b/libvips/conversion/byteswap.c
@@ -254,7 +254,8 @@ vips_byteswap_init(VipsByteswap *byteswap)
  *
  * Swap the byte order in an image.
  *
- * See also: vips_rawload().
+ * ::: seealso
+ *     [ctor@Image.rawload].
  *
  * Returns: 0 on success, -1 on error.
  */

--- a/libvips/conversion/cache.c
+++ b/libvips/conversion/cache.c
@@ -1,4 +1,4 @@
-/* vips_sink_screen() as an operation.
+/* [method@Image.sink_screen] as an operation.
  *
  * 13/1/12
  * 	- from tilecache.c
@@ -143,25 +143,19 @@ vips_cache_init(VipsCache *cache)
 }
 
 /**
- * vips_cache: (method)
+ * vips_cache:
  * @in: input image
  * @out: (out): output image
  * @...: %NULL-terminated list of optional named arguments
  *
- * Optional arguments:
- *
- * * @tile_width: width of tiles in cache
- * * @tile_height: height of tiles in cache
- * * @max_tiles: maximum number of tiles to cache
- *
- * This operation behaves rather like vips_copy() between images
+ * This operation behaves rather like [method@Image.copy] between images
  * @in and @out, except that it keeps a cache of computed pixels.
  * This cache is made of up to @max_tiles tiles (a value of -1
  * means any number of tiles), and each tile is of size @tile_width
  * by @tile_height pixels. By default it will cache 250 128 x 128 pixel tiles,
  * enough for two 1920 x 1080 images.
  *
- * This operation is a thin wrapper over vips_sink_screen(), see the
+ * This operation is a thin wrapper over [method@Image.sink_screen], see the
  * documentation for that operation for details.
  *
  * It uses a set of background threads to calculate pixels and the various
@@ -170,7 +164,13 @@ vips_cache_init(VipsCache *cache)
  * of those pixels have been calculated. Pixels are calculated with a set of
  * threads.
  *
- * See also: vips_tilecache().
+ * ::: tip "Optional arguments"
+ *     * @tile_width: width of tiles in cache
+ *     * @tile_height: height of tiles in cache
+ *     * @max_tiles: maximum number of tiles to cache
+ *
+ * ::: seealso
+ *     [method@Image.tilecache].
  *
  * Returns: 0 on success, -1 on error.
  */

--- a/libvips/conversion/cast.c
+++ b/libvips/conversion/cast.c
@@ -565,10 +565,6 @@ vips_castv(VipsImage *in, VipsImage **out, VipsBandFormat format, va_list ap)
  * @format: format to convert to
  * @...: %NULL-terminated list of optional named arguments
  *
- * Optional arguments:
- *
- * * @shift: %gboolean, integer values are shifted
- *
  * Convert @in to @format. You can convert between any pair of formats.
  * Floats are truncated (not rounded). Out of range values are clipped.
  *
@@ -579,8 +575,12 @@ vips_castv(VipsImage *in, VipsImage **out, VipsBandFormat format, va_list ap)
  * shift every value left by 8 bits. The bottom bit is copied into the new
  * bits, so 255 would become 65535.
  *
- * See also: vips_scale(), vips_complexform(), vips_real(), vips_imag(),
- * vips_cast_uchar(), vips_msb().
+ * ::: tip "Optional arguments"
+ *     * @shift: %gboolean, integer values are shifted
+ *
+ * ::: seealso
+ *     [method@Image.scale], [method@Image.complexform], [method@Image.real],
+ *     [method@Image.imag], [method@Image.cast_uchar], [method@Image.msb].
  *
  * Returns: 0 on success, -1 on error
  */
@@ -603,11 +603,10 @@ vips_cast(VipsImage *in, VipsImage **out, VipsBandFormat format, ...)
  * @out: (out): output image
  * @...: %NULL-terminated list of optional named arguments
  *
- * Optional arguments:
+ * Convert @in to [enum@Vips.BandFormat.UCHAR]. See [method@Image.cast].
  *
- * * @shift: %gboolean, integer values are shifted
- *
- * Convert @in to #VIPS_FORMAT_UCHAR. See vips_cast().
+ * ::: tip "Optional arguments"
+ *     * @shift: %gboolean, integer values are shifted
  *
  * Returns: 0 on success, -1 on error
  */
@@ -630,11 +629,10 @@ vips_cast_uchar(VipsImage *in, VipsImage **out, ...)
  * @out: (out): output image
  * @...: %NULL-terminated list of optional named arguments
  *
- * Optional arguments:
+ * Convert @in to [enum@Vips.BandFormat.CHAR]. See [method@Image.cast].
  *
- * * @shift: %gboolean, integer values are shifted
- *
- * Convert @in to #VIPS_FORMAT_CHAR. See vips_cast().
+ * ::: tip "Optional arguments"
+ *     * @shift: %gboolean, integer values are shifted
  *
  * Returns: 0 on success, -1 on error
  */
@@ -657,11 +655,10 @@ vips_cast_char(VipsImage *in, VipsImage **out, ...)
  * @out: (out): output image
  * @...: %NULL-terminated list of optional named arguments
  *
- * Optional arguments:
+ * Convert @in to [enum@Vips.BandFormat.USHORT]. See [method@Image.cast].
  *
- * * @shift: %gboolean, integer values are shifted
- *
- * Convert @in to #VIPS_FORMAT_USHORT. See vips_cast().
+ * ::: tip "Optional arguments"
+ *     * @shift: %gboolean, integer values are shifted
  *
  * Returns: 0 on success, -1 on error
  */
@@ -684,11 +681,10 @@ vips_cast_ushort(VipsImage *in, VipsImage **out, ...)
  * @out: (out): output image
  * @...: %NULL-terminated list of optional named arguments
  *
- * Optional arguments:
+ * Convert @in to [enum@Vips.BandFormat.SHORT]. See [method@Image.cast].
  *
- * * @shift: %gboolean, integer values are shifted
- *
- * Convert @in to #VIPS_FORMAT_SHORT. See vips_cast().
+ * ::: tip "Optional arguments"
+ *     * @shift: %gboolean, integer values are shifted
  *
  * Returns: 0 on success, -1 on error
  */
@@ -711,11 +707,10 @@ vips_cast_short(VipsImage *in, VipsImage **out, ...)
  * @out: (out): output image
  * @...: %NULL-terminated list of optional named arguments
  *
- * Optional arguments:
+ * Convert @in to [enum@Vips.BandFormat.UINT]. See [method@Image.cast].
  *
- * * @shift: %gboolean, integer values are shifted
- *
- * Convert @in to #VIPS_FORMAT_UINT. See vips_cast().
+ * ::: tip "Optional arguments"
+ *     * @shift: %gboolean, integer values are shifted
  *
  * Returns: 0 on success, -1 on error
  */
@@ -738,11 +733,10 @@ vips_cast_uint(VipsImage *in, VipsImage **out, ...)
  * @out: (out): output image
  * @...: %NULL-terminated list of optional named arguments
  *
- * Optional arguments:
+ * Convert @in to [enum@Vips.BandFormat.INT]. See [method@Image.cast].
  *
- * * @shift: %gboolean, integer values are shifted
- *
- * Convert @in to #VIPS_FORMAT_INT. See vips_cast().
+ * ::: tip "Optional arguments"
+ *     * @shift: %gboolean, integer values are shifted
  *
  * Returns: 0 on success, -1 on error
  */
@@ -765,7 +759,7 @@ vips_cast_int(VipsImage *in, VipsImage **out, ...)
  * @out: (out): output image
  * @...: %NULL-terminated list of optional named arguments
  *
- * Convert @in to #VIPS_FORMAT_FLOAT. See vips_cast().
+ * Convert @in to [enum@Vips.BandFormat.FLOAT]. See [method@Image.cast].
  *
  * Returns: 0 on success, -1 on error
  */
@@ -788,7 +782,7 @@ vips_cast_float(VipsImage *in, VipsImage **out, ...)
  * @out: (out): output image
  * @...: %NULL-terminated list of optional named arguments
  *
- * Convert @in to #VIPS_FORMAT_DOUBLE. See vips_cast().
+ * Convert @in to [enum@Vips.BandFormat.DOUBLE]. See [method@Image.cast].
  *
  * Returns: 0 on success, -1 on error
  */
@@ -811,7 +805,7 @@ vips_cast_double(VipsImage *in, VipsImage **out, ...)
  * @out: (out): output image
  * @...: %NULL-terminated list of optional named arguments
  *
- * Convert @in to #VIPS_FORMAT_COMPLEX. See vips_cast().
+ * Convert @in to [enum@Vips.BandFormat.COMPLEX]. See [method@Image.cast].
  *
  * Returns: 0 on success, -1 on error
  */
@@ -834,7 +828,7 @@ vips_cast_complex(VipsImage *in, VipsImage **out, ...)
  * @out: (out): output image
  * @...: %NULL-terminated list of optional named arguments
  *
- * Convert @in to #VIPS_FORMAT_DPCOMPLEX. See vips_cast().
+ * Convert @in to [enum@Vips.BandFormat.DPCOMPLEX]. See [method@Image.cast].
  *
  * Returns: 0 on success, -1 on error
  */

--- a/libvips/conversion/conversion.c
+++ b/libvips/conversion/conversion.c
@@ -57,13 +57,6 @@
  * @mode: array of (@n - 1) #VipsBlendMode
  * @...: %NULL-terminated list of optional named arguments
  *
- * Optional arguments:
- *
- * * @compositing_space: #VipsInterpretation to composite in
- * * @premultiplied: %gboolean, images are already premultiplied
- * * @x: #VipsArrayInt, array of (@n - 1) x coordinates
- * * @y: #VipsArrayInt, array of (@n - 1) y coordinates
- *
  * Composite an array of images together.
  *
  * Images are placed in a stack, with @in[0] at the bottom and @in[@n - 1] at
@@ -72,15 +65,17 @@
  * in @mode.
  *
  * Images are transformed to a compositing space before processing. This is
- * #VIPS_INTERPRETATION_sRGB, #VIPS_INTERPRETATION_B_W,
- * #VIPS_INTERPRETATION_RGB16, or #VIPS_INTERPRETATION_GREY16
+ * [enum@Vips.Interpretation.sRGB], [enum@Vips.Interpretation.B_W],
+ * [enum@Vips.Interpretation.RGB16], or [enum@Vips.Interpretation.GREY16]
  * by default, depending on
  * how many bands and bits the input images have. You can select any other
- * space, such as #VIPS_INTERPRETATION_LAB or #VIPS_INTERPRETATION_scRGB.
+ * space, such as [enum@Vips.Interpretation.LAB] or
+ * [enum@Vips.Interpretation.scRGB].
  *
  * The output image is in the compositing space. It will always be
- * #VIPS_FORMAT_FLOAT unless one of the inputs is #VIPS_FORMAT_DOUBLE, in
- * which case the output will be double as well.
+ * [enum@Vips.BandFormat.FLOAT] unless one of the inputs is
+ * [enum@Vips.BandFormat.DOUBLE], in which case the output will be double
+ * as well.
  *
  * Complex images are not supported.
  *
@@ -93,10 +88,17 @@
  * against that rectangle.
  *
  * Image are normally treated as unpremultiplied, so this operation can be used
- * directly on PNG images. If your images have been through vips_premultiply(),
- * set @premultiplied.
+ * directly on PNG images. If your images have been through
+ * [method@Image.premultiply], set @premultiplied.
  *
- * See also: vips_insert().
+ * ::: tip "Optional arguments"
+ *     * @compositing_space: [enum@Interpretation] to composite in
+ *     * @premultiplied: %gboolean, images are already premultiplied
+ *     * @x: [struct@ArrayInt], array of (@n - 1) x coordinates
+ *     * @y: [struct@ArrayInt], array of (@n - 1) y coordinates
+ *
+ * ::: seealso
+ *     [method@Image.insert].
  *
  * Returns: 0 on success, -1 on error
  */
@@ -109,14 +111,13 @@
  * @mode: composite with this blend mode
  * @...: %NULL-terminated list of optional named arguments
  *
- * Optional arguments:
+ * Composite @overlay on top of @base with @mode. See [func@Image.composite].
  *
- * * @compositing_space: #VipsInterpretation to composite in
- * * @premultiplied: %gboolean, images are already premultiplied
- * * @x: %gint, position of overlay
- * * @y: %gint, position of overlay
- *
- * Composite @overlay on top of @base with @mode. See vips_composite().
+ * ::: tip "Optional arguments"
+ *     * @compositing_space: [enum@Interpretation] to composite in
+ *     * @premultiplied: %gboolean, images are already premultiplied
+ *     * @x: %gint, position of overlay
+ *     * @y: %gint, position of overlay
  *
  * Returns: 0 on success, -1 on error
  */
@@ -149,7 +150,7 @@
  * @VIPS_BLEND_MODE_DIFFERENCE: difference of the two
  * @VIPS_BLEND_MODE_EXCLUSION: somewhat like DIFFERENCE, but lower-contrast
  *
- * The various Porter-Duff and PDF blend modes. See vips_composite(),
+ * The various Porter-Duff and PDF blend modes. See [func@Image.composite],
  * for example.
  *
  * The Cairo docs have a nice explanation of all the blend modes:
@@ -165,12 +166,13 @@
  * @VIPS_ALIGN_CENTRE: align centre
  * @VIPS_ALIGN_HIGH: align high coordinate edge
  *
- * See vips_join() and so on.
+ * See [method@Image.join] and so on.
  *
- * Operations like vips_join() need to be told whether to align images on the
+ * Operations like [method@Image.join] need to be told whether to align images on the
  * low or high coordinate edge, or centre.
  *
- * See also: vips_join().
+ * ::: seealso
+ *     [method@Image.join].
  */
 
 /**
@@ -180,11 +182,12 @@
  * @VIPS_ANGLE_D180: 180 degree rotate
  * @VIPS_ANGLE_D270: 90 degrees anti-clockwise
  *
- * See vips_rot() and so on.
+ * See [method@Image.rot] and so on.
  *
  * Fixed rotate angles.
  *
- * See also: vips_rot().
+ * ::: seealso
+ *     [method@Image.rot].
  */
 
 /**
@@ -198,14 +201,15 @@
  * @VIPS_INTERESTING_ALL: everything is interesting
  *
  * Pick the algorithm vips uses to decide image "interestingness". This is used
- * by vips_smartcrop(), for example, to decide what parts of the image to
+ * by [method@Image.smartcrop], for example, to decide what parts of the image to
  * keep.
  *
  * #VIPS_INTERESTING_NONE and #VIPS_INTERESTING_LOW mean the same -- the
  * crop is positioned at the top or left. #VIPS_INTERESTING_HIGH positions at
  * the bottom or right.
  *
- * See also: vips_smartcrop().
+ * ::: seealso
+ *     [method@Image.smartcrop].
  */
 
 /**
@@ -220,7 +224,7 @@
  * @VIPS_COMPASS_DIRECTION_SOUTH_WEST: south-west
  * @VIPS_COMPASS_DIRECTION_NORTH_WEST: north-west
  *
- * A direction on a compass. Used for vips_gravity(), for example.
+ * A direction on a compass. Used for [method@Image.gravity], for example.
  */
 
 /**
@@ -234,11 +238,12 @@
  * @VIPS_ANGLE45_D270: 90 degrees anti-clockwise
  * @VIPS_ANGLE45_D315: 45 degrees anti-clockwise
  *
- * See vips_rot45() and so on.
+ * See [method@Image.rot45] and so on.
  *
  * Fixed rotate angles.
  *
- * See also: vips_rot45().
+ * ::: seealso
+ *     [method@Image.rot45].
  */
 
 /**
@@ -250,7 +255,7 @@
  * @VIPS_EXTEND_WHITE: extend with white (all bits set) pixels
  * @VIPS_EXTEND_BACKGROUND: extend with colour from the @background property
  *
- * See vips_embed(), vips_conv(), vips_affine() and so on.
+ * See [method@Image.embed], [method@Image.conv], [method@Image.affine] and so on.
  *
  * When the edges of an image are extended, you can specify
  * how you want the extension done.
@@ -272,7 +277,8 @@
  * We have to specify the exact value of each enum member since we have to
  * keep these frozen for back compat with vips7.
  *
- * See also: vips_embed().
+ * ::: seealso
+ *     [method@Image.embed].
  */
 
 /**
@@ -280,12 +286,13 @@
  * @VIPS_DIRECTION_HORIZONTAL: left-right
  * @VIPS_DIRECTION_VERTICAL: top-bottom
  *
- * See vips_flip(), vips_join() and so on.
+ * See [method@Image.flip], [method@Image.join] and so on.
  *
- * Operations like vips_flip() need to be told whether to flip left-right or
+ * Operations like [method@Image.flip] need to be told whether to flip left-right or
  * top-bottom.
  *
- * See also: vips_flip(), vips_join().
+ * ::: seealso
+ *     [method@Image.flip], [method@Image.join].
  */
 
 G_DEFINE_ABSTRACT_TYPE(VipsConversion, vips_conversion, VIPS_TYPE_OPERATION);

--- a/libvips/conversion/copy.c
+++ b/libvips/conversion/copy.c
@@ -364,19 +364,6 @@ vips_copy_init(VipsCopy *copy)
  * @out: (out): output image
  * @...: %NULL-terminated list of optional named arguments
  *
- * Optional arguments:
- *
- * * @width: %gint, set image width
- * * @height: %gint, set image height
- * * @bands: %gint, set image bands
- * * @format: #VipsBandFormat, set image format
- * * @coding: #VipsCoding, set image coding
- * * @interpretation: #VipsInterpretation, set image interpretation
- * * @xres: %gdouble, set image xres
- * * @yres: %gdouble, set image yres
- * * @xoffset: %gint, set image xoffset
- * * @yoffset: %gint, set image yoffset
- *
  * Copy an image, optionally modifying the header. VIPS copies images by
  * copying pointers, so this operation is instant, even for very large images.
  *
@@ -385,7 +372,21 @@ vips_copy_init(VipsCopy *copy)
  * you can turn a 4-band uchar image into a 2-band ushort image, but you
  * cannot change a 100 x 100 RGB image into a 300 x 100 mono image.
  *
- * See also: vips_byteswap(), vips_bandfold(), vips_bandunfold().
+ * ::: tip "Optional arguments"
+ *     * @width: %gint, set image width
+ *     * @height: %gint, set image height
+ *     * @bands: %gint, set image bands
+ *     * @format: [enum@BandFormat], set image format
+ *     * @coding: [enum@Coding], set image coding
+ *     * @interpretation: [enum@Interpretation], set image interpretation
+ *     * @xres: %gdouble, set image xres
+ *     * @yres: %gdouble, set image yres
+ *     * @xoffset: %gint, set image xoffset
+ *     * @yoffset: %gint, set image yoffset
+ *
+ * ::: seealso
+ *     [method@Image.byteswap], [method@Image.bandfold],
+ *     [method@Image.bandunfold].
  *
  * Returns: 0 on success, -1 on error.
  */
@@ -412,10 +413,11 @@ vips_copy(VipsImage *in, VipsImage **out, ...)
  * again to output. If the image is already a file, just copy straight
  * through.
  *
- * The file is allocated with vips_image_new_temp_file().
+ * The file is allocated with [ctor@Image.new_temp_file].
  * The file is automatically deleted when @out is closed.
  *
- * See also: vips_copy(), vips_image_new_temp_file().
+ * ::: seealso
+ *     [method@Image.copy], [ctor@Image.new_temp_file].
  *
  * Returns: 0 on success, -1 on error
  */

--- a/libvips/conversion/embed.c
+++ b/libvips/conversion/embed.c
@@ -682,18 +682,17 @@ vips_embed_init(VipsEmbed *embed)
  * @height: @out should be this many pixels down
  * @...: %NULL-terminated list of optional named arguments
  *
- * Optional arguments:
+ * The opposite of [method@Image.extract_area]: embed @in within an image of
+ * size @width by @height at position @x, @y.
  *
- * * @extend: #VipsExtend to generate the edge pixels (default: black)
- * * @background: #VipsArrayDouble colour for edge pixels
+ * @extend controls what appears in the new pels, see [enum@Extend].
  *
- * The opposite of vips_extract_area(): embed @in within an image of size
- * @width by @height at position @x, @y.
+ * ::: tip "Optional arguments"
+ *     * @extend: [enum@Extend] to generate the edge pixels (default: black)
+ *     * @background: [struct@ArrayDouble] colour for edge pixels
  *
- * @extend
- * controls what appears in the new pels, see #VipsExtend.
- *
- * See also: vips_extract_area(), vips_insert().
+ * ::: seealso
+ *     [method@Image.extract_area], [method@Image.insert].
  *
  * Returns: 0 on success, -1 on error.
  */
@@ -830,18 +829,17 @@ vips_gravity_init(VipsGravity *gravity)
  * @height: @out should be this many pixels down
  * @...: %NULL-terminated list of optional named arguments
  *
- * Optional arguments:
+ * The opposite of [method@Image.extract_area]: place @in within an image of
+ * size @width by @height at a certain gravity.
  *
- * * @extend: #VipsExtend to generate the edge pixels (default: black)
- * * @background: #VipsArrayDouble colour for edge pixels
+ * @extend controls what appears in the new pels, see #VipsExtend.
  *
- * The opposite of vips_extract_area(): place @in within an image of size
- * @width by @height at a certain gravity.
+ * ::: tip "Optional arguments"
+ *     * @extend: #VipsExtend to generate the edge pixels (default: black)
+ *     * @background: [struct@ArrayDouble] colour for edge pixels
  *
- * @extend
- * controls what appears in the new pels, see #VipsExtend.
- *
- * See also: vips_extract_area(), vips_insert().
+ * ::: seealso
+ *     [method@Image.extract_area], [method@Image.insert].
  *
  * Returns: 0 on success, -1 on error.
  */

--- a/libvips/conversion/extract.c
+++ b/libvips/conversion/extract.c
@@ -250,7 +250,8 @@ vips_extract_area_init(VipsExtractArea *extract)
  *
  * Extract an area from an image. The area must fit within @in.
  *
- * See also: vips_extract_bands(), vips_smartcrop().
+ * ::: seealso
+ *     [method@Image.extract_band], [method@Image.smartcrop].
  *
  * Returns: 0 on success, -1 on error.
  */
@@ -306,9 +307,10 @@ vips_crop_get_type(void)
  * @height: height of area to extract
  * @...: %NULL-terminated list of optional named arguments
  *
- * A synonym for vips_extract_area().
+ * A synonym for [method@Image.extract_area].
  *
- * See also: vips_extract_bands(), vips_smartcrop().
+ * ::: seealso
+ *     [method@Image.extract_band], [method@Image.smartcrop].
  *
  * Returns: 0 on success, -1 on error.
  */
@@ -462,15 +464,15 @@ vips_extract_band_init(VipsExtractBand *extract)
  * @band: index of first band to extract
  * @...: %NULL-terminated list of optional named arguments
  *
- * Optional arguments:
- *
- * * @n: number of bands to extract
- *
  * Extract a band or bands from an image. Extracting out of range is an error.
  *
  * @n defaults to 1.
  *
- * See also: vips_extract_area().
+ * ::: tip "Optional arguments"
+ *     * @n: %gint, number of bands to extract
+ *
+ * ::: seealso
+ *     [method@Image.extract_area].
  *
  * Returns: 0 on success, -1 on error.
  */

--- a/libvips/conversion/falsecolour.c
+++ b/libvips/conversion/falsecolour.c
@@ -399,7 +399,8 @@ vips_falsecolour_init(VipsFalsecolour *falsecolour)
  * map. The map is supposed to make small differences in brightness more
  * obvious.
  *
- * See also: vips_maplut().
+ * ::: seealso
+ *     [method@Image.maplut].
  *
  * Returns: 0 on success, -1 on error
  */

--- a/libvips/conversion/flatten.c
+++ b/libvips/conversion/flatten.c
@@ -6,7 +6,7 @@
  * 4/1/14
  * 	- better rounding
  * 9/5/15
- * 	- add max_alpha to match vips_premultiply() etc.
+ * 	- add max_alpha to match [method@Image.premultiply] etc.
  * 25/5/16
  * 	- max_alpha defaults to 65535 for RGB16/GREY16
  * 12/9/21
@@ -449,11 +449,6 @@ vips_flatten_init(VipsFlatten *flatten)
  * @out: (out): output image
  * @...: %NULL-terminated list of optional named arguments
  *
- * Optional arguments:
- *
- * * @background: #VipsArrayDouble colour for new pixels
- * * @max_alpha: %gdouble, maximum value for alpha
- *
  * Take the last band of @in as an alpha and use it to blend the
  * remaining channels with @background.
  *
@@ -461,14 +456,18 @@ vips_flatten_init(VipsFlatten *flatten)
  * and 0 means 100% background. @background defaults to zero (black).
  *
  * @max_alpha has the default value 255, or 65535 for images tagged as
- * #VIPS_INTERPRETATION_RGB16 or
- * #VIPS_INTERPRETATION_GREY16.
+ * [enum@Vips.Interpretation.RGB16] or [enum@Vips.Interpretation.GREY16].
  *
  * Useful for flattening PNG images to RGB.
  *
  * Non-complex images only.
  *
- * See also: vips_premultiply(), vips_pngload().
+ * ::: tip "Optional arguments"
+ *     * @background: [struct@ArrayDouble] colour for new pixels
+ *     * @max_alpha: %gdouble, maximum value for alpha
+ *
+ * ::: seealso
+ *     [method@Image.premultiply], [ctor@Image.pngload].
  *
  * Returns: 0 on success, -1 on error
  */

--- a/libvips/conversion/flip.c
+++ b/libvips/conversion/flip.c
@@ -264,7 +264,8 @@ vips_flip_init(VipsFlip *flip)
  *
  * Flips an image left-right or up-down.
  *
- * See also: vips_rot().
+ * ::: seealso
+ *     [method@Image.rot].
  *
  * Returns: 0 on success, -1 on error
  */

--- a/libvips/conversion/gamma.c
+++ b/libvips/conversion/gamma.c
@@ -164,14 +164,14 @@ vips_gamma_init(VipsGamma *gamma)
  * @out: (out): output image
  * @...: %NULL-terminated list of optional named arguments
  *
- * Optional arguments:
- *
- * * @exponent: gamma, default 1.0 / 2.4
- *
  * Calculate @in ** (1 / @exponent), normalising to the maximum range of the
  * input type. For float types use 1.0 as the maximum.
  *
- * See also: vips_identity(), vips_pow_const1(), vips_maplut()
+ * ::: tip "Optional arguments"
+ *     * @exponent: %gdouble, gamma, default 1.0 / 2.4
+ *
+ * ::: seealso
+ *     [ctor@Image.identity], [method@Image.pow_const1], [method@Image.maplut]
  *
  * Returns: 0 on success, -1 on error
  */

--- a/libvips/conversion/grid.c
+++ b/libvips/conversion/grid.c
@@ -252,7 +252,8 @@ vips_grid_init(VipsGrid *grid)
  * only really need two of these. Requiring three is a double-check that the
  * image has the expected geometry.
  *
- * See also: vips_embed(), vips_insert(), vips_join().
+ * ::: seealso
+ *     [method@Image.embed], [method@Image.insert], [method@Image.join].
  *
  * Returns: 0 on success, -1 on error
  */

--- a/libvips/conversion/ifthenelse.c
+++ b/libvips/conversion/ifthenelse.c
@@ -558,15 +558,11 @@ vips_ifthenelse_init(VipsIfthenelse *ifthenelse)
 
 /**
  * vips_ifthenelse: (method)
- * @cond: condition #VipsImage
- * @in1: then #VipsImage
- * @in2: else #VipsImage
- * @out: (out): output #VipsImage
+ * @cond: condition [class@Image]
+ * @in1: then [class@Image]
+ * @in2: else [class@Image]
+ * @out: (out): output [class@Image]
  * @...: %NULL-terminated list of optional named arguments
- *
- * Optional arguments:
- *
- * * @blend: blend smoothly between @in1 and @in2
  *
  * This operation scans the condition image @cond
  * and uses it to select pixels from either the then image @in1 or the else
@@ -585,9 +581,15 @@ vips_ifthenelse_init(VipsIfthenelse *ifthenelse)
  * If @blend is %TRUE, then values in @out are smoothly blended between @in1
  * and @in2 using the formula:
  *
- *   @out = (@cond / 255) * @in1 + (1 - @cond / 255) * @in2
+ * ```
+ *     out = (cond / 255) * in1 + (1 - cond / 255) * in2
+ * ```
  *
- * See also: vips_equal().
+ * ::: tip "Optional arguments"
+ *     * @blend: %gboolean, blend smoothly between @in1 and @in2
+ *
+ * ::: seealso
+ *     [method@Image.equal].
  *
  * Returns: 0 on success, -1 on error
  */

--- a/libvips/conversion/insert.c
+++ b/libvips/conversion/insert.c
@@ -520,11 +520,6 @@ vips_insert_init(VipsInsert *insert)
  * @y: top position of @sub
  * @...: %NULL-terminated list of optional named arguments
  *
- * Optional arguments:
- *
- * * @expand: expand output to hold whole of both images
- * * @background: colour for new pixels
- *
  * Insert @sub into @main at position @x, @y.
  *
  * Normally @out shows the whole of @main. If @expand is #TRUE then @out is
@@ -544,7 +539,12 @@ vips_insert_init(VipsInsert *insert)
  * Smallest common format in
  * <link linkend="libvips-arithmetic">arithmetic</link>).
  *
- * See also: vips_join(), vips_embed(), vips_extract_area().
+ * ::: tip "Optional arguments"
+ *     * @expand: %gdouble, expand output to hold whole of both images
+ *     * @background: [struct@ArrayDouble], colour for new pixels
+ *
+ * ::: seealso
+ *     [method@Image.join], [method@Image.embed], [method@Image.extract_area].
  *
  * Returns: 0 on success, -1 on error
  */

--- a/libvips/conversion/join.c
+++ b/libvips/conversion/join.c
@@ -284,8 +284,6 @@ vips_join_class_init(VipsJoinClass *class)
 static void
 vips_join_init(VipsJoin *join)
 {
-	/* Init our instance fields.
-	 */
 	join->background = vips_array_double_newv(1, 0.0);
 }
 
@@ -296,13 +294,6 @@ vips_join_init(VipsJoin *join)
  * @out: (out): output image
  * @direction: join horizontally or vertically
  * @...: %NULL-terminated list of optional named arguments
- *
- * Optional arguments:
- *
- * * @expand: %TRUE to expand the output image to hold all of the input pixels
- * * @shim: space between images, in pixels
- * * @background: background ink colour
- * * @align: low, centre or high alignment
  *
  * Join @in1 and @in2 together, left-right or up-down depending on the value
  * of @direction.
@@ -329,9 +320,17 @@ vips_join_init(VipsJoin *join)
  * <link linkend="libvips-arithmetic">arithmetic</link>).
  *
  * If you are going to be joining many thousands of images in a regular
- * grid, vips_arrayjoin() is a better choice.
+ * grid, [func@Image.arrayjoin] is a better choice.
  *
- * See also: vips_arrayjoin(), vips_insert().
+ * ::: tip "Optional arguments"
+ *     * @expand: %gboolean, %TRUE to expand the output image to hold all of
+ *       the input pixels
+ *     * @shim: %gint, space between images, in pixels
+ *     * @background: [struct@ArrayDouble], background ink colour
+ *     * @align: [enumAlign], low, centre or high alignment
+ *
+ * ::: seealso
+ *     [func@Image.arrayjoin], [method@Image.insert].
  *
  * Returns: 0 on success, -1 on error
  */

--- a/libvips/conversion/msb.c
+++ b/libvips/conversion/msb.c
@@ -269,10 +269,6 @@ vips_msb_init(VipsMsb *msb)
  * @out: (out): output image
  * @...: %NULL-terminated list of optional named arguments
  *
- * Optional arguments:
- *
- * * @band: %gint, msb just this band
- *
  * Turn any integer image to 8-bit unsigned char by discarding all but the most
  * significant byte. Signed values are converted to unsigned by adding 128.
  *
@@ -280,7 +276,11 @@ vips_msb_init(VipsMsb *msb)
  *
  * This operator also works for LABQ coding.
  *
- * See also: vips_scale(), vips_cast().
+ * ::: tip "Optional arguments"
+ *     * @band: %gint, msb just this band
+ *
+ * ::: seealso
+ *     [method@Image.scale], [method@Image.cast].
  *
  * Returns: 0 on success, -1 on error.
  */

--- a/libvips/conversion/premultiply.c
+++ b/libvips/conversion/premultiply.c
@@ -283,19 +283,15 @@ vips_premultiply_init(VipsPremultiply *premultiply)
  * @out: (out): output image
  * @...: %NULL-terminated list of optional named arguments
  *
- * Optional arguments:
- *
- * * @max_alpha: %gdouble, maximum value for alpha
- *
  * Premultiplies any alpha channel.
- * The final band is taken to be the alpha
- * and the bands are transformed as:
  *
- * |[
- *   alpha = clip(0, in[in.bands - 1], @max_alpha);
- *   norm = alpha / @max_alpha;
- *   out = [in[0] * norm, ..., in[in.bands - 1] * norm, alpha];
- * ]|
+ * The final band is taken to be the alpha and the bands are transformed as:
+ *
+ * ```
+ *   alpha = clip(0, in[in.bands - 1], max_alpha)
+ *   norm = alpha / max_alpha
+ *   out = [in[0] * norm, ..., in[in.bands - 1] * norm, alpha]
+ * ```
  *
  * So for an N-band image, the first N - 1 bands are multiplied by the clipped
  * and normalised final band, the final band is clipped.
@@ -303,16 +299,20 @@ vips_premultiply_init(VipsPremultiply *premultiply)
  * the image is passed through unaltered.
  *
  * The result is
- * #VIPS_FORMAT_FLOAT unless the input format is #VIPS_FORMAT_DOUBLE, in which
- * case the output is double as well.
+ * [enum@Vips.BandFormat.FLOAT] unless the input format is
+ * [enum@Vips.BandFormat.DOUBLE], in which case the output is double as well.
  *
  * @max_alpha has the default value 255, or 65535 for images tagged as
- * #VIPS_INTERPRETATION_RGB16 or
- * #VIPS_INTERPRETATION_GREY16.
+ * [enum@Vips.Interpretation.RGB16] or [enum@Vips.Interpretation.GREY16], and
+ * 1.0 for images tagged as [enum@Vips.Interpretation.scRGB].
  *
  * Non-complex images only.
  *
- * See also: vips_unpremultiply(), vips_flatten().
+ * ::: tip "Optional arguments"
+ *     * @max_alpha: %gdouble, maximum value for alpha
+ *
+ * ::: seealso
+ *     [method@Image.unpremultiply], [method@Image.flatten].
  *
  * Returns: 0 on success, -1 on error
  */

--- a/libvips/conversion/recomb.c
+++ b/libvips/conversion/recomb.c
@@ -254,7 +254,8 @@ vips_recomb_init(VipsRecomb *recomb)
  *
  * It's useful for various sorts of colour space conversions.
  *
- * See also: vips_bandmean().
+ * ::: seealso
+ *     [method@Image.bandmean].
  *
  * Returns: 0 on success, -1 on error
  */

--- a/libvips/conversion/replicate.c
+++ b/libvips/conversion/replicate.c
@@ -228,7 +228,8 @@ vips_replicate_init(VipsReplicate *replicate)
  *
  * Repeats an image many times.
  *
- * See also: vips_extract_area().
+ * ::: seealso
+ *     [method@Image.extract_area].
  *
  * Returns: 0 on success, -1 on error
  */

--- a/libvips/conversion/rot.c
+++ b/libvips/conversion/rot.c
@@ -395,10 +395,11 @@ vips_rotv(VipsImage *in, VipsImage **out, VipsAngle angle, va_list ap)
  *
  * Rotate @in by a multiple of 90 degrees.
  *
- * Use vips_similarity() to rotate by an arbitrary angle. vips_rot45() is
- * useful for rotating convolution masks by 45 degrees.
+ * Use [method@Image.similarity] to rotate by an arbitrary angle.
+ * [method@Image.rot45] is useful for rotating convolution masks by 45 degrees.
  *
- * See also: vips_flip(), vips_similarity(), vips_rot45().
+ * ::: seealso
+ *     [method@Image.flip], [method@Image.similarity], [method@Image.rot45].
  *
  * Returns: 0 on success, -1 on error
  */
@@ -421,9 +422,10 @@ vips_rot(VipsImage *in, VipsImage **out, VipsAngle angle, ...)
  * @out: output image
  * @...: %NULL-terminated list of optional named arguments
  *
- * Rotate @in by 90 degrees clockwise. A convenience function over vips_rot().
+ * Rotate @in by 90 degrees clockwise. A convenience function over [method@Image.rot].
  *
- * See also: vips_rot().
+ * ::: seealso
+ *     [method@Image.rot].
  *
  * Returns: 0 on success, -1 on error
  */
@@ -446,9 +448,10 @@ vips_rot90(VipsImage *in, VipsImage **out, ...)
  * @out: (out): output image
  * @...: %NULL-terminated list of optional named arguments
  *
- * Rotate @in by 180 degrees. A convenience function over vips_rot().
+ * Rotate @in by 180 degrees. A convenience function over [method@Image.rot].
  *
- * See also: vips_rot().
+ * ::: seealso
+ *     [method@Image.rot].
  *
  * Returns: 0 on success, -1 on error
  */
@@ -471,9 +474,10 @@ vips_rot180(VipsImage *in, VipsImage **out, ...)
  * @out: (out): output image
  * @...: %NULL-terminated list of optional named arguments
  *
- * Rotate @in by 270 degrees clockwise. A convenience function over vips_rot().
+ * Rotate @in by 270 degrees clockwise. A convenience function over [method@Image.rot].
  *
- * See also: vips_rot().
+ * ::: seealso
+ *     [method@Image.rot].
  *
  * Returns: 0 on success, -1 on error
  */

--- a/libvips/conversion/rot45.c
+++ b/libvips/conversion/rot45.c
@@ -290,17 +290,17 @@ vips_rot45_init(VipsRot45 *rot45)
  * @out: (out): output image
  * @...: %NULL-terminated list of optional named arguments
  *
- * Optional arguments:
- *
- * * @angle: #VipsAngle45 rotation angle
- *
  * Rotate @in by a multiple of 45 degrees. Odd-length sides and square images
  * only.
  *
  * This operation is useful for rotating convolution masks. Use
- * vips_similarity() to rotate images by arbitrary angles.
+ * [method@Image.similarity] to rotate images by arbitrary angles.
  *
- * See also: vips_rot(), vips_similarity().
+ * ::: tip "Optional arguments"
+ *     * @angle: [enum@Angle45], rotation angle
+ *
+ * ::: seealso
+ *     [method@Image.rot], [method@Image.similarity].
  *
  * Returns: 0 on success, -1 on error
  */

--- a/libvips/conversion/scale.c
+++ b/libvips/conversion/scale.c
@@ -184,11 +184,6 @@ vips_scale_init(VipsScale *scale)
  * @out: (out): output image
  * @...: %NULL-terminated list of optional named arguments
  *
- * Optional arguments:
- *
- * * @log: log scale pixels
- * * @exp: exponent for log scale
- *
  * Search the image for the maximum and minimum value, then return the image
  * as unsigned 8-bit, scaled so that the maximum value is 255 and the
  * minimum is zero.
@@ -196,7 +191,12 @@ vips_scale_init(VipsScale *scale)
  * If @log is set, transform with log10(1.0 + pow(x, @exp)) + .5,
  * then scale so max == 255. By default, @exp is 0.25.
  *
- * See also: vips_cast().
+ * ::: tip "Optional arguments"
+ *     * @log: %gboolean, log scale pixels
+ *     * @exp: %gdouble, exponent for log scale
+ *
+ * ::: seealso
+ *     [method@Image.cast].
  *
  * Returns: 0 on success, -1 on error
  */

--- a/libvips/conversion/sequential.c
+++ b/libvips/conversion/sequential.c
@@ -282,19 +282,19 @@ vips_sequential_init(VipsSequential *sequential)
  * @out: (out): output image
  * @...: %NULL-terminated list of optional named arguments
  *
- * Optional arguments:
- *
- * * @tile_height: height of cache strips
- *
- * This operation behaves rather like vips_copy() between images
+ * This operation behaves rather like [method@Image.copy] between images
  * @in and @out, except that it checks that pixels on @in are only requested
  * top-to-bottom. This operation is useful for loading file formats which are
  * strictly top-to-bottom, like PNG.
  *
  * @tile_height can be used to set the size of the tiles that
- * vips_sequential() uses. The default value is 1.
+ * [method@Image.sequential] uses. The default value is 1.
  *
- * See also: vips_cache(), vips_linecache(), vips_tilecache().
+ * ::: tip "Optional arguments"
+ *     * @tile_height: %gint, height of cache strips
+ *
+ * ::: seealso
+ *     [method@Image.linecache], [method@Image.tilecache].
  *
  * Returns: 0 on success, -1 on error.
  */

--- a/libvips/conversion/smartcrop.c
+++ b/libvips/conversion/smartcrop.c
@@ -493,13 +493,6 @@ vips_smartcrop_init(VipsSmartcrop *smartcrop)
  * @height: height of area to extract
  * @...: %NULL-terminated list of optional named arguments
  *
- * Optional arguments:
- *
- * * @interesting: #VipsInteresting to use to find interesting areas (default: #VIPS_INTERESTING_ATTENTION)
- * * @premultiplied: %gboolean, input image already has premultiplied alpha
- * * @attention_x: %gint, horizontal position of attention centre when using attention based cropping
- * * @attention_y: %gint, vertical position of attention centre when using attention based cropping
- *
  * Crop an image down to a specified width and height by removing boring parts.
  *
  * Use @interesting to pick the method vips uses to decide which bits of the
@@ -508,7 +501,17 @@ vips_smartcrop_init(VipsSmartcrop *smartcrop)
  * You can test xoffset / yoffset on @out to find the location of the crop
  * within the input image.
  *
- * See also: vips_extract_area().
+ * ::: tip "Optional arguments"
+ *     * @interesting: [enum@Interesting] to use to find interesting areas
+ *       (default: [enum@Vips.Interesting.ATTENTION])
+ *     * @premultiplied: %gboolean, input image already has premultiplied alpha
+ *     * @attention_x: %gint, horizontal position of attention centre when
+ *       using attention based cropping (output)
+ *     * @attention_y: %gint, vertical position of attention centre when
+ *       using attention based cropping (output)
+ *
+ * ::: seealso
+ *     [method@Image.extract_area].
  *
  * Returns: 0 on success, -1 on error.
  */

--- a/libvips/conversion/subsample.c
+++ b/libvips/conversion/subsample.c
@@ -14,7 +14,7 @@
  * 2/11/13
  * 	- add @point to force point sample mode
  * 22/1/16
- * 	- remove SEQUENTIAL hint, it confuses vips_sequential()
+ * 	- remove SEQUENTIAL hint, it confuses [method@Image.sequential]
  */
 
 /*
@@ -260,7 +260,7 @@ vips_subsample_class_init(VipsSubsampleClass *class)
 	vobject_class->build = vips_subsample_build;
 
 	/* We don't work well as sequential: we can easily skip the first few
-	 * scanlines, and that confuses vips_sequential().
+	 * scanlines, and that confuses [method@Image.sequential].
 	 */
 
 	VIPS_ARG_IMAGE(class, "input", 1,
@@ -304,10 +304,6 @@ vips_subsample_init(VipsSubsample *subsample)
  * @yfac: vertical shrink factor
  * @...: %NULL-terminated list of optional named arguments
  *
- * Optional arguments:
- *
- * * @point: turn on point sample mode
- *
  * Subsample an image by an integer fraction. This is fast, nearest-neighbour
  * shrink.
  *
@@ -318,7 +314,11 @@ vips_subsample_init(VipsSubsample *subsample)
  * If @point is set, @in will always be sampled in points. This can be faster
  * if the previous operations in the pipeline are very slow.
  *
- * See also: vips_affine(), vips_shrink(), vips_zoom().
+ * ::: tip "Optional arguments"
+ *     * @point: %gboolean, turn on point sample mode
+ *
+ * ::: seealso
+ *     [method@Image.affine], [method@Image.shrink], [method@Image.zoom].
  *
  * Returns: 0 on success, -1 on error.
  */

--- a/libvips/conversion/switch.c
+++ b/libvips/conversion/switch.c
@@ -238,9 +238,10 @@ vips_switchv(VipsImage **tests, VipsImage **out, int n, va_list ap)
  * bounding box of the set of images in @tests, and that size is used for
  * @out. @tests can have up to 255 elements.
  *
- * Combine with vips_case() to make an efficient multi-way vips_ifthenelse().
+ * Combine with [method@Image.case] to make an efficient multi-way [method@Image.ifthenelse].
  *
- * See also: vips_maplut(), vips_case(), vips_ifthenelse().
+ * ::: seealso
+ *     [method@Image.maplut], [method@Image.case], [method@Image.ifthenelse].
  *
  * Returns: 0 on success, -1 on error
  */

--- a/libvips/conversion/tilecache.c
+++ b/libvips/conversion/tilecache.c
@@ -822,40 +822,41 @@ vips_tile_cache_init(VipsTileCache *cache)
  * @out: (out): output image
  * @...: %NULL-terminated list of optional named arguments
  *
- * Optional arguments:
  *
- * * @tile_width: width of tiles in cache
- * * @tile_height: height of tiles in cache
- * * @max_tiles: maximum number of tiles to cache
- * * @access: hint expected access pattern #VipsAccess
- * * @threaded: allow many threads
- * * @persistent: don't drop cache at end of computation
- *
- * This operation behaves rather like vips_copy() between images
+ * This operation behaves rather like [method@Image.copy] between images
  * @in and @out, except that it keeps a cache of computed pixels.
  * This cache is made of up to @max_tiles tiles (a value of -1
  * means any number of tiles), and each tile is of size @tile_width
  * by @tile_height pixels.
  *
  * Each cache tile is made with a single call to
- * vips_region_prepare().
+ * [method@Region.prepare].
  *
  * When the cache fills, a tile is chosen for reuse. If @access is
- * #VIPS_ACCESS_RANDOM, then the least-recently-used tile is reused. If
- * @access is #VIPS_ACCESS_SEQUENTIAL
+ * [enum@Vips.Access.RANDOM], then the least-recently-used tile is reused. If
+ * @access is [enum@Vips.Access.SEQUENTIAL]
  * the top-most tile is reused.
  *
  * By default, @tile_width and @tile_height are 128 pixels, and the operation
- * will cache up to 1,000 tiles. @access defaults to #VIPS_ACCESS_RANDOM.
+ * will cache up to 1,000 tiles. @access defaults to [enum@Vips.Access.RANDOM].
  *
  * Normally, only a single thread at once is allowed to calculate tiles. If
- * you set @threaded to %TRUE, vips_tilecache() will allow many threads to
- * calculate tiles at once, and share the cache between them.
+ * you set @threaded to %TRUE, [method@Image.tilecache] will allow many
+ * threads to calculate tiles at once, and share the cache between them.
  *
  * Normally the cache is dropped when computation finishes. Set @persistent to
  * %TRUE to keep the cache between computations.
  *
- * See also: vips_cache(), vips_linecache().
+ * ::: tip "Optional arguments"
+ *     * @tile_width: %gint, width of tiles in cache
+ *     * @tile_height: %gint, height of tiles in cache
+ *     * @max_tiles: %gint, maximum number of tiles to cache
+ *     * @access: [enum@Access], hint expected access pattern
+ *     * @threaded: %gboolean, allow many threads
+ *     * @persistent: %gboolean, don't drop cache at end of computation
+ *
+ * ::: seealso
+ *     [method@Image.linecache].
  *
  * Returns: 0 on success, -1 on error.
  */
@@ -995,34 +996,33 @@ vips_line_cache_init(VipsLineCache *cache)
  * @out: (out): output image
  * @...: %NULL-terminated list of optional named arguments
  *
- * Optional arguments:
- *
- * * @access: hint expected access pattern #VipsAccess
- * * @tile_height: height of tiles in cache
- * * @threaded: allow many threads
- *
- * This operation behaves rather like vips_copy() between images
+ * This operation behaves rather like [method@Image.copy] between images
  * @in and @out, except that it keeps a cache of computed scanlines.
  *
  * The number of lines cached is enough for a small amount of non-local
  * access.
  *
- * Each cache tile is made with a single call to
- * vips_region_prepare().
+ * Each cache tile is made with a single call to [method@Region.prepare].
  *
  * When the cache fills, a tile is chosen for reuse. If @access is
- * #VIPS_ACCESS_RANDOM, then the least-recently-used tile is reused. If
- * @access is #VIPS_ACCESS_SEQUENTIAL, then
- * the top-most tile is reused. @access defaults to #VIPS_ACCESS_RANDOM.
+ * [enum@Vips.Access.RANDOM], then the least-recently-used tile is reused. If
+ * @access is [enum@Vips.Access.SEQUENTIAL], then
+ * the top-most tile is reused. @access defaults to [enum@Vips.Access.RANDOM].
  *
  * @tile_height can be used to set the size of the strips that
- * vips_linecache() uses. The default is 1 (a single scanline).
+ * [method@Image.linecache] uses. The default is 1 (a single scanline).
  *
  * Normally, only a single thread at once is allowed to calculate tiles. If
- * you set @threaded to %TRUE, vips_linecache() will allow many threads to
- * calculate tiles at once and share the cache between them.
+ * you set @threaded to %TRUE, [method@Image.linecache] will allow many
+ * threads to calculate tiles at once and share the cache between them.
  *
- * See also: vips_cache(), vips_tilecache().
+ * ::: tip "Optional arguments"
+ *     * @access: [enum@Access], hint expected access pattern
+ *     * @tile_height: %gint, height of tiles in cache
+ *     * @threaded: %gboolean, allow many threads
+ *
+ * ::: seealso
+ *     [method@Image.tilecache].
  *
  * Returns: 0 on success, -1 on error.
  */

--- a/libvips/conversion/transpose3d.c
+++ b/libvips/conversion/transpose3d.c
@@ -188,10 +188,6 @@ vips_transpose3d_init(VipsTranspose3d *transpose3d)
  * @out: (out): output image
  * @...: %NULL-terminated list of optional named arguments
  *
- * Optional arguments:
- *
- * * @page_height: %gint, size of each input page
- *
  * Transpose a volumetric image.
  *
  * Volumetric images are very tall, thin images, with the metadata item
@@ -206,7 +202,11 @@ vips_transpose3d_init(VipsTranspose3d *transpose3d)
  * #VIPS_META_PAGE_HEIGHT in the output image is the number of pages in the
  * input image.
  *
- * See also: vips_grid().
+ * ::: tip "Optional arguments"
+ *     * @page_height: %gint, size of each input page
+ *
+ * ::: seealso
+ *     [method@Image.grid].
  *
  * Returns: 0 on success, -1 on error
  */

--- a/libvips/conversion/unpremultiply.c
+++ b/libvips/conversion/unpremultiply.c
@@ -352,39 +352,39 @@ vips_unpremultiply_init(VipsUnpremultiply *unpremultiply)
  * @out: (out): output image
  * @...: %NULL-terminated list of optional named arguments
  *
- * Optional arguments:
- *
- * * @max_alpha: %gdouble, maximum value for alpha
- * * @alpha_band: %gint, band containing alpha data
- *
  * Unpremultiplies any alpha channel.
+ *
  * Band @alpha_band (by default the final band) contains the alpha and all
  * other bands are transformed as:
  *
- * |[
- *   alpha = (int) clip(0, in[in.bands - 1], @max_alpha);
- *   norm = (double) alpha / @max_alpha;
+ * ```
+ *   alpha = (int) clip(0, in[in.bands - 1], max_alpha);
+ *   norm = (double) alpha / max_alpha
  *   if (alpha == 0)
- *   	out = [0, ..., 0, alpha];
+ *   	out = [0, ..., 0, alpha]
  *   else
- *   	out = [in[0] / norm, ..., in[in.bands - 1] / norm, alpha];
- * ]|
+ *   	out = [in[0] / norm, ..., in[in.bands - 1] / norm, alpha]
+ * ```
  *
  * So for an N-band image, the first N - 1 bands are divided by the clipped
  * and normalised final band, the final band is clipped.
  * If there is only a single band, the image is passed through unaltered.
  *
- * The result is
- * #VIPS_FORMAT_FLOAT unless the input format is #VIPS_FORMAT_DOUBLE, in which
- * case the output is double as well.
+ * The result is [enum@Vips.BandFormat.FLOAT] unless the input format is
+ * [enum@Vips.BandFormat.DOUBLE], in which case the output is double as well.
  *
  * @max_alpha has the default value 255, or 65535 for images tagged as
- * #VIPS_INTERPRETATION_RGB16 or
- * #VIPS_INTERPRETATION_GREY16.
+ * [enum@Vips.Interpretation.RGB16] or [enum@Vips.Interpretation.GREY16], and
+ * 1.0 for images tagged as  [enum@Vips.Interpretation.scRGB.
  *
  * Non-complex images only.
  *
- * See also: vips_premultiply(), vips_flatten().
+ * ::: tip "Optional arguments"
+ *     * @max_alpha: %gdouble, maximum value for alpha
+ *     * @alpha_band: %gint, band containing alpha data
+ *
+ * ::: seealso
+ *     [method@Image.premultiply], [method@Image.flatten].
  *
  * Returns: 0 on success, -1 on error
  */

--- a/libvips/conversion/wrap.c
+++ b/libvips/conversion/wrap.c
@@ -147,16 +147,17 @@ vips_wrap_init(VipsWrap *wrap)
  * @out: (out): output image
  * @...: %NULL-terminated list of optional named arguments
  *
- * Optional arguments:
- *
- * * @x: horizontal displacement
- * * @y: vertical displacement
- *
  * Slice an image up and move the segments about so that the pixel that was
- * at 0, 0 is now at @x, @y. If @x and @y are not set, they default to the
- * centre of the image.
+ * at 0, 0 is now at @x, @y.
  *
- * See also: vips_embed(), vips_replicate().
+ * If @x and @y are not set, they default to the centre of the image.
+ *
+ * ::: tip "Optional arguments"
+ *     * @x: horizontal displacement
+ *     * @y: vertical displacement
+ *
+ * ::: seealso
+ *     [method@Image.embed], [method@Image.replicate].
  *
  * Returns: 0 on success, -1 on error
  */

--- a/libvips/conversion/zoom.c
+++ b/libvips/conversion/zoom.c
@@ -406,7 +406,8 @@ vips_zoom_init(VipsZoom *zoom)
  * Zoom an image by repeating pixels. This is fast nearest-neighbour
  * zoom.
  *
- * See also: vips_affine(), vips_subsample().
+ * ::: seealso
+ *     [method@Image.affine], [method@Image.subsample].
  *
  * Returns: 0 on success, -1 on error.
  */


### PR DESCRIPTION
update conversion docs to new format, revise arithmetic and colour

I added "optional arg" annotations as tips (not notes), and moved then to the end of the comment block:

![image](https://github.com/user-attachments/assets/7c5da1ec-8829-452c-8f73-d36cf8dab1e8)

- using tips makes them look different from seealso
- the first para of a doc comment is supposed to be a one-line summary, so we can't put optional args there, unfortunately

The Image class page now looks like:

![image](https://github.com/user-attachments/assets/172b6052-3e6e-4292-ba1a-335bce45ac77)

So ifthenelse now has a sensible description, though icc_transform does not.