### PR TITLE
rename thumbnail's profile arguments

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -23,6 +23,8 @@ master
 - share and reuse openslide connections
 - drop support for openslide 3.3
 - fix vips_quadratic()
+- rename `thumbnail`'s export/import profile options as input/output for
+  consistency
 
 8.16.1
 

--- a/doc/using-vipsthumbnail.md
+++ b/doc/using-vipsthumbnail.md
@@ -275,7 +275,7 @@ Now transform to sRGB and don't attach a profile (you can also use
 `keep=none`, though that will remove *all* metadata from the image):
 
 ```bash
-$ vipsthumbnail shark.jpg --export-profile srgb -o tn_shark.jpg[profile=none]
+$ vipsthumbnail shark.jpg --output-profile srgb -o tn_shark.jpg[profile=none]
 $ ls -l tn_shark.jpg
 -rw-r–r– 1 john john 4229 Nov  9 14:33 tn_shark.jpg
 ```
@@ -291,7 +291,7 @@ space, even though it has no embedded profile.
 
 
 ```bash
-$ vipsthumbnail kgdev.jpg --import-profile /my/profiles/a98.icm
+$ vipsthumbnail kgdev.jpg --input-profile /my/profiles/a98.icm
 ```
 
 ## Final suggestion
@@ -301,6 +301,6 @@ Putting all this together, I suggest this as a sensible set of options:
 ```bash
 $ vipsthumbnail fred.jpg \
     --size 128 \
-    --export-profile srgb \
+    --output-profile srgb \
     -o tn_%s.jpg[optimize_coding,keep=none]
 ```

--- a/man/vipsthumbnail.1
+++ b/man/vipsthumbnail.1
@@ -5,7 +5,7 @@ vipsthumbnail \- make thumbnails of image files
 .B vipsthumbnail [flags] imagefile1 imagefile2 ...
 .SH DESCRIPTION
 .B vipsthumbnail(1)
-processes each 
+processes each
 .B imagefile
 in turn, shrinking each image to fit within a 128 by 128 pixel square.
 The shrunk image is written to a new file named
@@ -17,9 +17,9 @@ For example:
 
  $ vipsthumbnail fred.png jim.tif
 
-will read image files 
+will read image files
 .B fred.png
-and 
+and
 .B jim.tif
 and write thumbnails to the files
 .B tn_fred.jpg
@@ -30,36 +30,36 @@ and
 
 will read image file
 .B fred.jpg
-and write a 64 x 64 pixel thumbnail to the file 
+and write a 64 x 64 pixel thumbnail to the file
 .B thumbnails/fred.png.
 
 .SH OPTIONS
 .TP
 .B -s N, --size=N
-Set the output thumbnail size to 
-.B N 
-x 
-.B N 
-pixels. 
+Set the output thumbnail size to
+.B N
+x
+.B N
+pixels.
 
 You can use "MxN" to specify a rectangular bounding box.
 The image is shrunk so that it just fits within this area, images
-which are smaller than this are expanded. 
+which are smaller than this are expanded.
 
 Use "xN" or "Mx" to just resize on
-one axis. 
+one axis.
 
 Append "<" to only resize if the input image is smaller than the
 target, append ">" to only resize if the input image is larger than the target.
 
 .TP
-.B -o FORMAT, --output=FORMAT     
+.B -o FORMAT, --output=FORMAT
 Set the output format string. The input filename has any file type suffix
-removed, then that value is substituted into 
+removed, then that value is substituted into
 .B FORMAT
 replacing
-.B %s. 
-If 
+.B %s.
+If
 .B FORMAT
 is a relative path, the name of the input directory is prepended. In other
 words, any path in
@@ -75,7 +75,7 @@ prepended. You can add format options too, for example
 will write JPEG images with Q set to 20.
 
 .TP
-.B -e PROFILE, --eprofile=PROFILE        
+.B -e PROFILE, --eprofile=PROFILE
 Export thumbnails with this ICC profile. Images are only colour-transformed if
 there is both an output and an input profile available. The input profile can
 either be embedded in the input image or supplied with the
@@ -83,8 +83,8 @@ either be embedded in the input image or supplied with the
 option.
 
 .TP
-.B -i PROFILE, --iprofile=PROFILE        
-Import images with this ICC profile, if no profile is embedded in the image. 
+.B -i PROFILE, --iprofile=PROFILE
+Import images with this ICC profile, if no profile is embedded in the image.
 Images are only colour-transformed if
 there is both an output and an input profile available. The output profile
 should be supplied with the
@@ -94,20 +94,20 @@ option.
 .TP
 .B -c, --crop
 Crop the output image down. The image is shrunk so as to completely fill the
-bounding box in both axes, then any excess is cropped off. 
+bounding box in both axes, then any excess is cropped off.
 
 .TP
 .B -d, --delete
 Delete the output profile from the image. This can save a small amount of
-space. 
+space.
 
 .TP
 .B -t, --rotate
-Auto-rotate images using EXIF orientation tags. 
+Auto-rotate images using EXIF orientation tags.
 
 .TP
 .B -a, --linear
-Shrink images in linear light colour space. This can be much slower. 
+Shrink images in linear light colour space. This can be much slower.
 
 .SH RETURN VALUE
 returns 0 on success and non-zero on error. Error can mean one or more

--- a/test/test-suite/test_resample.py
+++ b/test/test-suite/test_resample.py
@@ -241,7 +241,7 @@ class TestResample:
     @pytest.mark.skipif(not pyvips.at_least_libvips(8, 5),
                         reason="requires libvips >= 8.5")
     def test_thumbnail_icc(self):
-        im = pyvips.Image.thumbnail(JPEG_FILE_XYB, 442, export_profile="srgb")
+        im = pyvips.Image.thumbnail(JPEG_FILE_XYB, 442, output_profile="srgb")
 
         assert im.width == 290
         assert im.height == 442

--- a/tools/vipsthumbnail.c
+++ b/tools/vipsthumbnail.c
@@ -105,6 +105,8 @@
  * 2/10/20
  * 	- support "stdin" as a magic input filename for thumbnail_source
  * 	- support ".suffix" as a magic output format for stdout write
+ * 30/4/25
+ *  - rename import/export profile args as input/oputput
  */
 
 #ifdef HAVE_CONFIG_H
@@ -131,8 +133,8 @@ static int thumbnail_width = 128;
 static int thumbnail_height = 128;
 static VipsSize size_restriction = VIPS_SIZE_BOTH;
 static char *output_format = "tn_%s.jpg";
-static char *export_profile = NULL;
-static char *import_profile = NULL;
+static char *output_profile = NULL;
+static char *input_profile = NULL;
 static gboolean linear_processing = FALSE;
 static gboolean crop_image = FALSE;
 static gboolean no_rotate_image = FALSE;
@@ -159,12 +161,12 @@ static GOptionEntry options[] = {
 		G_OPTION_ARG_STRING, &output_format,
 		N_("output to FORMAT"),
 		N_("FORMAT") },
-	{ "export-profile", 'e', 0,
-		G_OPTION_ARG_FILENAME, &export_profile,
+	{ "output-profile", 0, 0,
+		G_OPTION_ARG_FILENAME, &output_profile,
 		N_("export with PROFILE"),
 		N_("PROFILE") },
-	{ "import-profile", 'i', 0,
-		G_OPTION_ARG_FILENAME, &import_profile,
+	{ "input-profile", 0, 0,
+		G_OPTION_ARG_FILENAME, &input_profile,
 		N_("import untagged images with PROFILE"),
 		N_("PROFILE") },
 	{ "linear", 'a', 0,
@@ -187,18 +189,28 @@ static GOptionEntry options[] = {
 	{ "version", 'v', 0, G_OPTION_ARG_NONE, &version,
 		N_("print version"), NULL },
 
+	/* All deprecated.
+	 */
+	{ "export-profile", 'e', G_OPTION_FLAG_HIDDEN,
+		G_OPTION_ARG_FILENAME, &output_profile,
+		N_("export with PROFILE"),
+		N_("PROFILE") },
+	{ "import-profile", 'i', G_OPTION_FLAG_HIDDEN,
+		G_OPTION_ARG_FILENAME, &input_profile,
+		N_("import untagged images with PROFILE"),
+		N_("PROFILE") },
+	{ "eprofile", 0, G_OPTION_FLAG_HIDDEN,
+		G_OPTION_ARG_FILENAME, &output_profile,
+		N_("export with PROFILE"),
+		N_("PROFILE") },
+	{ "iprofile", 0, G_OPTION_FLAG_HIDDEN,
+		G_OPTION_ARG_FILENAME, &input_profile,
+		N_("import untagged images with PROFILE"),
+		N_("PROFILE") },
 	{ "format", 'f', G_OPTION_FLAG_HIDDEN,
 		G_OPTION_ARG_STRING, &output_format,
 		N_("set output format string to FORMAT"),
 		N_("FORMAT") },
-	{ "eprofile", 0, G_OPTION_FLAG_HIDDEN,
-		G_OPTION_ARG_FILENAME, &export_profile,
-		N_("export with PROFILE"),
-		N_("PROFILE") },
-	{ "iprofile", 0, G_OPTION_FLAG_HIDDEN,
-		G_OPTION_ARG_FILENAME, &import_profile,
-		N_("import untagged images with PROFILE"),
-		N_("PROFILE") },
 	{ "rotate", 't', G_OPTION_FLAG_HIDDEN,
 		G_OPTION_ARG_NONE, &rotate_image,
 		N_("(deprecated, does nothing)"), NULL },
@@ -321,8 +333,8 @@ thumbnail_process(VipsObject *process, const char *name)
 				"no-rotate", no_rotate_image,
 				"crop", interesting,
 				"linear", linear_processing,
-				"import-profile", import_profile,
-				"export-profile", export_profile,
+				"import-profile", input_profile,
+				"output-profile", output_profile,
 				"intent", intent,
 				NULL)) {
 			VIPS_UNREF(source);
@@ -337,8 +349,8 @@ thumbnail_process(VipsObject *process, const char *name)
 				"no-rotate", no_rotate_image,
 				"crop", interesting,
 				"linear", linear_processing,
-				"import-profile", import_profile,
-				"export-profile", export_profile,
+				"import-profile", input_profile,
+				"output-profile", output_profile,
 				"intent", intent,
 				NULL))
 			return -1;


### PR DESCRIPTION
We use `input-profile` and `output-profile` everywhere else, but `thumbnail` calls them `import-profile` and `export-profile`, confusingly. LittleCMS seems to use `input-profile` and `output-profile` too.