### PR TITLE
matrixload: ensure sniff data is null-terminated

### DIFF
--- a/libvips/foreign/matrixload.c
+++ b/libvips/foreign/matrixload.c
@@ -429,7 +429,8 @@ vips_foreign_load_matrix_source_is_a_source(VipsSource *source)
 
 	if ((bytes_read = vips_source_sniff_at_most(source, &data, 79)) <= 0)
 		return FALSE;
-	g_strlcpy(line, (const char *) data, 80);
+	data[bytes_read] = '\0';
+	g_strlcpy(line, (const char *) data, sizeof(line));
 
 	vips_error_freeze();
 	result = parse_matrix_header(line, &width, &height, &scale, &offset);

--- a/test/test-suite/test_connection.py
+++ b/test/test-suite/test_connection.py
@@ -102,6 +102,15 @@ class TestConnection:
 
         assert (im - self.mono).abs().max() == 0
 
+    @skip_if_no("svgload_source")
+    def test_connection_svg(self):
+        svg = b'<svg xmlns="http://www.w3.org/2000/svg" width="1" height="1" />'
+        x = pyvips.Source.new_from_memory(svg)
+        im = pyvips.Image.new_from_source(x, "")
+
+        assert im.width == 1
+        assert im.height == 1
+
     def test_connection_csv(self):
         x = pyvips.Target.new_to_memory()
         self.mono.csvsave_target(x)


### PR DESCRIPTION
As required by `g_strlcpy()`.

<details>
  <summary>Details</summary>

```console
=================================================================
==5472==ERROR: AddressSanitizer: heap-buffer-overflow on address 0x12acb2f65b40 at pc 0x7ffa9109cdc8 bp 0x00551e3fb3d0 sp 0x00551e3fb418
READ of size 1 at 0x12acb2f65b40 thread T-1
    #0 0x7ffa9109cdc7 in g_strlcpy /var/tmp/tmp-glib-x86_64-w64-mingw32.shared.all.debug/glib-2.85.0.build_/../glib-2.85.0/glib/gstrfuncs.c:1476:14
    #1 0x7ffa9185d214 in vips_foreign_load_matrix_source_is_a_source /var/tmp/tmp-vips-all-x86_64-w64-mingw32.shared.all.debug/libvips-libvips-8f95205.build_/../libvips-libvips-8f95205/libvips/foreign/matrixload.c:432:2
    #2 0x7ffa9182b30a in vips_foreign_find_load_source_sub /var/tmp/tmp-vips-all-x86_64-w64-mingw32.shared.all.debug/libvips-libvips-8f95205.build_/../libvips-libvips-8f95205/libvips/foreign/foreign.c:747:7
    #3 0x7ffa91d53c29 in vips_slist_map2 /var/tmp/tmp-vips-all-x86_64-w64-mingw32.shared.all.debug/libvips-libvips-8f95205.build_/../libvips-libvips-8f95205/libvips/iofuncs/util.c:118:33
    #4 0x7ffa9182b139 in vips_foreign_map /var/tmp/tmp-vips-all-x86_64-w64-mingw32.shared.all.debug/libvips-libvips-8f95205.build_/../libvips-libvips-8f95205/libvips/foreign/foreign.c:499:11
    #5 0x7ffa9182b139 in vips_foreign_find_load_source /var/tmp/tmp-vips-all-x86_64-w64-mingw32.shared.all.debug/libvips-libvips-8f95205.build_/../libvips-libvips-8f95205/libvips/foreign/foreign.c:777:46
    #6 0x7ffa38c19a24  (<unknown module>)
0x12acb2f65b40 is located 0 bytes after 128-byte region [0x12acb2f65ac0,0x12acb2f65b40)
allocated by thread T0 here:
    #0 0x7ffa904ba636 in realloc /usr/local/mxe/tmp-compiler-rt-sanitizers-x86_64-w64-mingw32.shared.all.debug/llvm-project-20.1.5.src/compiler-rt/lib/asan/asan_malloc_win.cpp:110:3
    #1 0x7ffa91063561 in g_realloc /var/tmp/tmp-glib-x86_64-w64-mingw32.shared.all.debug/glib-2.85.0.build_/../glib-2.85.0/glib/gmem.c:171:16
    #2 0x7ffa90fc6f4b in g_array_maybe_expand /var/tmp/tmp-glib-x86_64-w64-mingw32.shared.all.debug/glib-2.85.0.build_/../glib-2.85.0/glib/garray.c:1074:21
    #3 0x7ffa90fc7d74 in g_array_set_size /var/tmp/tmp-glib-x86_64-w64-mingw32.shared.all.debug/glib-2.85.0.build_/../glib-2.85.0/glib/garray.c:766:7
    #4 0x7ffa91cd2b56 in vips_source_sniff_at_most /var/tmp/tmp-vips-all-x86_64-w64-mingw32.shared.all.debug/libvips-libvips-8f95205.build_/../libvips-libvips-8f95205/libvips/iofuncs/source.c:1354:2
    #5 0x7ffa9185d1f0 in vips_foreign_load_matrix_source_is_a_source /var/tmp/tmp-vips-all-x86_64-w64-mingw32.shared.all.debug/libvips-libvips-8f95205.build_/../libvips-libvips-8f95205/libvips/foreign/matrixload.c:430:20
    #6 0x7ffa9182b30a in vips_foreign_find_load_source_sub /var/tmp/tmp-vips-all-x86_64-w64-mingw32.shared.all.debug/libvips-libvips-8f95205.build_/../libvips-libvips-8f95205/libvips/foreign/foreign.c:747:7
    #7 0x7ffa91d53c29 in vips_slist_map2 /var/tmp/tmp-vips-all-x86_64-w64-mingw32.shared.all.debug/libvips-libvips-8f95205.build_/../libvips-libvips-8f95205/libvips/iofuncs/util.c:118:33
    #8 0x7ffa9182b139 in vips_foreign_map /var/tmp/tmp-vips-all-x86_64-w64-mingw32.shared.all.debug/libvips-libvips-8f95205.build_/../libvips-libvips-8f95205/libvips/foreign/foreign.c:499:11
    #9 0x7ffa9182b139 in vips_foreign_find_load_source /var/tmp/tmp-vips-all-x86_64-w64-mingw32.shared.all.debug/libvips-libvips-8f95205.build_/../libvips-libvips-8f95205/libvips/foreign/foreign.c:777:46
    #10 0x7ffa38c19a24  (<unknown module>)
SUMMARY: AddressSanitizer: heap-buffer-overflow /var/tmp/tmp-glib-x86_64-w64-mingw32.shared.all.debug/glib-2.85.0.build_/../glib-2.85.0/glib/gstrfuncs.c:1476:14 in g_strlcpy
Shadow bytes around the buggy address:
  0x12acb2f65880: fd fd fd fd fd fd fd fd fd fd fd fd fd fd fd fd
  0x12acb2f65900: fa fa fa fa fa fa fa fa fd fd fd fd fd fd fd fd
  0x12acb2f65980: fd fd fd fd fd fd fd fd fa fa fa fa fa fa fa fa
  0x12acb2f65a00: fd fd fd fd fd fd fd fd fd fd fd fd fd fd fd fd
  0x12acb2f65a80: fa fa fa fa fa fa fa fa 00 00 00 00 00 00 00 00
=>0x12acb2f65b00: 00 00 00 00 00 00 00 00[fa]fa fa fa fa fa fa fa
  0x12acb2f65b80: fd fd fd fd fd fd fd fd fd fd fd fd fd fd fd fd
  0x12acb2f65c00: fa fa fa fa fa fa fa fa fd fd fd fd fd fd fd fd
  0x12acb2f65c80: fd fd fd fd fd fd fd fd fa fa fa fa fa fa fa fa
  0x12acb2f65d00: fd fd fd fd fd fd fd fd fd fd fd fd fd fd fd fd
  0x12acb2f65d80: fa fa fa fa fa fa fa fa fd fd fd fd fd fd fd fd
Shadow byte legend (one shadow byte represents 8 application bytes):
  Addressable:           00
  Partially addressable: 01 02 03 04 05 06 07
  Heap left redzone:       fa
  Freed heap region:       fd
  Stack left redzone:      f1
  Stack mid redzone:       f2
  Stack right redzone:     f3
  Stack after return:      f5
  Stack use after scope:   f8
  Global redzone:          f9
  Global init order:       f6
  Poisoned by user:        f7
  Container overflow:      fc
  Array cookie:            ac
  Intra object redzone:    bb
  ASan internal:           fe
  Left alloca redzone:     ca
  Right alloca redzone:    cb
==5472==ABORTING
=================================================================
==5472==ERROR: AddressSanitizer: heap-buffer-overflow on address 0x12acb2f65b40 at pc 0x7ffa9109cdc8 bp 0x00551e3fb3d0 sp 0x00551e3fb418
READ of size 1 at 0x12acb2f65b40 thread T-1
    #0 0x7ffa9109cdc7 in g_strlcpy /var/tmp/tmp-glib-x86_64-w64-mingw32.shared.all.debug/glib-2.85.0.build_/../glib-2.85.0/glib/gstrfuncs.c:1476:14
    #1 0x7ffa9185d214 in vips_foreign_load_matrix_source_is_a_source /var/tmp/tmp-vips-all-x86_64-w64-mingw32.shared.all.debug/libvips-libvips-8f95205.build_/../libvips-libvips-8f95205/libvips/foreign/matrixload.c:432:2
    #2 0x7ffa9182b30a in vips_foreign_find_load_source_sub /var/tmp/tmp-vips-all-x86_64-w64-mingw32.shared.all.debug/libvips-libvips-8f95205.build_/../libvips-libvips-8f95205/libvips/foreign/foreign.c:747:7
    #3 0x7ffa91d53c29 in vips_slist_map2 /var/tmp/tmp-vips-all-x86_64-w64-mingw32.shared.all.debug/libvips-libvips-8f95205.build_/../libvips-libvips-8f95205/libvips/iofuncs/util.c:118:33
    #4 0x7ffa9182b139 in vips_foreign_map /var/tmp/tmp-vips-all-x86_64-w64-mingw32.shared.all.debug/libvips-libvips-8f95205.build_/../libvips-libvips-8f95205/libvips/foreign/foreign.c:499:11
    #5 0x7ffa9182b139 in vips_foreign_find_load_source /var/tmp/tmp-vips-all-x86_64-w64-mingw32.shared.all.debug/libvips-libvips-8f95205.build_/../libvips-libvips-8f95205/libvips/foreign/foreign.c:777:46
    #6 0x7ffa38c19a24  (<unknown module>)
0x12acb2f65b40 is located 0 bytes after 128-byte region [0x12acb2f65ac0,0x12acb2f65b40)
allocated by thread T0 here:
    #0 0x7ffa904ba636 in realloc /usr/local/mxe/tmp-compiler-rt-sanitizers-x86_64-w64-mingw32.shared.all.debug/llvm-project-20.1.5.src/compiler-rt/lib/asan/asan_malloc_win.cpp:110:3
    #1 0x7ffa91063561 in g_realloc /var/tmp/tmp-glib-x86_64-w64-mingw32.shared.all.debug/glib-2.85.0.build_/../glib-2.85.0/glib/gmem.c:171:16
    #2 0x7ffa90fc6f4b in g_array_maybe_expand /var/tmp/tmp-glib-x86_64-w64-mingw32.shared.all.debug/glib-2.85.0.build_/../glib-2.85.0/glib/garray.c:1074:21
    #3 0x7ffa90fc7d74 in g_array_set_size /var/tmp/tmp-glib-x86_64-w64-mingw32.shared.all.debug/glib-2.85.0.build_/../glib-2.85.0/glib/garray.c:766:7
    #4 0x7ffa91cd2b56 in vips_source_sniff_at_most /var/tmp/tmp-vips-all-x86_64-w64-mingw32.shared.all.debug/libvips-libvips-8f95205.build_/../libvips-libvips-8f95205/libvips/iofuncs/source.c:1354:2
    #5 0x7ffa9185d1f0 in vips_foreign_load_matrix_source_is_a_source /var/tmp/tmp-vips-all-x86_64-w64-mingw32.shared.all.debug/libvips-libvips-8f95205.build_/../libvips-libvips-8f95205/libvips/foreign/matrixload.c:430:20
    #6 0x7ffa9182b30a in vips_foreign_find_load_source_sub /var/tmp/tmp-vips-all-x86_64-w64-mingw32.shared.all.debug/libvips-libvips-8f95205.build_/../libvips-libvips-8f95205/libvips/foreign/foreign.c:747:7
    #7 0x7ffa91d53c29 in vips_slist_map2 /var/tmp/tmp-vips-all-x86_64-w64-mingw32.shared.all.debug/libvips-libvips-8f95205.build_/../libvips-libvips-8f95205/libvips/iofuncs/util.c:118:33
    #8 0x7ffa9182b139 in vips_foreign_map /var/tmp/tmp-vips-all-x86_64-w64-mingw32.shared.all.debug/libvips-libvips-8f95205.build_/../libvips-libvips-8f95205/libvips/foreign/foreign.c:499:11
    #9 0x7ffa9182b139 in vips_foreign_find_load_source /var/tmp/tmp-vips-all-x86_64-w64-mingw32.shared.all.debug/libvips-libvips-8f95205.build_/../libvips-libvips-8f95205/libvips/foreign/foreign.c:777:46
    #10 0x7ffa38c19a24  (<unknown module>)
SUMMARY: AddressSanitizer: heap-buffer-overflow /var/tmp/tmp-glib-x86_64-w64-mingw32.shared.all.debug/glib-2.85.0.build_/../glib-2.85.0/glib/gstrfuncs.c:1476:14 in g_strlcpy
Shadow bytes around the buggy address:
  0x12acb2f65880: fd fd fd fd fd fd fd fd fd fd fd fd fd fd fd fd
  0x12acb2f65900: fa fa fa fa fa fa fa fa fd fd fd fd fd fd fd fd
  0x12acb2f65980: fd fd fd fd fd fd fd fd fa fa fa fa fa fa fa fa
  0x12acb2f65a00: fd fd fd fd fd fd fd fd fd fd fd fd fd fd fd fd
  0x12acb2f65a80: fa fa fa fa fa fa fa fa 00 00 00 00 00 00 00 00
=>0x12acb2f65b00: 00 00 00 00 00 00 00 00[fa]fa fa fa fa fa fa fa
  0x12acb2f65b80: fd fd fd fd fd fd fd fd fd fd fd fd fd fd fd fd
  0x12acb2f65c00: fa fa fa fa fa fa fa fa fd fd fd fd fd fd fd fd
  0x12acb2f65c80: fd fd fd fd fd fd fd fd fa fa fa fa fa fa fa fa
  0x12acb2f65d00: fd fd fd fd fd fd fd fd fd fd fd fd fd fd fd fd
  0x12acb2f65d80: fa fa fa fa fa fa fa fa fd fd fd fd fd fd fd fd
Shadow byte legend (one shadow byte represents 8 application bytes):
  Addressable:           00
  Partially addressable: 01 02 03 04 05 06 07
  Heap left redzone:       fa
  Freed heap region:       fd
  Stack left redzone:      f1
  Stack mid redzone:       f2
  Stack right redzone:     f3
  Stack after return:      f5
  Stack use after scope:   f8
  Global redzone:          f9
  Global init order:       f6
  Poisoned by user:        f7
  Container overflow:      fc
  Array cookie:            ac
  Intra object redzone:    bb
  ASan internal:           fe
  Left alloca redzone:     ca
  Right alloca redzone:    cb
==5472==ABORTING
```
</details>

---

This issue was detected by AddressSanitizer on Windows but not on Linux, likely due to differences in how `strlcpy()` is handled. On Windows, `strlcpy()` is not available and [is emulated by GLib](https://github.com/GNOME/glib/blob/2.85.0/glib/gstrfuncs.c#L1447-L1481):
```console
Checking for function "strlcpy" : NO 
```

Whereas on Linux, `strlcpy()` is available (since glibc 2.38), but ASan [likely lacks an interceptor](https://github.com/llvm/llvm-project/blob/llvmorg-20.1.5/compiler-rt/lib/sanitizer_common/sanitizer_platform_interceptors.h#L549-L550) for it (issue https://github.com/llvm/llvm-project/issues/114377 could be related here).