### PR TITLE
composite: transform to compositing space only if necessary

### DIFF
--- a/libvips/conversion/composite.cpp
+++ b/libvips/conversion/composite.cpp
@@ -1396,12 +1396,20 @@ vips_composite_base_build(VipsObject *object)
 					  : VIPS_INTERPRETATION_sRGB);
 	}
 
-	compositing = (VipsImage **)
-		vips_object_local_array(object, n);
+	compositing = (VipsImage **) vips_object_local_array(object, n);
 	for (int i = 0; i < n; i++)
-		if (vips_colourspace(in[i], &compositing[i],
+		if (in[i]->Type == composite->compositing_space) {
+			/* Already the right type ... just copy the image pointer
+			 * and add a ref.
+			 */
+			compositing[i] = in[i];
+			g_object_ref(in[i]);
+		}
+		else {
+			if (vips_colourspace(in[i], &compositing[i],
 				composite->compositing_space, nullptr))
 			return -1;
+		}
 	in = compositing;
 
 	/* Check that they all now match in bands. This can fail for some

--- a/test/test-suite/test_conversion.py
+++ b/test/test-suite/test_conversion.py
@@ -438,7 +438,7 @@ class TestConversion:
         comp = base.composite(overlay, "over")
 
         assert_almost_equal_objects(comp(0, 0), [51.8, 52.8, 53.8, 255],
-                                    threshold=1)
+                                    threshold=0.1)
 
     def test_unpremultiply(self):
         for fmt in unsigned_formats + [pyvips.BandFormat.SHORT,


### PR DESCRIPTION
After PR #4516, the colourspace operation would enforce the image format, which is undesirable for composite operations. For example, casting a float image back to uchar leads to precision loss.

Originally found in https://github.com/lovell/sharp/pull/4402.