### PR TITLE
doc: port remainder to gi-docgen linking syntax

### DIFF
--- a/doc/file-format.md
+++ b/doc/file-format.md
@@ -58,7 +58,7 @@ swapping automatically.
 
 ## The image data
 
-If `coding` is set to [enum@Vips.Coding.none], pixels are stored in native C
+If `coding` is set to [enum@Vips.Coding.NONE], pixels are stored in native C
 format, that is, the native format of the machine that wrote the data. If you
 open a big-endian image on a little-endian machine, libvips will automatically
 byte-swap for you.  libvips has 10 band formats, see [enum@BandFormat].
@@ -66,12 +66,12 @@ Image data is stored as a simple list of scanlines, from the top of the
 image to the bottom. Pixels are band-interleaved, so RGBRGBRGBRGB, for
 example. There is no padding at the end of scanlines.
 
-If `coding` is set to [enum@Vips.Coding.labq], each pixel is four bytes, with
+If `coding` is set to [enum@Vips.Coding.LABQ], each pixel is four bytes, with
 10 bits for L\* and 11 bits for each of a\* and b\*. These 32 bits are packed
 into 4 bytes, with the most significant 8 bits of each value in the first
 3 bytes, and the left-over bits packed into the final byte as 2:3:3.
 
-If `coding` is set to [enum@Vips.Coding.rad], each pixel is RGB or XYZ float,
+If `coding` is set to [enum@Vips.Coding.RAD], each pixel is RGB or XYZ float,
 with 8 bits of mantissa and then 8 bits of exponent, shared between the
 three channels. This coding style is used by the Radiance family of programs
 (and the HDR format) commonly used for HDR imaging.

--- a/doc/libvips-arithmetic.md
+++ b/doc/libvips-arithmetic.md
@@ -20,9 +20,9 @@ single-band images freely.
 Arithmetic operations try to preserve precision by increasing the number of
 bits in the output image when necessary. Generally, this follows the ANSI C
 conventions for type promotion, so multiplying two
-[enum@Vips.BandFormat.uchar] images together, for example, produces a
-[enum@Vips.BandFormat.ushort] image, and taking the [method@Image.cos] of a
-[enum@Vips.BandFormat.ushort] image produces [enum@Vips.BandFormat.float]
+[enum@Vips.BandFormat.UCHAR] images together, for example, produces a
+[enum@Vips.BandFormat.USHORT] image, and taking the [method@Image.cos] of a
+[enum@Vips.BandFormat.USHORT] image produces [enum@Vips.BandFormat.FLOAT]
 image.
 
 After processing, use [method@Image.cast] and friends to take then format
@@ -30,7 +30,7 @@ back down again.[method@Image.cast_uchar], for example, will cast any image
 down to 8-bit unsigned.
 
 Images have an interpretation: a meaning for the pixel values. With
-[enum@Vips.Interpretation.srgb], for example, the first three bands will be
+[enum@Vips.Interpretation.SRGB], for example, the first three bands will be
 interpreted (for example, by a saver like [method@Image.jpegsave]) as R, G
 and B, with values in 0 - 255, and any fourth band will be interpreted as an
 alpha channel.

--- a/doc/libvips-colour.md
+++ b/doc/libvips-colour.md
@@ -17,16 +17,16 @@ the HDR imaging community.
 The colour functions can be divided into three main groups. First,
 functions to transform images between the different colour spaces supported
 by libvips:
-[enum@Vips.Interpretation.srgb], [enum@Vips.Interpretation.scrgb],
-[enum@Vips.Interpretation.b_w], [enum@Vips.Interpretation.xyz],
-[enum@Vips.Interpretation.yxy], [enum@Vips.Interpretation.lab],
-[enum@Vips.Interpretation.lch], and [enum@Vips.Interpretation.cmc].
+[enum@Vips.Interpretation.SRGB], [enum@Vips.Interpretation.SCRGB],
+[enum@Vips.Interpretation.B_W], [enum@Vips.Interpretation.XYZ],
+[enum@Vips.Interpretation.YXY], [enum@Vips.Interpretation.LAB],
+[enum@Vips.Interpretation.LCH], and [enum@Vips.Interpretation.CMC].
 
 There are also a set of minor colourspaces which are one of the above in a
 slightly different format:
-[enum@Vips.Interpretation.lab], [enum@Vips.Interpretation.labq],
-[enum@Vips.Interpretation.labs], [enum@Vips.Interpretation.lch],
-[enum@Vips.Interpretation.rgb16], and [enum@Vips.Interpretation.grey16].
+[enum@Vips.Interpretation.LAB], [enum@Vips.Interpretation.LABQ],
+[enum@Vips.Interpretation.LABS], [enum@Vips.Interpretation.LCH],
+[enum@Vips.Interpretation.RGB16], and [enum@Vips.Interpretation.GREY16].
 
 Use [method@Image.colourspace] to move an image to a target colourspace
 using the best sequence of colour transform operations.
@@ -41,39 +41,39 @@ This figure shows how the libvips colour spaces interconvert:
 
 The colour spaces supported by libvips are:
 
-- [enum@Vips.Interpretation.lab]: CIELAB '76 colourspace with a D65 white.
+- [enum@Vips.Interpretation.LAB]: CIELAB '76 colourspace with a D65 white.
   This uses three floats for each band, and bands have the obvious range.<br /><br />
-  There are two variants, [enum@Vips.Interpretation.labq] and
-  [enum@Vips.Interpretation.labs], which use ints to store values. These are
+  There are two variants, [enum@Vips.Interpretation.LABQ] and
+  [enum@Vips.Interpretation.LABS], which use ints to store values. These are
   less precise, but can be quicker to store and process.<br /><br />
-  [enum@Vips.Interpretation.lch] is the same, but with a\*b\* as polar
+  [enum@Vips.Interpretation.LCH] is the same, but with a\*b\* as polar
   coordinates. Hue is expressed in degrees.
 
-- [enum@Vips.Interpretation.xyz]: CIE XYZ. This uses three floats.
+- [enum@Vips.Interpretation.XYZ]: CIE XYZ. This uses three floats.
   See [const@D75_X0] and friends for values for the ranges under various
   illuminants.<br /><br />
-  [enum@Vips.Interpretation.yxy] is the same, but with little x and y.
+  [enum@Vips.Interpretation.YXY] is the same, but with little x and y.
 
-- [enum@Vips.Interpretation.scrgb]: a linear colourspace with the sRGB
+- [enum@Vips.Interpretation.SCRGB]: a linear colourspace with the sRGB
   primaries. This is useful if you need linear light and don't care
   much what the primaries are.<br /><br />
   Linearization is performed with the usual sRGB equations, see below.
 
-- [enum@Vips.Interpretation.srgb]: the standard sRGB colourspace, see:
+- [enum@Vips.Interpretation.SRGB]: the standard sRGB colourspace, see:
   [wikipedia sRGB](http://en.wikipedia.org/wiki/SRGB).<br /><br />
   This uses three 8-bit values for each of RGB.<br /><br />
-  [enum@Vips.Interpretation.rgb16] is the same, but using three 16-bit values
+  [enum@Vips.Interpretation.RGB16] is the same, but using three 16-bit values
   for RGB.<br /><br />
-  [enum@Vips.Interpretation.hsv] is sRGB, but in polar coordinates.
-  [enum@Vips.Interpretation.lch] is much better, only use HSV if you have to.
+  [enum@Vips.Interpretation.HSV] is sRGB, but in polar coordinates.
+  [enum@Vips.Interpretation.LCH] is much better, only use HSV if you have to.
 
-- [enum@Vips.Interpretation.b_w]: a monochrome image, roughly G from sRGB.
-  The grey value is calculated in linear [enum@Vips.Interpretation.scrgb]
+- [enum@Vips.Interpretation.B_W]: a monochrome image, roughly G from sRGB.
+  The grey value is calculated in linear [enum@Vips.Interpretation.SCRGB]
   space with RGB ratios 0.2126, 0.7152, 0.0722 as defined by CIE 1931 linear
   luminance.<br /><br />
-  [enum@Vips.Interpretation.grey16] is the same, but using 16 bits.
+  [enum@Vips.Interpretation.GREY16] is the same, but using 16 bits.
 
-- [enum@Vips.Interpretation.cmc]: a colour space based on the CMC(1:1)
+- [enum@Vips.Interpretation.CMC]: a colour space based on the CMC(1:1)
   colour difference measurement. This is a highly uniform colour space,
   and much better than CIELAB for expressing small differences.<br /><br />
   The CMC colourspace is described in “Uniform Colour Space Based on the

--- a/doc/libvips-histogram.md
+++ b/doc/libvips-histogram.md
@@ -5,7 +5,7 @@ Title: Operator index > By section > Histogram
 Histograms and look-up tables are 1xn or nx1 images, where n is less than
 256 or less than 65536, corresponding to 8- and 16-bit unsigned int images.
 They are tagged with a [enum@Interpretation] of
-[enum@Vips.Interpretation.histogram] and usually displayed by user-interfaces
+[enum@Vips.Interpretation.HISTOGRAM] and usually displayed by user-interfaces
 such as nip2 as plots rather than images.
 
 These functions can be broadly grouped as things to find or build

--- a/doc/libvips-morphology.md
+++ b/doc/libvips-morphology.md
@@ -32,7 +32,7 @@ VipsImage *mask = vips_image_new_matrixv(3, 3,
 ```
 
 applied to an image with [method@Image.morph]
-[enum@Vips.OperationMorphology.dilate] will do a 4-connected dilation.
+[enum@Vips.OperationMorphology.DILATE] will do a 4-connected dilation.
 
 Dilate sets pixels in the output if any part of the mask matches, whereas
 erode sets pixels only if all the mask matches.

--- a/libvips/convolution/conv.c
+++ b/libvips/convolution/conv.c
@@ -184,7 +184,7 @@ vips_conv_init(VipsConv *conv)
  * [enum@Vips.BandFormat.DOUBLE].
  *
  * If @precision is [enum@Vips.Precision.INTEGER], then elements of @mask
- * are converted to integers before convolution, using rint(),
+ * are converted to integers before convolution, using `rint()`,
  * and the output image always has the same [enum@BandFormat] as the input
  * image.
  *

--- a/libvips/convolution/convi.c
+++ b/libvips/convolution/convi.c
@@ -1267,7 +1267,7 @@ vips_convi_init(VipsConvi *convi)
  * Integer convolution. This is a low-level operation, see [method@Image.conv] for
  * something more convenient.
  *
- * @mask is converted to an integer mask with rint() of each element, rint of
+ * @mask is converted to an integer mask with `rint()` of each element, rint of
  * scale and rint of offset. Each output pixel is then calculated as
  *
  * ```

--- a/libvips/foreign/foreign.c
+++ b/libvips/foreign/foreign.c
@@ -702,7 +702,7 @@ vips_foreign_find_load_buffer_sub(VipsForeignLoadClass *load_class,
  * 	vips -l | grep load_buffer
  *
  * ::: seealso
- *     vips_image_new_from_buffer().
+ *     [ctor@Image.new_from_buffer].
  *
  * Returns: (transfer none): the name of an operation on success, `NULL` on
  * error.
@@ -764,7 +764,7 @@ vips_foreign_find_load_source_sub(void *item, void *a, void *b)
  * 	vips -l | grep load_source
  *
  * ::: seealso
- *     vips_image_new_from_source().
+ *     [ctor@Image.new_from_source].
  *
  * Returns: (transfer none): the name of an operation on success, `NULL` on
  * error.

--- a/libvips/foreign/jp2kload.c
+++ b/libvips/foreign/jp2kload.c
@@ -1646,7 +1646,7 @@ vips__foreign_load_jp2k_decompress(VipsImage *out,
  * ::: tip "Optional arguments"
  *     * @page: `gint`, load this page
  *     * @oneshot: `gboolean`, load pages in one-shot mode
- *     * @fail_on: #VipsFailOn, types of read error to fail on
+ *     * @fail_on: [enum@FailOn], types of read error to fail on
  *
  * ::: seealso
  *     [ctor@Image.new_from_file].
@@ -1681,7 +1681,7 @@ vips_jp2kload(const char *filename, VipsImage **out, ...)
  * ::: tip "Optional arguments"
  *     * @page: `gint`, load this page
  *     * @oneshot: `gboolean`, load pages in one-shot mode
- *     * @fail_on: #VipsFailOn, types of read error to fail on
+ *     * @fail_on: [enum@FailOn], types of read error to fail on
  *
  * Returns: 0 on success, -1 on error.
  */
@@ -1716,7 +1716,7 @@ vips_jp2kload_buffer(void *buf, size_t len, VipsImage **out, ...)
  * ::: tip "Optional arguments"
  *     * @page: `gint`, load this page
  *     * @oneshot: `gboolean`, load pages in one-shot mode
- *     * @fail_on: #VipsFailOn, types of read error to fail on
+ *     * @fail_on: [enum@FailOn], types of read error to fail on
  *
  * Returns: 0 on success, -1 on error.
  */

--- a/libvips/include/vips/connection.h
+++ b/libvips/include/vips/connection.h
@@ -185,14 +185,14 @@ typedef struct _VipsSourceClass {
 	 */
 
 	/* Read from the source into the supplied buffer, args exactly as
-	 * read(2). Set errno on error.
+	 * [`read()`](man:read(2)). Set errno on error.
 	 *
 	 * We must return gint64, since ssize_t is often defined as unsigned
 	 * on Windows.
 	 */
 	gint64 (*read)(VipsSource *source, void *buffer, size_t length);
 
-	/* Seek to a certain position, args exactly as lseek(2). Set errno on
+	/* Seek to a certain position, args exactly as [`lseek()`](man:lseek(2)). Set errno on
 	 * error.
 	 *
 	 * Unseekable sources should always return -1. VipsSource will then
@@ -451,14 +451,14 @@ typedef struct _VipsTargetClass {
 	 */
 
 	/* Read from the target into the supplied buffer, args exactly as
-	 * read(2). Set errno on error.
+	 * [`read()`](man:read(2)). Set errno on error.
 	 *
 	 * We must return gint64, since ssize_t is often defined as unsigned
 	 * on Windows.
 	 */
 	gint64 (*read)(VipsTarget *target, void *buffer, size_t length);
 
-	/* Seek output. Args exactly as lseek(2).
+	/* Seek output. Args exactly as [`lseek()`](man:lseek(2)).
 	 *
 	 * We have to use int64 rather than off_t, since we must work on
 	 * Windows, where off_t can be 32-bits.

--- a/libvips/include/vips/header.h
+++ b/libvips/include/vips/header.h
@@ -73,7 +73,7 @@ extern "C" {
  * The name we use to attach an ICC profile. The file read and write
  * operations for TIFF, JPEG, PNG and others use this item of metadata to
  * attach and save ICC profiles. The profile is updated by the
- * vips_icc_transform() operations.
+ * [method@Image.icc_transform] operations.
  */
 #define VIPS_META_ICC_NAME "icc-profile-data"
 
@@ -117,8 +117,8 @@ extern "C" {
 /**
  * VIPS_META_SEQUENTIAL:
  *
- * Images loaded via vips_sequential() have this int field defined. Some
- * operations (eg. vips_shrinkv()) add extra caches if they see it on their
+ * Images loaded via [method@Image.sequential] have this int field defined. Some
+ * operations (eg. [method@Image.shrinkv]) add extra caches if they see it on their
  * input.
  */
 #define VIPS_META_SEQUENTIAL "vips-sequential"

--- a/libvips/iofuncs/buf.c
+++ b/libvips/iofuncs/buf.c
@@ -494,10 +494,10 @@ vips_buf_appendd(VipsBuf *buf, int d)
 /**
  * vips_buf_appendgv:
  * @buf: the buffer
- * @value: #GValue to format and append
+ * @value: [struct@GObject.Value] to format and append
  *
- * Format and append a #GValue as a printable thing. We display text line "3144
- * bytes of binary data" for BLOBs like icc-profile-data.
+ * Format and append a [struct@GObject.Value] as a printable thing.
+ * We display text line "3144 bytes of binary data" for BLOBs like icc-profile-data.
  *
  * Use [method@Image.get_as_string] to make a text representation of a field.
  * That will base64-encode blobs, for example.

--- a/libvips/iofuncs/error.c
+++ b/libvips/iofuncs/error.c
@@ -248,7 +248,7 @@ vips_verror_system(int err, const char *domain, const char *fmt, va_list ap)
  * @fmt: `printf()`-style format string for the error
  * @...: arguments to the format string
  *
- * Format the string in the style of printf() and append to the error buffer.
+ * Format the string in the style of [`printf()`](man:printf(3)) and append to the error buffer.
  * Then create and append a localised message based on the system error code,
  * usually the value of errno.
  *

--- a/libvips/iofuncs/generate.c
+++ b/libvips/iofuncs/generate.c
@@ -662,7 +662,7 @@ write_vips(VipsRegion *region, VipsRect *area, void *a)
  *
  * Generates an image. The action depends on the image type.
  *
- * For images created with [ctor@Image.new], vips_image_generate() just
+ * For images created with [ctor@Image.new], [method@Image.generate] just
  * attaches the start/generate/stop callbacks and returns.
  *
  * For images created with [ctor@Image.new_memory], memory is allocated for

--- a/libvips/iofuncs/image.c
+++ b/libvips/iofuncs/image.c
@@ -153,9 +153,9 @@
  * The type of access an operation has to supply. See [method@Image.tilecache]
  * and [class@Foreign].
  *
- * @VIPS_ACCESS_RANDOM means requests can come in any order.
+ * [enum@Vips.Access.RANDOM] means requests can come in any order.
  *
- * @VIPS_ACCESS_SEQUENTIAL means requests will be top-to-bottom, but with some
+ * [enum@Vips.Access.SEQUENTIAL] means requests will be top-to-bottom, but with some
  * amount of buffering behind the read point for small non-local accesses.
  */
 
@@ -176,20 +176,20 @@
  * will use the most general style requested by the operations
  * in the pipeline.
  *
- * @VIPS_DEMAND_STYLE_SMALLTILE -- This is the most general demand format.
+ * [enum@Vips.DemandStyle.SMALLTILE] -- This is the most general demand format.
  * Output is demanded in small (around 100x100 pel) sections. This style works
  * reasonably efficiently, even for bizarre operations like 45 degree rotate.
  *
- * @VIPS_DEMAND_STYLE_FATSTRIP -- This operation would like to output strips
+ * [enum@Vips.DemandStyle.FATSTRIP] -- This operation would like to output strips
  * the width of the image and as high as possible. This option is suitable
  * for area operations which do not violently transform coordinates, such
  * as [method@Image.conv].
  *
- * @VIPS_DEMAND_STYLE_THINSTRIP -- This operation would like to output strips
+ * [enum@Vips.DemandStyle.THINSTRIP] -- This operation would like to output strips
  * the width of the image and a few pels high. This option is suitable for
  * point-to-point operations, such as those in the arithmetic package.
  *
- * @VIPS_DEMAND_STYLE_ANY -- This image is not being demand-read from a disc
+ * [enum@Vips.DemandStyle.ANY] -- This image is not being demand-read from a disc
  * file (even indirectly) so any demand style is OK. It's used for things like
  * [ctor@Image.black] where the pixels are calculated.
  *
@@ -206,7 +206,7 @@
  * @VIPS_INTERPRETATION_XYZ: the first three bands are CIE XYZ
  * @VIPS_INTERPRETATION_LAB: pixels are in CIE Lab space
  * @VIPS_INTERPRETATION_CMYK: the first four bands are in CMYK space
- * @VIPS_INTERPRETATION_LABQ: implies @VIPS_CODING_LABQ
+ * @VIPS_INTERPRETATION_LABQ: implies [enum@Vips.Coding.LABQ]
  * @VIPS_INTERPRETATION_RGB: generic RGB space
  * @VIPS_INTERPRETATION_CMC: a uniform colourspace based on CMC(1:1)
  * @VIPS_INTERPRETATION_LCH: pixels are in CIE LCh space
@@ -220,7 +220,7 @@
  * @VIPS_INTERPRETATION_MATRIX: a matrix
  *
  * How the values in an image should be interpreted. For example, a
- * three-band float image of type @VIPS_INTERPRETATION_LAB should have its
+ * three-band float image of type [enum@Vips.Interpretation.LAB] should have its
  * pixels interpreted as coordinates in CIE Lab space.
  *
  * RGB and sRGB are treated in the same way. Use the colourspace functions if
@@ -327,7 +327,7 @@
  * If VIPS_DEBUG is defined, you get a version that checks bounds for you.
  *
  * ::: seealso
- *     [method@Image.wio_input], [method@Image.inplace], VIPS_REGION_ADDR().
+ *     [method@Image.wio_input], [method@Image.inplace], [func@REGION_ADDR].
  *
  * Returns: The address of pixel (@X,@Y) in @I.
  */
@@ -1776,7 +1776,7 @@ vips_image_new_memory(void)
  * vips_image_memory: (constructor)
  *
  * A renamed [ctor@Image.new_memory] ... Some gobject binding systems do not
- * like more than one _new() method.
+ * like more than one `_new()` method.
  *
  * ::: seealso
  *     [ctor@Image.new_memory].
@@ -2558,7 +2558,7 @@ vips_get_disc_threshold(void)
  *
  * The file is created in the temporary directory. This is set with the
  * environment variable TMPDIR. If this is not set, then on Unix systems, vips
- * will default to /tmp. On Windows, vips uses GetTempPath() to find the
+ * will default to /tmp. On Windows, vips uses `GetTempPath()` to find the
  * temporary directory.
  *
  * ::: seealso
@@ -2873,7 +2873,7 @@ vips_image_write_to_target(VipsImage *in,
  *
  * Writes @in to memory as a simple, unformatted C-style array.
  *
- * The caller is responsible for freeing this memory with g_free().
+ * The caller is responsible for freeing this memory with [func@GLib.free].
  *
  * ::: seealso
  *     [method@Image.write_to_buffer].
@@ -3201,7 +3201,7 @@ vips_image_write_prepare(VipsImage *image)
  *
  * Write a line of pixels to an image. This function must be called repeatedly
  * with @ypos increasing from 0 to [property@Image:height].
- * @linebuffer must be VIPS_IMAGE_SIZEOF_LINE() bytes long.
+ * @linebuffer must be [func@IMAGE_SIZEOF_LINE] bytes long.
  *
  * ::: seealso
  *     [method@Image.generate].
@@ -3392,10 +3392,10 @@ vips_image_copy_memory(VipsImage *image)
  * vips_image_wio_input:
  * @image: image to transform
  *
- * Check that an image is readable via the VIPS_IMAGE_ADDR() macro, that is,
+ * Check that an image is readable via the [func@IMAGE_ADDR] macro, that is,
  * that the entire image is in memory and all pixels can be read with
- * VIPS_IMAGE_ADDR().  If it
- * isn't, try to transform it so that VIPS_IMAGE_ADDR() can work.
+ * [func@IMAGE_ADDR].  If it
+ * isn't, try to transform it so that [func@IMAGE_ADDR] can work.
  *
  * Since this function modifies @image, it is not thread-safe. Only call it on
  * images which you are sure have not been shared with another thread. If the
@@ -3404,7 +3404,7 @@ vips_image_copy_memory(VipsImage *image)
  *
  * ::: seealso
  *     [method@Image.copy_memory], [method@Image.pio_input],
- *     [method@Image.inplace], VIPS_IMAGE_ADDR().
+ *     [method@Image.inplace], [func@IMAGE_ADDR].
  *
  * Returns: 0 on success, or -1 on error.
  */
@@ -3570,7 +3570,7 @@ vips__image_wio_output(VipsImage *image)
  *
  * Gets @image ready for an in-place operation, such as
  * [method@Image.draw_circle]. After calling this function you can both read
- * and write the image with VIPS_IMAGE_ADDR().
+ * and write the image with [func@IMAGE_ADDR].
  *
  * This method is called for you by the base class of the draw operations,
  * there's no need to call it yourself.

--- a/libvips/iofuncs/memory.c
+++ b/libvips/iofuncs/memory.c
@@ -424,10 +424,10 @@ vips_tracked_aligned_alloc(size_t size, size_t align)
 /**
  * vips_tracked_open:
  * @pathname: name of file to open
- * @flags: flags for open()
+ * @flags: flags for `open()`
  * @mode: open mode
  *
- * Exactly as open(2), but the number of files currently open via
+ * Exactly as [`open()`](man:open(2)), but the number of files currently open via
  * [func@tracked_open] is available via [func@tracked_get_files]. This is used
  * by the vips operation cache to drop cache when the number of files
  * available is low.
@@ -464,9 +464,9 @@ vips_tracked_open(const char *pathname, int flags, int mode)
 
 /**
  * vips_tracked_close:
- * @fd: file to close()
+ * @fd: file to `close()`
  *
- * Exactly as close(2), but update the number of files currently open via
+ * Exactly as [`close()`](man:close(2)), but update the number of files currently open via
  * [func@tracked_get_files]. This is used
  * by the vips operation cache to drop cache when the number of files
  * available is low.

--- a/libvips/iofuncs/object.c
+++ b/libvips/iofuncs/object.c
@@ -179,20 +179,20 @@
  * Input gobjects are automatically reffed, output gobjects automatically ref
  * us. We also automatically watch for "destroy" and unlink.
  *
- * @VIPS_ARGUMENT_SET_ALWAYS is handy for arguments which are set from C. For
+ * [flags@Vips.ArgumentFlags.SET_ALWAYS] is handy for arguments which are set from C. For
  * example, VipsImage::width is a property that gives access to the Xsize
  * member of struct _VipsImage. We default its 'assigned' to TRUE
  * since the field is always set directly by C.
  *
- * @VIPS_ARGUMENT_DEPRECATED arguments are not shown in help text, are not
+ * [flags@Vips.ArgumentFlags.DEPRECATED] arguments are not shown in help text, are not
  * looked for if required, are not checked for "have-been-set". You can
  * deprecate a required argument, but you must obviously add a new required
  * argument if you do.
  *
- * Input args with @VIPS_ARGUMENT_MODIFY will be modified by the operation.
+ * Input args with [flags@Vips.ArgumentFlags.MODIFY] will be modified by the operation.
  * This is used for things like the in-place drawing operations.
  *
- * @VIPS_ARGUMENT_NON_HASHABLE stops the argument being used in hash and
+ * [flags@Vips.ArgumentFlags.NON_HASHABLE] stops the argument being used in hash and
  * equality tests. It's useful for arguments like `revalidate` which
  * control the behaviour of the operator cache.
  */
@@ -3242,7 +3242,7 @@ vips_object_unref_outputs(VipsObject *object)
  *
  * Fetch the object description. Useful for language bindings.
  *
- * @object.description is only available after _build(), which can be too
+ * [property@VipsObject:description] is only available after `_build()`, which can be too
  * late. This function fetches from the instance, if possible, but falls back
  * to the class description if we are too early.
  *

--- a/libvips/iofuncs/operation.c
+++ b/libvips/iofuncs/operation.c
@@ -172,7 +172,7 @@
  *
  * Flags we associate with an operation.
  *
- * @VIPS_OPERATION_SEQUENTIAL means that the operation works like
+ * [flags@Vips.OperationFlags.SEQUENTIAL] means that the operation works like
  * [method@Image.conv]: it can process images top-to-bottom with only small
  * non-local references.
  *
@@ -186,21 +186,21 @@
  * not at the top of the image. In this case, the first part of the image will
  * be read and discarded
  *
- * @VIPS_OPERATION_NOCACHE means that the operation must not be cached by
+ * [flags@Vips.OperationFlags.NOCACHE] means that the operation must not be cached by
  * vips.
  *
- * @VIPS_OPERATION_DEPRECATED means this is an old operation kept in vips for
+ * [flags@Vips.OperationFlags.DEPRECATED] means this is an old operation kept in vips for
  * compatibility only and should be hidden from users.
  *
- * @VIPS_OPERATION_UNTRUSTED means the operation depends on external libraries
+ * [flags@Vips.OperationFlags.UNTRUSTED] means the operation depends on external libraries
  * which have not been hardened against attack. It should probably not be used
  * on untrusted input. Use [func@block_untrusted_set] to block all
  * untrusted operations.
  *
- * @VIPS_OPERATION_BLOCKED means the operation is prevented from executing. Use
+ * [flags@Vips.OperationFlags.BLOCKED] means the operation is prevented from executing. Use
  * [func@Operation.block_set] to enable and disable groups of operations.
  *
- * @VIPS_OPERATION_REVALIDATE force the operation to run, updating the cache
+ * [flags@Vips.OperationFlags.REVALIDATE] force the operation to run, updating the cache
  * with the new value. This is used by eg. VipsForeignLoad to implement the
  * "revalidate" argument.
  */

--- a/libvips/iofuncs/region.c
+++ b/libvips/iofuncs/region.c
@@ -896,7 +896,7 @@ vips_region_fill(VipsRegion *reg,
  * @reg->valid.
  *
  * For int images, @value is
- * passed to memset(), so it usually needs to be 0 or 255. For float images,
+ * passed to [`memset()`](man:memset(3)), so it usually needs to be 0 or 255. For float images,
  * value is cast to a float and copied in to each band element.
  *
  * @r is clipped against

--- a/libvips/iofuncs/source.c
+++ b/libvips/iofuncs/source.c
@@ -424,7 +424,7 @@ vips_source_init(VipsSource *source)
  * @descriptor: read from this file descriptor
  *
  * Create an source attached to a file descriptor. @descriptor is
- * closed with close() when source is finalized.
+ * closed with [`close()`](man:close(2)) when source is finalized.
  *
  * Returns: a new source.
  */
@@ -780,7 +780,7 @@ vips_source_print(VipsSource *source)
  * Return the number of bytes actually read. If all bytes have been read from
  * the file, return 0.
  *
- * Arguments exactly as read(2).
+ * Arguments exactly as [`read()`](man:read(2)).
  *
  * Returns: the number of bytes read, 0 on end of file, -1 on error.
  */
@@ -1170,7 +1170,7 @@ vips_source_map_blob(VipsSource *source)
  * @whence: seek relative to this point
  *
  * Move the file read position. You can't call this after pixel decode starts.
- * The arguments are exactly as lseek(2).
+ * The arguments are exactly as [`lseek()`](man:lseek(2)).
  *
  * Returns: the new file position, or -1 on error.
  */

--- a/libvips/iofuncs/util.c
+++ b/libvips/iofuncs/util.c
@@ -70,8 +70,8 @@
 
 /**
  * vips_slist_equal:
- * @l1: (element-type guint8): a #GSList
- * @l2: (element-type guint8): another #GSList
+ * @l1: (element-type guint8): a [struct@GLib.SList]
+ * @l2: (element-type guint8): another [struct@GLib.SList]
  *
  * Test two lists for equality.
  *
@@ -96,7 +96,7 @@ vips_slist_equal(GSList *l1, GSList *l2)
 
 /**
  * vips_slist_map2:
- * @list: (element-type guint8): a #GSList
+ * @list: (element-type guint8): a [struct@GLib.SList]
  * @fn: (scope call): function to apply to each list element
  * @a: user data
  * @b: user data
@@ -124,7 +124,7 @@ vips_slist_map2(GSList *list, VipsSListMap2Fn fn, void *a, void *b)
 
 /**
  * vips_slist_map2_rev:
- * @list: (element-type guint8): a #GSList
+ * @list: (element-type guint8): a [struct@GLib.SList]
  * @fn: (scope call): function to apply to each list element
  * @a: user data
  * @b: user data
@@ -153,7 +153,7 @@ vips_slist_map2_rev(GSList *list, VipsSListMap2Fn fn, void *a, void *b)
 
 /**
  * vips_slist_map4:
- * @list: (element-type guint8): a #GSList
+ * @list: (element-type guint8): a [struct@GLib.SList]
  * @fn: (scope call): function to apply to each list element
  * @a: user data
  * @b: user data
@@ -185,7 +185,7 @@ vips_slist_map4(GSList *list,
 
 /**
  * vips_slist_fold2:
- * @list: (element-type guint8): a #GSList
+ * @list: (element-type guint8): a [struct@GLib.SList]
  * @start: initial value for the accumulator
  * @fn: (scope call): function to apply to each list element
  * @a: user data
@@ -215,7 +215,7 @@ vips_slist_fold2(GSList *list, void *start,
 
 /**
  * vips_slist_filter:
- * @list: (element-type guint8): a #GSList
+ * @list: (element-type guint8): a [struct@GLib.SList]
  * @fn: (scope call): function to call for each element.
  * @a: user data
  * @b: user data
@@ -264,7 +264,7 @@ vips_slist_free_all_cb(void *thing, void *dummy)
 
 /**
  * vips_slist_free_all:
- * @list: (element-type guint8): a #GSList
+ * @list: (element-type guint8): a [struct@GLib.SList]
  *
  * Free a [struct@GLib.SList] of things which need [func@GLib.free]ing.
  */
@@ -930,7 +930,7 @@ vips__gvalue_ref_string_new(const char *text)
 
 /**
  * vips__gslist_gvalue_free:
- * @list: (element-type GValue): a #GSList of GValue
+ * @list: (element-type GValue): a [struct@GLib.SList] of GValue
  *
  * Free a GSList of GValue.
  */
@@ -943,7 +943,7 @@ vips__gslist_gvalue_free(GSList *list)
 
 /**
  * vips__gslist_gvalue_copy:
- * @list: (element-type GValue): a #GSList of GValue
+ * @list: (element-type GValue): a [struct@GLib.SList] of GValue
  *
  * Copy a GSList of GValue.
  *
@@ -968,8 +968,8 @@ vips__gslist_gvalue_copy(const GSList *list)
 
 /**
  * vips__gslist_gvalue_merge:
- * @a: (element-type GValue): a #GSList of GValue
- * @b: (element-type GValue): a #GSList of GValue
+ * @a: (element-type GValue): a [struct@GLib.SList] of GValue
+ * @b: (element-type GValue): a [struct@GLib.SList] of GValue
  *
  * Merge two GSList of GValue ... append to a all elements in b which are not
  * in a. Works for any vips refcounted type (string, blob, etc.).
@@ -1015,7 +1015,7 @@ vips__gslist_gvalue_merge(GSList *a, const GSList *b)
 
 /**
  * vips__gslist_gvalue_get:
- * @list: (element-type GValue): a #GSList of GValue
+ * @list: (element-type GValue): a [struct@GLib.SList] of GValue
  *
  * Make a char * from GSList of GValue. Each GValue should be a ref_string.
  *

--- a/libvips/morphology/rank.c
+++ b/libvips/morphology/rank.c
@@ -617,7 +617,9 @@ vips_rank_init(VipsRank *rank)
  *
  * For a median filter with mask size m (3 for 3x3, 5 for 5x5, etc.) use
  *
- *  vips_rank(in, out, m, m, m * m / 2);
+ * ```c
+ * vips_rank(in, out, m, m, m * m / 2);
+ * ```
  *
  * The special cases n == 0 and n == m * m - 1 are useful dilate and
  * expand operators.
@@ -650,7 +652,9 @@ vips_rank(VipsImage *in, VipsImage **out,
  *
  * A convenience function equivalent to:
  *
- *  vips_rank(in, out, size, size, (size * size) / 2);
+ * ```c
+ * vips_rank(in, out, size, size, (size * size) / 2);
+ * ```
  *
  * ::: seealso
  *     [method@Image.rank].


### PR DESCRIPTION
I missed these in PR #4499 (`grep`-ing in `Vips-8.0.gir` is much easier than though all the files in `libvips/*`).

While we're here, change the enum members to uppercase in the Markdown files for consistency.