### PR TITLE
OSS-Fuzz: revise Meson-specific workarounds

### DIFF
--- a/fuzz/oss_fuzz_build.sh
+++ b/fuzz/oss_fuzz_build.sh
@@ -195,7 +195,7 @@ export LDFLAGS+=" $CFLAGS"
 # Disable building man pages, gettext po files, tools, and tests
 sed -i "/subdir('man')/{N;N;N;d;}" meson.build
 meson setup build --prefix=$WORK --libdir=lib --prefer-static --default-library=static --buildtype=debugoptimized \
-  -Ddeprecated=false -Dexamples=false -Dcplusplus=false -Dmodules=disabled \
+  -Dbackend_max_links=4 -Ddeprecated=false -Dexamples=false -Dcplusplus=false -Dmodules=disabled \
   -Dfuzzing_engine=oss-fuzz -Dfuzzer_ldflags="$LIB_FUZZING_ENGINE" \
   -Dcpp_link_args="$LDFLAGS -Wl,-rpath=\$ORIGIN/lib"
 meson install -C build --tag devel

--- a/fuzz/oss_fuzz_build.sh
+++ b/fuzz/oss_fuzz_build.sh
@@ -188,9 +188,6 @@ cmake \
 cmake --build . --target install
 popd
 
-# FIXME: Workaround for https://github.com/mesonbuild/meson/issues/14533
-export LDFLAGS+=" $CFLAGS"
-
 # libvips
 # Disable building man pages, gettext po files, tools, and tests
 sed -i "/subdir('man')/{N;N;N;d;}" meson.build

--- a/fuzz/oss_fuzz_build.sh
+++ b/fuzz/oss_fuzz_build.sh
@@ -188,13 +188,15 @@ cmake \
 cmake --build . --target install
 popd
 
+# FIXME: Workaround for https://github.com/mesonbuild/meson/issues/14640
+export LDFLAGS+=" -Wl,-rpath=\$ORIGIN/lib"
+
 # libvips
 # Disable building man pages, gettext po files, tools, and tests
 sed -i "/subdir('man')/{N;N;N;d;}" meson.build
 meson setup build --prefix=$WORK --libdir=lib --prefer-static --default-library=static --buildtype=debugoptimized \
   -Dbackend_max_links=4 -Ddeprecated=false -Dexamples=false -Dcplusplus=false -Dmodules=disabled \
-  -Dfuzzing_engine=oss-fuzz -Dfuzzer_ldflags="$LIB_FUZZING_ENGINE" \
-  -Dcpp_link_args="$LDFLAGS -Wl,-rpath=\$ORIGIN/lib"
+  -Dfuzzing_engine=oss-fuzz -Dfuzzer_ldflags="$LIB_FUZZING_ENGINE"
 meson install -C build --tag devel
 
 # Copy fuzz executables to $OUT


### PR DESCRIPTION
Both issues[^1][^2] have been resolved in Meson 1.8.1, though this uncovered a new Meson bug[^3], for which I added a workaround in commit 695cb9bec7c438013f6e1bef179b7c39589df938.

Note: rebase merge, don't squash.

[^1]: https://github.com/mesonbuild/meson/issues/14524
[^2]: https://github.com/mesonbuild/meson/issues/14533
[^3]: https://github.com/mesonbuild/meson/issues/14640