### PR TITLE
improve scaling of hough_line feature space

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -34,6 +34,7 @@ master
 - increase minimum version of libheif dependency to 1.11.0
 - heifload: limit per-image memory usage to 2GB (requires libheif 1.20.0+).
 - svgload: introduce high_bitdepth parameter for SVG 128-bit load support [kstanikviacbs]
+- improve scaling of hough_line feature space [ecbypi]
 
 8.16.1
 

--- a/test/test-suite/test_arithmetic.py
+++ b/test/test-suite/test_arithmetic.py
@@ -397,8 +397,7 @@ class TestArithmetic:
             assert pytest.approx(r) == 40
 
     def test_hough_line(self):
-        # hough_line changed the way it codes parameter space in 8.7 ... don't
-        # test earlier versions
+        # hough_line changed the way it codes parameter space (again) in 8.17
         test = pyvips.Image.black(100, 100).draw_line(100, 10, 90, 90, 10)
 
         for fmt in all_formats:
@@ -411,7 +410,7 @@ class TestArithmetic:
             distance = test.height * y // hough.height
 
             assert pytest.approx(angle) == 45
-            assert pytest.approx(distance) == 70
+            assert pytest.approx(distance) == 75
 
     def test_sin(self):
         def my_sin(x):


### PR DESCRIPTION
we were not scaling against the diagonal size, nor correctly considering negative angles

thanks ecbypi

see https://github.com/libvips/libvips/issues/4494