### PR TITLE
svgload: removed implicit vips_gamma call

### DIFF
--- a/libvips/foreign/svgload.c
+++ b/libvips/foreign/svgload.c
@@ -740,10 +740,11 @@ vips_foreign_load_svg_load(VipsForeignLoad *load)
 			"tile_width", TILE_SIZE,
 			"tile_height", TILE_SIZE,
 			"max_tiles", 2 * (1 + t[0]->Xsize / TILE_SIZE),
-			NULL))
+			NULL) ||
+		vips_image_write(t[1], load->real))
 		return -1;
 
-	return vips_image_write(t[1], load->real);
+	return 0;
 }
 
 static void

--- a/libvips/foreign/svgload.c
+++ b/libvips/foreign/svgload.c
@@ -743,14 +743,7 @@ vips_foreign_load_svg_load(VipsForeignLoad *load)
 			NULL))
 		return -1;
 
-	VipsImage *in = t[1];
-	if (svg->high_bitdepth) {
-		if (vips_gamma(in, &t[2], NULL))
-			return -1;
-		in = t[2];
-	}
-
-	return vips_image_write(in, load->real);
+	return vips_image_write(t[1], load->real);
 }
 
 static void


### PR DESCRIPTION
After a while of working with this change I've realized that call to `vips_gamma` inside `svgload` is quite implicit and maybe not that expected. 

I've included it initially to make sure `svgload` API is consistent in terms of gamma handling (no matter of `high_bitdepth` flag passed, since `high_bitdepth=false` outputs non-linear gamma already), but this could probably could have gone too far. 

First of all - as we output scRGB - having non-linear gamma inside is rather confusing and not expected by the user. Another thing is typical usages of scRGB - one of the examples is actually my current case - I compose the output of `svgload` with blending, alphas etc. and it is recommended to do so in linear spaces AFAIK. And thus I actually need to revert that gamma operation before passing the image to `composite` (with `compositing-space=scrgb`). 

So for now I think better approach would be to keep the linear gamma in scRGB output of `high_bitdepth=true` option and let users decide what do to next with gamma. Please let me know if my way of thinking makes sense to you, I'm really curious what are others thoughts on this. 