### PR TITLE
Lower libheif version requirement to 1.7.0

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -31,7 +31,7 @@ master
   public API
 - jxlsave: add support for chunked save (requires libjxl 0.9.0+)
 - increase minimum version of libjxl dependency to 0.7.0
-- increase minimum version of libheif dependency to 1.11.0
+- increase minimum version of libheif dependency to 1.7.0
 - improve scaling of hough_line feature space [ecbypi]
 - heifload: limit per-image memory usage to 2GB (requires libheif 1.20.0+)
 - svgload: add support for scRGB output via `high_bitdepth` flag [kstanikviacbs]

--- a/libvips/foreign/heifsave.c
+++ b/libvips/foreign/heifsave.c
@@ -268,7 +268,9 @@ vips_foreign_save_heif_write_page(VipsForeignSaveHeif *heif, int page)
 
 	struct heif_error error;
 	struct heif_encoding_options *options;
+#ifdef HAVE_HEIF_ENCODING_OPTIONS_OUTPUT_NCLX_PROFILE
 	struct heif_color_profile_nclx *nclx = NULL;
+#endif
 
 	/* A profile supplied as an argument overrides an embedded
 	 * profile.
@@ -285,6 +287,7 @@ vips_foreign_save_heif_write_page(VipsForeignSaveHeif *heif, int page)
 	options = heif_encoding_options_alloc();
 	options->save_alpha_channel = save->ready->Bands > 3;
 
+#ifdef HAVE_HEIF_ENCODING_OPTIONS_OUTPUT_NCLX_PROFILE
 	/* Matrix coefficients have to be identity (CICP x/y/0) in lossless
 	 * mode.
 	 */
@@ -301,6 +304,7 @@ vips_foreign_save_heif_write_page(VipsForeignSaveHeif *heif, int page)
 		 */
 		options->macOS_compatibility_workaround_no_nclx_profile = 0;
 	}
+#endif /*HAVE_HEIF_ENCODING_OPTIONS_OUTPUT_NCLX_PROFILE*/
 
 #ifdef HAVE_HEIF_ENCODING_OPTIONS_IMAGE_ORIENTATION
 	/* EXIF orientation is informational in the HEIF specification.
@@ -327,7 +331,9 @@ vips_foreign_save_heif_write_page(VipsForeignSaveHeif *heif, int page)
 #endif /*DEBUG*/
 
 	heif_encoding_options_free(options);
+#ifdef HAVE_HEIF_ENCODING_OPTIONS_OUTPUT_NCLX_PROFILE
 	VIPS_FREEF(heif_nclx_color_profile_free, nclx);
+#endif
 
 	if (error.code) {
 		vips__heif_error(&error);
@@ -505,7 +511,9 @@ vips_foreign_save_heif_build(VipsObject *object)
 	struct heif_writer writer;
 	char *chroma;
 	const struct heif_encoder_descriptor *out_encoder;
+#ifdef HAVE_HEIF_ENCODER_PARAMETER_GET_VALID_INTEGER_VALUES
 	const struct heif_encoder_parameter *const *param;
+#endif
 	gboolean has_alpha;
 
 	if (VIPS_OBJECT_CLASS(vips_foreign_save_heif_parent_class)-> build(object))
@@ -610,6 +618,7 @@ vips_foreign_save_heif_build(VipsObject *object)
 		return -1;
 	}
 
+#ifdef HAVE_HEIF_ENCODER_PARAMETER_GET_VALID_INTEGER_VALUES
 	for (param = heif_encoder_list_parameters(heif->encoder);
 		*param; param++) {
 		int have_minimum;
@@ -635,6 +644,7 @@ vips_foreign_save_heif_build(VipsObject *object)
 			return -1;
 		}
 	}
+#endif /*HAVE_HEIF_ENCODER_PARAMETER_GET_VALID_INTEGER_VALUES*/
 
 	/* Try to enable auto_tiles. This can make AVIF encoding a lot faster,
 	 * with only a very small increase in file size.

--- a/meson.build
+++ b/meson.build
@@ -483,7 +483,7 @@ if pdfium_dep.found()
     pdf_loader = pdfium_dep
 endif
 
-libheif_dep = dependency('libheif', version: '>=1.11.0', required: get_option('heif'))
+libheif_dep = dependency('libheif', version: '>=1.7.0', required: get_option('heif'))
 libheif_module = false
 if libheif_dep.found()
     libheif_module = modules_enabled and not get_option('heif-module').disabled()
@@ -494,6 +494,10 @@ if libheif_dep.found()
         external_deps += libheif_dep
     endif
     cfg_var.set('HAVE_HEIF', true)
+    # added in 1.10.0
+    cfg_var.set('HAVE_HEIF_ENCODER_PARAMETER_GET_VALID_INTEGER_VALUES', cpp.has_function('heif_encoder_parameter_get_valid_integer_values', prefix: '#include <libheif/heif.h>', dependencies: libheif_dep))
+    # added in 1.11.0
+    cfg_var.set('HAVE_HEIF_ENCODING_OPTIONS_OUTPUT_NCLX_PROFILE', cpp.has_member('struct heif_encoding_options', 'output_nclx_profile', prefix: '#include <libheif/heif.h>', dependencies: libheif_dep))
     # heif_init added in 1.13.0
     cfg_var.set('HAVE_HEIF_INIT', libheif_dep.version().version_compare('>=1.13.0'))
     # heif_encoding_options.image_orientation added in 1.14.0


### PR DESCRIPTION
For compat with RHEL 8 (and its derivatives).

Context: #4550.