### PR TITLE
Lower libjxl version requirement to 0.9.x

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -30,7 +30,7 @@ master
 - move vips_image_preeval(), vips_image_eval(), vips_image_posteval() into the
   public API
 - jxlsave writes in chunks, for lower memory use on large images (but we now
-  need libjxl 0.11 at minimum)
+  need libjxl 0.9 at minimum)
 - increase minimum version of libheif dependency to 1.11.0
 - improve scaling of hough_line feature space [ecbypi]
 - heifload: limit per-image memory usage to 2GB (requires libheif 1.20.0+)

--- a/meson.build
+++ b/meson.build
@@ -506,9 +506,9 @@ if libheif_dep.found()
     cfg_var.set('HAVE_HEIF_MAX_TOTAL_MEMORY', cpp.has_member('struct heif_security_limits', 'max_total_memory', prefix: '#include <libheif/heif.h>', dependencies: libheif_dep))
 endif
 
-# need v0.11+ for chunked write
-libjxl_dep = dependency('libjxl', version: '>=0.11', required: get_option('jpeg-xl'))
-libjxl_threads_dep = dependency('libjxl_threads', version: '>=0.11', required: get_option('jpeg-xl'))
+# need v0.9+ for JxlEncoderAddChunkedFrame()
+libjxl_dep = dependency('libjxl', version: '>=0.9', required: get_option('jpeg-xl'))
+libjxl_threads_dep = dependency('libjxl_threads', version: '>=0.9', required: get_option('jpeg-xl'))
 libjxl_found = libjxl_dep.found() and libjxl_threads_dep.found()
 libjxl_module = false
 if libjxl_found


### PR DESCRIPTION
RHEL 10 (and its derivatives) only includes libjxl 0.10.3 in EPEL. EPEL 8 and 9 provide only libjxl 0.7.0, and even that upgrade was somewhat controversial due to ABI/API concerns (see e.g. https://phpc.social/@remi/109381841149751828).

@remicollet FYI. This would ensure that the `vips-jxl` package remains available for RHEL 10 with the upcoming libvips 8.17 release in your repository (it can't be lowered any further, unfortunately).