### PR TITLE
svgload: replaced vips_gamma with linearization through LUT usage

### DIFF
--- a/libvips/colour/pcolour.h
+++ b/libvips/colour/pcolour.h
@@ -209,10 +209,8 @@ void vips__pythagoras_line(VipsColour *colour,
  * vips_col_make_tables_RGB_16() before use to initialize.
  */
 extern float vips_v2Y_8[256];
-extern float vips_v2Y_16[65536];
 
 void vips_col_make_tables_RGB_8(void);
-void vips_col_make_tables_RGB_16(void);
 
 /* A colour-transforming function.
  */

--- a/libvips/colour/sRGB2scRGB.c
+++ b/libvips/colour/sRGB2scRGB.c
@@ -59,6 +59,7 @@
 #include <math.h>
 
 #include <vips/vips.h>
+#include <vips/internal.h>
 
 #include "pcolour.h"
 

--- a/libvips/foreign/cairo.c
+++ b/libvips/foreign/cairo.c
@@ -127,9 +127,6 @@ vips__bgra2rgba(guint32 *restrict p, int n)
 	}
 }
 
-extern float vips_v2Y_16[65536];
-void vips_col_make_tables_RGB_16(void);
-
 /*
  * Convert from Cairo-style premultiplied RGBA128F to straight RGBA, for one row.
  * It also linearizes the pixel values.

--- a/libvips/foreign/cairo.c
+++ b/libvips/foreign/cairo.c
@@ -142,15 +142,16 @@ vips__premultiplied_rgb1282scrgba(float *restrict p, int n)
 {
 	vips_col_make_tables_RGB_16();
 	for (int x = 0; x < n; x++) {
-		float r = VIPS_CLIP(0, p[0], 1);
-		float g = VIPS_CLIP(0, p[1], 1);
-		float b = VIPS_CLIP(0, p[2], 1);
-		float a = p[3];
+		// CLIP is much faster than FCLIP, and we want an int result
+		int ri = VIPS_CLIP(0, (int) (p[0] * 65535), 65535);
+		int gi = VIPS_CLIP(0, (int) (p[1] * 65535), 65535);
+		int bi = VIPS_CLIP(0, (int) (p[2] * 65535), 65535);
 
 		// linearize the values with LUT
-		r = vips_v2Y_16[(int) (65535 * r)];
-		g = vips_v2Y_16[(int) (65535 * g)];
-		b = vips_v2Y_16[(int) (65535 * b)];
+		float r = vips_v2Y_16[ri];
+		float g = vips_v2Y_16[gi];
+		float b = vips_v2Y_16[bi];
+		float a = p[3];
 
 		p[0] = a > 0.00001 ? r / a : 0.0F;
 		p[1] = a > 0.00001 ? g / a : 0.0F;

--- a/libvips/foreign/cairo.c
+++ b/libvips/foreign/cairo.c
@@ -127,25 +127,88 @@ vips__bgra2rgba(guint32 *restrict p, int n)
 	}
 }
 
-/*
- * Convert from Cairo-style premultiplied RGBA128F to straight RGBA, for one row.
+/**
+ * @brief Converts a normal sRGB color value to a linear sRGB color value.
  *
- * Processes 'n' pixels in the 'p' buffer.
- * The data is assumed to be RGBA (R, G, B, A) 32-bit floats per pixel.
+ * This function removes the gamma correction from a non-linear sRGB component,
+ * transforming it into a linear light intensity value. It implements the
+ * inverse sRGB Electro-Optical Transfer Function (EOTF).
+ *
+ * @param c A single non-linear sRGB color component, expected in the [0, 1] range.
+ * @return The corresponding linear sRGB color component, also in the [0, 1] range.
+ *
+ * @note This function is the C port of the `linearize` function found in librsvg.
+ * For reference, the Rust source code for this function is available at:
+ * https://github.com/GNOME/librsvg/blob/2.60.0/rsvg/build.rs#L28
+ */
+static inline float
+linearize(float c)
+{
+	// The threshold (0.04045f) is the point where the linear segment of the
+	// sRGB transfer function (used for encoding) meets the power-law segment.
+	// This value is derived directly from the sRGB specification: 12.92 * 0.0031308.
+	if (c <= 0.04045f) {
+		return c / 12.92f;
+	}
+	else {
+		// Apply the inverse power-law function for sRGB linearization.
+		// All numerical literals use the 'f' suffix to explicitly ensure
+		// single-precision float-point arithmetic throughout the calculation.
+		return powf(((c + 0.055f) / 1.055f), 2.4f);
+	}
+}
+
+/**
+ * @brief Converts a row of Cairo-style premultiplied RGBA128F pixels to linear RGBA.
+ *
+ * This function processes 'n' pixels in the 'p' buffer. For each pixel, it performs
+ * two main operations:
+ * 1. Un-premultiplies the R, G, and B color components by their respective
+ * alpha channel value. This converts colors from a premultiplied format
+ * (common in graphics APIs like Cairo) to a straight alpha format.
+ * 2. Applies the inverse sRGB gamma correction (linearization) to the
+ * un-premultiplied R, G, and B components. This transforms the colors
+ * from a perceptually uniform (non-linear sRGB) space to a linear light
+ * intensity space, which is often required for further image processing,
+ * blending, or accurate color calculations.
+ *
+ * The input and output data are assumed to be RGBA (Red, Green, Blue, Alpha)
+ * with 32-bit floats per channel. The alpha channel (A) remains unchanged
+ * (linear) throughout this process.
+ *
+ * @param p A pointer to the start of the pixel data (premultiplied RGBA floats).
+ * @param n The number of pixels to process in the row.
+ *
+ * @note This function expects the *output* from librsvg (which typically provides
+ * premultiplied sRGB data) and converts it to linear space.
+ * Therefore, `linearize_float` is called *after* the un-premultiplication step.
  */
 void
 vips__premultiplied_rgb1282scrgba(float *restrict p, int n)
 {
+	// A small epsilon value used to safely check if alpha is close to zero.
+	// This prevents division by zero or numerical instability for nearly transparent pixels.
+	const float ALPHA_EPSILON = 0.00001f;
+
 	for (int x = 0; x < n; x++) {
-		float r = p[0];
-		float g = p[1];
-		float b = p[2];
-		float a = p[3];
+		float r = p[x * 4 + 0];
+		float g = p[x * 4 + 1];
+		float b = p[x * 4 + 2];
+		float a = p[x * 4 + 3]; // Alpha component remains linear
 
-		p[0] = a > 0.00001 ? r / a : 0.0F;
-		p[1] = a > 0.00001 ? g / a : 0.0F;
-		p[2] = a > 0.00001 ? b / a : 0.0F;
+		// Step 1: Un-premultiply R, G, B components.
+		// If alpha is extremely small, the color components are effectively zero,
+		// and setting them to 0.0f avoids NaN/Inf results from division.
+		float unmultiplied_r = (a > ALPHA_EPSILON) ? r / a : 0.0f;
+		float unmultiplied_g = (a > ALPHA_EPSILON) ? g / a : 0.0f;
+		float unmultiplied_b = (a > ALPHA_EPSILON) ? b / a : 0.0f;
 
-		p += 4;
+		// Step 2: Apply sRGB linearization (inverse gamma correction).
+		// This converts the color components from non-linear sRGB space
+		// to a linear light intensity space.
+		p[x * 4 + 0] = linearize(unmultiplied_r);
+		p[x * 4 + 1] = linearize(unmultiplied_g);
+		p[x * 4 + 2] = linearize(unmultiplied_b);
+		p[x * 4 + 3] = a; // Alpha channel is kept as is (linear)
 	}
 }

--- a/libvips/foreign/svgload.c
+++ b/libvips/foreign/svgload.c
@@ -740,17 +740,11 @@ vips_foreign_load_svg_load(VipsForeignLoad *load)
 			"tile_width", TILE_SIZE,
 			"tile_height", TILE_SIZE,
 			"max_tiles", 2 * (1 + t[0]->Xsize / TILE_SIZE),
-			NULL))
+			NULL) ||
+		vips_image_write(t[1], load->real))
 		return -1;
 
-	VipsImage *in = t[1];
-	if (svg->high_bitdepth) {
-		if (vips_gamma(in, &t[2], NULL))
-			return -1;
-		in = t[2];
-	}
-
-	return vips_image_write(in, load->real);
+	return 0;
 }
 
 static void

--- a/libvips/include/vips/internal.h
+++ b/libvips/include/vips/internal.h
@@ -152,6 +152,8 @@ extern char *vips__disc_threshold;
 extern gboolean vips__cache_dump;
 extern gboolean vips__cache_trace;
 
+extern float vips_v2Y_16[65536];
+
 void vips__thread_init(void);
 void vips__threadpool_init(void);
 void vips__threadpool_shutdown(void);
@@ -328,6 +330,7 @@ void vips__premultiplied_rgb1282scrgba(float *p, int n);
 void vips__bgra2rgba(guint32 *restrict p, int n);
 void vips__Lab2LabQ_vec(VipsPel *out, float *in, int width);
 void vips__LabQ2Lab_vec(float *out, VipsPel *in, int width);
+void vips_col_make_tables_RGB_16(void);
 
 #ifdef DEBUG_LEAK
 extern GQuark vips__image_pixels_quark;


### PR DESCRIPTION
As it was pointed out in discussion here: https://github.com/libvips/libvips/pull/4529 - performing additional `vips_gamma` operation does not guarantee enough similarity between `high_biptdepth=true|false` outputs. 

As suggested - it turns out that `librsvg` - instead of simple pow operation applies sRGB curve as shown here:
https://github.com/GNOME/librsvg/blob/2.60.0/rsvg/build.rs#L28

This PR introduces port of mentioned logic and uses it as part of `svgload` pipeline. 

Please let me know if there's already an existing equivalent function available I should use instead and if there's a better place to apply it to pixels. 