### PR TITLE
cplusplus: install Doxygen docs in `doc/vips-cpp`

### DIFF
--- a/cplusplus/meson.build
+++ b/cplusplus/meson.build
@@ -59,6 +59,6 @@ if get_option('cpp-docs')
         output: 'html',
         command: [doxygen, doxyfile],
         install: true,
-        install_dir: get_option('prefix') / get_option('datadir') / 'doc' / 'vips-doc'
+        install_dir: get_option('prefix') / get_option('datadir') / 'doc' / 'vips-cpp'
     )
 endif


### PR DESCRIPTION
Previously, Doxygen documentation was installed in `doc/vips-doc`, which could be confused with GI-DocGen output located in `doc/vips`.