### PR TITLE
Revert "OSS-Fuzz: limit link jobs to 4 (#4108)"

### DIFF
--- a/fuzz/oss_fuzz_build.sh
+++ b/fuzz/oss_fuzz_build.sh
@@ -192,7 +192,7 @@ popd
 # Disable building man pages, gettext po files, tools, and tests
 sed -i "/subdir('man')/{N;N;N;d;}" meson.build
 meson setup build --prefix=$WORK --libdir=lib --prefer-static --default-library=static --buildtype=debugoptimized \
-  -Dbackend_max_links=4 -Ddeprecated=false -Dexamples=false -Dcplusplus=false -Dmodules=disabled \
+  -Ddeprecated=false -Dexamples=false -Dcplusplus=false -Dmodules=disabled \
   -Dfuzzing_engine=oss-fuzz -Dfuzzer_ldflags="$LIB_FUZZING_ENGINE" \
   -Dcpp_link_args="$LDFLAGS -Wl,-rpath=\$ORIGIN/lib"
 meson install -C build --tag devel


### PR DESCRIPTION
Mitigates issue https://github.com/mesonbuild/meson/issues/14524, the fuzz introspector build was already broken for some time due to https://github.com/google/oss-fuzz/pull/12983#issuecomment-2659255900.

This reverts commit 50caa1922fa88e02c8cbfb3192fe8282d7da6eee.