### PR TITLE
Ignore VipsSaveable type when generating introspection data

### DIFF
--- a/libvips/include/vips/enumtypes.c.in
+++ b/libvips/include/vips/enumtypes.c.in
@@ -5,14 +5,6 @@
 #include <config.h>
 #endif /*HAVE_CONFIG_H*/
 #include <vips/vips.h>
-
-/* Alias for backwards compatibility.
- */
-GType
-vips_saveable_get_type(void)
-{
-	return vips_foreign_saveable_get_type();
-}
 /*** END file-header ***/
 
 /*** BEGIN file-production ***/
@@ -46,3 +38,11 @@ GType
 }
 /*** END value-tail ***/
 
+/*** BEGIN file-tail ***/
+/* Deprecated enumerations */
+GType
+vips_saveable_get_type(void)
+{
+	return vips_foreign_saveable_get_type();
+}
+/*** END file-tail ***/

--- a/libvips/include/vips/enumtypes.h.in
+++ b/libvips/include/vips/enumtypes.h.in
@@ -4,10 +4,6 @@
 
 G_BEGIN_DECLS
 
-VIPS_API
-GType vips_saveable_get_type(void) G_GNUC_CONST;
-#define VIPS_TYPE_SAVEABLE (vips_saveable_get_type())
-
 /*** END file-header ***/
 
 /*** BEGIN file-production ***/
@@ -21,6 +17,12 @@ GType @enum_name@_get_type(void) G_GNUC_CONST;
 /*** END value-header ***/
 
 /*** BEGIN file-tail ***/
+/* Deprecated enumerations */
+#ifndef __GI_SCANNER__
+VIPS_API
+GType vips_saveable_get_type(void) G_GNUC_CONST;
+#define VIPS_TYPE_SAVEABLE (vips_saveable_get_type())
+#endif /*__GI_SCANNER__*/
 G_END_DECLS
 
 #endif /*VIPS_ENUM_TYPES_H*/


### PR DESCRIPTION
Otherwise, it will end up including `vips_saveable_get_type()` in the docs.