### PR TITLE
fix delay metadata for webp and jxl save

### DIFF
--- a/libvips/foreign/cgifsave.c
+++ b/libvips/foreign/cgifsave.c
@@ -666,8 +666,7 @@ vips_foreign_save_cgif_write_frame(VipsForeignSaveCgif *cgif)
 
 	if (cgif->delay &&
 		cgif->page_number < cgif->delay_length)
-		frame_config.delay =
-			rint(cgif->delay[cgif->page_number] / 10.0);
+		frame_config.delay = rint(cgif->delay[cgif->page_number] / 10.0);
 
 	/* Attach a local palette, if we need one.
 	 */

--- a/libvips/foreign/jxlsave.c
+++ b/libvips/foreign/jxlsave.c
@@ -317,7 +317,7 @@ vips_foreign_save_jxl_get_delay(VipsForeignSaveJxl *jxl, int page_number)
 	/* Force frames with a small or no duration to 100ms for consistency
 	 * with web browsers and other transcoding tools.
 	 */
-	return VIPS_MIN(100, delay);
+	return delay <= 10 ? 100 : delay;
 }
 
 static int

--- a/libvips/foreign/jxlsave.c
+++ b/libvips/foreign/jxlsave.c
@@ -303,6 +303,24 @@ vips_foreign_save_jxl_process_output(VipsForeignSaveJxl *jxl)
 }
 
 static int
+vips_foreign_save_jxl_get_delay(VipsForeignSaveJxl *jxl, int page_number)
+{
+	int delay;
+
+	if (jxl->delay &&
+		page_number < jxl->delay_length)
+		delay = jxl->delay[page_number];
+	else
+		// the old gif delay field was in centiseconds, so convert to ms
+		delay = jxl->gif_delay * 10;
+
+	/* Force frames with a small or no duration to 100ms for consistency
+	 * with web browsers and other transcoding tools.
+	 */
+	return VIPS_MIN(100, delay);
+}
+
+static int
 vips_foreign_save_jxl_add_frame(VipsForeignSaveJxl *jxl)
 {
 #ifdef HAVE_LIBJXL_0_7
@@ -326,10 +344,9 @@ vips_foreign_save_jxl_add_frame(VipsForeignSaveJxl *jxl)
 
 		if (!jxl->is_animated)
 			header.duration = 0xffffffff;
-		else if (jxl->delay && jxl->page_number < jxl->delay_length)
-			header.duration = jxl->delay[jxl->page_number];
 		else
-			header.duration = jxl->gif_delay * 10;
+			header.duration =
+				vips_foreign_save_jxl_get_delay(jxl, jxl->page_number);
 
 		JxlEncoderSetFrameHeader(frame_settings, &header);
 	}
@@ -472,7 +489,6 @@ vips_foreign_save_jxl_build(VipsObject *object)
 
 	VipsImage *in;
 	VipsBandFormat format;
-	int i;
 
 	if (VIPS_OBJECT_CLASS(vips_foreign_save_jxl_parent_class)->build(object))
 		return -1;
@@ -696,8 +712,7 @@ vips_foreign_save_jxl_build(VipsObject *object)
 		 */
 		jxl->gif_delay = 10;
 		if (vips_image_get_typeof(save->ready, "gif-delay") &&
-			vips_image_get_int(save->ready, "gif-delay",
-				&jxl->gif_delay))
+			vips_image_get_int(save->ready, "gif-delay", &jxl->gif_delay))
 			return -1;
 
 		/* New images have an array of ints instead.
@@ -714,17 +729,6 @@ vips_foreign_save_jxl_build(VipsObject *object)
 		if (vips_image_get_typeof(save->ready, "delay") ||
 			vips_image_get_typeof(save->ready, "gif-delay"))
 			jxl->is_animated = TRUE;
-
-		/* Force frames with a small or no duration to 100ms
-		 * to be consistent with web browsers and other
-		 * transcoding tools.
-		 */
-		if (jxl->gif_delay <= 1)
-			jxl->gif_delay = 10;
-
-		for (i = 0; i < jxl->delay_length; i++)
-			if (jxl->delay[i] <= 10)
-				jxl->delay[i] = 100;
 	}
 
 #ifdef DEBUG

--- a/libvips/foreign/webpsave.c
+++ b/libvips/foreign/webpsave.c
@@ -294,6 +294,24 @@ vips_foreign_save_webp_write_webp_image(VipsForeignSaveWebp *webp,
 	return 0;
 }
 
+static int
+vips_foreign_save_webp_get_delay(VipsForeignSaveWebp *webp, int page_number)
+{
+	int delay;
+
+	if (webp->delay &&
+		page_number < webp->delay_length)
+		delay = webp->delay[page_number];
+	else
+		// the old gif delay field was in centiseconds, so convert to ms
+		delay = webp->gif_delay * 10;
+
+	/* Force frames with a small or no duration to 100ms for consistency
+	 * with web browsers and other transcoding tools.
+	 */
+	return VIPS_MIN(100, delay);
+}
+
 /* We have a complete frame --- write!
  */
 static int
@@ -318,11 +336,8 @@ vips_foreign_save_webp_write_frame(VipsForeignSaveWebp *webp)
 
 		/* Adjust current timestamp
 		 */
-		if (webp->delay &&
-			webp->page_number < webp->delay_length)
-			webp->timestamp_ms += webp->delay[webp->page_number];
-		else
-			webp->timestamp_ms += webp->gif_delay * 10;
+		webp->timestamp_ms +=
+			vips_foreign_save_webp_get_delay(webp, webp->page_number);
 	}
 	else {
 		/* Single image write
@@ -636,7 +651,6 @@ vips_foreign_save_webp_init_anim_enc(VipsForeignSaveWebp *webp)
 	int page_height = vips_image_get_page_height(save->ready);
 
 	WebPAnimEncoderOptions anim_config;
-	int i;
 
 	/* Init config for animated write
 	 */
@@ -659,30 +673,18 @@ vips_foreign_save_webp_init_anim_enc(VipsForeignSaveWebp *webp)
 	/* Get delay array
 	 *
 	 * There might just be the old gif-delay field. This is centiseconds.
+	 * New images have an array of ints giving millisecond durations.
 	 */
 	webp->gif_delay = 10;
 	if (vips_image_get_typeof(save->ready, "gif-delay") &&
 		vips_image_get_int(save->ready, "gif-delay", &webp->gif_delay))
 		return -1;
 
-	/* New images have an array of ints instead.
-	 */
 	webp->delay = NULL;
 	if (vips_image_get_typeof(save->ready, "delay") &&
 		vips_image_get_array_int(save->ready, "delay",
 			&webp->delay, &webp->delay_length))
 		return -1;
-
-	/* Force frames with a small or no duration to 100ms
-	 * to be consistent with web browsers and other
-	 * transcoding tools.
-	 */
-	if (webp->gif_delay <= 1)
-		webp->gif_delay = 10;
-
-	for (i = 0; i < webp->delay_length; i++)
-		if (webp->delay[i] <= 10)
-			webp->delay[i] = 100;
 
 	return 0;
 }

--- a/libvips/foreign/webpsave.c
+++ b/libvips/foreign/webpsave.c
@@ -309,7 +309,7 @@ vips_foreign_save_webp_get_delay(VipsForeignSaveWebp *webp, int page_number)
 	/* Force frames with a small or no duration to 100ms for consistency
 	 * with web browsers and other transcoding tools.
 	 */
-	return VIPS_MIN(100, delay);
+	return delay <= 10 ? 100 : delay;
 }
 
 /* We have a complete frame --- write!


### PR DESCRIPTION
we could modify a const pointer in some cases, causing unexpected side effects via the operation cache

see https://github.com/libvips/libvips/issues/4479