### PR TITLE
Add ppmload_buffer

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -36,6 +36,7 @@ master
 - heifload: limit per-image memory usage to 2GB (requires libheif 1.20.0+)
 - svgload: add support for scRGB output via `high_bitdepth` flag [kstanikviacbs]
 - remove vipsprofile from default install
+- add ppmload_buffer [kleisauke]
 
 8.16.1
 

--- a/cplusplus/include/vips/VImage8.h
+++ b/cplusplus/include/vips/VImage8.h
@@ -5074,7 +5074,22 @@ public:
 	static VImage ppmload(const char *filename, VOption *options = nullptr);
 
 	/**
-	 * Load ppm base class.
+	 * Load ppm from buffer.
+	 *
+	 * **Optional parameters**
+	 *   - **memory** -- Force open via memory, bool.
+	 *   - **access** -- Required access pattern for this file, VipsAccess.
+	 *   - **fail_on** -- Error level to fail on, VipsFailOn.
+	 *   - **revalidate** -- Don't use a cached result for this operation, bool.
+	 *
+	 * @param buffer Buffer to load from.
+	 * @param options Set of options.
+	 * @return Output image.
+	 */
+	static VImage ppmload_buffer(VipsBlob *buffer, VOption *options = nullptr);
+
+	/**
+	 * Load ppm from source.
 	 *
 	 * **Optional parameters**
 	 *   - **memory** -- Force open via memory, bool.

--- a/cplusplus/vips-operators.cpp
+++ b/cplusplus/vips-operators.cpp
@@ -2731,6 +2731,18 @@ VImage::ppmload(const char *filename, VOption *options)
 }
 
 VImage
+VImage::ppmload_buffer(VipsBlob *buffer, VOption *options)
+{
+	VImage out;
+
+	call("ppmload_buffer", (options ? options : VImage::option())
+			->set("out", &out)
+			->set("buffer", buffer));
+
+	return out;
+}
+
+VImage
 VImage::ppmload_source(VSource source, VOption *options)
 {
 	VImage out;

--- a/doc/function-list.md
+++ b/doc/function-list.md
@@ -260,7 +260,8 @@ API docs each function links to for more details.
 | `pngsave_buffer` | Save image to buffer as png | [method@Image.pngsave_buffer] |
 | `pngsave_target` | Save image to target as png | [method@Image.pngsave_target] |
 | `ppmload` | Load ppm from file | [ctor@Image.ppmload] |
-| `ppmload_source` | Load ppm base class | [ctor@Image.ppmload_source] |
+| `ppmload_buffer` | Load ppm from buffer | [ctor@Image.ppmload_buffer] |
+| `ppmload_source` | Load ppm from source | [ctor@Image.ppmload_source] |
 | `ppmsave` | Save image to ppm file | [method@Image.ppmsave] |
 | `ppmsave_target` | Save to ppm | [method@Image.ppmsave_target] |
 | `premultiply` | Premultiply image alpha | [method@Image.premultiply] |

--- a/libvips/foreign/foreign.c
+++ b/libvips/foreign/foreign.c
@@ -2924,6 +2924,7 @@ vips_foreign_operation_init(void)
 	extern GType vips_foreign_load_mat_get_type(void);
 
 	extern GType vips_foreign_load_ppm_file_get_type(void);
+	extern GType vips_foreign_load_ppm_buffer_get_type(void);
 	extern GType vips_foreign_load_ppm_source_get_type(void);
 	extern GType vips_foreign_save_ppm_file_get_type(void);
 	extern GType vips_foreign_save_pbm_target_get_type(void);
@@ -3083,6 +3084,7 @@ vips_foreign_operation_init(void)
 
 #ifdef HAVE_PPM
 	vips_foreign_load_ppm_file_get_type();
+	vips_foreign_load_ppm_buffer_get_type();
 	vips_foreign_load_ppm_source_get_type();
 	vips_foreign_save_ppm_file_get_type();
 	vips_foreign_save_pbm_target_get_type();

--- a/libvips/foreign/ppmload.c
+++ b/libvips/foreign/ppmload.c
@@ -47,6 +47,8 @@
  * 	- byteswap binary loads
  * 9/3/23
  *	- pfm assumes linear 0-1 [NiHoel]
+ * 2/6/25
+ *	- add ppmload_buffer [kleisauke]
  */
 
 /*
@@ -838,6 +840,79 @@ vips_foreign_load_ppm_file_init(VipsForeignLoadPpmFile *file)
 {
 }
 
+typedef struct _VipsForeignLoadPpmBuffer {
+	VipsForeignLoadPpm parent_object;
+
+	/* Load from a buffer.
+	 */
+	VipsBlob *blob;
+
+} VipsForeignLoadPpmBuffer;
+
+typedef VipsForeignLoadPpmClass VipsForeignLoadPpmBufferClass;
+
+G_DEFINE_TYPE(VipsForeignLoadPpmBuffer, vips_foreign_load_ppm_buffer,
+	vips_foreign_load_ppm_get_type());
+
+static int
+vips_foreign_load_ppm_buffer_build(VipsObject *object)
+{
+	VipsForeignLoadPpm *ppm = (VipsForeignLoadPpm *) object;
+	VipsForeignLoadPpmBuffer *buffer = (VipsForeignLoadPpmBuffer *) object;
+
+	if (buffer->blob &&
+		!(ppm->source = vips_source_new_from_memory(
+			  VIPS_AREA(buffer->blob)->data,
+			  VIPS_AREA(buffer->blob)->length)))
+		return -1;
+
+	return VIPS_OBJECT_CLASS(vips_foreign_load_ppm_buffer_parent_class)
+		->build(object);
+}
+
+static gboolean
+vips_foreign_load_ppm_is_a_buffer(const void *buf, size_t len)
+{
+	VipsSource *source;
+	gboolean result;
+
+	if (!(source = vips_source_new_from_memory(buf, len)))
+		return FALSE;
+	result = vips_foreign_load_ppm_is_a_source(source);
+	VIPS_UNREF(source);
+
+	return result;
+}
+
+static void
+vips_foreign_load_ppm_buffer_class_init(VipsForeignLoadPpmBufferClass *class)
+{
+	GObjectClass *gobject_class = G_OBJECT_CLASS(class);
+	VipsObjectClass *object_class = (VipsObjectClass *) class;
+	VipsForeignLoadClass *load_class = (VipsForeignLoadClass *) class;
+
+	gobject_class->set_property = vips_object_set_property;
+	gobject_class->get_property = vips_object_get_property;
+
+	object_class->nickname = "ppmload_buffer";
+	object_class->description = _("load ppm from buffer");
+	object_class->build = vips_foreign_load_ppm_buffer_build;
+
+	load_class->is_a_buffer = vips_foreign_load_ppm_is_a_buffer;
+
+	VIPS_ARG_BOXED(class, "buffer", 1,
+		_("Buffer"),
+		_("Buffer to load from"),
+		VIPS_ARGUMENT_REQUIRED_INPUT,
+		G_STRUCT_OFFSET(VipsForeignLoadPpmBuffer, blob),
+		VIPS_TYPE_BLOB);
+}
+
+static void
+vips_foreign_load_ppm_buffer_init(VipsForeignLoadPpmBuffer *buffer)
+{
+}
+
 typedef struct _VipsForeignLoadPpmSource {
 	VipsForeignLoadPpm parent_object;
 
@@ -880,6 +955,7 @@ vips_foreign_load_ppm_source_class_init(VipsForeignLoadPpmFileClass *class)
 	gobject_class->get_property = vips_object_get_property;
 
 	object_class->nickname = "ppmload_source";
+	object_class->description = _("load ppm from source");
 	object_class->build = vips_foreign_load_ppm_source_build;
 
 	operation_class->flags |= VIPS_OPERATION_NOCACHE;
@@ -927,6 +1003,40 @@ vips_ppmload(const char *filename, VipsImage **out, ...)
 	va_start(ap, out);
 	result = vips_call_split("ppmload", ap, filename, out);
 	va_end(ap);
+
+	return result;
+}
+
+/**
+ * vips_ppmload_buffer:
+ * @buf: (array length=len) (element-type guint8): memory area to load
+ * @len: (type gsize): size of memory area
+ * @out: (out): image to write
+ * @...: `NULL`-terminated list of optional named arguments
+ *
+ * Exactly as [ctor@Image.ppmload], but read from a memory source.
+ *
+ * ::: seealso
+ *     [ctor@Image.ppmload].
+ *
+ * Returns: 0 on success, -1 on error.
+ */
+int
+vips_ppmload_buffer(void *buf, size_t len, VipsImage **out, ...)
+{
+	va_list ap;
+	VipsBlob *blob;
+	int result;
+
+	/* We don't take a copy of the data or free it.
+	 */
+	blob = vips_blob_new(NULL, buf, len);
+
+	va_start(ap, out);
+	result = vips_call_split("ppmload_buffer", ap, blob, out);
+	va_end(ap);
+
+	vips_area_unref(VIPS_AREA(blob));
 
 	return result;
 }

--- a/libvips/include/vips/foreign.h
+++ b/libvips/include/vips/foreign.h
@@ -797,6 +797,9 @@ VIPS_API
 int vips_ppmload(const char *filename, VipsImage **out, ...)
 	G_GNUC_NULL_TERMINATED;
 VIPS_API
+int vips_ppmload_buffer(void *buf, size_t len, VipsImage **out, ...)
+	G_GNUC_NULL_TERMINATED;
+VIPS_API
 int vips_ppmload_source(VipsSource *source, VipsImage **out, ...)
 	G_GNUC_NULL_TERMINATED;
 VIPS_API

--- a/test/test-suite/test_foreign.py
+++ b/test/test-suite/test_foreign.py
@@ -1274,8 +1274,7 @@ class TestForeign:
         self.save_load_file("%s.ppm", "[ascii]", grey16, 0)
         self.save_load_file("%s.ppm", "[ascii]", rgb16, 0)
 
-        source = pyvips.Source.new_from_memory(b'P1\n#\n#\n1 1\n0\n')
-        im = pyvips.Image.ppmload_source(source)
+        im = pyvips.Image.new_from_buffer(b'P1\n#\n#\n1 1\n0\n', "")
         assert im.height == 1
         assert im.width == 1
 


### PR DESCRIPTION
`ppmload`'s sniffer is very fast and already has some fuzz coverage via `jpegsave_file_fuzzer`. Let's introduce a buffer-based variant for this loader as well, so that `new_from_buffer()` works with PPM images and to extend the fuzz coverage of this loader further.

Users can disable this functionality by setting the `VIPS_BLOCK_UNTRUSTED` environment variable or compiling with `-Dppm=false`.

I also reviewed the other loaders that already supports the source API but lack a buffer variant. In these cases, I don't think a buffer loader is necessary:
- `csvload`: must be explicitly called since it lacks a sniffer;
- `matrixload`: sniffer is relatively slow;
- `vipsload` and `fitsload`: only support sources with an associated filename.
