### PR TITLE
OSS-Fuzz: add workaround for mesonbuild/meson#14533

### DIFF
--- a/fuzz/oss_fuzz_build.sh
+++ b/fuzz/oss_fuzz_build.sh
@@ -188,6 +188,9 @@ cmake \
 cmake --build . --target install
 popd
 
+# FIXME: Workaround for https://github.com/mesonbuild/meson/issues/14533
+export LDFLAGS+=" $CFLAGS"
+
 # libvips
 # Disable building man pages, gettext po files, tools, and tests
 sed -i "/subdir('man')/{N;N;N;d;}" meson.build


### PR DESCRIPTION
By appending the sanitizer-specific flags to the `LDFLAGS` env.