### PR TITLE
text: ensure key is copied before inserting into hash table

### DIFF
--- a/libvips/create/text.c
+++ b/libvips/create/text.c
@@ -381,7 +381,7 @@ vips_text_autofit(VipsText *text)
 static void *
 vips_text_init_once(void *client)
 {
-	vips_text_fontmap = pango_cairo_font_map_new();;
+	vips_text_fontmap = pango_cairo_font_map_new();
 	vips_text_fontfiles = g_hash_table_new(g_str_hash, g_str_equal);
 
 	return NULL;
@@ -424,7 +424,7 @@ vips_text_build(VipsObject *object)
 
 #ifdef HAVE_FONTCONFIG
 	if (text->fontfile &&
-		!g_hash_table_lookup(vips_text_fontfiles, text->fontfile)) {
+		!g_hash_table_contains(vips_text_fontfiles, text->fontfile)) {
 		/* This can fail if you eg. add the same font from two
 		 * different files. Just warn.
 		 */
@@ -433,8 +433,7 @@ vips_text_build(VipsObject *object)
 			g_warning("unable to load fontfile \"%s\"",
 				text->fontfile);
 		g_hash_table_insert(vips_text_fontfiles,
-			text->fontfile,
-			g_strdup(text->fontfile));
+			g_strdup(text->fontfile), NULL);
 
 		/* We need to inform that pango should invalidate its
 		 * fontconfig cache whenever any changes are made.


### PR DESCRIPTION
Originally reported at https://github.com/lovell/sharp/issues/4401.

<details>
  <summary>Details</summary>

```console
=================================================================
==148010==ERROR: AddressSanitizer: heap-use-after-free on address 0x7bede9d6bbc0 at pc 0x7fbdeae51605 bp 0x7bbd9c7fbe70 sp 0x7bbd9c7fb618
READ of size 1 at 0x7bede9d6bbc0 thread T9
    #0 0x7fbdeae51604 in strcmp (/usr/lib64/llvm20/bin/../../../lib/clang/20/lib/x86_64-redhat-linux-gnu/libclang_rt.asan.so+0x51604) (BuildId: aa6231e817f72469c44a6c6cee9f0694a87db7fb)
    #1 0x7bbda7cd6ccc in g_str_equal (/lib64/libglib-2.0.so.0+0x2bccc) (BuildId: 2acd4dfbc176f0dd02c08005d3214bc81469bc57)
    #2 0x7bbda7cd7a3d in g_hash_table_lookup (/lib64/libglib-2.0.so.0+0x2ca3d) (BuildId: 2acd4dfbc176f0dd02c08005d3214bc81469bc57)
    #3 0x7bbda883fc3c in vips_text_build /home/kleisauke/libvips/build/../libvips/create/text.c:427:4
    #4 0x7bbda86075a1 in vips_object_build /home/kleisauke/libvips/build/../libvips/iofuncs/object.c:369:6
    #5 0x7bbda8641ca0 in vips_cache_operation_buildp /home/kleisauke/libvips/build/../libvips/iofuncs/cache.c:904:7
    #6 0x7bbde811e93e in vips::VImage::call_option_string(char const*, char const*, vips::VOption*) /home/kleisauke/libvips/build/../cplusplus/VImage.cpp:531:6
    #7 0x7bbde816f91f in vips::VImage::call(char const*, vips::VOption*) /home/kleisauke/libvips/build/../cplusplus/VImage.cpp:557:2
    #8 0x7bbde816f91f in vips::VImage::text(char const*, vips::VOption*) /home/kleisauke/libvips/build/../cplusplus/vips-operators.cpp:3544:2
    #9 0x7fbde9d310af in sharp::OpenInput(sharp::InputDescriptor*) /home/kleisauke/sharp-crash-repro/node_modules/sharp/src/build/../common.cc:502:17
    #10 0x7fbde9d49e75 in PipelineWorker::Execute() /home/kleisauke/sharp-crash-repro/node_modules/sharp/src/build/../pipeline.cc:46:43
    #11 0x7fbde9d3721b in Napi::AsyncWorker::OnExecute(Napi::Env) /home/kleisauke/sharp-crash-repro/node_modules/sharp/src/build/../../../node-addon-api/napi-inl.h:5452:5
    #12 0x000001039ba7 in node::ThreadPoolWork::ScheduleWork()::'lambda'(uv_work_s*)::_FUN(uv_work_s*) (/usr/bin/node+0x1039ba7) (BuildId: c9f05177937e924cb3097f21173cbd0d9bee44d3)
    #13 0x0000020b522f in worker /home/iojs/build/ws/out/../deps/uv/src/threadpool.c:123:5
    #14 0x7fbdeaed84ca  (/usr/lib64/llvm20/bin/../../../lib/clang/20/lib/x86_64-redhat-linux-gnu/libclang_rt.asan.so+0xd84ca) (BuildId: aa6231e817f72469c44a6c6cee9f0694a87db7fb)
    #15 0x7fbdea87f1d3 in start_thread (/lib64/libc.so.6+0x711d3) (BuildId: 2b3c02fe7e4d3811767175b6f323692a10a4e116)
    #16 0x7fbdea901ceb in __GI___clone3 (/lib64/libc.so.6+0xf3ceb) (BuildId: 2b3c02fe7e4d3811767175b6f323692a10a4e116)

0x7bede9d6bbc0 is located 0 bytes inside of 31-byte region [0x7bede9d6bbc0,0x7bede9d6bbdf)
freed by thread T8 here:
    #0 0x7fbdeaeda8fa in free (/usr/lib64/llvm20/bin/../../../lib/clang/20/lib/x86_64-redhat-linux-gnu/libclang_rt.asan.so+0xda8fa) (BuildId: aa6231e817f72469c44a6c6cee9f0694a87db7fb)
    #1 0x7bbda7cec484 in g_free (/lib64/libglib-2.0.so.0+0x41484) (BuildId: 2acd4dfbc176f0dd02c08005d3214bc81469bc57)
    #2 0x7bbda860c47c in vips_object_set_property /home/kleisauke/libvips/build/../libvips/iofuncs/object.c:1242:4
    #3 0x7bbde8539ac8  (/lib64/libgobject-2.0.so.0+0x17ac8) (BuildId: 172b1e49717cb70069b0b510e2c99f618880723b)
    #4 0x7bbde853cecd in g_object_set_valist (/lib64/libgobject-2.0.so.0+0x1aecd) (BuildId: 172b1e49717cb70069b0b510e2c99f618880723b)
    #5 0x7bbde853d37a in g_object_set (/lib64/libgobject-2.0.so.0+0x1b37a) (BuildId: 172b1e49717cb70069b0b510e2c99f618880723b)
    #6 0x7bbda861ce66 in vips_object_free_argument /home/kleisauke/libvips/build/../libvips/iofuncs/object.c:973:3
    #7 0x7bbda860789c in vips_argument_map /home/kleisauke/libvips/build/../libvips/iofuncs/object.c:609:17
    #8 0x7bbda861b8c6 in vips_argument_free_all /home/kleisauke/libvips/build/../libvips/iofuncs/object.c:993:2
    #9 0x7bbda861b8c6 in vips_object_dispose /home/kleisauke/libvips/build/../libvips/iofuncs/object.c:1025:2
    #10 0x7bbde8537e17 in g_object_unref (/lib64/libgobject-2.0.so.0+0x15e17) (BuildId: 172b1e49717cb70069b0b510e2c99f618880723b)
    #11 0x7bbde853d37a in g_object_set (/lib64/libgobject-2.0.so.0+0x1b37a) (BuildId: 172b1e49717cb70069b0b510e2c99f618880723b)
    #12 0x7bbde8528ae9 in g_closure_invoke (/lib64/libgobject-2.0.so.0+0x6ae9) (BuildId: 172b1e49717cb70069b0b510e2c99f618880723b)
    #13 0x7bbde8546ab9  (/lib64/libgobject-2.0.so.0+0x24ab9) (BuildId: 172b1e49717cb70069b0b510e2c99f618880723b)
    #14 0x7bbde8548af5  (/lib64/libgobject-2.0.so.0+0x26af5) (BuildId: 172b1e49717cb70069b0b510e2c99f618880723b)
    #15 0x7bbde8548d67 in g_signal_emit_valist (/lib64/libgobject-2.0.so.0+0x26d67) (BuildId: 172b1e49717cb70069b0b510e2c99f618880723b)
    #16 0x7bbde8548e22 in g_signal_emit (/lib64/libgobject-2.0.so.0+0x26e22) (BuildId: 172b1e49717cb70069b0b510e2c99f618880723b)
    #17 0x7bbda861b841 in vips_object_close /home/kleisauke/libvips/build/../libvips/iofuncs/object.c:294:3
    #18 0x7bbda861b841 in vips_object_dispose /home/kleisauke/libvips/build/../libvips/iofuncs/object.c:1021:2
    #19 0x7bbde8537e17 in g_object_unref (/lib64/libgobject-2.0.so.0+0x15e17) (BuildId: 172b1e49717cb70069b0b510e2c99f618880723b)
    #20 0x7bbda860adcc in vips_object_clear_member /home/kleisauke/libvips/build/../libvips/iofuncs/object.c
    #21 0x7bbda860adcc in vips__object_set_member /home/kleisauke/libvips/build/../libvips/iofuncs/object.c:1096:2
    #22 0x7bbda860c5e0 in vips_object_set_property /home/kleisauke/libvips/build/../libvips/iofuncs/object.c:1249:3
    #23 0x7bbde8539c2e  (/lib64/libgobject-2.0.so.0+0x17c2e) (BuildId: 172b1e49717cb70069b0b510e2c99f618880723b)
    #24 0x7bbde853cecd in g_object_set_valist (/lib64/libgobject-2.0.so.0+0x1aecd) (BuildId: 172b1e49717cb70069b0b510e2c99f618880723b)
    #25 0x7bbde853d37a in g_object_set (/lib64/libgobject-2.0.so.0+0x1b37a) (BuildId: 172b1e49717cb70069b0b510e2c99f618880723b)
    #26 0x7bbda861cb03 in vips_object_dispose_argument /home/kleisauke/libvips/build/../libvips/iofuncs/object.c:926:3
    #27 0x7bbda860789c in vips_argument_map /home/kleisauke/libvips/build/../libvips/iofuncs/object.c:609:17
    #28 0x7bbda861b7cf in vips_argument_dispose_all /home/kleisauke/libvips/build/../libvips/iofuncs/object.c:952:2
    #29 0x7bbda861b7cf in vips_object_dispose /home/kleisauke/libvips/build/../libvips/iofuncs/object.c:1019:2
    #30 0x7bbde8537e17 in g_object_unref (/lib64/libgobject-2.0.so.0+0x15e17) (BuildId: 172b1e49717cb70069b0b510e2c99f618880723b)
    #31 0x7bbde853d37a in g_object_set (/lib64/libgobject-2.0.so.0+0x1b37a) (BuildId: 172b1e49717cb70069b0b510e2c99f618880723b)

previously allocated by thread T8 here:
    #0 0x7fbdeaedab98 in malloc (/usr/lib64/llvm20/bin/../../../lib/clang/20/lib/x86_64-redhat-linux-gnu/libclang_rt.asan.so+0xdab98) (BuildId: aa6231e817f72469c44a6c6cee9f0694a87db7fb)
    #1 0x7bbda7cf1fe9 in g_malloc (/lib64/libglib-2.0.so.0+0x46fe9) (BuildId: 2acd4dfbc176f0dd02c08005d3214bc81469bc57)
    #2 0x7bbda7d0be39 in g_strdup (/lib64/libglib-2.0.so.0+0x60e39) (BuildId: 2acd4dfbc176f0dd02c08005d3214bc81469bc57)
    #3 0x7bbda860c74c in vips_object_set_property /home/kleisauke/libvips/build/../libvips/iofuncs/object.c:1243:13
    #4 0x7bbde8539ac8  (/lib64/libgobject-2.0.so.0+0x17ac8) (BuildId: 172b1e49717cb70069b0b510e2c99f618880723b)
    #5 0x7bbde853ca72 in g_object_setv (/lib64/libgobject-2.0.so.0+0x1aa72) (BuildId: 172b1e49717cb70069b0b510e2c99f618880723b)
    #6 0x7bbde853ccc0 in g_object_set_property (/lib64/libgobject-2.0.so.0+0x1acc0) (BuildId: 172b1e49717cb70069b0b510e2c99f618880723b)
    #7 0x7bbde811cbe6 in vips::set_property(_VipsObject*, char const*, _GValue const*) /home/kleisauke/libvips/build/../cplusplus/VImage.cpp:420:3
    #8 0x7bbde811cbe6 in vips::VOption::set_operation(_VipsOperation*) /home/kleisauke/libvips/build/../cplusplus/VImage.cpp:440:4
    #9 0x7bbde811e936 in vips::VImage::call_option_string(char const*, char const*, vips::VOption*) /home/kleisauke/libvips/build/../cplusplus/VImage.cpp:527:12
    #10 0x7bbde816f91f in vips::VImage::call(char const*, vips::VOption*) /home/kleisauke/libvips/build/../cplusplus/VImage.cpp:557:2
    #11 0x7bbde816f91f in vips::VImage::text(char const*, vips::VOption*) /home/kleisauke/libvips/build/../cplusplus/vips-operators.cpp:3544:2
    #12 0x7fbde9d310af in sharp::OpenInput(sharp::InputDescriptor*) /home/kleisauke/sharp-crash-repro/node_modules/sharp/src/build/../common.cc:502:17
    #13 0x7fbde9d49e75 in PipelineWorker::Execute() /home/kleisauke/sharp-crash-repro/node_modules/sharp/src/build/../pipeline.cc:46:43
    #14 0x7fbde9d3721b in Napi::AsyncWorker::OnExecute(Napi::Env) /home/kleisauke/sharp-crash-repro/node_modules/sharp/src/build/../../../node-addon-api/napi-inl.h:5452:5
    #15 0x000001039ba7 in node::ThreadPoolWork::ScheduleWork()::'lambda'(uv_work_s*)::_FUN(uv_work_s*) (/usr/bin/node+0x1039ba7) (BuildId: c9f05177937e924cb3097f21173cbd0d9bee44d3)
    #16 0x0000020b522f in worker /home/iojs/build/ws/out/../deps/uv/src/threadpool.c:123:5
    #17 0x7fbdeaed84ca  (/usr/lib64/llvm20/bin/../../../lib/clang/20/lib/x86_64-redhat-linux-gnu/libclang_rt.asan.so+0xd84ca) (BuildId: aa6231e817f72469c44a6c6cee9f0694a87db7fb)
    #18 0x7fbdea87f1d3 in start_thread (/lib64/libc.so.6+0x711d3) (BuildId: 2b3c02fe7e4d3811767175b6f323692a10a4e116)
    #19 0x7fbdea901ceb in __GI___clone3 (/lib64/libc.so.6+0xf3ceb) (BuildId: 2b3c02fe7e4d3811767175b6f323692a10a4e116)

Thread T9 created by T0 here:
    #0 0x7fbdeaebeb55 in pthread_create (/usr/lib64/llvm20/bin/../../../lib/clang/20/lib/x86_64-redhat-linux-gnu/libclang_rt.asan.so+0xbeb55) (BuildId: aa6231e817f72469c44a6c6cee9f0694a87db7fb)
    #1 0x0000020c89f1 in uv_thread_create_ex /home/iojs/build/ws/out/../deps/uv/src/unix/thread.c:181:9
    #2 0x0000020b557e in init_threads /home/iojs/build/ws/out/../deps/uv/src/threadpool.c:235:9
    #3 0x0000020b557e in init_once /home/iojs/build/ws/out/../deps/uv/src/threadpool.c:262:3
    #4 0x7fbdea884553 in __pthread_once_slow.isra.0 (/lib64/libc.so.6+0x76553) (BuildId: 2b3c02fe7e4d3811767175b6f323692a10a4e116)
    #5 0x7fbdea8845c8 in __pthread_once@GLIBC_2.2.5 (/lib64/libc.so.6+0x765c8) (BuildId: 2b3c02fe7e4d3811767175b6f323692a10a4e116)
    #6 0x0000020c8f58 in uv_once /home/iojs/build/ws/out/../deps/uv/src/unix/thread.c:454:7
    #7 0x0000020b599b in uv__work_submit /home/iojs/build/ws/out/../deps/uv/src/threadpool.c:271:3
    #8 0x0000020b599b in uv_queue_work /home/iojs/build/ws/out/../deps/uv/src/threadpool.c:380:3
    #9 0x00000103744b in napi_queue_async_work (/usr/bin/node+0x103744b) (BuildId: c9f05177937e924cb3097f21173cbd0d9bee44d3)
    #10 0x7fbde9d461e1 in Napi::AsyncWorker::Queue() /home/kleisauke/sharp-crash-repro/node_modules/sharp/src/build/../../../node-addon-api/napi-inl.h:5396:24
    #11 0x7fbde9d461e1 in pipeline(Napi::CallbackInfo const&) /home/kleisauke/sharp-crash-repro/node_modules/sharp/src/build/../pipeline.cc:1817:11
    #12 0x7fbde9d59de6 in Napi::details::CallbackData<Napi::Value (*)(Napi::CallbackInfo const&), Napi::Value>::Wrapper(napi_env__*, napi_callback_info__*)::'lambda'()::operator()() const /home/kleisauke/sharp-crash-repro/node_modules/sharp/src/build/../../../node-addon-api/napi-inl.h:168:14
    #13 0x7fbde9d59de6 in napi_value__* Napi::details::WrapCallback<Napi::details::CallbackData<Napi::Value (*)(Napi::CallbackInfo const&), Napi::Value>::Wrapper(napi_env__*, napi_callback_info__*)::'lambda'()>(napi_env__*, Napi::details::CallbackData<Napi::Value (*)(Napi::CallbackInfo const&), Napi::Value>::Wrapper(napi_env__*, napi_callback_info__*)::'lambda'()) /home/kleisauke/sharp-crash-repro/node_modules/sharp/src/build/../../../node-addon-api/napi-inl.h:89:12
    #14 0x7fbde9d59d9b in Napi::details::CallbackData<Napi::Value (*)(Napi::CallbackInfo const&), Napi::Value>::Wrapper(napi_env__*, napi_callback_info__*) /home/kleisauke/sharp-crash-repro/node_modules/sharp/src/build/../../../node-addon-api/napi-inl.h:163:12
    #15 0x000001007f90 in v8impl::(anonymous namespace)::FunctionCallbackWrapper::Invoke(v8::FunctionCallbackInfo<v8::Value> const&) js_native_api_v8.cc
    #16 0x7bbdc948f08c  (<unknown module>)
    #17 0x7bbdc948d653  (<unknown module>)
    #18 0x7bbdc95b79fc  (<unknown module>)
    #19 0x7bbdc948def9  (<unknown module>)
    #20 0x7bbdc9641100  (<unknown module>)
    #21 0x7bbdc948d653  (<unknown module>)
    #22 0x7bbdc948d653  (<unknown module>)
    #23 0x7bbdc948d653  (<unknown module>)
    #24 0x7bbdc948d653  (<unknown module>)
    #25 0x7bbdc948d653  (<unknown module>)
    #26 0x7bbdc948d653  (<unknown module>)
    #27 0x7bbdc948d653  (<unknown module>)
    #28 0x7bbdc948d653  (<unknown module>)
    #29 0x7bbdc948d653  (<unknown module>)
    #30 0x7bbdc948d653  (<unknown module>)
    #31 0x7bbdc948d653  (<unknown module>)
    #32 0x7bbdc948d653  (<unknown module>)
    #33 0x7bbdc948d653  (<unknown module>)
    #34 0x7bbdc948b21b  (<unknown module>)
    #35 0x7bbdc948af66  (<unknown module>)
    #36 0x0000014e2200 in v8::internal::(anonymous namespace)::Invoke(v8::internal::Isolate*, v8::internal::(anonymous namespace)::InvokeParams const&) execution.cc
    #37 0x0000014e30ae in v8::internal::Execution::Call(v8::internal::Isolate*, v8::internal::DirectHandle<v8::internal::Object>, v8::internal::DirectHandle<v8::internal::Object>, v8::base::Vector<v8::internal::DirectHandle<v8::internal::Object> const>) (/usr/bin/node+0x14e30ae) (BuildId: c9f05177937e924cb3097f21173cbd0d9bee44d3)
    #38 0x000001350066 in v8::Function::Call(v8::Isolate*, v8::Local<v8::Context>, v8::Local<v8::Value>, int, v8::Local<v8::Value>*) (/usr/bin/node+0x1350066) (BuildId: c9f05177937e924cb3097f21173cbd0d9bee44d3)
    #39 0x00000105a812 in node::builtins::BuiltinLoader::CompileAndCall(v8::Local<v8::Context>, char const*, node::Realm*) (/usr/bin/node+0x105a812) (BuildId: c9f05177937e924cb3097f21173cbd0d9bee44d3)
    #40 0x00000113dd62 in node::Realm::ExecuteBootstrapper(char const*) (/usr/bin/node+0x113dd62) (BuildId: c9f05177937e924cb3097f21173cbd0d9bee44d3)
    #41 0x00000102705f in node::StartExecution(node::Environment*, char const*) node.cc
    #42 0x00000102db4e in node::StartExecution(node::Environment*, std::function<v8::MaybeLocal<v8::Value> (node::StartExecutionCallbackInfo const&)>) (/usr/bin/node+0x102db4e) (BuildId: c9f05177937e924cb3097f21173cbd0d9bee44d3)
    #43 0x000000f6bd63 in node::LoadEnvironment(node::Environment*, std::function<v8::MaybeLocal<v8::Value> (node::StartExecutionCallbackInfo const&)>, std::function<void (node::Environment*, v8::Local<v8::Value>, v8::Local<v8::Value>)>) (/usr/bin/node+0xf6bd63) (BuildId: c9f05177937e924cb3097f21173cbd0d9bee44d3)
    #44 0x0000010e1e63 in node::NodeMainInstance::Run() (/usr/bin/node+0x10e1e63) (BuildId: c9f05177937e924cb3097f21173cbd0d9bee44d3)
    #45 0x000001030571 in node::Start(int, char**) (/usr/bin/node+0x1030571) (BuildId: c9f05177937e924cb3097f21173cbd0d9bee44d3)
    #46 0x7fbdea8115f4 in __libc_start_call_main (/lib64/libc.so.6+0x35f4) (BuildId: 2b3c02fe7e4d3811767175b6f323692a10a4e116)
    #47 0x7fbdea8116a7 in __libc_start_main@GLIBC_2.2.5 (/lib64/libc.so.6+0x36a7) (BuildId: 2b3c02fe7e4d3811767175b6f323692a10a4e116)
    #48 0x000000f631ed in _start (/usr/bin/node+0xf631ed) (BuildId: c9f05177937e924cb3097f21173cbd0d9bee44d3)

Thread T8 created by T0 here:
    #0 0x7fbdeaebeb55 in pthread_create (/usr/lib64/llvm20/bin/../../../lib/clang/20/lib/x86_64-redhat-linux-gnu/libclang_rt.asan.so+0xbeb55) (BuildId: aa6231e817f72469c44a6c6cee9f0694a87db7fb)
    #1 0x0000020c89f1 in uv_thread_create_ex /home/iojs/build/ws/out/../deps/uv/src/unix/thread.c:181:9
    #2 0x0000020b557e in init_threads /home/iojs/build/ws/out/../deps/uv/src/threadpool.c:235:9
    #3 0x0000020b557e in init_once /home/iojs/build/ws/out/../deps/uv/src/threadpool.c:262:3
    #4 0x7fbdea884553 in __pthread_once_slow.isra.0 (/lib64/libc.so.6+0x76553) (BuildId: 2b3c02fe7e4d3811767175b6f323692a10a4e116)
    #5 0x7fbdea8845c8 in __pthread_once@GLIBC_2.2.5 (/lib64/libc.so.6+0x765c8) (BuildId: 2b3c02fe7e4d3811767175b6f323692a10a4e116)
    #6 0x0000020c8f58 in uv_once /home/iojs/build/ws/out/../deps/uv/src/unix/thread.c:454:7
    #7 0x0000020b599b in uv__work_submit /home/iojs/build/ws/out/../deps/uv/src/threadpool.c:271:3
    #8 0x0000020b599b in uv_queue_work /home/iojs/build/ws/out/../deps/uv/src/threadpool.c:380:3
    #9 0x00000103744b in napi_queue_async_work (/usr/bin/node+0x103744b) (BuildId: c9f05177937e924cb3097f21173cbd0d9bee44d3)
    #10 0x7fbde9d461e1 in Napi::AsyncWorker::Queue() /home/kleisauke/sharp-crash-repro/node_modules/sharp/src/build/../../../node-addon-api/napi-inl.h:5396:24
    #11 0x7fbde9d461e1 in pipeline(Napi::CallbackInfo const&) /home/kleisauke/sharp-crash-repro/node_modules/sharp/src/build/../pipeline.cc:1817:11
    #12 0x7fbde9d59de6 in Napi::details::CallbackData<Napi::Value (*)(Napi::CallbackInfo const&), Napi::Value>::Wrapper(napi_env__*, napi_callback_info__*)::'lambda'()::operator()() const /home/kleisauke/sharp-crash-repro/node_modules/sharp/src/build/../../../node-addon-api/napi-inl.h:168:14
    #13 0x7fbde9d59de6 in napi_value__* Napi::details::WrapCallback<Napi::details::CallbackData<Napi::Value (*)(Napi::CallbackInfo const&), Napi::Value>::Wrapper(napi_env__*, napi_callback_info__*)::'lambda'()>(napi_env__*, Napi::details::CallbackData<Napi::Value (*)(Napi::CallbackInfo const&), Napi::Value>::Wrapper(napi_env__*, napi_callback_info__*)::'lambda'()) /home/kleisauke/sharp-crash-repro/node_modules/sharp/src/build/../../../node-addon-api/napi-inl.h:89:12
    #14 0x7fbde9d59d9b in Napi::details::CallbackData<Napi::Value (*)(Napi::CallbackInfo const&), Napi::Value>::Wrapper(napi_env__*, napi_callback_info__*) /home/kleisauke/sharp-crash-repro/node_modules/sharp/src/build/../../../node-addon-api/napi-inl.h:163:12
    #15 0x000001007f90 in v8impl::(anonymous namespace)::FunctionCallbackWrapper::Invoke(v8::FunctionCallbackInfo<v8::Value> const&) js_native_api_v8.cc
    #16 0x7bbdc948f08c  (<unknown module>)
    #17 0x7bbdc948d653  (<unknown module>)
    #18 0x7bbdc95b79fc  (<unknown module>)
    #19 0x7bbdc948def9  (<unknown module>)
    #20 0x7bbdc9641100  (<unknown module>)
    #21 0x7bbdc948d653  (<unknown module>)
    #22 0x7bbdc948d653  (<unknown module>)
    #23 0x7bbdc948d653  (<unknown module>)
    #24 0x7bbdc948d653  (<unknown module>)
    #25 0x7bbdc948d653  (<unknown module>)
    #26 0x7bbdc948d653  (<unknown module>)
    #27 0x7bbdc948d653  (<unknown module>)
    #28 0x7bbdc948d653  (<unknown module>)
    #29 0x7bbdc948d653  (<unknown module>)
    #30 0x7bbdc948d653  (<unknown module>)
    #31 0x7bbdc948d653  (<unknown module>)
    #32 0x7bbdc948d653  (<unknown module>)
    #33 0x7bbdc948d653  (<unknown module>)
    #34 0x7bbdc948b21b  (<unknown module>)
    #35 0x7bbdc948af66  (<unknown module>)
    #36 0x0000014e2200 in v8::internal::(anonymous namespace)::Invoke(v8::internal::Isolate*, v8::internal::(anonymous namespace)::InvokeParams const&) execution.cc
    #37 0x0000014e30ae in v8::internal::Execution::Call(v8::internal::Isolate*, v8::internal::DirectHandle<v8::internal::Object>, v8::internal::DirectHandle<v8::internal::Object>, v8::base::Vector<v8::internal::DirectHandle<v8::internal::Object> const>) (/usr/bin/node+0x14e30ae) (BuildId: c9f05177937e924cb3097f21173cbd0d9bee44d3)
    #38 0x000001350066 in v8::Function::Call(v8::Isolate*, v8::Local<v8::Context>, v8::Local<v8::Value>, int, v8::Local<v8::Value>*) (/usr/bin/node+0x1350066) (BuildId: c9f05177937e924cb3097f21173cbd0d9bee44d3)
    #39 0x00000105a812 in node::builtins::BuiltinLoader::CompileAndCall(v8::Local<v8::Context>, char const*, node::Realm*) (/usr/bin/node+0x105a812) (BuildId: c9f05177937e924cb3097f21173cbd0d9bee44d3)
    #40 0x00000113dd62 in node::Realm::ExecuteBootstrapper(char const*) (/usr/bin/node+0x113dd62) (BuildId: c9f05177937e924cb3097f21173cbd0d9bee44d3)
    #41 0x00000102705f in node::StartExecution(node::Environment*, char const*) node.cc
    #42 0x00000102db4e in node::StartExecution(node::Environment*, std::function<v8::MaybeLocal<v8::Value> (node::StartExecutionCallbackInfo const&)>) (/usr/bin/node+0x102db4e) (BuildId: c9f05177937e924cb3097f21173cbd0d9bee44d3)
    #43 0x000000f6bd63 in node::LoadEnvironment(node::Environment*, std::function<v8::MaybeLocal<v8::Value> (node::StartExecutionCallbackInfo const&)>, std::function<void (node::Environment*, v8::Local<v8::Value>, v8::Local<v8::Value>)>) (/usr/bin/node+0xf6bd63) (BuildId: c9f05177937e924cb3097f21173cbd0d9bee44d3)
    #44 0x0000010e1e63 in node::NodeMainInstance::Run() (/usr/bin/node+0x10e1e63) (BuildId: c9f05177937e924cb3097f21173cbd0d9bee44d3)
    #45 0x000001030571 in node::Start(int, char**) (/usr/bin/node+0x1030571) (BuildId: c9f05177937e924cb3097f21173cbd0d9bee44d3)
    #46 0x7fbdea8115f4 in __libc_start_call_main (/lib64/libc.so.6+0x35f4) (BuildId: 2b3c02fe7e4d3811767175b6f323692a10a4e116)
    #47 0x7fbdea8116a7 in __libc_start_main@GLIBC_2.2.5 (/lib64/libc.so.6+0x36a7) (BuildId: 2b3c02fe7e4d3811767175b6f323692a10a4e116)
    #48 0x000000f631ed in _start (/usr/bin/node+0xf631ed) (BuildId: c9f05177937e924cb3097f21173cbd0d9bee44d3)

SUMMARY: AddressSanitizer: heap-use-after-free (/lib64/libglib-2.0.so.0+0x2bccc) (BuildId: 2acd4dfbc176f0dd02c08005d3214bc81469bc57) in g_str_equal
Shadow bytes around the buggy address:
  0x7bede9d6b900: fd fa fa fa fd fd fd fa fa fa fd fd fd fa fa fa
  0x7bede9d6b980: fd fd fd fa fa fa fd fd fd fa fa fa fd fd fd fa
  0x7bede9d6ba00: fa fa fd fd fd fa fa fa fd fd fd fd fa fa fd fd
  0x7bede9d6ba80: fd fa fa fa fd fd fd fa fa fa fd fd fd fa fa fa
  0x7bede9d6bb00: fd fd fd fd fa fa fd fd fd fd fa fa fd fd fd fd
=>0x7bede9d6bb80: fa fa fd fd fd fa fa fa[fd]fd fd fd fa fa fd fd
  0x7bede9d6bc00: fd fa fa fa fd fd fd fd fa fa fd fd fd fd fa fa
  0x7bede9d6bc80: fd fd fd fd fa fa fd fd fd fd fa fa fd fd fd fd
  0x7bede9d6bd00: fa fa fd fd fd fa fa fa fd fd fd fa fa fa fd fd
  0x7bede9d6bd80: fd fa fa fa fd fd fd fa fa fa fd fd fd fa fa fa
  0x7bede9d6be00: fd fd fd fa fa fa fd fd fd fa fa fa fd fd fd fa
Shadow byte legend (one shadow byte represents 8 application bytes):
  Addressable:           00
  Partially addressable: 01 02 03 04 05 06 07 
  Heap left redzone:       fa
  Freed heap region:       fd
  Stack left redzone:      f1
  Stack mid redzone:       f2
  Stack right redzone:     f3
  Stack after return:      f5
  Stack use after scope:   f8
  Global redzone:          f9
  Global init order:       f6
  Poisoned by user:        f7
  Container overflow:      fc
  Array cookie:            ac
  Intra object redzone:    bb
  ASan internal:           fe
  Left alloca redzone:     ca
  Right alloca redzone:    cb
==148010==ABORTING
```
</details>

This might also resolve issue #3660 and https://github.com/libvips/ruby-vips/issues/414.