### PR TITLE
doc: minor gi-docgen improvements

### DIFF
--- a/libvips/arithmetic/boolean.c
+++ b/libvips/arithmetic/boolean.c
@@ -622,7 +622,7 @@ vips_boolean_constv(VipsImage *in, VipsImage **out,
  * Perform various boolean operations on an image against an array of
  * constants.
  *
- * The output type is always uchar, with 0 for FALSE and 255 for TRUE.
+ * The output type is always uchar, with 0 for `FALSE` and 255 for `TRUE`.
  *
  * If the array of constants has just one element, that constant is used for
  * all image bands. If the array has more than one element and they have

--- a/libvips/arithmetic/relational.c
+++ b/libvips/arithmetic/relational.c
@@ -274,7 +274,7 @@ vips_relationalv(VipsImage *left, VipsImage *right, VipsImage **out,
  *
  * Perform various relational operations on pairs of images.
  *
- * The output type is always uchar, with 0 for FALSE and 255 for TRUE.
+ * The output type is always uchar, with 0 for `FALSE` and 255 for `TRUE`.
  *
  * Less-than and greater-than for complex images compare the modulus.
  *
@@ -657,7 +657,7 @@ vips_relational_constv(VipsImage *in, VipsImage **out,
  * Perform various relational operations on an image and an array of
  * constants.
  *
- * The output type is always uchar, with 0 for FALSE and 255 for TRUE.
+ * The output type is always uchar, with 0 for `FALSE` and 255 for `TRUE`.
  *
  * If the array of constants has just one element, that constant is used for
  * all image bands. If the array has more than one element and they have

--- a/libvips/conversion/ifthenelse.c
+++ b/libvips/conversion/ifthenelse.c
@@ -582,7 +582,7 @@ vips_ifthenelse_init(VipsIfthenelse *ifthenelse)
  * and @in2 using the formula:
  *
  * ```
- *     out = (cond / 255) * in1 + (1 - cond / 255) * in2
+ * out = (cond / 255) * in1 + (1 - cond / 255) * in2
  * ```
  *
  * ::: tip "Optional arguments"

--- a/libvips/conversion/premultiply.c
+++ b/libvips/conversion/premultiply.c
@@ -288,9 +288,9 @@ vips_premultiply_init(VipsPremultiply *premultiply)
  * The final band is taken to be the alpha and the bands are transformed as:
  *
  * ```
- *   alpha = clip(0, in[in.bands - 1], max_alpha)
- *   norm = alpha / max_alpha
- *   out = [in[0] * norm, ..., in[in.bands - 1] * norm, alpha]
+ * alpha = clip(0, in[in.bands - 1], max_alpha)
+ * norm = alpha / max_alpha
+ * out = [in[0] * norm, ..., in[in.bands - 1] * norm, alpha]
  * ```
  *
  * So for an N-band image, the first N - 1 bands are multiplied by the clipped

--- a/libvips/conversion/unpremultiply.c
+++ b/libvips/conversion/unpremultiply.c
@@ -358,12 +358,12 @@ vips_unpremultiply_init(VipsUnpremultiply *unpremultiply)
  * other bands are transformed as:
  *
  * ```
- *   alpha = (int) clip(0, in[in.bands - 1], max_alpha);
- *   norm = (double) alpha / max_alpha
- *   if (alpha == 0)
- *   	out = [0, ..., 0, alpha]
- *   else
- *   	out = [in[0] / norm, ..., in[in.bands - 1] / norm, alpha]
+ * alpha = (int) clip(0, in[in.bands - 1], max_alpha);
+ * norm = (double) alpha / max_alpha
+ * if (alpha == 0)
+ *     out = [0, ..., 0, alpha]
+ * else
+ *     out = [in[0] / norm, ..., in[in.bands - 1] / norm, alpha]
  * ```
  *
  * So for an N-band image, the first N - 1 bands are divided by the clipped

--- a/libvips/convolution/sharpen.c
+++ b/libvips/convolution/sharpen.c
@@ -409,34 +409,34 @@ vips_sharpen_init(VipsSharpen *sharpen)
  * The lookup table is formed like this:
  *
  * ```
- * .                     ^
- * .                  y2 |- - - - - -----------
- * .                     |         /
- * .                     |        / slope m2
- * .                     |    .../
- * .             -x1     | ...   |
- * . -------------------...---------------------->
- * .             |   ... |      x1
- * .             |... slope m1
- * .             /       |
- * .            / m2     |
- * .           /         |
- * .          /          |
- * .         /           |
- * .        /            |
- * . ______/ _ _ _ _ _ _ | -y3
- * .                     |
+ *                     ^
+ *                  y2 |- - - - - -----------
+ *                     |         /
+ *                     |        / slope m2
+ *                     |    .../
+ *             -x1     | ...   |
+ * -------------------...---------------------->
+ *             |   ... |      x1
+ *             |... slope m1
+ *             /       |
+ *            / m2     |
+ *           /         |
+ *          /          |
+ *         /           |
+ *        /            |
+ * ______/ _ _ _ _ _ _ | -y3
+ *                     |
  * ```
  *
  * For screen output, we suggest the following settings (the defaults):
  *
  * ```
- *   sigma == 0.5
- *   x1 == 2
- *   y2 == 10         (don't brighten by more than 10 L*)
- *   y3 == 20         (can darken by up to 20 L*)
- *   m1 == 0          (no sharpening in flat areas)
- *   m2 == 3          (some sharpening in jaggy areas)
+ * sigma == 0.5
+ * x1 == 2
+ * y2 == 10         (don't brighten by more than 10 L*)
+ * y3 == 20         (can darken by up to 20 L*)
+ * m1 == 0          (no sharpening in flat areas)
+ * m2 == 3          (some sharpening in jaggy areas)
  * ```
  *
  * If you want more or less sharpening, we suggest you just change the

--- a/libvips/foreign/cgifsave.c
+++ b/libvips/foreign/cgifsave.c
@@ -1153,15 +1153,15 @@ vips_foreign_save_cgif_buffer_init(VipsForeignSaveCgifBuffer *buffer)
  * Use @interpalette_maxerror to set the threshold below which the
  * previously generated palette will be reused.
  *
- * If @reuse is TRUE, the GIF will be saved with a single global
+ * If @reuse is `TRUE`, the GIF will be saved with a single global
  * palette taken from the metadata in @in, and no new palette optimisation
  * will be done.
  *
- * If @interlace is TRUE, the GIF file will be interlaced (progressive GIF).
+ * If @interlace is `TRUE`, the GIF file will be interlaced (progressive GIF).
  * These files may be better for display over a slow network
  * connection, but need more memory to encode.
  *
- * If @keep_duplicate_frames is TRUE, duplicate frames in the input will be
+ * If @keep_duplicate_frames is `TRUE`, duplicate frames in the input will be
  * kept in the output instead of combining them.
  *
  * ::: tip "Optional arguments"

--- a/libvips/foreign/foreign.c
+++ b/libvips/foreign/foreign.c
@@ -158,8 +158,8 @@
  * The suffix list is used to select a format to save a file in, and to pick a
  * loader if you don't define [func@Foreign.is_a].
  *
- * You should also define [property@VipsObject:nickname] and
- * [property@VipsObject:description] in [class@Object].
+ * You should also define [property@Object:nickname] and
+ * [property@Object:description] in [class@Object].
  *
  * As a complete example, here's code for a PNG loader, minus the actual
  * calls to libpng.

--- a/libvips/foreign/foreign.c
+++ b/libvips/foreign/foreign.c
@@ -457,11 +457,11 @@ file_compare(VipsForeignClass *a, VipsForeignClass *b, void *user_data)
 /**
  * vips_foreign_map:
  * @base: base class to search below (eg. "VipsForeignLoad")
- * @fn: (scope call): function to apply to each [class@Foreign]Class
+ * @fn: (scope call): function to apply to each [class@Foreign]
  * @a: user data
  * @b: user data
  *
- * Apply a function to every [class@Foreign]Class that VIPS knows about. Foreigns
+ * Apply a function to every [class@Foreign] that VIPS knows about. Foreigns
  * are presented to the function in priority order.
  *
  * Like all VIPS map functions, if @fn returns `NULL`, iteration continues. If

--- a/libvips/foreign/jpegsave.c
+++ b/libvips/foreign/jpegsave.c
@@ -559,17 +559,17 @@ vips_foreign_save_jpeg_mime_init(VipsForeignSaveJpegMime *mime)
  * If @quant_table is set and the version of libjpeg supports it
  * (e.g. mozjpeg >= 3.0) it selects the quantization table to use:
  *
- * * 0 — Tables from JPEG Annex K (vips and libjpeg default)
- * * 1 — Flat table
- * * 2 — Table tuned for MSSIM on Kodak image set
- * * 3 — Table from ImageMagick by N. Robidoux (current mozjpeg default)
- * * 4 — Table tuned for PSNR-HVS-M on Kodak image set
- * * 5 — Table from Relevance of Human Vision to JPEG-DCT Compression (1992)
- * * 6 — Table from DCTune Perceptual Optimization of Compressed Dental
+ * - 0 — Tables from JPEG Annex K (vips and libjpeg default)
+ * - 1 — Flat table
+ * - 2 — Table tuned for MSSIM on Kodak image set
+ * - 3 — Table from ImageMagick by N. Robidoux (current mozjpeg default)
+ * - 4 — Table tuned for PSNR-HVS-M on Kodak image set
+ * - 5 — Table from Relevance of Human Vision to JPEG-DCT Compression (1992)
+ * - 6 — Table from DCTune Perceptual Optimization of Compressed Dental
  *   X-Rays (1997)
- * * 7 — Table from A Visual Detection Model for DCT Coefficient
+ * - 7 — Table from A Visual Detection Model for DCT Coefficient
  *   Quantization (1993)
- * * 8 — Table from An Improved Detection Model for DCT Coefficient
+ * - 8 — Table from An Improved Detection Model for DCT Coefficient
  *   Quantization (1993)
  *
  * Quantization table 0 is the default in vips and libjpeg(-turbo), but it

--- a/libvips/foreign/magickload.c
+++ b/libvips/foreign/magickload.c
@@ -75,7 +75,7 @@
  * attached to the libMagick image is copied on to the VIPS image.
  *
  * The reader should also work with most versions of GraphicsMagick. See the
- * "--with-magickpackage" configure option.
+ * `-Dmagick-package` configure option.
  *
  * The file format is usually guessed from the filename suffix, or sniffed
  * from the file contents.

--- a/libvips/foreign/tiffload.c
+++ b/libvips/foreign/tiffload.c
@@ -502,7 +502,7 @@ vips_foreign_load_tiff_buffer_init(VipsForeignLoadTiffBuffer *buffer)
  * operations will use [const@META_ORIENTATION], if present, to set the
  * orientation of output images.
  *
- * If @autorotate is TRUE, the image will be rotated upright during load and
+ * If @autorotate is `TRUE`, the image will be rotated upright during load and
  * no metadata attached. This can be very slow.
  *
  * If @subifd is -1 (the default), the main image is selected for each page.

--- a/libvips/foreign/tiffsave.c
+++ b/libvips/foreign/tiffsave.c
@@ -635,7 +635,7 @@ vips_foreign_save_tiff_buffer_init(VipsForeignSaveTiffBuffer *buffer)
  * differencing. Please refer to the libtiff
  * specifications for further discussion of various predictors.
  *
- * Set @tile to TRUE to write a tiled tiff.  By default tiff are written in
+ * Set @tile to `TRUE` to write a tiled tiff.  By default tiff are written in
  * strips. Use @tile_width and @tile_height to set the tile size. The defaiult
  * is 128 by 128.
  *

--- a/libvips/histogram/maplut.c
+++ b/libvips/histogram/maplut.c
@@ -783,10 +783,10 @@ vips_maplut_init(VipsMaplut *maplut)
  * The lut may have any type and the output image will be that type.
  *
  * The input image will be cast to one of the unsigned integer types, that is,
- * VIPS_FORMAT_UCHAR, VIPS_FORMAT_USHORT or VIPS_FORMAT_UINT.
+ * [enum@Vips.BandFormat.UCHAR], [enum@Vips.BandFormat.USHORT] or [enum@Vips.BandFormat.UINT].
  *
  * If @lut is too small for the input type (for example, if @in is
- * VIPS_FORMAT_UCHAR but @lut only has 100 elements), the lut is padded out
+ * [enum@Vips.BandFormat.UCHAR] but @lut only has 100 elements), the lut is padded out
  * by copying the last element. Overflows are reported at the end of
  * computation.
  * If @lut is too large, extra values are ignored.

--- a/libvips/include/vips/foreign.h
+++ b/libvips/include/vips/foreign.h
@@ -317,7 +317,8 @@ void vips_foreign_load_invalidate(VipsImage *image);
  *
  * The set of image types supported by a saver.
  *
- * See also: [class@ForeignSave].
+ * ::: seealso
+ *     [class@ForeignSave].
  */
 typedef enum /*< flags >*/ {
 	VIPS_FOREIGN_SAVEABLE_MONO = 1,

--- a/libvips/include/vips/header.h
+++ b/libvips/include/vips/header.h
@@ -129,21 +129,21 @@ extern "C" {
  * The orientation tag for this image. An int from 1 - 8 using the standard
  * exif/tiff meanings.
  *
- * * 1 - The 0th row represents the visual top of the image, and the 0th column
+ * - 1 - The 0th row represents the visual top of the image, and the 0th column
  *   represents the visual left-hand side.
- * * 2 - The 0th row represents the visual top of the image, and the 0th column
+ * - 2 - The 0th row represents the visual top of the image, and the 0th column
  *   represents the visual right-hand side.
- * * 3 - The 0th row represents the visual bottom of the image, and the 0th
+ * - 3 - The 0th row represents the visual bottom of the image, and the 0th
  *   column represents the visual right-hand side.
- * * 4 - The 0th row represents the visual bottom of the image, and the 0th
+ * - 4 - The 0th row represents the visual bottom of the image, and the 0th
  *   column represents the visual left-hand side.
- * * 5 - The 0th row represents the visual left-hand side of the image, and the
+ * - 5 - The 0th row represents the visual left-hand side of the image, and the
  *   0th column represents the visual top.
- * * 6 - The 0th row represents the visual right-hand side of the image, and the
+ * - 6 - The 0th row represents the visual right-hand side of the image, and the
  *   0th column represents the visual top.
- * * 7 - The 0th row represents the visual right-hand side of the image, and the
+ * - 7 - The 0th row represents the visual right-hand side of the image, and the
  *   0th column represents the visual bottom.
- * * 8 - The 0th row represents the visual left-hand side of the image, and the
+ * - 8 - The 0th row represents the visual left-hand side of the image, and the
  *   0th column represents the visual bottom.
  */
 #define VIPS_META_ORIENTATION "orientation"

--- a/libvips/iofuncs/buf.c
+++ b/libvips/iofuncs/buf.c
@@ -61,9 +61,9 @@
  *
  * vips_buf_appends(&buf, "Numbers are: ");
  * for (i = 0; i < array_length; i++) {
- *   if (i > 0)
- *     vips_buf_appends(&buf, ", ");
- *   vips_buf_appendg(&buf, array[i]);
+ *     if (i > 0)
+ *         vips_buf_appends(&buf, ", ");
+ *     vips_buf_appendg(&buf, array[i]);
  * }
  * printf("%s", vips_buf_all(&buf));
  * ```

--- a/libvips/iofuncs/connection.c
+++ b/libvips/iofuncs/connection.c
@@ -141,7 +141,7 @@ vips_connection_init(VipsConnection *connection)
  * vips_connection_filename:
  * @connection: connection to operate on
  *
- * Returns: any filename associated with this connection, or NULL.
+ * Returns: any filename associated with this connection, or `NULL`.
  */
 const char *
 vips_connection_filename(VipsConnection *connection)

--- a/libvips/iofuncs/image.c
+++ b/libvips/iofuncs/image.c
@@ -320,11 +320,11 @@
  * @X: x coordinate
  * @Y: y coordinate
  *
- * This macro returns a pointer to a pixel in an image, cast to a [alias@Pel]*.
+ * This macro returns a pointer to a pixel in an image, cast to a [alias@Pel] \*.
  * It only works for images which are fully available in memory, so memory
  * buffers and small mapped images only.
  *
- * If VIPS_DEBUG is defined, you get a version that checks bounds for you.
+ * If `VIPS_DEBUG` is defined, you get a version that checks bounds for you.
  *
  * ::: seealso
  *     [method@Image.wio_input], [method@Image.inplace], [func@REGION_ADDR].
@@ -343,7 +343,7 @@
  * fully available in memory, so memory buffers and small
  * mapped images only.
  *
- * If VIPS_DEBUG is defined, you get a version that checks bounds and image
+ * If `VIPS_DEBUG` is defined, you get a version that checks bounds and image
  * type for you.
  *
  * ::: seealso
@@ -386,8 +386,8 @@ G_DEFINE_TYPE(VipsImage, vips_image, VIPS_TYPE_OBJECT);
  * @progress: `TRUE` to enable progress messages
  *
  * If set, vips will print messages about the progress of computation to
- * stdout. This can also be enabled with the --vips-progress option, or by
- * setting the environment variable VIPS_PROGRESS.
+ * stdout. This can also be enabled with the `--vips-progress` option, or by
+ * setting the environment variable `VIPS_PROGRESS`.
  */
 void
 vips_progress_set(gboolean progress)
@@ -1447,7 +1447,7 @@ vips_image_minimise_all(VipsImage *image)
  * vips_image_is_sequential:
  * @image: [class@Image] to minimise
  *
- * TRUE if any of the images upstream from @image were opened in sequential
+ * `TRUE` if any of the images upstream from @image were opened in sequential
  * mode. Some operations change behaviour slightly in sequential mode to
  * optimize memory behaviour.
  *
@@ -1853,7 +1853,7 @@ vips_filename_get_options(const char *vips_filename)
  * OpenEXR, CSV, WebP, Radiance, RAW, PPM and others.
  *
  * Load options may be appended to @filename as `[name=value,...]` or given as
- * a NULL-terminated list of name-value pairs at the end of the arguments.
+ * a `NULL`-terminated list of name-value pairs at the end of the arguments.
  * Options given in the function call override options given in the filename.
  * Many loaders add extra options, see [ctor@Image.jpegload], for example.
  *
@@ -2139,7 +2139,7 @@ vips_image_new_from_memory_copy(const void *data, size_t size,
  * freed when the image is closed. See for example [signal@Object::close].
  *
  * Load options may be given in @option_string as `[name=value,...]` or given as
- * a NULL-terminated list of name-value pairs at the end of the arguments.
+ * a `NULL`-terminated list of name-value pairs at the end of the arguments.
  * Options given in the function call override options given in the filename.
  *
  * ::: seealso
@@ -2189,7 +2189,7 @@ vips_image_new_from_buffer(const void *buf, size_t len,
  * loader recommended by [func@Foreign.find_load_source].
  *
  * Load options may be given in @option_string as `[name=value,...]` or given as
- * a NULL-terminated list of name-value pairs at the end of the arguments.
+ * a `NULL`-terminated list of name-value pairs at the end of the arguments.
  * Options given in the function call override options given in the string.
  *
  * ::: seealso
@@ -2513,7 +2513,7 @@ vips_image_set_delete_on_close(VipsImage *image, gboolean delete_on_close)
  *
  * Return the number of bytes at which we flip between open via memory and
  * open via disc. This defaults to 100mb, but can be changed with the
- * VIPS_DISC_THRESHOLD environment variable or the --vips-disc-threshold
+ * `VIPS_DISC_THRESHOLD` environment variable or the `--vips-disc-threshold`
  * command-line flag. See [ctor@Image.new_from_file].
  *
  * Returns: disc threshold in bytes.
@@ -2679,7 +2679,7 @@ vips_image_write(VipsImage *image, VipsImage *out)
  * [func@Foreign.find_save].
  *
  * Save options may be appended to @filename as `[name=value,...]` or given as
- * a NULL-terminated list of name-value pairs at the end of the arguments.
+ * a `NULL`-terminated list of name-value pairs at the end of the arguments.
  * Options given in the function call override options given in the filename.
  *
  * ::: seealso
@@ -2743,7 +2743,7 @@ vips_image_write_to_file(VipsImage *image, const char *name, ...)
  * Writes @in to a memory buffer in a format specified by @suffix.
  *
  * Save options may be appended to @suffix as `[name=value,...]` or given as
- * a NULL-terminated list of name-value pairs at the end of the arguments.
+ * a `NULL`-terminated list of name-value pairs at the end of the arguments.
  * Options given in the function call override options given in the filename.
  *
  * Currently only TIFF, JPEG and PNG formats are supported.
@@ -2833,7 +2833,7 @@ vips_image_write_to_buffer(VipsImage *in,
  * Writes @in to @output in format @suffix.
  *
  * Save options may be appended to @suffix as `[name=value,...]` or given as
- * a NULL-terminated list of name-value pairs at the end of the arguments.
+ * a `NULL`-terminated list of name-value pairs at the end of the arguments.
  * Options given in the function call override options given in the filename.
  *
  * You can call the various save operations directly if you wish, see

--- a/libvips/iofuncs/init.c
+++ b/libvips/iofuncs/init.c
@@ -234,20 +234,20 @@ vips_get_prgname(void)
  *
  * [func@INIT] does approximately the following:
  *
- * + checks that the libvips your program is expecting is
+ * - checks that the libvips your program is expecting is
  *   binary-compatible with the vips library you're running against
  *
- * + sets a minimum stack size, see above
+ * - sets a minimum stack size, see above
  *
- * + initialises any libraries that VIPS is using, including GObject
+ * - initialises any libraries that VIPS is using, including GObject
  *   and the threading system, if necessary
  *
- * + guesses where the VIPS data files are and sets up
+ * - guesses where the VIPS data files are and sets up
  *   internationalisation -- see [func@guess_prefix]
  *
- * + creates the main vips types, including [class@Image] and friends
+ * - creates the main vips types, including [class@Image] and friends
  *
- * + loads any plugins from $libdir/vips-x.y/, where x and y are the
+ * - loads any plugins from $libdir/vips-x.y/, where x and y are the
  *   major and minor version numbers for this VIPS.
  *
  * Example:

--- a/libvips/iofuncs/object.c
+++ b/libvips/iofuncs/object.c
@@ -181,7 +181,7 @@
  *
  * [flags@Vips.ArgumentFlags.SET_ALWAYS] is handy for arguments which are set from C. For
  * example, VipsImage::width is a property that gives access to the Xsize
- * member of struct _VipsImage. We default its 'assigned' to TRUE
+ * member of struct _VipsImage. We default its 'assigned' to `TRUE`
  * since the field is always set directly by C.
  *
  * [flags@Vips.ArgumentFlags.DEPRECATED] arguments are not shown in help text, are not
@@ -2956,7 +2956,7 @@ vips_class_build_hash_cb(void *dummy)
  *
  * Search below @basename, return the [alias@GObject.Type] of the class
  * whose name or @nickname matches, or 0 for not found.
- * If @basename is NULL, the whole of [class@Object] is searched.
+ * If @basename is `NULL`, the whole of [class@Object] is searched.
  *
  * This function uses a cache, so it should be quick.
  *
@@ -3055,11 +3055,11 @@ vips_object_local_array_cb(VipsObject *parent, VipsObjectLocal *local)
  * @parent: objects unref when this object unrefs
  * @n: array size
  *
- * Make an array of NULL VipsObject pointers. When @parent closes, every
- * non-NULL pointer in the array will be unreffed and the array will be
+ * Make an array of `NULL` VipsObject pointers. When @parent closes, every
+ * non-`NULL` pointer in the array will be unreffed and the array will be
  * freed. Handy for creating a set of temporary images for a function.
  *
- * The array is NULL-terminated, ie. contains an extra NULL element at the
+ * The array is `NULL`-terminated, ie. contains an extra `NULL` element at the
  * end.
  *
  * Example:
@@ -3075,7 +3075,7 @@ vips_object_local_array_cb(VipsObject *parent, VipsObjectLocal *local)
  *   return -1;
  * ```
  *
- * Returns: an array of NULL pointers of length @n
+ * Returns: an array of `NULL` pointers of length @n
  */
 VipsObject **
 vips_object_local_array(VipsObject *parent, int n)

--- a/libvips/iofuncs/object.c
+++ b/libvips/iofuncs/object.c
@@ -3072,7 +3072,7 @@ vips_object_local_array_cb(VipsObject *parent, VipsObjectLocal *local)
  *     vips_invert(t[0], &t[1], NULL) ||
  *     vips_add(t[1], t[0], &t[2], NULL) ||
  *     vips_costra(t[2], out, NULL))
- *   return -1;
+ *     return -1;
  * ```
  *
  * Returns: an array of `NULL` pointers of length @n

--- a/libvips/iofuncs/object.c
+++ b/libvips/iofuncs/object.c
@@ -180,7 +180,7 @@
  * us. We also automatically watch for "destroy" and unlink.
  *
  * [flags@Vips.ArgumentFlags.SET_ALWAYS] is handy for arguments which are set from C. For
- * example, VipsImage::width is a property that gives access to the Xsize
+ * example, [property@Image:width] is a property that gives access to the Xsize
  * member of struct _VipsImage. We default its 'assigned' to `TRUE`
  * since the field is always set directly by C.
  *
@@ -582,7 +582,7 @@ vips_argument_table_destroy(VipsArgumentTable *table)
  * @a: client data
  * @b: client data
  *
- * Loop over the vips_arguments to an object. Stop when @fn returns non-`NULL`
+ * Loop over the [struct@Argument] of an object. Stop when @fn returns non-`NULL`
  * and return that value.
  *
  * Returns: `NULL` if @fn returns `NULL` for all arguments, otherwise the first
@@ -3055,7 +3055,7 @@ vips_object_local_array_cb(VipsObject *parent, VipsObjectLocal *local)
  * @parent: objects unref when this object unrefs
  * @n: array size
  *
- * Make an array of `NULL` VipsObject pointers. When @parent closes, every
+ * Make an array of `NULL` [class@Object] pointers. When @parent closes, every
  * non-`NULL` pointer in the array will be unreffed and the array will be
  * freed. Handy for creating a set of temporary images for a function.
  *

--- a/libvips/iofuncs/object.c
+++ b/libvips/iofuncs/object.c
@@ -3242,7 +3242,7 @@ vips_object_unref_outputs(VipsObject *object)
  *
  * Fetch the object description. Useful for language bindings.
  *
- * [property@VipsObject:description] is only available after `_build()`, which can be too
+ * [property@Object:description] is only available after `_build()`, which can be too
  * late. This function fetches from the instance, if possible, but falls back
  * to the class description if we are too early.
  *

--- a/libvips/iofuncs/operation.c
+++ b/libvips/iofuncs/operation.c
@@ -140,7 +140,7 @@
  *
  * if (vips_invert(im, &t[0], NULL) ||
  *     vips_flip(t[0], &t[1], VIPS_DIRECTION_HORIZONTAL, NULL))
- *   return -1;
+ *     return -1;
  * ```
  *
  * where `parent` is some enclosing object which will be unreffed when this

--- a/libvips/iofuncs/operation.c
+++ b/libvips/iofuncs/operation.c
@@ -56,7 +56,7 @@
  *
  * An abstract base class for all operations in libvips.
  *
- * It builds on [class@VipsObject] to provide the introspection and
+ * It builds on [class@Object] to provide the introspection and
  * command-line interface to libvips.
  *
  * It also maintains a cache of recent operations. See below.

--- a/libvips/iofuncs/region.c
+++ b/libvips/iofuncs/region.c
@@ -785,9 +785,9 @@ vips_region_region(VipsRegion *reg,
  * Do two regions point to the same piece of image? ie.
  *
  * ```c
- * 	VIPS_REGION_ADDR(reg1, x, y) == VIPS_REGION_ADDR(reg2, x, y) &&
- * 	*VIPS_REGION_ADDR(reg1, x, y) ==
- * 		*VIPS_REGION_ADDR(reg2, x, y) for all x, y, reg1, reg2.
+ * VIPS_REGION_ADDR(reg1, x, y) == VIPS_REGION_ADDR(reg2, x, y) &&
+ * *VIPS_REGION_ADDR(reg1, x, y) ==
+ *     *VIPS_REGION_ADDR(reg2, x, y) for all x, y, reg1, reg2.
  * ```
  *
  * Returns: non-zero on equality.

--- a/libvips/iofuncs/sbuf.c
+++ b/libvips/iofuncs/sbuf.c
@@ -323,7 +323,7 @@ vips_sbuf_require(VipsSbuf *sbuf, int require)
  * line character (or characters, for DOS files) are removed, and the string
  * is terminated with a null (`\0` character).
  *
- * Returns NULL on end of file or read error.
+ * Returns `NULL` on end of file or read error.
  *
  * If the line is longer than some arbitrary (but large) limit, it is
  * truncated. If you need to be able to read very long lines, use the
@@ -332,7 +332,7 @@ vips_sbuf_require(VipsSbuf *sbuf, int require)
  * The return value is owned by @sbuf and must not be freed. It
  * is valid until the next get call to @sbuf.
  *
- * Returns: the next line of text, or NULL on EOF or read error.
+ * Returns: the next line of text, or `NULL` on EOF or read error.
  */
 const char *
 vips_sbuf_get_line(VipsSbuf *sbuf)
@@ -398,7 +398,7 @@ vips_sbuf_get_line(VipsSbuf *sbuf)
  * This is slower than [method@Sbuf.get_line], but can work with lines of
  * any length.
  *
- * Returns: the next line of text, or NULL on EOF or read error.
+ * Returns: the next line of text, or `NULL` on EOF or read error.
  */
 char *
 vips_sbuf_get_line_copy(VipsSbuf *sbuf)
@@ -464,7 +464,7 @@ vips_sbuf_get_line_copy(VipsSbuf *sbuf)
  * The return value is owned by @sbuf and must not be freed. It
  * is valid until the next get call to @sbuf.
  *
- * Returns: the next block of non-whitespace, or NULL on EOF or read error.
+ * Returns: the next block of non-whitespace, or `NULL` on EOF or read error.
  */
 const char *
 vips_sbuf_get_non_whitespace(VipsSbuf *sbuf)

--- a/libvips/iofuncs/sinkdisc.c
+++ b/libvips/iofuncs/sinkdisc.c
@@ -476,7 +476,8 @@ write_free(Write *write)
  * The function should write the pixels in @area from @region. @a is the
  * value passed into [method@Image.sink_disc].
  *
- * See also: [method@Image.sink_disc].
+ * ::: seealso
+ *     [method@Image.sink_disc].
  *
  * Returns: 0 on success, -1 on error.
  */
@@ -498,7 +499,8 @@ write_free(Write *write)
  * disc files. Things like [method@Image.jpegsave], for example, use this to write
  * images to files in JPEG format.
  *
- * See also: [func@concurrency_set].
+ * ::: seealso
+ *     [func@concurrency_set].
  *
  * Returns: 0 on success, -1 on error.
  */

--- a/libvips/iofuncs/source.c
+++ b/libvips/iofuncs/source.c
@@ -1049,7 +1049,7 @@ vips_source_is_mappable(VipsSource *source)
  * @source: source to operate on
  *
  * Test if this source is a simple file with support for seek. Named pipes,
- * for example, will fail this test. If TRUE, you can use
+ * for example, will fail this test. If `TRUE`, you can use
  * [method@Connection.filename] to find the filename.
  *
  * Use this to add basic source support for older loaders which can only work
@@ -1073,7 +1073,7 @@ vips_source_is_file(VipsSource *source)
 /**
  * vips_source_map:
  * @source: source to operate on
- * @length: return the file length here, or NULL
+ * @length: return the file length here, or `NULL`
  *
  * Map the source entirely into memory and return a pointer to the
  * start. If @length is non-NULL, the source size is written to it.
@@ -1083,7 +1083,7 @@ vips_source_is_file(VipsSource *source)
  *
  * The pointer is valid for as long as @source is alive.
  *
- * Returns: a pointer to the start of the file contents, or NULL on error.
+ * Returns: a pointer to the start of the file contents, or `NULL` on error.
  */
 const void *
 vips_source_map(VipsSource *source, size_t *length)
@@ -1142,7 +1142,7 @@ vips_source_map_cb(void *a, VipsArea *area)
  * Just like [method@Source.map], but return a [struct@Blob] containing the
  * pointer. @source will stay alive as long as the result is alive.
  *
- * Returns: a new [struct@Blob] containing the data, or NULL on error.
+ * Returns: a new [struct@Blob] containing the data, or `NULL` on error.
  */
 VipsBlob *
 vips_source_map_blob(VipsSource *source)
@@ -1381,9 +1381,9 @@ vips_source_sniff_at_most(VipsSource *source,
  * @length: number of bytes to sniff
  *
  * Return a pointer to the first few bytes of the file. If the file is too
- * short, return NULL.
+ * short, return `NULL`.
  *
- * Returns: a pointer to the bytes at the start of the file, or NULL on error.
+ * Returns: a pointer to the bytes at the start of the file, or `NULL` on error.
  */
 unsigned char *
 vips_source_sniff(VipsSource *source, size_t length)

--- a/libvips/iofuncs/targetcustom.c
+++ b/libvips/iofuncs/targetcustom.c
@@ -329,7 +329,7 @@ vips_target_custom_class_init(VipsTargetCustomClass *class)
 	 * VipsTargetCustom::finish:
 	 * @target_custom: the target being operated on
 	 *
-	 * Deprecated for VipsTargetCustom::end.
+	 * Deprecated for [signal@TargetCustom::end].
 	 */
 	vips_target_custom_signals[SIG_FINISH] = g_signal_new("finish",
 		G_TYPE_FROM_CLASS(class),

--- a/libvips/iofuncs/thread.c
+++ b/libvips/iofuncs/thread.c
@@ -196,7 +196,7 @@ vips__concurrency_get_default(void)
  * [func@threadpool_run].
  *
  * The special value 0 means "default". In this case, the number of threads
- * is set by the environment variable VIPS_CONCURRENCY, or if that is not
+ * is set by the environment variable `VIPS_CONCURRENCY`, or if that is not
  * set, the number of threads available on the host machine.
  *
  * ::: seealso
@@ -228,12 +228,12 @@ vips_concurrency_set(int concurrency)
  *
  * If [func@concurrency_set] has been called, this value is used. The special
  * value 0 means "default". You can also use the command-line argument
- * "--vips-concurrency" to set this value.
+ * `--vips-concurrency` to set this value.
  *
  * If [func@concurrency_set] has not been called and no command-line argument
- * was used, vips uses the value of the environment variable VIPS_CONCURRENCY,
+ * was used, vips uses the value of the environment variable `VIPS_CONCURRENCY`.
  *
- * If VIPS_CONCURRENCY has not been set, vips finds the number of hardware
+ * If `VIPS_CONCURRENCY` has not been set, vips finds the number of hardware
  * threads that the host machine can run in parallel and uses that value.
  *
  * The final value is clipped to the range 1 - 1024.

--- a/libvips/iofuncs/threadpool.c
+++ b/libvips/iofuncs/threadpool.c
@@ -555,7 +555,7 @@ vips_threadpool_new(VipsImage *im)
  * ::: seealso
  *     [func@threadpool_run].
  *
- * Returns: a new [class@ThreadState] object, or NULL on error
+ * Returns: a new [class@ThreadState] object, or `NULL` on error
  */
 
 /**

--- a/libvips/iofuncs/threadpool.c
+++ b/libvips/iofuncs/threadpool.c
@@ -80,7 +80,7 @@
 /**
  * VipsThreadState:
  *
- * A [class@VipsThreadState] represents a per-thread state.
+ * A [class@ThreadState] represents a per-thread state.
  *
  * [callback@ThreadpoolAllocateFn] functions can use these members to
  * communicate with [callback@ThreadpoolWorkFn] functions.

--- a/libvips/iofuncs/type.c
+++ b/libvips/iofuncs/type.c
@@ -339,7 +339,7 @@ vips_area_free_array_object(GObject **array, VipsArea *area)
  * An area which holds an array of [class@GObject.Object] s. See [ctor@Area.new_array]. When
  * the area is freed, each [class@GObject.Object] will be unreffed.
  *
- * Add an extra NULL element at the end, handy for eg.
+ * Add an extra `NULL` element at the end, handy for eg.
  * [func@Image.pipeline_array] etc.
  *
  * ::: seealso
@@ -556,7 +556,7 @@ transform_save_string_ref_string(const GValue *src_value, GValue *dest_value)
  * ::: seealso
  *     [method@Area.unref].
  *
- * Returns: (transfer full) (nullable): the new [struct@RefString], or NULL on
+ * Returns: (transfer full) (nullable): the new [struct@RefString], or `NULL` on
  * error.
  */
 VipsRefString *
@@ -1274,7 +1274,7 @@ G_DEFINE_BOXED_TYPE_WITH_CODE(VipsArrayDouble, vips_array_double,
  * will be automatically unreffed for you by
  * [method@Area.unref].
  *
- * Add an extra NULL element at the end, handy for eg.
+ * Add an extra `NULL` element at the end, handy for eg.
  * [func@Image.pipeline_array] etc.
  *
  * ::: seealso
@@ -1313,7 +1313,7 @@ vips_array_image_new(VipsImage **array, int n)
  * will be automatically unreffed for you by
  * [method@Area.unref].
  *
- * Add an extra NULL element at the end, handy for eg.
+ * Add an extra `NULL` element at the end, handy for eg.
  * [func@Image.pipeline_array] etc.
  *
  * ::: seealso

--- a/libvips/mosaicing/matrixinvert.c
+++ b/libvips/mosaicing/matrixinvert.c
@@ -109,7 +109,7 @@ vips_matrixinvert_dispose(GObject *gobject)
  *   PRESS, W. et al, 1992.  Numerical Recipes in C; The Art of Scientific
  *   Computing, 2nd ed.  Cambridge: Cambridge University Press, pp. 43-50.
  *
- * Returns: the decomposed matrix on success, or NULL on error.
+ * Returns: the decomposed matrix on success, or `NULL` on error.
  */
 static VipsImage *
 lu_decomp(VipsImage *mat)

--- a/libvips/resample/affine.c
+++ b/libvips/resample/affine.c
@@ -732,16 +732,16 @@ vips_affine_init(VipsAffine *affine)
  * The transform is:
  *
  * ```
- *  X = @a * (x + @idx) + @b * (y + @idy) + @odx
- *  Y = @c * (x + @idx) + @d * (y + @idy) + @doy
- *  ```
+ * X = @a * (x + @idx) + @b * (y + @idy) + @odx
+ * Y = @c * (x + @idx) + @d * (y + @idy) + @doy
+ * ```
  *
- *  where:
+ * where:
  *
- *  ```
- *  x and y are the coordinates in input image.
- *  X and Y are the coordinates in output image.
- *  (0,0) is the upper left corner.
+ * ```
+ * x and y are the coordinates in input image.
+ * X and Y are the coordinates in output image.
+ * (0,0) is the upper left corner.
  * ```
  *
  * The section of the output space defined by @oarea is written to

--- a/libvips/resample/interpolate.c
+++ b/libvips/resample/interpolate.c
@@ -91,7 +91,7 @@ G_DEFINE_ABSTRACT_TYPE(VipsInterpolate, vips_interpolate, VIPS_TYPE_OBJECT);
  * The interpolated value should be written to the pixel pointed to by @out.
  *
  * ::: seealso
- *     [struct@VipsInterpolateClass].
+ *     [struct@InterpolateClass].
  */
 
 /**
@@ -117,8 +117,8 @@ G_DEFINE_ABSTRACT_TYPE(VipsInterpolate, vips_interpolate, VIPS_TYPE_OBJECT);
  * offset that a specific interpolator needs, or you can leave
  * @get_window_offset `NULL` and set a constant value in @window_offset.
  *
- * You also need to set [property@VipsObject:nickname] and
- * [property@VipsObject:description] in [class@Object].
+ * You also need to set [property@Object:nickname] and
+ * [property@Object:description] in [class@Object].
  *
  * ::: seealso
  *     [callback@InterpolateMethod], [class@Object] or

--- a/libvips/resample/quadratic.c
+++ b/libvips/resample/quadratic.c
@@ -370,15 +370,15 @@ vips_quadratic_init(VipsQuadratic *quadratic)
  * The coefficients are in the input matrix, ordered as:
  *
  * ```
- *   a g
- *   --
- *   b h
- *   c i
- *   --
- *   d j
- *   --
- *   e k
- *   f l
+ * a g
+ * --
+ * b h
+ * c i
+ * --
+ * d j
+ * --
+ * e k
+ * f l
  * ```
  *
  * The matrix height may be 1, 3, 4, 6


### PR DESCRIPTION
See the individual commits for more details. As a possible follow-up, we could remove the `doc/rename.{sed,sh}` scripts now.