### PR TITLE
foreign: inline parent build chain calls where applicable

### DIFF
--- a/libvips/foreign/csvload.c
+++ b/libvips/foreign/csvload.c
@@ -140,10 +140,8 @@ vips_foreign_load_csv_build(VipsObject *object)
 	csv->sepmap[(int) '\n'] = 0;
 	csv->whitemap[(int) '\n'] = 0;
 
-	if (VIPS_OBJECT_CLASS(vips_foreign_load_csv_parent_class)->build(object))
-		return -1;
-
-	return 0;
+	return VIPS_OBJECT_CLASS(vips_foreign_load_csv_parent_class)
+		->build(object);
 }
 
 static VipsForeignFlags
@@ -556,10 +554,8 @@ vips_foreign_load_csv_file_build(VipsObject *object)
 					vips_source_new_from_file(file->filename)))
 			return -1;
 
-	if (VIPS_OBJECT_CLASS(vips_foreign_load_csv_file_parent_class)->build(object))
-		return -1;
-
-	return 0;
+	return VIPS_OBJECT_CLASS(vips_foreign_load_csv_file_parent_class)
+		->build(object);
 }
 
 static const char *vips_foreign_load_csv_suffs[] = {
@@ -622,11 +618,8 @@ vips_foreign_load_csv_source_build(VipsObject *object)
 		g_object_ref(csv->source);
 	}
 
-	if (VIPS_OBJECT_CLASS(vips_foreign_load_csv_source_parent_class)
-			->build(object))
-		return -1;
-
-	return 0;
+	return VIPS_OBJECT_CLASS(vips_foreign_load_csv_source_parent_class)
+		->build(object);
 }
 
 static gboolean

--- a/libvips/foreign/dzsave.c
+++ b/libvips/foreign/dzsave.c
@@ -2510,11 +2510,8 @@ vips_foreign_save_dz_target_build(VipsObject *object)
 	dz->target = target->target;
 	g_object_ref(dz->target);
 
-	if (VIPS_OBJECT_CLASS(vips_foreign_save_dz_target_parent_class)
-			->build(object))
-		return -1;
-
-	return 0;
+	return VIPS_OBJECT_CLASS(vips_foreign_save_dz_target_parent_class)
+		->build(object);
 }
 
 static void
@@ -2570,11 +2567,8 @@ vips_foreign_save_dz_file_build(VipsObject *object)
 
 	dz->filename = file->filename;
 
-	if (VIPS_OBJECT_CLASS(vips_foreign_save_dz_file_parent_class)
-			->build(object))
-		return -1;
-
-	return 0;
+	return VIPS_OBJECT_CLASS(vips_foreign_save_dz_file_parent_class)
+		->build(object);
 }
 
 static void

--- a/libvips/foreign/fitsload.c
+++ b/libvips/foreign/fitsload.c
@@ -105,10 +105,8 @@ vips_foreign_load_fits_build(VipsObject *object)
 		fits->filename = filename;
 	}
 
-	if (VIPS_OBJECT_CLASS(vips_foreign_load_fits_parent_class)->build(object))
-		return -1;
-
-	return 0;
+	return VIPS_OBJECT_CLASS(vips_foreign_load_fits_parent_class)
+		->build(object);
 }
 
 static VipsForeignFlags
@@ -229,11 +227,8 @@ vips_foreign_load_fits_file_build(VipsObject *object)
 		!(fits->source = vips_source_new_from_file(file->filename)))
 		return -1;
 
-	if (VIPS_OBJECT_CLASS(vips_foreign_load_fits_file_parent_class)
-			->build(object))
-		return -1;
-
-	return 0;
+	return VIPS_OBJECT_CLASS(vips_foreign_load_fits_file_parent_class)
+		->build(object);
 }
 
 static void
@@ -294,11 +289,8 @@ vips_foreign_load_fits_source_build(VipsObject *object)
 		g_object_ref(fits->source);
 	}
 
-	if (VIPS_OBJECT_CLASS(vips_foreign_load_fits_source_parent_class)
-			->build(object))
-		return -1;
-
-	return 0;
+	return VIPS_OBJECT_CLASS(vips_foreign_load_fits_source_parent_class)
+		->build(object);
 }
 
 static gboolean

--- a/libvips/foreign/foreign.c
+++ b/libvips/foreign/foreign.c
@@ -1808,10 +1808,7 @@ vips_foreign_save_build(VipsObject *object)
 		save->ready = ready;
 	}
 
-	if (VIPS_OBJECT_CLASS(vips_foreign_save_parent_class)->build(object))
-		return -1;
-
-	return 0;
+	return VIPS_OBJECT_CLASS(vips_foreign_save_parent_class)->build(object);
 }
 
 #define UC VIPS_FORMAT_UCHAR

--- a/libvips/foreign/heifload.c
+++ b/libvips/foreign/heifload.c
@@ -373,10 +373,8 @@ vips_foreign_load_heif_build(VipsObject *object)
 		}
 	}
 
-	if (VIPS_OBJECT_CLASS(vips_foreign_load_heif_parent_class)->build(object))
-		return -1;
-
-	return 0;
+	return VIPS_OBJECT_CLASS(vips_foreign_load_heif_parent_class)
+		->build(object);
 }
 
 static const char *heif_magic[] = {
@@ -1232,11 +1230,8 @@ vips_foreign_load_heif_file_build(VipsObject *object)
 		!(heif->source = vips_source_new_from_file(file->filename)))
 		return -1;
 
-	if (VIPS_OBJECT_CLASS(vips_foreign_load_heif_file_parent_class)
-			->build(object))
-		return -1;
-
-	return 0;
+	return VIPS_OBJECT_CLASS(vips_foreign_load_heif_file_parent_class)
+		->build(object);
 }
 
 static int
@@ -1308,11 +1303,8 @@ vips_foreign_load_heif_buffer_build(VipsObject *object)
 			VIPS_AREA(buffer->buf)->length)))
 		return -1;
 
-	if (VIPS_OBJECT_CLASS(vips_foreign_load_heif_file_parent_class)
-			->build(object))
-		return -1;
-
-	return 0;
+	return VIPS_OBJECT_CLASS(vips_foreign_load_heif_buffer_parent_class)
+		->build(object);
 }
 
 static gboolean
@@ -1376,11 +1368,8 @@ vips_foreign_load_heif_source_build(VipsObject *object)
 		g_object_ref(heif->source);
 	}
 
-	if (VIPS_OBJECT_CLASS(vips_foreign_load_heif_source_parent_class)
-			->build(object))
-		return -1;
-
-	return 0;
+	return VIPS_OBJECT_CLASS(vips_foreign_load_heif_source_parent_class)
+		->build(object);
 }
 
 static gboolean

--- a/libvips/foreign/heifsave.c
+++ b/libvips/foreign/heifsave.c
@@ -860,11 +860,8 @@ vips_foreign_save_heif_file_build(VipsObject *object)
 	if (vips_iscasepostfix(file->filename, ".avif"))
 		heif->compression = VIPS_FOREIGN_HEIF_COMPRESSION_AV1;
 
-	if (VIPS_OBJECT_CLASS(vips_foreign_save_heif_file_parent_class)
-			->build(object))
-		return -1;
-
-	return 0;
+	return VIPS_OBJECT_CLASS(vips_foreign_save_heif_file_parent_class)
+		->build(object);
 }
 
 static void
@@ -982,11 +979,8 @@ vips_foreign_save_heif_target_build(VipsObject *object)
 		g_object_ref(heif->target);
 	}
 
-	if (VIPS_OBJECT_CLASS(vips_foreign_save_heif_target_parent_class)
-			->build(object))
-		return -1;
-
-	return 0;
+	return VIPS_OBJECT_CLASS(vips_foreign_save_heif_target_parent_class)
+		->build(object);
 }
 
 static void

--- a/libvips/foreign/jp2kload.c
+++ b/libvips/foreign/jp2kload.c
@@ -241,10 +241,8 @@ vips_foreign_load_jp2k_build(VipsObject *object)
 		}
 	}
 
-	if (VIPS_OBJECT_CLASS(vips_foreign_load_jp2k_parent_class)->build(object))
-		return -1;
-
-	return 0;
+	return VIPS_OBJECT_CLASS(vips_foreign_load_jp2k_parent_class)
+		->build(object);
 }
 
 #define JP2_RFC3745_MAGIC "\x00\x00\x00\x0c\x6a\x50\x20\x20\x0d\x0a\x87\x0a"
@@ -1277,11 +1275,8 @@ vips_foreign_load_jp2k_file_build(VipsObject *object)
 		!(jp2k->source = vips_source_new_from_file(file->filename)))
 		return -1;
 
-	if (VIPS_OBJECT_CLASS(vips_foreign_load_jp2k_file_parent_class)
-			->build(object))
-		return -1;
-
-	return 0;
+	return VIPS_OBJECT_CLASS(vips_foreign_load_jp2k_file_parent_class)
+		->build(object);
 }
 
 const char *vips__jp2k_suffs[] = {
@@ -1359,11 +1354,8 @@ vips_foreign_load_jp2k_buffer_build(VipsObject *object)
 				  VIPS_AREA(buffer->buf)->length)))
 			return -1;
 
-	if (VIPS_OBJECT_CLASS(vips_foreign_load_jp2k_file_parent_class)
-			->build(object))
-		return -1;
-
-	return 0;
+	return VIPS_OBJECT_CLASS(vips_foreign_load_jp2k_buffer_parent_class)
+		->build(object);
 }
 
 static gboolean
@@ -1434,11 +1426,8 @@ vips_foreign_load_jp2k_source_build(VipsObject *object)
 		g_object_ref(jp2k->source);
 	}
 
-	if (VIPS_OBJECT_CLASS(vips_foreign_load_jp2k_source_parent_class)
-			->build(object))
-		return -1;
-
-	return 0;
+	return VIPS_OBJECT_CLASS(vips_foreign_load_jp2k_source_parent_class)
+		->build(object);
 }
 
 static void

--- a/libvips/foreign/jp2ksave.c
+++ b/libvips/foreign/jp2ksave.c
@@ -1040,11 +1040,8 @@ vips_foreign_save_jp2k_file_build(VipsObject *object)
 	if (!(jp2k->target = vips_target_new_to_file(file->filename)))
 		return -1;
 
-	if (VIPS_OBJECT_CLASS(vips_foreign_save_jp2k_file_parent_class)
-			->build(object))
-		return -1;
-
-	return 0;
+	return VIPS_OBJECT_CLASS(vips_foreign_save_jp2k_file_parent_class)
+		->build(object);
 }
 
 static void
@@ -1158,11 +1155,8 @@ vips_foreign_save_jp2k_target_build(VipsObject *object)
 		g_object_ref(jp2k->target);
 	}
 
-	if (VIPS_OBJECT_CLASS(vips_foreign_save_jp2k_target_parent_class)
-			->build(object))
-		return -1;
-
-	return 0;
+	return VIPS_OBJECT_CLASS(vips_foreign_save_jp2k_target_parent_class)
+		->build(object);
 }
 
 static void

--- a/libvips/foreign/jpegload.c
+++ b/libvips/foreign/jpegload.c
@@ -117,10 +117,8 @@ vips_foreign_load_jpeg_build(VipsObject *object)
 		return -1;
 	}
 
-	if (VIPS_OBJECT_CLASS(vips_foreign_load_jpeg_parent_class)->build(object))
-		return -1;
-
-	return 0;
+	return VIPS_OBJECT_CLASS(vips_foreign_load_jpeg_parent_class)
+		->build(object);
 }
 
 static VipsForeignFlags
@@ -241,11 +239,8 @@ vips_foreign_load_jpeg_source_build(VipsObject *object)
 		g_object_ref(jpeg->source);
 	}
 
-	if (VIPS_OBJECT_CLASS(vips_foreign_load_jpeg_source_parent_class)
-			->build(object))
-		return -1;
-
-	return 0;
+	return VIPS_OBJECT_CLASS(vips_foreign_load_jpeg_source_parent_class)
+		->build(object);
 }
 
 static gboolean
@@ -310,11 +305,8 @@ vips_foreign_load_jpeg_file_build(VipsObject *object)
 				vips_source_new_from_file(file->filename)))
 		return -1;
 
-	if (VIPS_OBJECT_CLASS(vips_foreign_load_jpeg_file_parent_class)
-			->build(object))
-		return -1;
-
-	return 0;
+	return VIPS_OBJECT_CLASS(vips_foreign_load_jpeg_file_parent_class)
+		->build(object);
 }
 
 static gboolean
@@ -388,11 +380,8 @@ vips_foreign_load_jpeg_buffer_build(VipsObject *object)
 			  VIPS_AREA(buffer->blob)->length)))
 		return -1;
 
-	if (VIPS_OBJECT_CLASS(vips_foreign_load_jpeg_buffer_parent_class)
-			->build(object))
-		return -1;
-
-	return 0;
+	return VIPS_OBJECT_CLASS(vips_foreign_load_jpeg_buffer_parent_class)
+		->build(object);
 }
 
 static gboolean

--- a/libvips/foreign/jxlload.c
+++ b/libvips/foreign/jxlload.c
@@ -205,10 +205,8 @@ vips_foreign_load_jxl_build(VipsObject *object)
 		return -1;
 	}
 
-	if (VIPS_OBJECT_CLASS(vips_foreign_load_jxl_parent_class)->build(object))
-		return -1;
-
-	return 0;
+	return VIPS_OBJECT_CLASS(vips_foreign_load_jxl_parent_class)
+		->build(object);
 }
 
 static gboolean
@@ -1164,10 +1162,8 @@ vips_foreign_load_jxl_file_build(VipsObject *object)
 		!(jxl->source = vips_source_new_from_file(file->filename)))
 		return -1;
 
-	if (VIPS_OBJECT_CLASS(vips_foreign_load_jxl_file_parent_class)->build(object))
-		return -1;
-
-	return 0;
+	return VIPS_OBJECT_CLASS(vips_foreign_load_jxl_file_parent_class)
+		->build(object);
 }
 
 const char *vips__jxl_suffs[] = { ".jxl", NULL };
@@ -1244,10 +1240,8 @@ vips_foreign_load_jxl_buffer_build(VipsObject *object)
 				  VIPS_AREA(buffer->buf)->length)))
 			return -1;
 
-	if (VIPS_OBJECT_CLASS(vips_foreign_load_jxl_file_parent_class)->build(object))
-		return -1;
-
-	return 0;
+	return VIPS_OBJECT_CLASS(vips_foreign_load_jxl_buffer_parent_class)
+		->build(object);
 }
 
 static gboolean
@@ -1318,11 +1312,8 @@ vips_foreign_load_jxl_source_build(VipsObject *object)
 		g_object_ref(jxl->source);
 	}
 
-	if (VIPS_OBJECT_CLASS(vips_foreign_load_jxl_source_parent_class)
-			->build(object))
-		return -1;
-
-	return 0;
+	return VIPS_OBJECT_CLASS(vips_foreign_load_jxl_source_parent_class)
+		->build(object);
 }
 
 static void

--- a/libvips/foreign/jxlsave.c
+++ b/libvips/foreign/jxlsave.c
@@ -992,10 +992,8 @@ vips_foreign_save_jxl_file_build(VipsObject *object)
 	if (!(jxl->target = vips_target_new_to_file(file->filename)))
 		return -1;
 
-	if (VIPS_OBJECT_CLASS(vips_foreign_save_jxl_file_parent_class)->build(object))
-		return -1;
-
-	return 0;
+	return VIPS_OBJECT_CLASS(vips_foreign_save_jxl_file_parent_class)
+		->build(object);
 }
 
 static void
@@ -1109,11 +1107,8 @@ vips_foreign_save_jxl_target_build(VipsObject *object)
 		g_object_ref(jxl->target);
 	}
 
-	if (VIPS_OBJECT_CLASS(vips_foreign_save_jxl_target_parent_class)
-			->build(object))
-		return -1;
-
-	return 0;
+	return VIPS_OBJECT_CLASS(vips_foreign_save_jxl_target_parent_class)
+		->build(object);
 }
 
 static void

--- a/libvips/foreign/magick6load.c
+++ b/libvips/foreign/magick6load.c
@@ -252,10 +252,8 @@ vips_foreign_load_magick_build(VipsObject *object)
 	if (magick->page > 0)
 		magick_set_number_scenes(magick->image_info, magick->page, magick->n);
 
-	if (VIPS_OBJECT_CLASS(vips_foreign_load_magick_parent_class)->build(object))
-		return -1;
-
-	return 0;
+	return VIPS_OBJECT_CLASS(vips_foreign_load_magick_parent_class)
+		->build(object);
 }
 
 static void

--- a/libvips/foreign/matrixload.c
+++ b/libvips/foreign/matrixload.c
@@ -94,10 +94,8 @@ vips_foreign_load_matrix_build(VipsObject *object)
 	if (!(matrix->sbuf = vips_sbuf_new_from_source(matrix->source)))
 		return -1;
 
-	if (VIPS_OBJECT_CLASS(vips_foreign_load_matrix_parent_class)->build(object))
-		return -1;
-
-	return 0;
+	return VIPS_OBJECT_CLASS(vips_foreign_load_matrix_parent_class)
+		->build(object);
 }
 
 static VipsForeignFlags
@@ -315,11 +313,8 @@ vips_foreign_load_matrix_file_build(VipsObject *object)
 					vips_source_new_from_file(file->filename)))
 			return -1;
 
-	if (VIPS_OBJECT_CLASS(vips_foreign_load_matrix_file_parent_class)
-			->build(object))
-		return -1;
-
-	return 0;
+	return VIPS_OBJECT_CLASS(vips_foreign_load_matrix_file_parent_class)
+		->build(object);
 }
 
 static const char *vips_foreign_load_matrix_suffs[] = {
@@ -408,11 +403,8 @@ vips_foreign_load_matrix_source_build(VipsObject *object)
 		g_object_ref(matrix->source);
 	}
 
-	if (VIPS_OBJECT_CLASS(vips_foreign_load_matrix_source_parent_class)
-			->build(object))
-		return -1;
-
-	return 0;
+	return VIPS_OBJECT_CLASS(vips_foreign_load_matrix_source_parent_class)
+		->build(object);
 }
 
 static int

--- a/libvips/foreign/matrixsave.c
+++ b/libvips/foreign/matrixsave.c
@@ -308,10 +308,8 @@ vips_foreign_print_matrix_build(VipsObject *object)
 	if (!(matrix->target = vips_target_new_to_descriptor(1)))
 		return -1;
 
-	if (VIPS_OBJECT_CLASS(vips_foreign_print_matrix_parent_class)->build(object))
-		return -1;
-
-	return 0;
+	return VIPS_OBJECT_CLASS(vips_foreign_print_matrix_parent_class)
+		->build(object);
 }
 
 static void

--- a/libvips/foreign/niftiload.c
+++ b/libvips/foreign/niftiload.c
@@ -134,10 +134,8 @@ vips_foreign_load_nifti_build(VipsObject *object)
 		nifti->filename = filename;
 	}
 
-	if (VIPS_OBJECT_CLASS(vips_foreign_load_nifti_parent_class)->build(object))
-		return -1;
-
-	return 0;
+	return VIPS_OBJECT_CLASS(vips_foreign_load_nifti_parent_class)
+		->build(object);
 }
 
 /* Map DT_* datatype values to VipsBandFormat.
@@ -637,11 +635,8 @@ vips_foreign_load_nifti_file_build(VipsObject *object)
 				vips_source_new_from_file(file->filename)))
 		return -1;
 
-	if (VIPS_OBJECT_CLASS(vips_foreign_load_nifti_file_parent_class)
-			->build(object))
-		return -1;
-
-	return 0;
+	return VIPS_OBJECT_CLASS(vips_foreign_load_nifti_file_parent_class)
+		->build(object);
 }
 
 const char *vips_foreign_nifti_suffs[] = {
@@ -748,11 +743,8 @@ vips_foreign_load_nifti_source_build(VipsObject *object)
 		g_object_ref(nifti->source);
 	}
 
-	if (VIPS_OBJECT_CLASS(vips_foreign_load_nifti_source_parent_class)
-			->build(object))
-		return -1;
-
-	return 0;
+	return VIPS_OBJECT_CLASS(vips_foreign_load_nifti_source_parent_class)
+		->build(object);
 }
 
 static gboolean

--- a/libvips/foreign/nsgifload.c
+++ b/libvips/foreign/nsgifload.c
@@ -715,11 +715,8 @@ vips_foreign_load_gif_file_build(VipsObject *object)
 					vips_source_new_from_file(file->filename)))
 			return -1;
 
-	if (VIPS_OBJECT_CLASS(vips_foreign_load_nsgif_file_parent_class)
-			->build(object))
-		return -1;
-
-	return 0;
+	return VIPS_OBJECT_CLASS(vips_foreign_load_nsgif_file_parent_class)
+		->build(object);
 }
 
 static const char *vips_foreign_nsgif_suffs[] = {
@@ -801,11 +798,8 @@ vips_foreign_load_nsgif_buffer_build(VipsObject *object)
 			  buffer->blob->length)))
 		return -1;
 
-	if (VIPS_OBJECT_CLASS(vips_foreign_load_nsgif_buffer_parent_class)
-			->build(object))
-		return -1;
-
-	return 0;
+	return VIPS_OBJECT_CLASS(vips_foreign_load_nsgif_buffer_parent_class)
+		->build(object);
 }
 
 static gboolean
@@ -878,11 +872,8 @@ vips_foreign_load_nsgif_source_build(VipsObject *object)
 		g_object_ref(gif->source);
 	}
 
-	if (VIPS_OBJECT_CLASS(vips_foreign_load_nsgif_source_parent_class)
-			->build(object))
-		return -1;
-
-	return 0;
+	return VIPS_OBJECT_CLASS(vips_foreign_load_nsgif_source_parent_class)
+		->build(object);
 }
 
 static void

--- a/libvips/foreign/openslideload.c
+++ b/libvips/foreign/openslideload.c
@@ -878,11 +878,8 @@ vips_foreign_load_openslide_build(VipsObject *object)
 		openslide->filename = filename;
 	}
 
-	if (VIPS_OBJECT_CLASS(vips_foreign_load_openslide_parent_class)
-			->build(object))
-		return -1;
-
-	return 0;
+	return VIPS_OBJECT_CLASS(vips_foreign_load_openslide_parent_class)
+		->build(object);
 }
 
 static VipsForeignFlags

--- a/libvips/foreign/pdfiumload.c
+++ b/libvips/foreign/pdfiumload.c
@@ -324,10 +324,8 @@ vips_foreign_load_pdf_build(VipsObject *object)
 		g_mutex_unlock(&vips_pdfium_mutex);
 	}
 
-	if (VIPS_OBJECT_CLASS(vips_foreign_load_pdf_parent_class)->build(object))
-		return -1;
-
-	return 0;
+	return VIPS_OBJECT_CLASS(vips_foreign_load_pdf_parent_class)
+		->build(object);
 }
 
 static VipsForeignFlags

--- a/libvips/foreign/pngload.c
+++ b/libvips/foreign/pngload.c
@@ -206,11 +206,8 @@ vips_foreign_load_png_source_build(VipsObject *object)
 		g_object_ref(png->source);
 	}
 
-	if (VIPS_OBJECT_CLASS(vips_foreign_load_png_source_parent_class)
-			->build(object))
-		return -1;
-
-	return 0;
+	return VIPS_OBJECT_CLASS(vips_foreign_load_png_source_parent_class)
+		->build(object);
 }
 
 static gboolean
@@ -275,10 +272,8 @@ vips_foreign_load_png_file_build(VipsObject *object)
 		!(png->source = vips_source_new_from_file(file->filename)))
 		return -1;
 
-	if (VIPS_OBJECT_CLASS(vips_foreign_load_png_file_parent_class)->build(object))
-		return -1;
-
-	return 0;
+	return VIPS_OBJECT_CLASS(vips_foreign_load_png_file_parent_class)
+		->build(object);
 }
 
 static gboolean
@@ -353,11 +348,8 @@ vips_foreign_load_png_buffer_build(VipsObject *object)
 			  VIPS_AREA(buffer->blob)->length)))
 		return -1;
 
-	if (VIPS_OBJECT_CLASS(vips_foreign_load_png_buffer_parent_class)
-			->build(object))
-		return -1;
-
-	return 0;
+	return VIPS_OBJECT_CLASS(vips_foreign_load_png_buffer_parent_class)
+		->build(object);
 }
 
 static gboolean

--- a/libvips/foreign/pngsave.c
+++ b/libvips/foreign/pngsave.c
@@ -315,11 +315,8 @@ vips_foreign_save_png_target_build(VipsObject *object)
 	png->target = target->target;
 	g_object_ref(png->target);
 
-	if (VIPS_OBJECT_CLASS(vips_foreign_save_png_target_parent_class)
-			->build(object))
-		return -1;
-
-	return 0;
+	return VIPS_OBJECT_CLASS(vips_foreign_save_png_target_parent_class)
+		->build(object);
 }
 
 static void

--- a/libvips/foreign/popplerload.c
+++ b/libvips/foreign/popplerload.c
@@ -201,10 +201,8 @@ vips_foreign_load_pdf_build(VipsObject *object)
 		return -1;
 	}
 
-	if (VIPS_OBJECT_CLASS(vips_foreign_load_pdf_parent_class)->build(object))
-		return -1;
-
-	return 0;
+	return VIPS_OBJECT_CLASS(vips_foreign_load_pdf_parent_class)
+		->build(object);
 }
 
 static VipsForeignFlags

--- a/libvips/foreign/ppmload.c
+++ b/libvips/foreign/ppmload.c
@@ -221,10 +221,8 @@ vips_foreign_load_ppm_build(VipsObject *object)
 	if (ppm->source)
 		ppm->sbuf = vips_sbuf_new_from_source(ppm->source);
 
-	if (VIPS_OBJECT_CLASS(vips_foreign_load_ppm_parent_class)->build(object))
-		return -1;
-
-	return 0;
+	return VIPS_OBJECT_CLASS(vips_foreign_load_ppm_parent_class)
+		->build(object);
 }
 
 /* Scan the header into our class.
@@ -803,10 +801,8 @@ vips_foreign_load_ppm_file_build(VipsObject *object)
 		!(ppm->source = vips_source_new_from_file(file->filename)))
 		return -1;
 
-	if (VIPS_OBJECT_CLASS(vips_foreign_load_ppm_file_parent_class)->build(object))
-		return -1;
-
-	return 0;
+	return VIPS_OBJECT_CLASS(vips_foreign_load_ppm_file_parent_class)
+		->build(object);
 }
 
 static void
@@ -861,11 +857,8 @@ vips_foreign_load_ppm_source_build(VipsObject *object)
 		g_object_ref(ppm->source);
 	}
 
-	if (VIPS_OBJECT_CLASS(vips_foreign_load_ppm_source_parent_class)
-			->build(object))
-		return -1;
-
-	return 0;
+	return VIPS_OBJECT_CLASS(vips_foreign_load_ppm_source_parent_class)
+		->build(object);
 }
 
 static void

--- a/libvips/foreign/radload.c
+++ b/libvips/foreign/radload.c
@@ -169,11 +169,8 @@ vips_foreign_load_rad_source_build(VipsObject *object)
 		g_object_ref(rad->source);
 	}
 
-	if (VIPS_OBJECT_CLASS(vips_foreign_load_rad_source_parent_class)
-			->build(object))
-		return -1;
-
-	return 0;
+	return VIPS_OBJECT_CLASS(vips_foreign_load_rad_source_parent_class)
+		->build(object);
 }
 
 static gboolean
@@ -238,10 +235,8 @@ vips_foreign_load_rad_file_build(VipsObject *object)
 		!(rad->source = vips_source_new_from_file(file->filename)))
 		return -1;
 
-	if (VIPS_OBJECT_CLASS(vips_foreign_load_rad_file_parent_class)->build(object))
-		return -1;
-
-	return 0;
+	return VIPS_OBJECT_CLASS(vips_foreign_load_rad_file_parent_class)
+		->build(object);
 }
 
 static int
@@ -316,10 +311,8 @@ vips_foreign_load_rad_buffer_build(VipsObject *object)
 			  VIPS_AREA(buffer->blob)->length)))
 		return -1;
 
-	if (VIPS_OBJECT_CLASS(vips_foreign_load_rad_file_parent_class)->build(object))
-		return -1;
-
-	return 0;
+	return VIPS_OBJECT_CLASS(vips_foreign_load_rad_buffer_parent_class)
+		->build(object);
 }
 
 static gboolean

--- a/libvips/foreign/spngload.c
+++ b/libvips/foreign/spngload.c
@@ -713,11 +713,8 @@ vips_foreign_load_png_source_build(VipsObject *object)
 		g_object_ref(png->source);
 	}
 
-	if (VIPS_OBJECT_CLASS(vips_foreign_load_png_source_parent_class)
-			->build(object))
-		return -1;
-
-	return 0;
+	return VIPS_OBJECT_CLASS(vips_foreign_load_png_source_parent_class)
+		->build(object);
 }
 
 static gboolean
@@ -790,10 +787,8 @@ vips_foreign_load_png_file_build(VipsObject *object)
 		!(png->source = vips_source_new_from_file(file->filename)))
 		return -1;
 
-	if (VIPS_OBJECT_CLASS(vips_foreign_load_png_file_parent_class)->build(object))
-		return -1;
-
-	return 0;
+	return VIPS_OBJECT_CLASS(vips_foreign_load_png_file_parent_class)
+		->build(object);
 }
 
 static gboolean
@@ -870,11 +865,8 @@ vips_foreign_load_png_buffer_build(VipsObject *object)
 			  VIPS_AREA(buffer->blob)->length)))
 		return -1;
 
-	if (VIPS_OBJECT_CLASS(vips_foreign_load_png_buffer_parent_class)
-			->build(object))
-		return -1;
-
-	return 0;
+	return VIPS_OBJECT_CLASS(vips_foreign_load_png_buffer_parent_class)
+		->build(object);
 }
 
 static gboolean

--- a/libvips/foreign/spngsave.c
+++ b/libvips/foreign/spngsave.c
@@ -842,11 +842,8 @@ vips_foreign_save_spng_file_build(VipsObject *object)
 	if (!(spng->target = vips_target_new_to_file(file->filename)))
 		return -1;
 
-	if (VIPS_OBJECT_CLASS(vips_foreign_save_spng_file_parent_class)
-			->build(object))
-		return -1;
-
-	return 0;
+	return VIPS_OBJECT_CLASS(vips_foreign_save_spng_file_parent_class)
+		->build(object);
 }
 
 static void

--- a/libvips/foreign/tiffload.c
+++ b/libvips/foreign/tiffload.c
@@ -265,11 +265,8 @@ vips_foreign_load_tiff_source_build(VipsObject *object)
 		g_object_ref(tiff->source);
 	}
 
-	if (VIPS_OBJECT_CLASS(vips_foreign_load_tiff_source_parent_class)
-			->build(object))
-		return -1;
-
-	return 0;
+	return VIPS_OBJECT_CLASS(vips_foreign_load_tiff_source_parent_class)
+		->build(object);
 }
 
 static gboolean
@@ -336,11 +333,8 @@ vips_foreign_load_tiff_file_build(VipsObject *object)
 				vips_source_new_from_file(file->filename)))
 		return -1;
 
-	if (VIPS_OBJECT_CLASS(vips_foreign_load_tiff_file_parent_class)
-			->build(object))
-		return -1;
-
-	return 0;
+	return VIPS_OBJECT_CLASS(vips_foreign_load_tiff_file_parent_class)
+		->build(object);
 }
 
 static gboolean
@@ -418,11 +412,8 @@ vips_foreign_load_tiff_buffer_build(VipsObject *object)
 			  VIPS_AREA(buffer->blob)->length)))
 		return -1;
 
-	if (VIPS_OBJECT_CLASS(vips_foreign_load_tiff_buffer_parent_class)
-			->build(object))
-		return -1;
-
-	return 0;
+	return VIPS_OBJECT_CLASS(vips_foreign_load_tiff_buffer_parent_class)
+		->build(object);
 }
 
 static gboolean

--- a/libvips/foreign/tiffsave.c
+++ b/libvips/foreign/tiffsave.c
@@ -452,11 +452,8 @@ vips_foreign_save_tiff_target_build(VipsObject *object)
 	tiff->target = target->target;
 	g_object_ref(tiff->target);
 
-	if (VIPS_OBJECT_CLASS(vips_foreign_save_tiff_target_parent_class)
-			->build(object))
-		return -1;
-
-	return 0;
+	return VIPS_OBJECT_CLASS(vips_foreign_save_tiff_target_parent_class)
+		->build(object);
 }
 
 static void
@@ -506,11 +503,8 @@ vips_foreign_save_tiff_file_build(VipsObject *object)
 	if (!(tiff->target = vips_target_new_to_file(file->filename)))
 		return -1;
 
-	if (VIPS_OBJECT_CLASS(vips_foreign_save_tiff_file_parent_class)
-			->build(object))
-		return -1;
-
-	return 0;
+	return VIPS_OBJECT_CLASS(vips_foreign_save_tiff_file_parent_class)
+		->build(object);
 }
 
 static void

--- a/libvips/foreign/vipsload.c
+++ b/libvips/foreign/vipsload.c
@@ -198,11 +198,8 @@ vips_foreign_load_vips_file_build(VipsObject *object)
 		!(vips->source = vips_source_new_from_file(file->filename)))
 		return -1;
 
-	if (VIPS_OBJECT_CLASS(vips_foreign_load_vips_file_parent_class)
-			->build(object))
-		return -1;
-
-	return 0;
+	return VIPS_OBJECT_CLASS(vips_foreign_load_vips_file_parent_class)
+		->build(object);
 }
 
 const char *vips__suffs[] = { ".v", ".vips", NULL };
@@ -269,11 +266,8 @@ vips_foreign_load_vips_source_build(VipsObject *object)
 		g_object_ref(vips->source);
 	}
 
-	if (VIPS_OBJECT_CLASS(vips_foreign_load_vips_source_parent_class)
-			->build(object))
-		return -1;
-
-	return 0;
+	return VIPS_OBJECT_CLASS(vips_foreign_load_vips_source_parent_class)
+		->build(object);
 }
 
 static gboolean

--- a/libvips/foreign/vipssave.c
+++ b/libvips/foreign/vipssave.c
@@ -170,11 +170,8 @@ vips_foreign_save_vips_file_build(VipsObject *object)
 	if (!(vips->target = vips_target_new_to_file(file->filename)))
 		return -1;
 
-	if (VIPS_OBJECT_CLASS(vips_foreign_save_vips_file_parent_class)
-			->build(object))
-		return -1;
-
-	return 0;
+	return VIPS_OBJECT_CLASS(vips_foreign_save_vips_file_parent_class)
+		->build(object);
 }
 
 static void
@@ -225,11 +222,8 @@ vips_foreign_save_vips_target_build(VipsObject *object)
 	vips->target = target->target;
 	g_object_ref(vips->target);
 
-	if (VIPS_OBJECT_CLASS(vips_foreign_save_vips_target_parent_class)
-			->build(object))
-		return -1;
-
-	return 0;
+	return VIPS_OBJECT_CLASS(vips_foreign_save_vips_target_parent_class)
+		->build(object);
 }
 
 static void

--- a/libvips/foreign/webpload.c
+++ b/libvips/foreign/webpload.c
@@ -106,10 +106,8 @@ vips_foreign_load_webp_build(VipsObject *object)
 		webp->shrink != 0)
 		webp->scale = 1.0 / webp->shrink; // FIXME: Invalidates operation cache
 
-	if (VIPS_OBJECT_CLASS(vips_foreign_load_webp_parent_class)->build(object))
-		return -1;
-
-	return 0;
+	return VIPS_OBJECT_CLASS(vips_foreign_load_webp_parent_class)
+		->build(object);
 }
 
 static VipsForeignFlags
@@ -235,11 +233,8 @@ vips_foreign_load_webp_source_build(VipsObject *object)
 		g_object_ref(webp->source);
 	}
 
-	if (VIPS_OBJECT_CLASS(vips_foreign_load_webp_source_parent_class)
-			->build(object))
-		return -1;
-
-	return 0;
+	return VIPS_OBJECT_CLASS(vips_foreign_load_webp_source_parent_class)
+		->build(object);
 }
 
 static void
@@ -300,11 +295,8 @@ vips_foreign_load_webp_file_build(VipsObject *object)
 				vips_source_new_from_file(file->filename)))
 		return -1;
 
-	if (VIPS_OBJECT_CLASS(vips_foreign_load_webp_file_parent_class)
-			->build(object))
-		return -1;
-
-	return 0;
+	return VIPS_OBJECT_CLASS(vips_foreign_load_webp_file_parent_class)
+			->build(object);
 }
 
 static gboolean
@@ -382,11 +374,8 @@ vips_foreign_load_webp_buffer_build(VipsObject *object)
 			  VIPS_AREA(buffer->blob)->length)))
 		return -1;
 
-	if (VIPS_OBJECT_CLASS(vips_foreign_load_webp_buffer_parent_class)
-			->build(object))
-		return -1;
-
-	return 0;
+	return VIPS_OBJECT_CLASS(vips_foreign_load_webp_buffer_parent_class)
+		->build(object);
 }
 
 static gboolean

--- a/libvips/foreign/webpsave.c
+++ b/libvips/foreign/webpsave.c
@@ -966,11 +966,8 @@ vips_foreign_save_webp_target_build(VipsObject *object)
 	webp->target = target->target;
 	g_object_ref(webp->target);
 
-	if (VIPS_OBJECT_CLASS(vips_foreign_save_webp_target_parent_class)
-			->build(object))
-		return -1;
-
-	return 0;
+	return VIPS_OBJECT_CLASS(vips_foreign_save_webp_target_parent_class)
+		->build(object);
 }
 
 static void
@@ -1018,11 +1015,8 @@ vips_foreign_save_webp_file_build(VipsObject *object)
 	if (!(webp->target = vips_target_new_to_file(file->filename)))
 		return -1;
 
-	if (VIPS_OBJECT_CLASS(vips_foreign_save_webp_file_parent_class)
-			->build(object))
-		return -1;
-
-	return 0;
+	return VIPS_OBJECT_CLASS(vips_foreign_save_webp_file_parent_class)
+		->build(object);
 }
 
 static void


### PR DESCRIPTION
Non-functional change. Also, ensure buffer loaders consistently reference the correct parent class (some were incorrectly referencing the file loader's parent class).