### PR TITLE
heifload: limit per-image memory usage to 2GB by default

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -32,6 +32,7 @@ master
 - jxlsave writes in chunks, for lower memory use on large images (but we now
   need libjxl 0.11 at minimum)
 - increase minimum version of libheif dependency to 1.11.0
+- heifload: limit per-image memory usage to 2GB (requires libheif 1.20.0+).
 
 8.16.1
 

--- a/libvips/foreign/heifload.c
+++ b/libvips/foreign/heifload.c
@@ -355,6 +355,11 @@ vips_foreign_load_heif_build(VipsObject *object)
 		 */
 		heif_context_set_maximum_image_size_limit(heif->ctx,
 			heif->unlimited ? USHRT_MAX : 0x4000);
+#ifdef HAVE_HEIF_MAX_TOTAL_MEMORY
+		if (!heif->unlimited)
+			heif_context_get_security_limits(heif->ctx)
+				->max_total_memory = 2UL * 1024 * 1024 * 1024;
+#endif /* HAVE_HEIF_MAX_TOTAL_MEMORY */
 #ifdef HAVE_HEIF_GET_DISABLED_SECURITY_LIMITS
 		if (heif->unlimited)
 			heif_context_set_security_limits(heif->ctx,

--- a/meson.build
+++ b/meson.build
@@ -500,6 +500,8 @@ if libheif_dep.found()
     cfg_var.set('HAVE_HEIF_ERROR_SUCCESS', libheif_dep.version().version_compare('>=1.17.0'))
     # heif_get_disabled_security_limits added in 1.19.0
     cfg_var.set('HAVE_HEIF_GET_DISABLED_SECURITY_LIMITS', cpp.has_function('heif_get_disabled_security_limits', prefix: '#include <libheif/heif.h>', dependencies: libheif_dep))
+    # heif_security_limits.max_total_memory added in 1.20.0
+    cfg_var.set('HAVE_HEIF_MAX_TOTAL_MEMORY', cpp.has_member('struct heif_security_limits', 'max_total_memory', prefix: '#include <libheif/heif.h>', dependencies: libheif_dep))
 endif
 
 # need v0.11+ for chunked write


### PR DESCRIPTION
The upstream default is 4GB, which is too big for the fuzz test environment and IMHO is too big for a sensible default. Halving the default limit to 2GB means all the current "Out-of-memory" fuzz test failures will go away, and seems to be sufficient to process all the HEIF images I've tested with. It is however an(other) arbitrary value and I'd be happy to modify it based on further feedback.

The existing `unlimited` flag can be used to remove this.

Before:
```
$ vips heifload clusterfuzz-testcase-minimized-rawsave_buffer_fuzzer-6038980984635392
clusterfuzz-testcase-minimized-rawsave_buffer_fuzzer-6038980984635392: bad seek to 1024
...
heif: Invalid input: Unexpected end of file (2.100)
```
After:
```
$ vips heifload clusterfuzz-testcase-minimized-rawsave_buffer_fuzzer-6038980984635392
clusterfuzz-testcase-minimized-rawsave_buffer_fuzzer-6038980984635392: bad seek to 1024
...
heif: Memory allocation error: Security limit exceeded: Memory usage of 3774939392 bytes for the 'saio' table exceeds the security limit of 2147483648 bytes of total memory usage (6.1000)
```
After with `--unlimited` flag:
```
$ vips heifload clusterfuzz-testcase-minimized-rawsave_buffer_fuzzer-6038980984635392 --unlimited
clusterfuzz-testcase-minimized-rawsave_buffer_fuzzer-6038980984635392: bad seek to 1024
...
heif: Invalid input: Unexpected end of file (2.100)
```