### PR TITLE
Apply i18n policy to all g_warning messages

### DIFF
--- a/libvips/arithmetic/measure.c
+++ b/libvips/arithmetic/measure.c
@@ -161,10 +161,10 @@ vips_measure_build(VipsObject *object)
 				 */
 				if (dev * 5 > fabs(avg) &&
 					fabs(avg) > 3)
-					g_warning(_("%s: "
-								"patch %d x %d, "
-								"band %d: "
-								"avg = %g, sdev = %g"),
+					g_warning("%s: "
+							  "patch %d x %d, "
+							  "band %d: "
+							  "avg = %g, sdev = %g",
 						class->nickname,
 						i, j, b, avg, dev);
 

--- a/libvips/colour/icc_transform.c
+++ b/libvips/colour/icc_transform.c
@@ -609,7 +609,7 @@ vips_icc_load_profile_blob(VipsIcc *icc, VipsBlob *blob,
 
 #ifdef DEBUG
 	printf("loading %s profile, intent %s, from blob %p\n",
-		direction == LCMS_USED_AS_INPUT ? _("input") : _("output"),
+		direction == LCMS_USED_AS_INPUT ? "input" : "output",
 		vips_enum_nick(VIPS_TYPE_INTENT, icc->intent),
 		blob);
 #endif /*DEBUG*/
@@ -634,11 +634,11 @@ vips_icc_load_profile_blob(VipsIcc *icc, VipsBlob *blob,
 
 	if (icc->intent != VIPS_INTENT_AUTO &&
 		icc->selected_intent != icc->intent)
-		g_warning(_("fallback to suggested %s intent, as profile "
-					"does not support %s %s intent"),
+		g_warning("fallback to suggested %s intent, as profile "
+				  "does not support %s %s intent",
 			vips_enum_nick(VIPS_TYPE_INTENT, icc->selected_intent),
 			vips_enum_nick(VIPS_TYPE_INTENT, icc->intent),
-			direction == LCMS_USED_AS_INPUT ? _("input") : _("output"));
+			direction == LCMS_USED_AS_INPUT ? "input" : "output");
 
 #ifdef DEBUG
 	vips_icc_print_profile("loaded from blob to make", profile);
@@ -659,9 +659,9 @@ vips_icc_load_profile_blob(VipsIcc *icc, VipsBlob *blob,
 
 	if (!cmsIsIntentSupported(profile, icc->selected_intent, direction)) {
 		VIPS_FREEF(cmsCloseProfile, profile);
-		g_warning(_("profile does not support %s %s intent"),
+		g_warning("profile does not support %s %s intent",
 			vips_enum_nick(VIPS_TYPE_INTENT, icc->selected_intent),
-			direction == LCMS_USED_AS_INPUT ? _("input") : _("output"));
+			direction == LCMS_USED_AS_INPUT ? "input" : "output");
 		return NULL;
 	}
 

--- a/libvips/conversion/tilecache.c
+++ b/libvips/conversion/tilecache.c
@@ -715,7 +715,7 @@ vips_tile_cache_gen(VipsRegion *out_region,
 						"vips_tile_cache_gen: error on tile %p\n",
 						tile);
 
-					g_warning(_("error in tile %d x %d"),
+					g_warning("error in tile %d x %d",
 						tile->pos.left, tile->pos.top);
 
 					vips_region_black(tile->region);

--- a/libvips/create/text.c
+++ b/libvips/create/text.c
@@ -430,7 +430,7 @@ vips_text_build(VipsObject *object)
 		 */
 		if (!FcConfigAppFontAddFile(NULL,
 				(const FcChar8 *) text->fontfile))
-			g_warning(_("unable to load fontfile \"%s\""),
+			g_warning("unable to load fontfile \"%s\"",
 				text->fontfile);
 		g_hash_table_insert(vips_text_fontfiles,
 			text->fontfile,

--- a/libvips/foreign/csvload.c
+++ b/libvips/foreign/csvload.c
@@ -298,7 +298,7 @@ vips_foreign_load_csv_read_double(VipsForeignLoadCsv *csv, double *out)
 			/* Only a warning, since (for example) exported
 			 * spreadsheets will often have text or date fields.
 			 */
-			g_warning(_("bad number, line %d, column %d"),
+			g_warning("bad number, line %d, column %d",
 				csv->lineno, csv->colno);
 	}
 

--- a/libvips/foreign/exif.c
+++ b/libvips/foreign/exif.c
@@ -1257,7 +1257,7 @@ vips_exif_image_field(VipsImage *image,
 	/* value must be a string.
 	 */
 	if (vips_image_get_string(image, field, &string)) {
-		g_warning(_("bad exif meta \"%s\""), field);
+		g_warning("bad exif meta \"%s\"", field);
 		return NULL;
 	}
 
@@ -1267,7 +1267,7 @@ vips_exif_image_field(VipsImage *image,
 	for (; g_ascii_isdigit(*p); p++)
 		;
 	if (*p != '-') {
-		g_warning(_("bad exif meta \"%s\""), field);
+		g_warning("bad exif meta \"%s\"", field);
 		return NULL;
 	}
 
@@ -1276,7 +1276,7 @@ vips_exif_image_field(VipsImage *image,
 	 */
 	if (!(tag = exif_tag_from_name(p + 1)) &&
 		strcmp(p + 1, "GPSVersionID") != 0) {
-		g_warning(_("bad exif meta \"%s\""), field);
+		g_warning("bad exif meta \"%s\"", field);
 		return NULL;
 	}
 
@@ -1316,7 +1316,7 @@ vips_exif_exif_entry(ExifEntry *entry, VipsExifRemove *ve)
 		/* No easy way to return an error code from here, sadly.
 		 */
 		if (vips_image_get_string(ve->image, vips_name, &vips_value))
-			g_warning(_("bad exif meta \"%s\""), vips_name);
+			g_warning("bad exif meta \"%s\"", vips_name);
 	}
 
 	/* Does this field exist on the image? If not, schedule it for

--- a/libvips/foreign/jpeg2vips.c
+++ b/libvips/foreign/jpeg2vips.c
@@ -412,7 +412,7 @@ static int
 readjpeg_free(ReadJpeg *jpeg)
 {
 	if (jpeg->eman.pub.num_warnings != 0) {
-		g_warning(_("read gave %ld warnings"),
+		g_warning("read gave %ld warnings",
 			jpeg->eman.pub.num_warnings);
 		g_warning("%s", vips_error_buffer());
 

--- a/libvips/foreign/spngload.c
+++ b/libvips/foreign/spngload.c
@@ -249,7 +249,7 @@ vips_foreign_load_png_set_header(VipsForeignLoadPng *png, VipsImage *image)
 		 * attacks.
 		 */
 		if (!png->unlimited && n_text > MAX_PNG_TEXT_CHUNKS) {
-			g_warning(_("%d text chunks, only %d text chunks will be loaded"),
+			g_warning("%d text chunks, only %d text chunks will be loaded",
 				n_text, MAX_PNG_TEXT_CHUNKS);
 			n_text = MAX_PNG_TEXT_CHUNKS;
 		}

--- a/libvips/foreign/vips2jpeg.c
+++ b/libvips/foreign/vips2jpeg.c
@@ -270,8 +270,8 @@ write_blob(Write *write, VipsImage *image, const char *field, int app)
 	 * For now, just ignore oversize objects and warn.
 	 */
 	if (data_length > MAX_BYTES_IN_MARKER)
-		g_warning(_("field \"%s\" is too large "
-					"for a single JPEG marker, ignoring"),
+		g_warning("field \"%s\" is too large "
+				  "for a single JPEG marker, ignoring",
 			field);
 	else {
 #ifdef DEBUG

--- a/libvips/foreign/vipspng.c
+++ b/libvips/foreign/vipspng.c
@@ -579,7 +579,7 @@ png2vips_header(Read *read, VipsImage *out)
 		 */
 		if (!read->unlimited &&
 			num_text > MAX_PNG_TEXT_CHUNKS) {
-			g_warning(_("%d text chunks, only %d text chunks will be loaded"),
+			g_warning("%d text chunks, only %d text chunks will be loaded",
 				num_text, MAX_PNG_TEXT_CHUNKS);
 			num_text = MAX_PNG_TEXT_CHUNKS;
 		}

--- a/libvips/histogram/maplut.c
+++ b/libvips/histogram/maplut.c
@@ -107,7 +107,7 @@ vips_maplut_posteval(VipsImage *image, VipsProgress *progress,
 	VipsMaplut *maplut)
 {
 	if (maplut->overflow)
-		g_warning(_("%d overflows detected"), maplut->overflow);
+		g_warning("%d overflows detected", maplut->overflow);
 }
 
 /* Our sequence value: the region this sequence is using, and local stats.

--- a/libvips/iofuncs/image.c
+++ b/libvips/iofuncs/image.c
@@ -967,7 +967,7 @@ vips_image_build(VipsObject *object)
 		 * still be able to process it without coredumps.
 		 */
 		if (image->file_length > sizeof_image)
-			g_warning(_("%s is longer than expected"),
+			g_warning("%s is longer than expected",
 				image->filename);
 		break;
 
@@ -2895,7 +2895,7 @@ vips_image_write_to_memory(VipsImage *in, size_t *size_out)
 		vips_error("vips_image_write_to_memory",
 			_("out of memory -- size == %dMB"),
 			(int) (size / (1024.0 * 1024.0)));
-		g_warning(_("out of memory -- size == %dMB"),
+		g_warning("out of memory -- size == %dMB",
 			(int) (size / (1024.0 * 1024.0)));
 		return NULL;
 	}

--- a/libvips/iofuncs/init.c
+++ b/libvips/iofuncs/init.c
@@ -314,7 +314,7 @@ vips_load_plugins(const char *fmt, ...)
 			 */
 			g_module_make_resident(module);
 		else
-			g_warning(_("unable to load \"%s\" -- %s"),
+			g_warning("unable to load \"%s\" -- %s",
 				path, g_module_error());
 	}
 

--- a/libvips/iofuncs/memory.c
+++ b/libvips/iofuncs/memory.c
@@ -319,7 +319,7 @@ vips_tracked_malloc(size_t size)
 		vips_error("vips_tracked",
 			_("out of memory -- size == %dMB"),
 			(int) (size / (1024.0 * 1024.0)));
-		g_warning(_("out of memory -- size == %dMB"),
+		g_warning("out of memory -- size == %dMB",
 			(int) (size / (1024.0 * 1024.0)));
 
 		return NULL;
@@ -393,7 +393,7 @@ vips_tracked_aligned_alloc(size_t size, size_t align)
 		vips_error("vips_tracked",
 			_("out of memory -- size == %dMB"),
 			(int) (size / (1024.0 * 1024.0)));
-		g_warning(_("out of memory -- size == %dMB"),
+		g_warning("out of memory -- size == %dMB",
 			(int) (size / (1024.0 * 1024.0)));
 
 		return NULL;

--- a/libvips/iofuncs/system.c
+++ b/libvips/iofuncs/system.c
@@ -231,7 +231,7 @@ vips_system_build(VipsObject *object)
 	if (std_error) {
 		g_strchomp(std_error);
 		if (strcmp(std_error, "") != 0)
-			g_warning(_("stderr output: %s"), std_error);
+			g_warning("stderr output: %s", std_error);
 	}
 	if (std_output) {
 		g_strchomp(std_output);

--- a/libvips/iofuncs/thread.c
+++ b/libvips/iofuncs/thread.c
@@ -182,7 +182,7 @@ vips__concurrency_get_default(void)
 		nthr > MAX_THREADS) {
 		nthr = VIPS_CLIP(1, nthr, MAX_THREADS);
 
-		g_warning(_("threads clipped to %d"), nthr);
+		g_warning("threads clipped to %d", nthr);
 	}
 
 	return nthr;
@@ -212,7 +212,7 @@ vips_concurrency_set(int concurrency)
 	else if (concurrency > MAX_THREADS) {
 		concurrency = MAX_THREADS;
 
-		g_warning(_("threads clipped to %d"), MAX_THREADS);
+		g_warning("threads clipped to %d", MAX_THREADS);
 	}
 
 	vips__concurrency = concurrency;

--- a/libvips/iofuncs/vips.c
+++ b/libvips/iofuncs/vips.c
@@ -1038,8 +1038,8 @@ vips_image_open_input(VipsImage *image)
 		return -1;
 	image->file_length = rsize;
 	if (psize > rsize)
-		g_warning(_("unable to read data for \"%s\", %s"),
-			image->filename, _("file has been truncated"));
+		g_warning("unable to read data for \"%s\", %s",
+			image->filename, "file has been truncated");
 
 	/* Set demand style. This suits a disc file we read sequentially.
 	 */
@@ -1050,7 +1050,7 @@ vips_image_open_input(VipsImage *image)
 	 * harmless.
 	 */
 	if (readhist(image)) {
-		g_warning(_("error reading vips image metadata: %s"),
+		g_warning("error reading vips image metadata: %s",
 			vips_error_buffer());
 		vips_error_clear();
 	}

--- a/po/de.po
+++ b/po/de.po
@@ -655,11 +655,6 @@ msgstr "Feld aus Konstanten"
 msgid "maximum of a pair of images"
 msgstr "ein Bilderpaar zusammenführen"
 
-#: libvips/arithmetic/measure.c:164
-#, fuzzy, c-format
-msgid "%s: patch %d x %d, band %d: avg = %g, sdev = %g"
-msgstr "Flicken %d x %d, Band %d: Durchschn. = %g, sdev = %g"
-
 #: libvips/arithmetic/measure.c:191
 #, fuzzy
 msgid "measure a set of patches on a color chart"
@@ -945,16 +940,6 @@ msgstr "nicht implementierter Ausgabefarbraum 0x%x"
 #, fuzzy
 msgid "no device profile"
 msgstr "kein eingebettetes Profil"
-
-#: libvips/colour/icc_transform.c:612 libvips/colour/icc_transform.c:635
-#: libvips/colour/icc_transform.c:658 libvips/iofuncs/operation.c:442
-msgid "input"
-msgstr "Eingabe"
-
-#: libvips/colour/icc_transform.c:612 libvips/colour/icc_transform.c:635
-#: libvips/colour/icc_transform.c:658 libvips/iofuncs/operation.c:443
-msgid "output"
-msgstr "Ausgabe"
 
 #: libvips/colour/icc_transform.c:631
 #, c-format
@@ -2151,11 +2136,6 @@ msgstr ""
 msgid "Keep cache between evaluations"
 msgstr ""
 
-#: libvips/conversion/tilecache.c:708
-#, c-format
-msgid "error in tile %d x %d"
-msgstr ""
-
 #: libvips/conversion/tilecache.c:796
 #, fuzzy
 msgid "cache an image as a set of tiles"
@@ -2860,11 +2840,6 @@ msgstr ""
 #: libvips/create/text.c:406
 msgid "invalid markup in text"
 msgstr "ungültige Auszeichnung im Text"
-
-#: libvips/create/text.c:428
-#, fuzzy, c-format
-msgid "unable to load fontfile \"%s\""
-msgstr "Profil »%s« kann nicht geöffnet werden"
 
 #: libvips/create/text.c:467
 msgid "no text to render"
@@ -3572,11 +3547,6 @@ msgstr "Puffer"
 msgid "Buffer to save to"
 msgstr "Puffer, in den gespeichert werden soll"
 
-#: libvips/foreign/csvload.c:301
-#, fuzzy, c-format
-msgid "bad number, line %d, column %d"
-msgstr "Fehler beim Auswerten von Nummer, Zeile %d, Spalte %d"
-
 #: libvips/foreign/csvload.c:341 libvips/foreign/csvload.c:402
 #: libvips/foreign/csvload.c:434
 #, fuzzy
@@ -3856,12 +3826,6 @@ msgstr "Fenster zu groß"
 #, fuzzy
 msgid "unable to init exif"
 msgstr "kann nicht gekürzt werden"
-
-#: libvips/foreign/exif.c:1260 libvips/foreign/exif.c:1270
-#: libvips/foreign/exif.c:1279 libvips/foreign/exif.c:1319
-#, fuzzy, c-format
-msgid "bad exif meta \"%s\""
-msgstr "falscher Modus »%s«"
 
 #: libvips/foreign/exif.c:1496
 msgid "error saving EXIF"
@@ -4292,11 +4256,6 @@ msgstr "»%s« ist kein bekanntes Dateiformat"
 #: libvips/foreign/jp2ksave.c:963
 msgid "save image in JPEG2000 format"
 msgstr ""
-
-#: libvips/foreign/jpeg2vips.c:415
-#, c-format
-msgid "read gave %ld warnings"
-msgstr "Lesen ergab %ld Warnungen"
 
 #: libvips/foreign/jpeg2vips.c:886 libvips/foreign/spngload.c:529
 #: libvips/foreign/vipspng.c:723
@@ -5210,11 +5169,6 @@ msgstr "Rohdatenbild in Datei-Deskriptor schreiben"
 msgid "write raw image to buffer"
 msgstr "Rohdatenbild in Datei-Deskriptor schreiben"
 
-#: libvips/foreign/spngload.c:252 libvips/foreign/vipspng.c:582
-#, c-format
-msgid "%d text chunks, only %d text chunks will be loaded"
-msgstr ""
-
 #: libvips/foreign/spngload.c:403
 #, fuzzy
 msgid "unknown color type"
@@ -5566,11 +5520,6 @@ msgstr "Bild in TIFF-Datei speichern"
 #, c-format
 msgid "%s"
 msgstr "%s"
-
-#: libvips/foreign/vips2jpeg.c:273
-#, c-format
-msgid "field \"%s\" is too large for a single JPEG marker, ignoring"
-msgstr ""
 
 #: libvips/foreign/vips2jpeg.c:1059
 #, fuzzy
@@ -6092,11 +6041,6 @@ msgstr ""
 msgid "hist_unary operations"
 msgstr "unäre Transaktionen"
 
-#: libvips/histogram/maplut.c:110
-#, c-format
-msgid "%d overflows detected"
-msgstr "%d Überläufe entdeckt"
-
 #: libvips/histogram/maplut.c:738
 msgid "map an image though a lut"
 msgstr ""
@@ -6425,11 +6369,6 @@ msgstr "%s %s: Erledigt in %ds      \n"
 msgid "unable to open \"%s\", file too short"
 msgstr "»%s« kann nicht geöffnet werden, Datei zu klein"
 
-#: libvips/iofuncs/image.c:985
-#, c-format
-msgid "%s is longer than expected"
-msgstr "%s ist länger als erwartet"
-
 #: libvips/iofuncs/image.c:1003
 #, c-format
 msgid "bad mode \"%s\""
@@ -6490,11 +6429,10 @@ msgstr "Verlauf kann nicht gelesen werden"
 msgid "bad array length --- should be %d, you passed %d"
 msgstr ""
 
-#: libvips/iofuncs/image.c:2886 libvips/iofuncs/image.c:2888
-#: libvips/iofuncs/memory.c:336 libvips/iofuncs/memory.c:338
-#: libvips/iofuncs/memory.c:409 libvips/iofuncs/memory.c:411
+#: libvips/iofuncs/image.c:2886 libvips/iofuncs/memory.c:336
+#: libvips/iofuncs/memory.c:409
 #, c-format
-msgid "out of memory --- size == %dMB"
+msgid "out of memory -- size == %dMB"
 msgstr "Hauptspeicher reicht nicht aus – Größe == %dMB"
 
 #: libvips/iofuncs/image.c:3179
@@ -6527,11 +6465,6 @@ msgstr "Bild nicht schreibbar"
 #: libvips/iofuncs/image.c:3602
 msgid "bad file type"
 msgstr "falscher Dateityp"
-
-#: libvips/iofuncs/init.c:316 tools/vips.c:772
-#, fuzzy, c-format
-msgid "unable to load \"%s\" -- %s"
-msgstr "»mmap« nicht möglich: \"%s\" - %s"
 
 #: libvips/iofuncs/init.c:1270
 #, fuzzy
@@ -6697,6 +6630,14 @@ msgstr "in"
 #: libvips/iofuncs/operation.c:409 libvips/iofuncs/operation.c:421
 msgid "max"
 msgstr ""
+
+#: libvips/iofuncs/operation.c:442
+msgid "input"
+msgstr "Eingabe"
+
+#: libvips/iofuncs/operation.c:443
+msgid "output"
+msgstr "Ausgabe"
 
 #: libvips/iofuncs/operation.c:618
 #, fuzzy
@@ -6886,11 +6827,6 @@ msgstr "es kann nicht zu einem %s-Bild ausgegeben werden"
 msgid "command \"%s\" failed"
 msgstr "Befehl fehlgeschlagen: »%s«"
 
-#: libvips/iofuncs/system.c:234
-#, c-format
-msgid "stderr output: %s"
-msgstr ""
-
 #: libvips/iofuncs/system.c:269
 msgid "run an external command"
 msgstr ""
@@ -6948,11 +6884,6 @@ msgstr ""
 #: libvips/iofuncs/thread.c:179
 msgid "unable to create thread"
 msgstr "Thread kann nicht erstellt werden"
-
-#: libvips/iofuncs/thread.c:214 libvips/iofuncs/thread.c:243
-#, c-format
-msgid "threads clipped to %d"
-msgstr "Threads an %d angeheftet"
 
 #: libvips/iofuncs/threadpool.c:193
 msgid "per-thread state for vipsthreadpool"
@@ -7088,8 +7019,7 @@ msgstr "falscher Namensraum in XML"
 msgid "error transforming from save format"
 msgstr "Fehler beim Umwandeln vom gespeicherten Format"
 
-#: libvips/iofuncs/vips.c:784 libvips/iofuncs/vips.c:1056
-#: libvips/iofuncs/window.c:232
+#: libvips/iofuncs/vips.c:784 libvips/iofuncs/window.c:232
 msgid "file has been truncated"
 msgstr "Datei wurde gekürzt"
 
@@ -7102,16 +7032,10 @@ msgstr "Fehler beim Umwandeln in das zu speichernde Format"
 msgid "unable to read header for \"%s\""
 msgstr "Kopfdaten für »%s« können nicht gelesen werden"
 
-#: libvips/iofuncs/vips.c:1055 libvips/iofuncs/window.c:231
+#: libvips/iofuncs/window.c:231
 #, c-format
 msgid "unable to read data for \"%s\", %s"
 msgstr "Daten für »%s« können nicht gelesen werden, %s"
-
-# http://radsite.lbl.gov/radiance/refer/Notes/picture_format.html
-#: libvips/iofuncs/vips.c:1067
-#, fuzzy, c-format
-msgid "error reading vips image metadata: %s"
-msgstr "Fehler beim Lesen der Radiance-Kopfzeilen"
 
 # http://techpubs.sgi.com/library/tpl/cgi-bin/getdoc.cgi?coll=0650&
 #        db=man&fname=/usr/share/catman/p_man/cat3/il_c/ilAbsImg.z
@@ -8059,6 +7983,11 @@ msgstr "Transaktion"
 #: tools/vips.c:706
 msgid "[ACTION] [OPTIONS] [PARAMETERS] - VIPS driver program"
 msgstr "[AKTION] [OPTIONEN] [PARAMETER] - VIPS-Treiberprogramm"
+
+#: tools/vips.c:772
+#, fuzzy, c-format
+msgid "unable to load \"%s\" -- %s"
+msgstr "»mmap« nicht möglich: \"%s\" - %s"
 
 #: tools/vips.c:916
 #, c-format

--- a/po/en_GB.po
+++ b/po/en_GB.po
@@ -613,11 +613,6 @@ msgstr ""
 msgid "maximum of a pair of images"
 msgstr ""
 
-#: libvips/arithmetic/measure.c:164
-#, c-format
-msgid "%s: patch %d x %d, band %d: avg = %g, sdev = %g"
-msgstr ""
-
 #: libvips/arithmetic/measure.c:191
 msgid "measure a set of patches on a color chart"
 msgstr "measure a set of patches on a colour chart"
@@ -884,16 +879,6 @@ msgstr "unimplemented output colour space 0x%x"
 
 #: libvips/colour/icc_transform.c:437
 msgid "no device profile"
-msgstr ""
-
-#: libvips/colour/icc_transform.c:612 libvips/colour/icc_transform.c:635
-#: libvips/colour/icc_transform.c:658 libvips/iofuncs/operation.c:442
-msgid "input"
-msgstr ""
-
-#: libvips/colour/icc_transform.c:612 libvips/colour/icc_transform.c:635
-#: libvips/colour/icc_transform.c:658 libvips/iofuncs/operation.c:443
-msgid "output"
 msgstr ""
 
 #: libvips/colour/icc_transform.c:631
@@ -2024,11 +2009,6 @@ msgstr ""
 msgid "Keep cache between evaluations"
 msgstr ""
 
-#: libvips/conversion/tilecache.c:708
-#, c-format
-msgid "error in tile %d x %d"
-msgstr ""
-
 #: libvips/conversion/tilecache.c:796
 msgid "cache an image as a set of tiles"
 msgstr ""
@@ -2688,11 +2668,6 @@ msgstr ""
 msgid "invalid markup in text"
 msgstr ""
 
-#: libvips/create/text.c:428
-#, c-format
-msgid "unable to load fontfile \"%s\""
-msgstr ""
-
 #: libvips/create/text.c:467
 msgid "no text to render"
 msgstr ""
@@ -3338,11 +3313,6 @@ msgstr ""
 msgid "Buffer to save to"
 msgstr ""
 
-#: libvips/foreign/csvload.c:301
-#, c-format
-msgid "bad number, line %d, column %d"
-msgstr ""
-
 #: libvips/foreign/csvload.c:341 libvips/foreign/csvload.c:402
 #: libvips/foreign/csvload.c:434
 msgid "unexpected end of file"
@@ -3594,12 +3564,6 @@ msgstr ""
 
 #: libvips/foreign/exif.c:208
 msgid "unable to init exif"
-msgstr ""
-
-#: libvips/foreign/exif.c:1260 libvips/foreign/exif.c:1270
-#: libvips/foreign/exif.c:1279 libvips/foreign/exif.c:1319
-#, c-format
-msgid "bad exif meta \"%s\""
 msgstr ""
 
 #: libvips/foreign/exif.c:1496
@@ -3999,11 +3963,6 @@ msgstr ""
 
 #: libvips/foreign/jp2ksave.c:963
 msgid "save image in JPEG2000 format"
-msgstr ""
-
-#: libvips/foreign/jpeg2vips.c:415
-#, c-format
-msgid "read gave %ld warnings"
 msgstr ""
 
 #: libvips/foreign/jpeg2vips.c:886 libvips/foreign/spngload.c:529
@@ -4830,11 +4789,6 @@ msgstr ""
 msgid "write raw image to buffer"
 msgstr ""
 
-#: libvips/foreign/spngload.c:252 libvips/foreign/vipspng.c:582
-#, c-format
-msgid "%d text chunks, only %d text chunks will be loaded"
-msgstr ""
-
 #: libvips/foreign/spngload.c:403
 #, fuzzy
 msgid "unknown color type"
@@ -5158,11 +5112,6 @@ msgstr ""
 #: libvips/foreign/vips2jpeg.c:176
 #, c-format
 msgid "%s"
-msgstr ""
-
-#: libvips/foreign/vips2jpeg.c:273
-#, c-format
-msgid "field \"%s\" is too large for a single JPEG marker, ignoring"
 msgstr ""
 
 #: libvips/foreign/vips2jpeg.c:1059
@@ -5630,11 +5579,6 @@ msgstr ""
 msgid "hist_unary operations"
 msgstr ""
 
-#: libvips/histogram/maplut.c:110
-#, c-format
-msgid "%d overflows detected"
-msgstr ""
-
 #: libvips/histogram/maplut.c:738
 msgid "map an image though a lut"
 msgstr ""
@@ -5937,11 +5881,6 @@ msgstr ""
 msgid "unable to open \"%s\", file too short"
 msgstr ""
 
-#: libvips/iofuncs/image.c:985
-#, c-format
-msgid "%s is longer than expected"
-msgstr ""
-
 #: libvips/iofuncs/image.c:1003
 #, c-format
 msgid "bad mode \"%s\""
@@ -6001,11 +5940,10 @@ msgstr ""
 msgid "bad array length --- should be %d, you passed %d"
 msgstr ""
 
-#: libvips/iofuncs/image.c:2886 libvips/iofuncs/image.c:2888
-#: libvips/iofuncs/memory.c:336 libvips/iofuncs/memory.c:338
-#: libvips/iofuncs/memory.c:409 libvips/iofuncs/memory.c:411
+#: libvips/iofuncs/image.c:2886 libvips/iofuncs/memory.c:336
+#: libvips/iofuncs/memory.c:409
 #, c-format
-msgid "out of memory --- size == %dMB"
+msgid "out of memory -- size == %dMB"
 msgstr ""
 
 #: libvips/iofuncs/image.c:3179
@@ -6037,11 +5975,6 @@ msgstr ""
 
 #: libvips/iofuncs/image.c:3602
 msgid "bad file type"
-msgstr ""
-
-#: libvips/iofuncs/init.c:316 tools/vips.c:772
-#, c-format
-msgid "unable to load \"%s\" -- %s"
 msgstr ""
 
 #: libvips/iofuncs/init.c:1270
@@ -6205,6 +6138,14 @@ msgstr ""
 
 #: libvips/iofuncs/operation.c:409 libvips/iofuncs/operation.c:421
 msgid "max"
+msgstr ""
+
+#: libvips/iofuncs/operation.c:437
+msgid "input"
+msgstr ""
+
+#: libvips/iofuncs/operation.c:438
+msgid "output"
 msgstr ""
 
 #: libvips/iofuncs/operation.c:618
@@ -6384,11 +6325,6 @@ msgstr ""
 msgid "command \"%s\" failed"
 msgstr ""
 
-#: libvips/iofuncs/system.c:234
-#, c-format
-msgid "stderr output: %s"
-msgstr ""
-
 #: libvips/iofuncs/system.c:269
 msgid "run an external command"
 msgstr ""
@@ -6439,11 +6375,6 @@ msgstr ""
 
 #: libvips/iofuncs/thread.c:179
 msgid "unable to create thread"
-msgstr ""
-
-#: libvips/iofuncs/thread.c:214 libvips/iofuncs/thread.c:243
-#, c-format
-msgid "threads clipped to %d"
 msgstr ""
 
 #: libvips/iofuncs/threadpool.c:193
@@ -6574,8 +6505,7 @@ msgstr ""
 msgid "error transforming from save format"
 msgstr ""
 
-#: libvips/iofuncs/vips.c:784 libvips/iofuncs/vips.c:1056
-#: libvips/iofuncs/window.c:232
+#: libvips/iofuncs/vips.c:784 libvips/iofuncs/window.c:232
 msgid "file has been truncated"
 msgstr ""
 
@@ -6588,14 +6518,9 @@ msgstr ""
 msgid "unable to read header for \"%s\""
 msgstr ""
 
-#: libvips/iofuncs/vips.c:1055 libvips/iofuncs/window.c:231
+#: libvips/iofuncs/window.c:231
 #, c-format
 msgid "unable to read data for \"%s\", %s"
-msgstr ""
-
-#: libvips/iofuncs/vips.c:1067
-#, c-format
-msgid "error reading vips image metadata: %s"
 msgstr ""
 
 #: libvips/morphology/countlines.c:135
@@ -7458,6 +7383,11 @@ msgstr ""
 
 #: tools/vips.c:706
 msgid "[ACTION] [OPTIONS] [PARAMETERS] - VIPS driver program"
+msgstr ""
+
+#: tools/vips.c:772
+#, c-format
+msgid "unable to load \"%s\" -- %s"
 msgstr ""
 
 #: tools/vips.c:916


### PR DESCRIPTION
In line with PR #4369.

This change was mostly automated with ast-grep:
```yaml
id: remove_i18n_from_g_warning
language: c
# Define rewriters
rewriters:
  - id: i18n-remove
    rule:
      kind: call_expression
      pattern: $ARG
    constraints:
      ARG: { regex: ^_ } # Only match if it starts with '_'
    transform:
      NEW_ARG:
        substring:
          source: $ARG
          startChar: 2
          endChar: -1
    fix: $NEW_ARG
# Find the target node
rule:
  pattern:
    context: g_warning($$$ARGS);
    selector: call_expression
# Apply rewriters to sub node
transform:
  REMOVE_I18N_ARGS:
    rewrite:
      rewriters: [i18n-remove]
      source: $$$ARGS
fix: g_warning($REMOVE_I18N_ARGS)
```
```console
$ ast-grep scan -r remove-i18n-from-g_warning.yml -U libvips/
Applied 106 changes
```
