### PR TITLE
test: remove compat for old libvips and pyvips versions

### DIFF
--- a/test/test-suite/test_arithmetic.py
+++ b/test/test-suite/test_arithmetic.py
@@ -469,10 +469,6 @@ class TestArithmetic:
         im = (pyvips.Image.black(100, 100) + [1, 2, 3]) / 3.0
         self.run_unary([im], my_atan, fmt=noncomplex_formats)
 
-    # this requires pyvips 2.1.16 for sinh
-    @pytest.mark.skipif(versiontuple(pyvips.__version__) <
-            versiontuple('2.1.16'),
-            reason='your pyvips is too old')
     def test_sinh(self):
         def my_sinh(x):
             if isinstance(x, pyvips.Image):
@@ -482,10 +478,6 @@ class TestArithmetic:
 
         self.run_unary(self.all_images, my_sinh, fmt=noncomplex_formats)
 
-    # this requires pyvips 2.1.16 for cosh
-    @pytest.mark.skipif(versiontuple(pyvips.__version__) <
-            versiontuple('2.1.16'),
-            reason='your pyvips is too old')
     def test_cosh(self):
         def my_cosh(x):
             if isinstance(x, pyvips.Image):
@@ -495,10 +487,6 @@ class TestArithmetic:
 
         self.run_unary(self.all_images, my_cosh, fmt=noncomplex_formats)
 
-    # this requires pyvips 2.1.16 for tanh
-    @pytest.mark.skipif(versiontuple(pyvips.__version__) <
-            versiontuple('2.1.16'),
-            reason='your pyvips is too old')
     def test_tanh(self):
         def my_tanh(x):
             if isinstance(x, pyvips.Image):
@@ -508,10 +496,6 @@ class TestArithmetic:
 
         self.run_unary(self.all_images, my_tanh, fmt=noncomplex_formats)
 
-    # this requires pyvips 2.1.16 for asinh
-    @pytest.mark.skipif(versiontuple(pyvips.__version__) <
-            versiontuple('2.1.16'),
-            reason='your pyvips is too old')
     def test_asinh(self):
         def my_asinh(x):
             if isinstance(x, pyvips.Image):
@@ -522,10 +506,6 @@ class TestArithmetic:
         im = (pyvips.Image.black(100, 100) + [4, 5, 6]) / 3.0
         self.run_unary([im], my_asinh, fmt=noncomplex_formats)
 
-    # this requires pyvips 2.1.16 for acosh
-    @pytest.mark.skipif(versiontuple(pyvips.__version__) <
-            versiontuple('2.1.16'),
-            reason='your pyvips is too old')
     def test_acosh(self):
         def my_acosh(x):
             if isinstance(x, pyvips.Image):
@@ -536,10 +516,6 @@ class TestArithmetic:
         im = (pyvips.Image.black(100, 100) + [4, 5, 6]) / 3.0
         self.run_unary([im], my_acosh, fmt=noncomplex_formats)
 
-    # this requires pyvips 2.1.16 for atanh
-    @pytest.mark.skipif(versiontuple(pyvips.__version__) <
-            versiontuple('2.1.16'),
-            reason='your pyvips is too old')
     def test_atanh(self):
         def my_atanh(x):
             if isinstance(x, pyvips.Image):
@@ -550,10 +526,6 @@ class TestArithmetic:
         im = (pyvips.Image.black(100, 100) + [0, 1, 2]) / 3.0
         self.run_unary([im], my_atanh, fmt=noncomplex_formats)
 
-    # this requires pyvips 2.1.16 for atan2
-    @pytest.mark.skipif(versiontuple(pyvips.__version__) <
-            versiontuple('2.1.16'),
-            reason='your pyvips is too old')
     def test_atan2(self):
         def my_atan2(x, y):
             if isinstance(x, pyvips.Image):
@@ -679,27 +651,26 @@ class TestArithmetic:
             assert pytest.approx(p2) == 10
 
     def test_find_trim(self):
-        if pyvips.type_find("VipsOperation", "find_trim") != 0:
-            im = pyvips.Image.black(50, 60) + 100
-            test = im.embed(10, 20, 200, 300, extend="white")
+        im = pyvips.Image.black(50, 60) + 100
+        test = im.embed(10, 20, 200, 300, extend="white")
 
-            for x in unsigned_formats + float_formats:
-                a = test.cast(x)
-                left, top, width, height = a.find_trim()
+        for x in unsigned_formats + float_formats:
+            a = test.cast(x)
+            left, top, width, height = a.find_trim()
 
-                assert left == 10
-                assert top == 20
-                assert width == 50
-                assert height == 60
-
-            test_rgb = test.bandjoin([test, test])
-            left, top, width, height = test_rgb.find_trim(line_art=True,
-                                                          background=[255, 255,
-                                                                      255])
             assert left == 10
             assert top == 20
             assert width == 50
             assert height == 60
+
+        test_rgb = test.bandjoin([test, test])
+        left, top, width, height = test_rgb.find_trim(line_art=True,
+                                                      background=[255, 255,
+                                                                  255])
+        assert left == 10
+        assert top == 20
+        assert width == 50
+        assert height == 60
 
     def test_profile(self):
         test = pyvips.Image.black(100, 100).draw_rect(100, 40, 50, 1, 1)

--- a/test/test-suite/test_connection.py
+++ b/test/test-suite/test_connection.py
@@ -102,8 +102,6 @@ class TestConnection:
 
         assert (im - self.mono).abs().max() == 0
 
-    @skip_if_no("csvload_source")
-    @skip_if_no("csvsave_target")
     def test_connection_csv(self):
         x = pyvips.Target.new_to_memory()
         self.mono.csvsave_target(x)

--- a/test/test-suite/test_conversion.py
+++ b/test/test-suite/test_conversion.py
@@ -242,7 +242,6 @@ class TestConversion:
             pixel = [int(x) & 0xff for x in pixel]
             assert_almost_equal_objects(pixel, [255, 255, 255])
 
-    @skip_if_no("gravity")
     def test_gravity(self):
         im = pyvips.Image.black(1, 1) + 255
 
@@ -317,13 +316,11 @@ class TestConversion:
             pixel = sub(5, 5)
             assert_almost_equal_objects(pixel, [2, 3, 4])
 
-    @skip_if_no("smartcrop")
     def test_smartcrop(self):
         test = self.image.smartcrop(100, 100)
         assert test.width == 100
         assert test.height == 100
 
-    @skip_if_no("smartcrop")
     def test_smartcrop_attention(self):
         test, opts = self.image.smartcrop(
             100, 100,
@@ -434,7 +431,6 @@ class TestConversion:
                 # differs ... don't require huge accuracy
                 assert abs(x - y) < 2
 
-    @skip_if_no("composite")
     def test_composite(self):
         # 50% transparent image
         overlay = self.colour.bandjoin(128)

--- a/test/test-suite/test_create.py
+++ b/test/test-suite/test_create.py
@@ -480,7 +480,6 @@ class TestCreate:
         assert im.bands == 1
         assert im.format == pyvips.BandFormat.FLOAT
 
-    @skip_if_no("worley")
     def test_worley(self):
         im = pyvips.Image.worley(512, 512)
         assert im.width == 512
@@ -488,7 +487,6 @@ class TestCreate:
         assert im.bands == 1
         assert im.format == pyvips.BandFormat.FLOAT
 
-    @skip_if_no("perlin")
     def test_perlin(self):
         im = pyvips.Image.perlin(512, 512)
         assert im.width == 512

--- a/test/test-suite/test_foreign.py
+++ b/test/test-suite/test_foreign.py
@@ -819,16 +819,14 @@ class TestForeign:
         assert im.height == height * 5
 
         # page/n let you pick a range of pages
-        # 'n' param added in 8.5
-        if pyvips.at_least_libvips(8, 5):
-            im = pyvips.Image.magickload(GIF_ANIM_FILE)
-            width = im.width
-            height = im.height
-            im = pyvips.Image.magickload(GIF_ANIM_FILE, page=1, n=2)
-            assert im.width == width
-            assert im.height == height * 2
-            page_height = im.get("page-height")
-            assert page_height == height
+        im = pyvips.Image.magickload(GIF_ANIM_FILE)
+        width = im.width
+        height = im.height
+        im = pyvips.Image.magickload(GIF_ANIM_FILE, page=1, n=2)
+        assert im.width == width
+        assert im.height == height * 2
+        page_height = im.get("page-height")
+        assert page_height == height
 
         # should work for dicom
         im = pyvips.Image.magickload(DICOM_FILE)
@@ -1464,7 +1462,7 @@ class TestForeign:
         # test keep=pyvips.ForeignKeep.ICC ... icc profiles should be
         # passed down
         filename = temp_filename(self.tempdir, '')
-        self.colour.dzsave(filename, keep=1 << 3) # pyvips.ForeignKeep.ICC
+        self.colour.dzsave(filename, keep=pyvips.ForeignKeep.ICC)
 
         y = pyvips.Image.new_from_file(filename + "_files/0/0_0.jpeg")
         assert y.get_typeof("icc-profile-data") != 0

--- a/test/test-suite/test_histogram.py
+++ b/test/test-suite/test_histogram.py
@@ -42,13 +42,12 @@ class TestHistogram:
         assert im.avg() < im2.avg()
         assert im.deviate() < im2.deviate()
 
-        if pyvips.at_least_libvips(8, 5):
-            im3 = im.hist_local(10, 10, max_slope=3)
+        im3 = im.hist_local(10, 10, max_slope=3)
 
-            assert im.width == im3.width
-            assert im.height == im3.height
+        assert im.width == im3.width
+        assert im.height == im3.height
 
-            assert im3.deviate() < im2.deviate()
+        assert im3.deviate() < im2.deviate()
 
     def test_hist_match(self):
         im = pyvips.Image.identity()

--- a/test/test-suite/test_iofuncs.py
+++ b/test/test-suite/test_iofuncs.py
@@ -71,18 +71,18 @@ class TestIofuncs:
         im1 = pyvips.Image.black(10, 10)
         im1.write_to_file(filename)
 
-        load1 = pyvips.Image.new_from_file(filename);
+        load1 = pyvips.Image.new_from_file(filename)
         assert load1.width == im1.width
 
         im2 = pyvips.Image.black(20, 20)
         im2.write_to_file(filename)
 
         # this will use the old, cached load
-        load2 = pyvips.Image.new_from_file(filename);
+        load2 = pyvips.Image.new_from_file(filename)
         assert load2.width == im1.width
 
         # load again with "revalidate" and we should see the new image
-        load2 = pyvips.Image.new_from_file(filename, revalidate=True);
+        load2 = pyvips.Image.new_from_file(filename, revalidate=True)
         assert load2.width == im2.width
 
         # load once more without revalidate and we should see the cached

--- a/test/test-suite/test_resample.py
+++ b/test/test-suite/test_resample.py
@@ -151,8 +151,6 @@ class TestResample:
         assert im2.height == int(im.height / 2.5 + 0.5)
         assert abs(im.avg() - im2.avg()) < 1
 
-    @pytest.mark.skipif(not pyvips.at_least_libvips(8, 5),
-                        reason="requires libvips >= 8.5")
     def test_thumbnail(self):
         im = pyvips.Image.thumbnail(JPEG_FILE, 100)
 
@@ -238,8 +236,6 @@ class TestResample:
             assert thumb.width < thumb.height
             assert thumb.height == 100
 
-    @pytest.mark.skipif(not pyvips.at_least_libvips(8, 5),
-                        reason="requires libvips >= 8.5")
     def test_thumbnail_icc(self):
         im = pyvips.Image.thumbnail(JPEG_FILE_XYB, 442, output_profile="srgb")
 


### PR DESCRIPTION
Assume the test suite is run with the latest versions of libvips and pyvips.

Diff is best viewable with the `Hide whitespace changes` option.