### PR TITLE
Increase minimum version of libheif dependency to 1.11.0

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -31,6 +31,7 @@ master
   public API
 - jxlsave writes in chunks, for lower memory use on large images (but we now
   need libjxl 0.11 at minimum)
+- increase minimum version of libheif dependency to 1.11.0
 
 8.16.1
 

--- a/libvips/foreign/heifsave.c
+++ b/libvips/foreign/heifsave.c
@@ -200,7 +200,6 @@ vips_foreign_save_heif_write_metadata(VipsForeignSaveHeif *heif)
 	return 0;
 }
 
-#ifdef HAVE_HEIF_COLOR_PROFILE
 static int
 vips_foreign_save_heif_add_icc(VipsForeignSaveHeif *heif,
 	const void *profile, size_t length)
@@ -261,7 +260,6 @@ vips_foreign_save_heif_add_orig_icc(VipsForeignSaveHeif *heif)
 
 	return 0;
 }
-#endif /*HAVE_HEIF_COLOR_PROFILE*/
 
 static int
 vips_foreign_save_heif_write_page(VipsForeignSaveHeif *heif, int page)
@@ -270,11 +268,8 @@ vips_foreign_save_heif_write_page(VipsForeignSaveHeif *heif, int page)
 
 	struct heif_error error;
 	struct heif_encoding_options *options;
-#ifdef HAVE_HEIF_ENCODING_OPTIONS_OUTPUT_NCLX_PROFILE
 	struct heif_color_profile_nclx *nclx = NULL;
-#endif
 
-#ifdef HAVE_HEIF_COLOR_PROFILE
 	/* A profile supplied as an argument overrides an embedded
 	 * profile.
 	 */
@@ -286,12 +281,10 @@ vips_foreign_save_heif_write_page(VipsForeignSaveHeif *heif, int page)
 		if (vips_foreign_save_heif_add_orig_icc(heif))
 			return -1;
 	}
-#endif /*HAVE_HEIF_COLOR_PROFILE*/
 
 	options = heif_encoding_options_alloc();
 	options->save_alpha_channel = save->ready->Bands > 3;
 
-#ifdef HAVE_HEIF_ENCODING_OPTIONS_OUTPUT_NCLX_PROFILE
 	/* Matrix coefficients have to be identity (CICP x/y/0) in lossless
 	 * mode.
 	 */
@@ -308,7 +301,6 @@ vips_foreign_save_heif_write_page(VipsForeignSaveHeif *heif, int page)
 		 */
 		options->macOS_compatibility_workaround_no_nclx_profile = 0;
 	}
-#endif /*HAVE_HEIF_ENCODING_OPTIONS_OUTPUT_NCLX_PROFILE*/
 
 #ifdef HAVE_HEIF_ENCODING_OPTIONS_IMAGE_ORIENTATION
 	/* EXIF orientation is informational in the HEIF specification.
@@ -335,9 +327,7 @@ vips_foreign_save_heif_write_page(VipsForeignSaveHeif *heif, int page)
 #endif /*DEBUG*/
 
 	heif_encoding_options_free(options);
-#ifdef HAVE_HEIF_ENCODING_OPTIONS_OUTPUT_NCLX_PROFILE
 	VIPS_FREEF(heif_nclx_color_profile_free, nclx);
-#endif
 
 	if (error.code) {
 		vips__heif_error(&error);
@@ -620,7 +610,6 @@ vips_foreign_save_heif_build(VipsObject *object)
 		return -1;
 	}
 
-#ifdef HAVE_HEIF_ENCODER_PARAMETER_GET_VALID_INTEGER_VALUES
 	for (param = heif_encoder_list_parameters(heif->encoder);
 		*param; param++) {
 		int have_minimum;
@@ -646,7 +635,6 @@ vips_foreign_save_heif_build(VipsObject *object)
 			return -1;
 		}
 	}
-#endif /*HAVE_HEIF_ENCODER_PARAMETER_GET_VALID_INTEGER_VALUES*/
 
 	/* Try to enable auto_tiles. This can make AVIF encoding a lot faster,
 	 * with only a very small increase in file size.

--- a/meson.build
+++ b/meson.build
@@ -481,7 +481,7 @@ if pdfium_dep.found()
     pdf_loader = pdfium_dep
 endif
 
-libheif_dep = dependency('libheif', version: '>=1.4.0', required: get_option('heif'))
+libheif_dep = dependency('libheif', version: '>=1.11.0', required: get_option('heif'))
 libheif_module = false
 if libheif_dep.found()
     libheif_module = modules_enabled and not get_option('heif-module').disabled()
@@ -492,18 +492,6 @@ if libheif_dep.found()
         external_deps += libheif_dep
     endif
     cfg_var.set('HAVE_HEIF', true)
-    # added in 1.6.0
-    cfg_var.set('HAVE_HEIF_COLOR_PROFILE', cpp.has_function('heif_image_handle_get_raw_color_profile', prefix: '#include <libheif/heif.h>', dependencies: libheif_dep))
-    cfg_var.set('HAVE_HEIF_SET_MAX_IMAGE_SIZE_LIMIT', cpp.has_function('heif_context_set_maximum_image_size_limit', prefix: '#include <libheif/heif.h>', dependencies: libheif_dep))
-    # added in 1.7.0
-    cfg_var.set('HAVE_HEIF_DECODING_OPTIONS_CONVERT_HDR_TO_8BIT', cpp.has_member('struct heif_decoding_options', 'convert_hdr_to_8bit', prefix: '#include <libheif/heif.h>', dependencies: libheif_dep))
-    # heif_main_brand added in 1.4.0, but heif_avif appeared in 1.7 ... just check
-    # the libheif version number since testing for enums is annoying
-    cfg_var.set('HAVE_HEIF_AVIF', libheif_dep.version().version_compare('>=1.7.0'))
-    # added in 1.10.0
-    cfg_var.set('HAVE_HEIF_ENCODER_PARAMETER_GET_VALID_INTEGER_VALUES', cpp.has_function('heif_encoder_parameter_get_valid_integer_values', prefix: '#include <libheif/heif.h>', dependencies: libheif_dep))
-    # added in 1.11.0
-    cfg_var.set('HAVE_HEIF_ENCODING_OPTIONS_OUTPUT_NCLX_PROFILE', cpp.has_member('struct heif_encoding_options', 'output_nclx_profile', prefix: '#include <libheif/heif.h>', dependencies: libheif_dep))
     # heif_init added in 1.13.0
     cfg_var.set('HAVE_HEIF_INIT', libheif_dep.version().version_compare('>=1.13.0'))
     # heif_encoding_options.image_orientation added in 1.14.0


### PR DESCRIPTION
Aligns with the libheif version provided by Debian 11, which seems to be the oldest version provided by any actively supported flavour of Linux (Ubuntu 20.04 is EOL this month).