### PR TITLE
svgload: introduce rgb128 parameter for SVG 128-bit load support

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -33,6 +33,7 @@ master
   need libjxl 0.11 at minimum)
 - increase minimum version of libheif dependency to 1.11.0
 - heifload: limit per-image memory usage to 2GB (requires libheif 1.20.0+).
+- svgload: introduce high_bitdepth parameter for SVG 128-bit load support [kstanikviacbs]
 
 8.16.1
 

--- a/cplusplus/include/vips/VImage8.h
+++ b/cplusplus/include/vips/VImage8.h
@@ -5784,6 +5784,7 @@ public:
 	 *   - **access** -- Required access pattern for this file, VipsAccess.
 	 *   - **fail_on** -- Error level to fail on, VipsFailOn.
 	 *   - **revalidate** -- Don't use a cached result for this operation, bool.
+	 *   - **rgb128** -- Enable 128-bit rendering
 	 *
 	 * @param filename Filename to load from.
 	 * @param options Set of options.
@@ -5803,6 +5804,7 @@ public:
 	 *   - **access** -- Required access pattern for this file, VipsAccess.
 	 *   - **fail_on** -- Error level to fail on, VipsFailOn.
 	 *   - **revalidate** -- Don't use a cached result for this operation, bool.
+	 *   - **rgb128** -- Enable 128-bit rendering
 	 *
 	 * @param buffer Buffer to load from.
 	 * @param options Set of options.
@@ -5822,6 +5824,7 @@ public:
 	 *   - **access** -- Required access pattern for this file, VipsAccess.
 	 *   - **fail_on** -- Error level to fail on, VipsFailOn.
 	 *   - **revalidate** -- Don't use a cached result for this operation, bool.
+	 *   - **rgb128** -- Enable 128-bit rendering
 	 *
 	 * @param source Source to load from.
 	 * @param options Set of options.

--- a/libvips/foreign/cairo.c
+++ b/libvips/foreign/cairo.c
@@ -134,32 +134,17 @@ vips__bgra2rgba(guint32 *restrict p, int n)
  * The data is assumed to be RGBA (R, G, B, A) 32-bit floats per pixel.
  */
 void vips__rgba128f_unpremultiplied(float *p, int n) {
-    // Iterate over each pixel in the current row
-    for (int x = 0; x < n; x++) {
-        // Calculate the pointer to the start of the current pixel (4 floats: R, G, B, A)
-        float *pixel = p + x * 4;
+	float *restrict pixel = p;
+	for (int x = 0; x < n; x++) {
+		float r = pixel[0];
+		float g = pixel[1];
+		float b = pixel[2];
+		float a = pixel[3];
 
-        float r_prem = pixel[0]; // Premultiplied Red
-        float g_prem = pixel[1]; // Premultiplied Green
-        float b_prem = pixel[2]; // Premultiplied Blue
-        float a = pixel[3]; // Alpha value
+		pixel[0] = a > 0.00001 ? r / a : 0.0;
+		pixel[1] = a > 0.00001 ? g / a : 0.0;
+		pixel[2] = a > 0.00001 ? b / a : 0.0;
 
-        // Use a small epsilon for float comparison to avoid division by exact zero,
-        // which can happen with floating-point numbers.
-        if (a > 0.00001) {
-            // Unpremultiply color channels by dividing by alpha
-            pixel[0] = (r_prem / a); // Write Straight Red back to buffer
-            pixel[1] = (g_prem / a); // Write Straight Green back to buffer
-            pixel[2] = (b_prem / a); // Write Straight Blue back to buffer
-            // pixel[3] (alpha) remains unchanged in memory
-        } else {
-            // Handle fully transparent pixels (alpha is 0 or very close to 0).
-            // The color is undefined, so set color channels to 0.0.
-            // The alpha channel should already be 0.0 in this case.
-            pixel[0] = 0.0;
-            pixel[1] = 0.0;
-            pixel[2] = 0.0;
-            // pixel[3] remains 0.0
-        }
-    }
+		pixel += 4;
+	}
 }

--- a/libvips/foreign/cairo.c
+++ b/libvips/foreign/cairo.c
@@ -133,7 +133,9 @@ vips__bgra2rgba(guint32 *restrict p, int n)
  * Processes ''n'' pixels in the ''p'' buffer.
  * The data is assumed to be RGBA (R, G, B, A) 32-bit floats per pixel.
  */
-void vips__rgba128f_unpremultiplied(float *p, int n) {
+void
+vips__premultiplied_rgb1282scrgba(float *p, int n)
+{
 	float *restrict pixel = p;
 	for (int x = 0; x < n; x++) {
 		float r = pixel[0];

--- a/libvips/include/vips/internal.h
+++ b/libvips/include/vips/internal.h
@@ -324,7 +324,7 @@ VIPS_API
 void vips__premultiplied_bgra2rgba(guint32 *restrict p, int n);
 VIPS_API
 void vips__rgba2bgra_premultiplied(guint32 *restrict p, int n);
-void vips__rgba128f_unpremultiplied(float *p, int n);
+void vips__premultiplied_rgb1282scrgba(float *p, int n);
 void vips__bgra2rgba(guint32 *restrict p, int n);
 void vips__Lab2LabQ_vec(VipsPel *out, float *in, int width);
 void vips__LabQ2Lab_vec(float *out, VipsPel *in, int width);

--- a/libvips/include/vips/internal.h
+++ b/libvips/include/vips/internal.h
@@ -324,6 +324,7 @@ VIPS_API
 void vips__premultiplied_bgra2rgba(guint32 *restrict p, int n);
 VIPS_API
 void vips__rgba2bgra_premultiplied(guint32 *restrict p, int n);
+void vips__rgba128f_unpremultiplied(float *p, int n);
 void vips__bgra2rgba(guint32 *restrict p, int n);
 void vips__Lab2LabQ_vec(VipsPel *out, float *in, int width);
 void vips__LabQ2Lab_vec(float *out, VipsPel *in, int width);

--- a/meson.build
+++ b/meson.build
@@ -390,8 +390,7 @@ if librsvg_found
     cfg_var.set('HAVE_RSVG', true)
     # rsvg_handle_set_stylesheet added in librsvg 2.48.0
     cfg_var.set('HAVE_RSVG_HANDLE_SET_STYLESHEET', cc.has_function('rsvg_handle_set_stylesheet', dependencies: librsvg_dep))
-    cfg_var.set('HAVE_128BIT_SVG_RENDERING',
-    librsvg_dep.version().version_compare('>=2.56.90') and cairo_dep.version().version_compare('>=1.17.2'))
+    cfg_var.set('HAVE_128BIT_SVG_RENDERING', librsvg_dep.version().version_compare('>=2.56.90') and cairo_dep.version().version_compare('>=1.17.2'))
 endif
 
 openslide_dep = dependency('openslide', version: '>=3.4.0', required: get_option('openslide'))

--- a/meson.build
+++ b/meson.build
@@ -384,12 +384,19 @@ endif
 librsvg_dep = dependency('librsvg-2.0', version: '>=2.40.3', required: get_option('rsvg'))
 cairo_dep = dependency('cairo', version: '>=1.2', required: get_option('rsvg'))
 librsvg_found = librsvg_dep.found() and cairo_dep.found()
+svg_128bit_support = false
 if librsvg_found
     external_deps += librsvg_dep
     external_deps += cairo_dep
     cfg_var.set('HAVE_RSVG', true)
     # rsvg_handle_set_stylesheet added in librsvg 2.48.0
     cfg_var.set('HAVE_RSVG_HANDLE_SET_STYLESHEET', cc.has_function('rsvg_handle_set_stylesheet', dependencies: librsvg_dep))
+    librsvg_128bit_dep = dependency('librsvg-2.0', version: '>=2.56.90', required: get_option('rsvg'))
+    cairo_128bit_dep = dependency('cairo', version: '>=1.17.2', required: get_option('rsvg'))
+    svg_128bit_support = librsvg_128bit_dep.found() and cairo_128bit_dep.found()
+    if svg_128bit_support
+        cfg_var.set('HAVE_128BIT_SVG_RENDERING', true)
+    endif
 endif
 
 openslide_dep = dependency('openslide', version: '>=3.4.0', required: get_option('openslide'))
@@ -657,6 +664,7 @@ build_summary = {
      'enable Analyze7 load': [get_option('analyze')],
      'enable PPM load/save': [get_option('ppm')],
      'enable GIF load': [get_option('nsgif')],
+     'enable SVG 128-bit rendering': [svg_128bit_support]
     },
 }
 build_features = {

--- a/meson.build
+++ b/meson.build
@@ -384,19 +384,14 @@ endif
 librsvg_dep = dependency('librsvg-2.0', version: '>=2.40.3', required: get_option('rsvg'))
 cairo_dep = dependency('cairo', version: '>=1.2', required: get_option('rsvg'))
 librsvg_found = librsvg_dep.found() and cairo_dep.found()
-svg_128bit_support = false
 if librsvg_found
     external_deps += librsvg_dep
     external_deps += cairo_dep
     cfg_var.set('HAVE_RSVG', true)
     # rsvg_handle_set_stylesheet added in librsvg 2.48.0
     cfg_var.set('HAVE_RSVG_HANDLE_SET_STYLESHEET', cc.has_function('rsvg_handle_set_stylesheet', dependencies: librsvg_dep))
-    librsvg_128bit_dep = dependency('librsvg-2.0', version: '>=2.56.90', required: get_option('rsvg'))
-    cairo_128bit_dep = dependency('cairo', version: '>=1.17.2', required: get_option('rsvg'))
-    svg_128bit_support = librsvg_128bit_dep.found() and cairo_128bit_dep.found()
-    if svg_128bit_support
-        cfg_var.set('HAVE_128BIT_SVG_RENDERING', true)
-    endif
+    cfg_var.set('HAVE_128BIT_SVG_RENDERING',
+    librsvg_dep.version().version_compare('>=2.56.90') and cairo_dep.version().version_compare('>=1.17.2'))
 endif
 
 openslide_dep = dependency('openslide', version: '>=3.4.0', required: get_option('openslide'))
@@ -664,7 +659,6 @@ build_summary = {
      'enable Analyze7 load': [get_option('analyze')],
      'enable PPM load/save': [get_option('ppm')],
      'enable GIF load': [get_option('nsgif')],
-     'enable SVG 128-bit rendering': [svg_128bit_support]
     },
 }
 build_features = {


### PR DESCRIPTION
With the increasing demand for high quality images - a need of rendering SVG with increased color-depth (more than 8 bit) has also appeared. 

Given Cairo introduced support for new data format unlocking this option for libvips -  `CAIRO_FORMAT_RGBA128F`: https://www.cairographics.org/news/cairo-1.17.2/ - this PR is an attempt to introduce `rgb128` flag into `svgload` to enable high-bit SVG rendering if needed. 