### PR TITLE
OSS-Fuzz: disable build of examples in spng

### DIFF
--- a/fuzz/oss_fuzz_build.sh
+++ b/fuzz/oss_fuzz_build.sh
@@ -103,7 +103,7 @@ popd
 # libspng
 pushd $SRC/libspng
 meson setup build --prefix=$WORK --libdir=lib --default-library=static --buildtype=debugoptimized \
-  -Dstatic_zlib=true
+  -Dstatic_zlib=true -Dbuild_examples=false
 meson install -C build --tag devel
 popd
 


### PR DESCRIPTION
Hopefully this would fix the failing CIFuzz build:
https://github.com/libvips/libvips/actions/runs/14728728549/job/41339474476