### PR TITLE
Update links in news posts

### DIFF
--- a/_posts/2017-03-16-What's-new-in-8.5.md
+++ b/_posts/2017-03-16-What's-new-in-8.5.md
@@ -9,9 +9,9 @@ ChangeLog if you need more details.
 
 Almost all of the logic from the `vipsthumbnail` program is now in
 a pair of new operators, [`vips_thumbnail()`]({{ site.baseurl
-}}/API/current/libvips-resample.html#vips-thumbnail)
+}}/API/current/ctor.Image.thumbnail.html)
 and [`vips_thumbnail_buffer()`]({{ site.baseurl
-}}/API/current/libvips-resample.html#vips-thumbnail-buffer).  These are
+}}/API/current/ctor.Image.thumbnail_buffer.html).  These are
 very handy for the various scripting languages with vips bindings: you can
 now make a high-quality, high-speed thumbnail in PHP (for example) with just:
 
@@ -27,7 +27,7 @@ The new thumbnail operator has also picked up some useful features:
   edges, skin tones and areas of saturated colour, and
   attempts to position the crop box over the most significant
   feature. There's a [`vips_smartcrop()`]({{ site.baseurl
-  }}/API/current/libvips-conversion.html#vips-smartcrop) operator as well.
+  }}/API/current/method.Image.smartcrop.html) operator as well.
 
 * **Crop constraints** Thanks to tomasc, libvips has crop constraints. You 
   can set it to only thumbnail if the image is larger or smaller than the target 
@@ -35,7 +35,7 @@ The new thumbnail operator has also picked up some useful features:
 
 * **Buffer sources** 
   [`vips_thumbnail_buffer()`]({{ site.baseurl
-  }}/API/current/libvips-resample.html#vips-thumbnail-buffer) will thumbnail
+  }}/API/current/ctor.Image.thumbnail_buffer.html) will thumbnail
   an image held as a formatted block of data in memory. This is useful for
   cloud services, where the filesystem is often rather slow.
 
@@ -45,7 +45,7 @@ make local histogram equalisation more useful.
 Plain local equalization removes
 all global brightness variation and can make images
 hard to understand.  [`vips_hist_local()`]({{ site.baseurl
-}}/API/current/libvips-histogram.html#vips-hist-local) now has a `max-slope`
+}}/API/current/method.Image.hist_local.html) now has a `max-slope`
 parameter you can use to limit how much equalisation can alter your image. A
 value of 3 generally works well.
 

--- a/_posts/2017-03-16-What's-new-in-8.5.md
+++ b/_posts/2017-03-16-What's-new-in-8.5.md
@@ -8,10 +8,10 @@ ChangeLog if you need more details.
 ## New operators
 
 Almost all of the logic from the `vipsthumbnail` program is now in
-a pair of new operators, [`vips_thumbnail()`]({{ site.baseurl
-}}/API/current/ctor.Image.thumbnail.html)
-and [`vips_thumbnail_buffer()`]({{ site.baseurl
-}}/API/current/ctor.Image.thumbnail_buffer.html).  These are
+a pair of new operators, [`vips_thumbnail()`](
+/API/current/ctor.Image.thumbnail.html)
+and [`vips_thumbnail_buffer()`](
+/API/current/ctor.Image.thumbnail_buffer.html).  These are
 very handy for the various scripting languages with vips bindings: you can
 now make a high-quality, high-speed thumbnail in PHP (for example) with just:
 
@@ -26,16 +26,16 @@ The new thumbnail operator has also picked up some useful features:
 * **Smart crop** A new cropping mode called `attention` searches the image for
   edges, skin tones and areas of saturated colour, and
   attempts to position the crop box over the most significant
-  feature. There's a [`vips_smartcrop()`]({{ site.baseurl
-  }}/API/current/method.Image.smartcrop.html) operator as well.
+  feature. There's a [`vips_smartcrop()`](
+  /API/current/method.Image.smartcrop.html) operator as well.
 
 * **Crop constraints** Thanks to tomasc, libvips has crop constraints. You 
   can set it to only thumbnail if the image is larger or smaller than the target 
   (the `<` and `>` modifiers in imagemagick), and to crop to a width or height. 
 
 * **Buffer sources** 
-  [`vips_thumbnail_buffer()`]({{ site.baseurl
-  }}/API/current/ctor.Image.thumbnail_buffer.html) will thumbnail
+  [`vips_thumbnail_buffer()`](
+  /API/current/ctor.Image.thumbnail_buffer.html) will thumbnail
   an image held as a formatted block of data in memory. This is useful for
   cloud services, where the filesystem is often rather slow.
 
@@ -44,16 +44,16 @@ make local histogram equalisation more useful.
 
 Plain local equalization removes
 all global brightness variation and can make images
-hard to understand.  [`vips_hist_local()`]({{ site.baseurl
-}}/API/current/method.Image.hist_local.html) now has a `max-slope`
+hard to understand.  [`vips_hist_local()`](
+/API/current/method.Image.hist_local.html) now has a `max-slope`
 parameter you can use to limit how much equalisation can alter your image. A
 value of 3 generally works well.
 
 For example, here's the famous NASA image of Io on the left, straight
 local-histogram equalization in the centre, and CLAHE on the right.
 
-[![Io with CLAHE]({{ site.baseurl }}/assets/images/tn_clahe.jpg)]({{
-site.baseurl }}/assets/images/clahe.jpg)
+[![Io with CLAHE](/assets/images/tn_clahe.jpg)](
+/assets/images/clahe.jpg)
 
 The centre image looks horrible, but it does have a lot of local detail. The
 CLAHE one is a interesting compromise: it still looks like the original, but

--- a/_posts/2017-11-28-What's-new-in-8.6.md
+++ b/_posts/2017-11-28-What's-new-in-8.6.md
@@ -9,12 +9,12 @@ if you need more details.
 
 ## New operators
 
-There are five new operators. The largest is [`vips_composite2()`]({{
-site.baseurl }}/API/current/method.Image.composite2.html): this will
+There are five new operators. The largest is [`vips_composite2()`](
+/API/current/method.Image.composite2.html): this will
 composite a pair of transparent images together using PDF-style blending
 modes. For example, given the standard libtiff and libpng demo images:
 
-[![PNG and TIFF demo images]({{ site.baseurl }}/assets/images/tn_pngtiff.png)]({{ site.baseurl }}/assets/images/pngtiff.png)
+[![PNG and TIFF demo images](/assets/images/tn_pngtiff.png)](/assets/images/pngtiff.png)
 
 Running:
 
@@ -24,37 +24,37 @@ $ vips composite2 cramps.png png_demo1.png x.png over
 
 Gives:
 
-[![Composite of PNG and TIFF demo images]({{ site.baseurl }}/assets/images/tn_composite.jpg)]({{ site.baseurl }}/assets/images/composite.png)
+[![Composite of PNG and TIFF demo images](/assets/images/tn_composite.jpg)](/assets/images/composite.png)
 
 `over` is probably the most useful, but `composite2` supports all the [PDF blend
-modes]({{ site.baseurl }}/API/current/enum.BlendMode.html).
+modes](/API/current/enum.BlendMode.html).
 
 `composite2` joins a pair of images, but you can join a whole array of images
 using an array of blend modes in a single operation with `composite`. Options
 let you control the compositing space and premultiplication handling.
 
-[`vips_fill_nearest()`]({{ site.baseurl
-}}/API/current/method.Image.fill_nearest.html) replaces every zero
+[`vips_fill_nearest()`](
+/API/current/method.Image.fill_nearest.html) replaces every zero
 pixel in an image with the nearest non-zero pixel. For example:
 
-[![Fill nearest image]({{ site.baseurl }}/assets/images/tn_fill-nearest.jpg)]({{ site.baseurl }}/assets/images/fill-nearest.png)
+[![Fill nearest image](/assets/images/tn_fill-nearest.jpg)](/assets/images/fill-nearest.png)
 
 The zero pixels on the left have all been replaced. It's reasonably quick
 (about a second for that example on this old laptop) and doesn't need that much
 memory. It's handy for things like cell counting, where you want to assign cell
 pixels to the nearest nucleus.
 
-[`vips_find_trim()`]({{ site.baseurl
-}}/API/current/method.Image.find_trim.html) searches an image in from
+[`vips_find_trim()`](
+/API/current/method.Image.find_trim.html) searches an image in from
 the edges and returns the bounding box of the non-background pixels. It's
 useful for automatically trimming away the edges from scanned images.
 
-[`vips_gravity()`]({{ site.baseurl
-}}/API/current/method.Image.gravity.html) places an image within a
+[`vips_gravity()`](
+/API/current/method.Image.gravity.html) places an image within a
 larger canvas, positioning the image according to a compass direction. It's
 just `vips_embed()` with a convenient interface.
 
-[`vips_thumbnail_image()`]({{ site.baseurl }}/API/current/method.Image.thumbnail_image.html) lets you thumbnail any image source. It can be
+[`vips_thumbnail_image()`](/API/current/method.Image.thumbnail_image.html) lets you thumbnail any image source. It can be
 useful if you need to do something to an image before making a thumbnail.
 
 ## New features
@@ -62,30 +62,30 @@ useful if you need to do something to an image before making a thumbnail.
 There are a few new options for existing operations.
 
 * A `FORCE` [resize
-  mode]({{ site.baseurl }}/API/current/enum.Size.html#force) lets
+  mode](/API/current/enum.Size.html#force) lets
   you break the image aspect ratio in resizing.
 
 * `thumbnail` and `vipsthumbnail` have an [option for rendering
-  intent]({{ site.baseurl }}/API/current/ctor.Image.thumbnail.html),
+  intent](/API/current/ctor.Image.thumbnail.html),
   credit to kleisauke.
 
-* [`vips_text()`]({{ site.baseurl }}/API/current/ctor.Image.text.html)
+* [`vips_text()`](/API/current/ctor.Image.text.html)
   can autofit text to a box. You give the size of the box to fill,
   and it'll automatically search for a DPI that just fills that area.
   Credit to gargsms.
 
-* [`VIPS_COMBINE_MIN`]({{ site.baseurl
-  }}/API/current/enum.Combine.html#min) is a new combining mode
+* [`VIPS_COMBINE_MIN`](
+  /API/current/enum.Combine.html#min) is a new combining mode
   for `vips_compass()`, handy for estimating gradients.
 
-* [`vips_hist_find_indexed()`]({{ site.baseurl
-  }}/API/current/method.Image.hist_find_indexed.html) now has a
+* [`vips_hist_find_indexed()`](
+  /API/current/method.Image.hist_find_indexed.html) now has a
   `combine` parameter. This makes it possible to quickly find the bounding
   boxes of a large number of objects, for example.
 
-* [`vips_affine()`]({{ site.baseurl
-  }}/API/current/method.Image.affine.html) and [`vips_similarity()`]({{
-  site.baseurl }}/API/current/method.Image.similarity.html) have a
+* [`vips_affine()`](
+  /API/current/method.Image.affine.html) and [`vips_similarity()`](
+  /API/current/method.Image.similarity.html) have a
   `background` parameter.  Previously, they always used 0 for new pixels
   and you had to composite on something else somehow.
 
@@ -133,11 +133,11 @@ There have been a few changes to existing features.
 Finally there are a range of smaller improvements:
 
 * New C API:
-  [`vips_image_new_from_image()`]({{ site.baseurl
-  }}/API/current/ctor.Image.new_from_image.html)
+  [`vips_image_new_from_image()`](
+  /API/current/ctor.Image.new_from_image.html)
   and
-  [`vips_image_new_from_image1()`]({{ site.baseurl
-  }}/API/current/ctor.Image.new_from_image1.html)
+  [`vips_image_new_from_image1()`](
+  /API/current/ctor.Image.new_from_image1.html)
   make a constant image. This has been added to all the language bindings too.
 
 * Better prefix guessing on Windows, credit to tumagonx.

--- a/_posts/2017-11-28-What's-new-in-8.6.md
+++ b/_posts/2017-11-28-What's-new-in-8.6.md
@@ -10,7 +10,7 @@ if you need more details.
 ## New operators
 
 There are five new operators. The largest is [`vips_composite2()`]({{
-site.baseurl }}/API/8.6/libvips-conversion.html#vips-composite2): this will
+site.baseurl }}/API/current/method.Image.composite2.html): this will
 composite a pair of transparent images together using PDF-style blending
 modes. For example, given the standard libtiff and libpng demo images:
 
@@ -27,14 +27,14 @@ Gives:
 [![Composite of PNG and TIFF demo images]({{ site.baseurl }}/assets/images/tn_composite.jpg)]({{ site.baseurl }}/assets/images/composite.png)
 
 `over` is probably the most useful, but `composite2` supports all the [PDF blend
-modes]({{ site.baseurl }}/API/8.6/libvips-conversion.html#VipsBlendMode).
+modes]({{ site.baseurl }}/API/current/enum.BlendMode.html).
 
 `composite2` joins a pair of images, but you can join a whole array of images
 using an array of blend modes in a single operation with `composite`. Options
 let you control the compositing space and premultiplication handling.
 
 [`vips_fill_nearest()`]({{ site.baseurl
-}}/API/8.6/libvips-morphology.html#vips-fill-nearest) replaces every zero
+}}/API/current/method.Image.fill_nearest.html) replaces every zero
 pixel in an image with the nearest non-zero pixel. For example:
 
 [![Fill nearest image]({{ site.baseurl }}/assets/images/tn_fill-nearest.jpg)]({{ site.baseurl }}/assets/images/fill-nearest.png)
@@ -45,16 +45,16 @@ memory. It's handy for things like cell counting, where you want to assign cell
 pixels to the nearest nucleus.
 
 [`vips_find_trim()`]({{ site.baseurl
-}}/API/8.6/libvips-arithmetic.html#vips-find-trim) searches an image in from
+}}/API/current/method.Image.find_trim.html) searches an image in from
 the edges and returns the bounding box of the non-background pixels. It's
 useful for automatically trimming away the edges from scanned images.
 
 [`vips_gravity()`]({{ site.baseurl
-}}/API/8.6/libvips-conversion.html#vips-gravity) places an image within a
+}}/API/current/method.Image.gravity.html) places an image within a
 larger canvas, positioning the image according to a compass direction. It's
 just `vips_embed()` with a convenient interface.
 
-[`vips_thumbnail_image()`]({{ site.baseurl }}/API/8.6/libvips-resample.html#vips-thumbnail-image) lets you thumbnail any image source. It can be
+[`vips_thumbnail_image()`]({{ site.baseurl }}/API/current/method.Image.thumbnail_image.html) lets you thumbnail any image source. It can be
 useful if you need to do something to an image before making a thumbnail.
 
 ## New features
@@ -62,30 +62,30 @@ useful if you need to do something to an image before making a thumbnail.
 There are a few new options for existing operations.
 
 * A `FORCE` [resize
-  mode]({{ site.baseurl }}/API/8.6/libvips-resample.html#VipsSize) lets
+  mode]({{ site.baseurl }}/API/current/enum.Size.html#force) lets
   you break the image aspect ratio in resizing.
 
 * `thumbnail` and `vipsthumbnail` have an [option for rendering
-  intent]({{ site.baseurl }}/API/8.6/libvips-resample.html#vips-thumbnail),
+  intent]({{ site.baseurl }}/API/current/ctor.Image.thumbnail.html),
   credit to kleisauke.
 
-* [`vips_text()`]({{ site.baseurl }}/API/8.6/libvips-create.html#vips-text)
+* [`vips_text()`]({{ site.baseurl }}/API/current/ctor.Image.text.html)
   can autofit text to a box. You give the size of the box to fill,
   and it'll automatically search for a DPI that just fills that area.
   Credit to gargsms.
 
 * [`VIPS_COMBINE_MIN`]({{ site.baseurl
-  }}/API/8.6/libvips-convolution.html#VipsCombine) is a new combining mode
+  }}/API/current/enum.Combine.html#min) is a new combining mode
   for `vips_compass()`, handy for estimating gradients.
 
 * [`vips_hist_find_indexed()`]({{ site.baseurl
-  }}/API/8.6/libvips-arithmetic.html#vips-hist-find-indexed) now has a
+  }}/API/current/method.Image.hist_find_indexed.html) now has a
   `combine` parameter. This makes it possible to quickly find the bounding
   boxes of a large number of objects, for example.
 
 * [`vips_affine()`]({{ site.baseurl
-  }}/API/8.6/libvips-resample.html#vips-affine) and [`vips_similarity()`]({{
-  site.baseurl }}/API/8.6/libvips-resample.html#vips-similarity) have a
+  }}/API/current/method.Image.affine.html) and [`vips_similarity()`]({{
+  site.baseurl }}/API/current/method.Image.similarity.html) have a
   `background` parameter.  Previously, they always used 0 for new pixels
   and you had to composite on something else somehow.
 
@@ -133,9 +133,11 @@ There have been a few changes to existing features.
 Finally there are a range of smaller improvements:
 
 * New C API:
-  [`vips_image_new_from_image()`](http://libvips.github.io/libvips/API/8.6/VipsImage.html#vips-image-new-from-image)
+  [`vips_image_new_from_image()`]({{ site.baseurl
+  }}/API/current/ctor.Image.new_from_image.html)
   and
-  [`vips_image_new_from_image1()`](http://libvips.github.io/libvips/API/8.6/VipsImage.html#vips-image-new-from-image1)
+  [`vips_image_new_from_image1()`]({{ site.baseurl
+  }}/API/current/ctor.Image.new_from_image1.html)
   make a constant image. This has been added to all the language bindings too.
 
 * Better prefix guessing on Windows, credit to tumagonx.

--- a/_posts/2018-04-10-libvips-for-dot-net.md
+++ b/_posts/2018-04-10-libvips-for-dot-net.md
@@ -14,7 +14,7 @@ install notes and an example:
 [https://github.com/kleisauke/net-vips](https://github.com/kleisauke/net-vips)
 
 But briefly, just [get the libvips shared library on your
-system]({{ site.baseurl }}/install.html) and enter:
+system](/install.html) and enter:
 
 	Install-Package NetVips
 

--- a/_posts/2018-07-26-What's-new-in-8.7.md
+++ b/_posts/2018-07-26-What's-new-in-8.7.md
@@ -10,53 +10,53 @@ if you need more details.
 
 # New operators
 
-libvips has a pair of new edge detectors. [`vips_sobel()`]({{ site.baseurl
-}}/API/current/method.Image.sobel.html) is very simple and
-is just a useful convenience, but [`vips_canny()`]({{ site.baseurl
-}}/API/current/method.Image.canny.html) is rather fancy.
+libvips has a pair of new edge detectors. [`vips_sobel()`](
+/API/current/method.Image.sobel.html) is very simple and
+is just a useful convenience, but [`vips_canny()`](
+/API/current/method.Image.canny.html) is rather fancy.
 
-![Canny edge detector]({{ site.baseurl }}/assets/images/canny.png)
+![Canny edge detector](/assets/images/canny.png)
 
-[`vips_canny()`]({{ site.baseurl
-}}/API/current/method.Image.canny.html) just does the streaming
+[`vips_canny()`](
+/API/current/method.Image.canny.html) just does the streaming
 part of the Canny algorithm. Thresholding and connectivity are up to you.
 
-[`vips_transpose3d()`]({{ site.baseurl
-}}/API/current/method.Image.transpose3d.html) is useful for volumetric
+[`vips_transpose3d()`](
+/API/current/method.Image.transpose3d.html) is useful for volumetric
 images. libvips loads volumes as a single very tall, thin image with all
 the image slices one above the other.  This new operation swaps the outer
 two dimensions, so output page N is made from all the Nth scanlines in the
 input pages.
 
-Finally, [`vips_rotate()`]({{ site.baseurl
-}}/API/current/method.Image.rotate.html)  is a convenience
-operation that just calls [`vips_similarity()`]({{ site.baseurl
-}}/API/current/method.Image.similarity.html) for you. It's supposed
+Finally, [`vips_rotate()`](
+/API/current/method.Image.rotate.html)  is a convenience
+operation that just calls [`vips_similarity()`](
+/API/current/method.Image.similarity.html) for you. It's supposed
 to be easier to find in the API.
 
 # Improvements to existing operators
 
-Thanks for work by fangqiao, [`vips_text()`]({{ site.baseurl
-}}/API/current/ctor.Image.text.html) has a new parameter `fontfile`. This
+Thanks for work by fangqiao, [`vips_text()`](
+/API/current/ctor.Image.text.html) has a new parameter `fontfile`. This
 lets you specify a font to render text with, without having to install the
 font on your system.
 
-medakk has added `x` and `y` parameters to [`vips_composite()`]({{
-site.baseurl }}/API/current/type_func.Image.composite.html), so you
+medakk has added `x` and `y` parameters to [`vips_composite()`](
+/API/current/type_func.Image.composite.html), so you
 can now position layers relative to each other.
 
-The Hough transform operators have been revised. [`vips_hough_line()`]({{
-site.baseurl }}/API/current/method.Image.hough_line.html)
-is 4x faster, and [`vips_hough_circle()`]({{ site.baseurl
-}}/API/current/method.Image.hough_circle.html) is 2x faster.
+The Hough transform operators have been revised. [`vips_hough_line()`](
+/API/current/method.Image.hough_line.html)
+is 4x faster, and [`vips_hough_circle()`](
+/API/current/method.Image.hough_circle.html) is 2x faster.
 
-There's now a [Mitchell interpolation kernel]({{ site.baseurl
-}}/API/current/enum.Kernel.html#mitchell) you can use for image resizing.
+There's now a [Mitchell interpolation kernel](
+/API/current/enum.Kernel.html#mitchell) you can use for image resizing.
 
 # New format support
 
-Work by dlemstra has resulted in [`vips_magicksave()`]({{ site.baseurl
-}}/API/current/method.Image.magicksave.html). This new operation can
+Work by dlemstra has resulted in [`vips_magicksave()`](
+/API/current/method.Image.magicksave.html). This new operation can
 write an image via libMagick in any format that libMagick supports. It's
 still missing some features like ICC profile support,
 but it works well for things like animated GIF write.
@@ -73,25 +73,25 @@ and save. This is a popular format for brain imaging.
 
 felixbuenemann has added support for 8-bit palette PNG
 images. These can be quite a bit smaller for some sorts of
-image. New parameters for [`vips_pngsave()`]({{ site.baseurl
-}}/API/current/method.Image.pngsave.html) let you control the dithering,
+image. New parameters for [`vips_pngsave()`](
+/API/current/method.Image.pngsave.html) let you control the dithering,
 number of colours, and quantisation quality.
 
 harukizaemon has added a system to the pyramid
-builders in [`vips_dzsave()`]({{ site.baseurl
-}}/API/current/method.Image.dzsave.html) and [`vips_tiffsave()`]({{
-site.baseurl }}/API/current/method.Image.tiffsave.html) to let you
+builders in [`vips_dzsave()`](
+/API/current/method.Image.dzsave.html) and [`vips_tiffsave()`](
+/API/current/method.Image.tiffsave.html) to let you
 specify a x2 shrink operation. As well as `mean`, (the previous system) you
 can now also specify `mode` and `median`.  These are useful for pyramiding
 large label sets.
 
-The [JPEG loader]({{ site.baseurl
-}}/API/current/ctor.Image.jpegload.html) has better metadata support. It
+The [JPEG loader](
+/API/current/ctor.Image.jpegload.html) has better metadata support. It
 will now tell you about the type of source image chroma subsampling, supports
 modification of string-valued EXIF tags, supports removal of the embedded
 thumbnail, and has a better system for reporting interlaced image sources.
 
-The [PDF loader]({{ site.baseurl }}/API/current/ctor.Image.pdfload.html)
+The [PDF loader](/API/current/ctor.Image.pdfload.html)
 has better support for PDFs with a transparent background, reports the
 number of pages in a document, and lets you use PDFium instead of poppler
 (see above).
@@ -108,13 +108,13 @@ Hopefully this will make it easier to catch errors.
 
 # Breaking changes
 
-Actually using [`vips_hough_line()`]({{ site.baseurl
-}}/API/current/method.Image.hough_line.html) in a project revealed
+Actually using [`vips_hough_line()`](
+/API/current/method.Image.hough_line.html) in a project revealed
 a flaw in the way that it encoded the parameter space. We've had to change
 this, but hopefully not too much code will break.
 
-The create functions like [`vips_black()`]({{ site.baseurl
-}}/API/current/ctor.Image.black.html) used to set their interpretation
+The create functions like [`vips_black()`](
+/API/current/ctor.Image.black.html) used to set their interpretation
 to `b-w` or `multiband` depending on whether they were outputting a single
 or a multiband image. This caused quite a bit of confusion, so they now
 always set `multiband`, even when outputting single band images.  The rules

--- a/_posts/2018-07-26-What's-new-in-8.7.md
+++ b/_posts/2018-07-26-What's-new-in-8.7.md
@@ -11,52 +11,52 @@ if you need more details.
 # New operators
 
 libvips has a pair of new edge detectors. [`vips_sobel()`]({{ site.baseurl
-}}/API/8.7/libvips-convolution.html#vips-sobel) is very simple and
+}}/API/current/method.Image.sobel.html) is very simple and
 is just a useful convenience, but [`vips_canny()`]({{ site.baseurl
-}}/API/8.7/libvips-convolution.html#vips-canny) is rather fancy.
+}}/API/current/method.Image.canny.html) is rather fancy.
 
 ![Canny edge detector]({{ site.baseurl }}/assets/images/canny.png)
 
 [`vips_canny()`]({{ site.baseurl
-}}/API/8.7/libvips-convolution.html#vips-canny) just does the streaming
+}}/API/current/method.Image.canny.html) just does the streaming
 part of the Canny algorithm. Thresholding and connectivity are up to you.
 
 [`vips_transpose3d()`]({{ site.baseurl
-}}/API/8.7/libvips-conversion.html#vips-transpose3d) is useful for volumetric
+}}/API/current/method.Image.transpose3d.html) is useful for volumetric
 images. libvips loads volumes as a single very tall, thin image with all
 the image slices one above the other.  This new operation swaps the outer
 two dimensions, so output page N is made from all the Nth scanlines in the
 input pages.
 
 Finally, [`vips_rotate()`]({{ site.baseurl
-}}/API/8.7/libvips-resample.html#vips-rotate)  is a convenience
+}}/API/current/method.Image.rotate.html)  is a convenience
 operation that just calls [`vips_similarity()`]({{ site.baseurl
-}}/API/8.7/libvips-resample.html#vips-similarity) for you. It's supposed
+}}/API/current/method.Image.similarity.html) for you. It's supposed
 to be easier to find in the API.
 
 # Improvements to existing operators
 
 Thanks for work by fangqiao, [`vips_text()`]({{ site.baseurl
-}}/API/8.7/libvips-create.html#vips-text) has a new parameter `fontfile`. This
+}}/API/current/ctor.Image.text.html) has a new parameter `fontfile`. This
 lets you specify a font to render text with, without having to install the
 font on your system.
 
 medakk has added `x` and `y` parameters to [`vips_composite()`]({{
-site.baseurl }}/API/8.7/libvips-conversion.html#vips-composite), so you
+site.baseurl }}/API/current/type_func.Image.composite.html), so you
 can now position layers relative to each other.
 
 The Hough transform operators have been revised. [`vips_hough_line()`]({{
-site.baseurl }}/API/8.7/libvips-arithmetic.html#vips-hough-line)
+site.baseurl }}/API/current/method.Image.hough_line.html)
 is 4x faster, and [`vips_hough_circle()`]({{ site.baseurl
-}}/API/8.7/libvips-arithmetic.html#vips-hough-circle) is 2x faster.
+}}/API/current/method.Image.hough_circle.html) is 2x faster.
 
 There's now a [Mitchell interpolation kernel]({{ site.baseurl
-}}/API/8.7/libvips-resample.html#VipsKernel) you can use for image resizing.
+}}/API/current/enum.Kernel.html#mitchell) you can use for image resizing.
 
 # New format support
 
 Work by dlemstra has resulted in [`vips_magicksave()`]({{ site.baseurl
-}}/API/8.7/VipsForeignSave.html#vips-magicksave). This new operation can
+}}/API/current/method.Image.magicksave.html). This new operation can
 write an image via libMagick in any format that libMagick supports. It's
 still missing some features like ICC profile support,
 but it works well for things like animated GIF write.
@@ -74,24 +74,24 @@ and save. This is a popular format for brain imaging.
 felixbuenemann has added support for 8-bit palette PNG
 images. These can be quite a bit smaller for some sorts of
 image. New parameters for [`vips_pngsave()`]({{ site.baseurl
-}}/API/8.7/VipsForeignSave.html#vips-pngsave) let you control the dithering,
+}}/API/current/method.Image.pngsave.html) let you control the dithering,
 number of colours, and quantisation quality.
 
 harukizaemon has added a system to the pyramid
 builders in [`vips_dzsave()`]({{ site.baseurl
-}}/API/8.7/VipsForeignSave.html#vips-dzsave) and [`vips_tiffsave()`]({{
-site.baseurl }}/API/8.7/VipsForeignSave.html#vips-tiffsave) to let you
+}}/API/current/method.Image.dzsave.html) and [`vips_tiffsave()`]({{
+site.baseurl }}/API/current/method.Image.tiffsave.html) to let you
 specify a x2 shrink operation. As well as `mean`, (the previous system) you
 can now also specify `mode` and `median`.  These are useful for pyramiding
 large label sets.
 
 The [JPEG loader]({{ site.baseurl
-}}/API/8.7/VipsForeignSave.html#vips-jpegload) has better metadata support. It
+}}/API/current/ctor.Image.jpegload.html) has better metadata support. It
 will now tell you about the type of source image chroma subsampling, supports
 modification of string-valued EXIF tags, supports removal of the embedded
 thumbnail, and has a better system for reporting interlaced image sources.
 
-The [PDF loader]({{ site.baseurl }}/API/8.7/VipsForeignSave.html#vips-pdfload)
+The [PDF loader]({{ site.baseurl }}/API/current/ctor.Image.pdfload.html)
 has better support for PDFs with a transparent background, reports the
 number of pages in a document, and lets you use PDFium instead of poppler
 (see above).
@@ -109,12 +109,12 @@ Hopefully this will make it easier to catch errors.
 # Breaking changes
 
 Actually using [`vips_hough_line()`]({{ site.baseurl
-}}/API/8.7/libvips-arithmetic.html#vips-hough-line) in a project revealed
+}}/API/current/method.Image.hough_line.html) in a project revealed
 a flaw in the way that it encoded the parameter space. We've had to change
 this, but hopefully not too much code will break.
 
 The create functions like [`vips_black()`]({{ site.baseurl
-}}/API/8.7/libvips-create.html#vips-black) used to set their interpretation
+}}/API/current/ctor.Image.black.html) used to set their interpretation
 to `b-w` or `multiband` depending on whether they were outputting a single
 or a multiband image. This caused quite a bit of confusion, so they now
 always set `multiband`, even when outputting single band images.  The rules

--- a/_posts/2019-04-22-What's-new-in-8.8.md
+++ b/_posts/2019-04-22-What's-new-in-8.8.md
@@ -36,7 +36,7 @@ $ vipsthumbnail dancing_banana2.lossless.webp -o x.gif
 
 Makes:
 
-![First frame of banana]({{ site.baseurl }}/assets/images/onebanana.gif)
+![First frame of banana](/assets/images/onebanana.gif)
 
 But:
 
@@ -46,7 +46,7 @@ $ vipsthumbnail dancing_banana2.lossless.webp[n=-1] -o x.gif
 
 Makes:
 
-![All of banana]({{ site.baseurl }}/assets/images/manybanana.gif)
+![All of banana](/assets/images/manybanana.gif)
 
 It'll work for any many-page format, so you can thumbnail many-page TIFFs,
 or even PDFs. For example:
@@ -61,7 +61,7 @@ sys 0m0.085s
 That's rendering a 40 page PDF as an animated webp image in 0.8s, though I'm 
 not sure if it's a useful thing to do.
 
-![All of banana]({{ site.baseurl }}/assets/images/nipguide.gif)
+![All of banana](/assets/images/nipguide.gif)
 
 # Built-in colour profiles
 

--- a/_posts/2019-11-29-True-streaming-for-libvips.md
+++ b/_posts/2019-11-29-True-streaming-for-libvips.md
@@ -39,7 +39,7 @@ write buckets using http `GET` and `POST` requests to addresses like
 Processing with a system that works in whole images, like
 ImageMagick, happens like this:
 
-![Processing with image-at-a-time systems]({{ site.baseurl }}/assets/images/magick-s3.png)
+![Processing with image-at-a-time systems](/assets/images/magick-s3.png)
 
 Reading from the left, first the data is downloaded from the bucket into
 a large area of memory, then the image is decompressed, then processed,
@@ -53,7 +53,7 @@ Current libvips is able to execute decode, process and encode all at the same
 time, in parallel, and without needing any intermediate images. It looks
 more like this:
 
-![Processing with current libvips]({{ site.baseurl }}/assets/images/old-libvips-s3.png)
+![Processing with current libvips](/assets/images/old-libvips-s3.png)
 
 Because the middle sections are overlapped we get much better *latency*:
 the total time the whole process takes from start to finish is much lower.
@@ -65,7 +65,7 @@ storage until it has finished compressing the whole output image.
 This is where true streaming comes in. libvips git master can now decode
 directly from a pipe and encode directly to a pipe. It looks more like this:
 
-![Processing with libvips streams]({{ site.baseurl }}/assets/images/new-libvips-s3.png)
+![Processing with libvips streams](/assets/images/new-libvips-s3.png)
 
 Now *everything* overlaps, and latency should drop again.
 

--- a/_posts/2019-12-11-What's-new-in-8.9.md
+++ b/_posts/2019-12-11-What's-new-in-8.9.md
@@ -103,12 +103,12 @@ curious.
 libvips has a pair of new operations which speed up many-way if-then-else.
 
 [`vips_switch()`]({{ site.baseurl
-}}/API/8.9/libvips-conversion.html#vips-switch) takes an array of N condition
+}}/API/current/type_func.Image.switch.html) takes an array of N condition
 images and for each pixel finds the index of the first non-zero pixel. If no
 pixels are non-zero, it sets the output to N + 1.
 
 [`vips_case()`]({ site.baseurl
-}}/API/8.9/API/8.9/libvips-histogram.html#vips-case)
+}}/API/current/method.Image.case.html)
 takes an index image plus an array of N + 1 result images and for each
 pixel copies the pixel selected by the index to the output. 
 

--- a/_posts/2019-12-11-What's-new-in-8.9.md
+++ b/_posts/2019-12-11-What's-new-in-8.9.md
@@ -20,14 +20,14 @@ result to the output.
 
 It looked something like this:
 
-![Processing with current libvips]({{ site.baseurl
-}}/assets/images/old-libvips-s3.png)
+![Processing with current libvips](
+/assets/images/old-libvips-s3.png)
 
 libvips now lets you connect pipelines to any source or destination, so
 you can do something more like this:
 
-![Processing with libvips streams]({{ site.baseurl
-}}/assets/images/new-libvips-s3.png)
+![Processing with libvips streams](
+/assets/images/new-libvips-s3.png)
 
 There's no buffering, so there should be a useful drop in latency.
 
@@ -80,8 +80,8 @@ image.write_to_target target, ".png"
 
 There's an optional `finish` handler. 
 
-A [post a few weeks ago]({{ site.baseurl
-}}/2019/11/29/True-streaming-for-libvips.html) introducing this in more
+A [post a few weeks ago](
+/2019/11/29/True-streaming-for-libvips.html) introducing this in more
 detail. pyvips, C and C++ also support this new feature.
 
 # OSS-Fuzz integration
@@ -94,21 +94,21 @@ their clusters is idle, it starts analyzing our code.
 It's been working away since August and only found two serious bugs, so that's
 great, and both have been fixed in 8.8. This means 8.9 should be very solid.
 
-There was a [post a few months ago]({{ site.baseurl
-}}2019/08/18/libvips-in-oss-fuzz.html) with a lot more detail, if you're
+There was a [post a few months ago](
+2019/08/18/libvips-in-oss-fuzz.html) with a lot more detail, if you're
 curious.
 
 # Switch/case
 
 libvips has a pair of new operations which speed up many-way if-then-else.
 
-[`vips_switch()`]({{ site.baseurl
-}}/API/current/type_func.Image.switch.html) takes an array of N condition
+[`vips_switch()`](
+/API/current/type_func.Image.switch.html) takes an array of N condition
 images and for each pixel finds the index of the first non-zero pixel. If no
 pixels are non-zero, it sets the output to N + 1.
 
-[`vips_case()`]({ site.baseurl
-}}/API/current/method.Image.case.html)
+[`vips_case()`](
+/API/current/method.Image.case.html)
 takes an index image plus an array of N + 1 result images and for each
 pixel copies the pixel selected by the index to the output. 
 

--- a/_posts/2020-06-18-What's-new-in-8.10.md
+++ b/_posts/2020-06-18-What's-new-in-8.10.md
@@ -51,7 +51,7 @@ Bioformats-style (OME-TIFF) image pyramids.
 
 libvips used to only write TIFF pyramids like this:
 
-![Old-style libvips TIFF pyramids]({{ site.baseurl }}/assets/images/old-pyr.png)
+![Old-style libvips TIFF pyramids](/assets/images/old-pyr.png)
 
 Each smaller version of the image is stored in a subsequent page in the TIFF
 file. This is easy and convenient, and how most TIFF pyramids writers work, but
@@ -70,7 +70,7 @@ for each band inside the page.
 
 A two-band OME-TIFF pyramid might look like this:
 
-![Bioformats-style TIFF pyramids]({{ site.baseurl }}/assets/images/new-pyr.png)
+![Bioformats-style TIFF pyramids](/assets/images/new-pyr.png)
 
 libvips has been able to read and write OME-TIFF for a long time, but it
 has not been able to read and write these SUBIFD images.

--- a/_posts/2020-09-01-libvips-for-webassembly.md
+++ b/_posts/2020-09-01-libvips-for-webassembly.md
@@ -146,7 +146,7 @@ All libvips operations and enumerations are exposed through
 so that the compiled code can be used in JavaScript.
 
 The binding itself is a variant of
-[libvips' C++ API]({{ site.baseurl }}/API/current/using-from-cplusplus.html),
+[libvips' C++ API](/API/current/using-from-cplusplus.html),
 with additional support for the `emscripten::val` C++ class to transliterate
 JavaScript code to C++. For example, consider this JavaScript code:
 
@@ -162,7 +162,7 @@ Which shrinks an image to fit within a 128×128 box. Excess pixels are trimmed
 away using the `attention` strategy that positioned the crop box over the
 most significant feature:
 
-[![Attention strategy]({{ site.baseurl }}/API/current/tn_owl.jpg)]({{ site.baseurl }}/API/current/tn_owl.jpg)
+[![Attention strategy](/API/current/tn_owl.jpg)](/API/current/tn_owl.jpg)
 
 This function and enumeration was automatically generated within C++ as:
 ```cpp

--- a/_posts/2020-09-01-libvips-for-webassembly.md
+++ b/_posts/2020-09-01-libvips-for-webassembly.md
@@ -146,7 +146,7 @@ All libvips operations and enumerations are exposed through
 so that the compiled code can be used in JavaScript.
 
 The binding itself is a variant of
-[libvips' C++ API]({{ site.baseurl }}/API/current/using-from-cpp.html),
+[libvips' C++ API]({{ site.baseurl }}/API/current/using-from-cplusplus.html),
 with additional support for the `emscripten::val` C++ class to transliterate
 JavaScript code to C++. For example, consider this JavaScript code:
 

--- a/_posts/2021-03-08-ruby-vips-mutate.md
+++ b/_posts/2021-03-08-ruby-vips-mutate.md
@@ -55,7 +55,7 @@ $ /usr/bin/time -f %M:%e ./circles.rb ~/pics/nina.jpg x.jpg
 
 To make this:
 
-![random circles]({{ site.baseurl }}/assets/images/circles1.jpg)
+![random circles](/assets/images/circles1.jpg)
 
 It works, but 13s and almost 5gb of memory to draw 1,000 circles is really
 not good.

--- a/_posts/2021-06-04-What's-new-in-8.11.md
+++ b/_posts/2021-06-04-What's-new-in-8.11.md
@@ -132,7 +132,7 @@ We've spent some time improving the C++ API.
 
 We now use [doxygen](https://www.doxygen.nl) to generate C++ API docs
 automatically, and we've written a set of API comments. Hopefully the [new
-documentation]({{ site.baseurl }}/API/8.11/cpp) should be a big improvement.
+documentation]({{ site.baseurl }}/API/current/cpp) should be a big improvement.
 
 There are a couple of functional improvements too. There's support for
 `VipsInterpolate`, `guint64` and a new constructor,

--- a/_posts/2021-06-04-What's-new-in-8.11.md
+++ b/_posts/2021-06-04-What's-new-in-8.11.md
@@ -34,7 +34,7 @@ patents and is fast enough to be practical.
 
 I made a sample image. You'll need to zoom in to check details:
 
-![image compression comparison]({{ site.baseurl }}/assets/images/astronauts.png)
+![image compression comparison](/assets/images/astronauts.png)
 
 Compression and decompression is quite a bit quicker than HEIC:
 
@@ -98,7 +98,7 @@ $ vips text x.png "😀<span foreground='red'>red</span><span background='cyan'>
 
 Makes this:
 
-![coloured text]({{ site.baseurl }}/assets/images/text.png)
+![coloured text](/assets/images/text.png)
 
 You can then use `composite` to render these text RGBA images on to another
 image.
@@ -132,7 +132,7 @@ We've spent some time improving the C++ API.
 
 We now use [doxygen](https://www.doxygen.nl) to generate C++ API docs
 automatically, and we've written a set of API comments. Hopefully the [new
-documentation]({{ site.baseurl }}/API/current/cpp) should be a big improvement.
+documentation](/API/current/cpp) should be a big improvement.
 
 There are a couple of functional improvements too. There's support for
 `VipsInterpolate`, `guint64` and a new constructor,

--- a/_posts/2022-05-28-What's-new-in-8.13.md
+++ b/_posts/2022-05-28-What's-new-in-8.13.md
@@ -48,9 +48,9 @@ blocked, but we've marked all loaders derived from `VipsForeignLoadJpeg`
 only load JPEG files.
 
 See [`vips_block_untrusted_set()`]({{ site.baseurl
-}}/API/current/libvips-vips.html#vips-block-untrusted-set) and
+}}/API/current/func.block_untrusted_set.html) and
 [`vips_operation_block_set()`]({{ site.baseurl
-}}/API/current/VipsOperation.html#vips-operation-block-set) for more details.
+}}/API/current/type_func.Operation.block_set.html) for more details.
 
 # Much better GIF save
 
@@ -185,7 +185,7 @@ has some more notes.
 # General minor improvements
 
 - add `extend`, `background` and `premultiplied` to [`vips_mapim()`]({{ site.baseurl
-  }}/API/current/libvips-resample.html#vips-mapim) to fix edge antialiasing
+  }}/API/current/method.Image.mapim.html) to fix edge antialiasing
   [GavinJoyce]
 - improve the pixel RNG for the noise operators
 - add support for regions in C++ API [shado23]

--- a/_posts/2022-05-28-What's-new-in-8.13.md
+++ b/_posts/2022-05-28-What's-new-in-8.13.md
@@ -47,10 +47,10 @@ blocked, but we've marked all loaders derived from `VipsForeignLoadJpeg`
 (so all the libjpeg loaders) as runnable. After these calls, libvips will
 only load JPEG files.
 
-See [`vips_block_untrusted_set()`]({{ site.baseurl
-}}/API/current/func.block_untrusted_set.html) and
-[`vips_operation_block_set()`]({{ site.baseurl
-}}/API/current/type_func.Operation.block_set.html) for more details.
+See [`vips_block_untrusted_set()`](
+/API/current/func.block_untrusted_set.html) and
+[`vips_operation_block_set()`](
+/API/current/type_func.Operation.block_set.html) for more details.
 
 # Much better GIF save
 
@@ -87,8 +87,8 @@ needs 4x less memory, makes GIFs which are 20% smaller, and produces higher
 quality output.
 
 The new GIF saver now has quite a few options to control
-compression, take [a look at the docs]({{ site.baseurl
-}}/API/current/VipsForeignSave.html#vips-gifsave).
+compression, take [a look at the docs](
+/API/current/VipsForeignSave.html#vips-gifsave).
 
 # Image resize quality improvements
 
@@ -184,8 +184,8 @@ has some more notes.
 
 # General minor improvements
 
-- add `extend`, `background` and `premultiplied` to [`vips_mapim()`]({{ site.baseurl
-  }}/API/current/method.Image.mapim.html) to fix edge antialiasing
+- add `extend`, `background` and `premultiplied` to [`vips_mapim()`](
+  /API/current/method.Image.mapim.html) to fix edge antialiasing
   [GavinJoyce]
 - improve the pixel RNG for the noise operators
 - add support for regions in C++ API [shado23]

--- a/_posts/2023-10-10-What's-new-in-8.15.md
+++ b/_posts/2023-10-10-What's-new-in-8.15.md
@@ -138,11 +138,11 @@ library, `libarchive`, which should improve portability.
 * PDF loading with PDFium now includes support for PDF forms, making it
   capable of rendering user-provided input in checkboxes and text fields.
 * We've added two new edge detectors,
-  [`vips_scharr()`](/API/current/libvips-convolution.html#vips-scharr) and
-  [`vips_prewitt()`](/API/current/libvips-convolution.html#vips-prewitt),
+  [`vips_scharr()`](/API/current/method.Image.scharr.html) and
+  [`vips_prewitt()`](/API/current/method.Image.prewitt.html),
   and improved the accuracy of
-  [`vips_sobel()`](/API/current/libvips-convolution.html#vips-sobel).  
-* [`vips_find_trim()`](/API/current/libvips-arithmetic.html#vips-find-trim)
+  [`vips_sobel()`](/API/current/method.Image.sobel.html).  
+* [`vips_find_trim()`](/API/current/method.Image.find_trim.html)
   features a `line_art` option.
 * GIF load now sets `interlaced=1` for interlaced GIF images.  
 * Improved C++ binding, taking advantage of C++11 features.  

--- a/_posts/2024-10-10-What's-new-in-8.16.md
+++ b/_posts/2024-10-10-What's-new-in-8.16.md
@@ -9,7 +9,7 @@ if you need more details.
 ## Signed Distance Fields
 
 libvips has a new
-[`vips_sdf()`]({{ site.baseurl }}/API/8.16/libvips-create.html#vips-sdf)
+[`vips_sdf()`]({{ site.baseurl }}/API/current/ctor.Image.sdf.html)
 operator. This can efficiently generate a range of basic shapes as Signed
 Distance Fields -- these are images where each pixel contains a signed value
 giving the distance to the closest edge. For example:
@@ -62,11 +62,11 @@ To make:
 
 Hmmm, possibly a person rowing a boat. This uses three
 other new operators: [`vips_minpair()`]({{ site.baseurl
-}}/API/8.16/libvips-arithmetic.html#vips-minpair) and [`vips_maxpair()`]({{
-site.baseurl }}/API/8.16/libvips-arithmetic.html#vips-maxpair),
+}}/API/current/method.Image.minpair.html) and [`vips_maxpair()`]({{
+site.baseurl }}/API/current/method.Image.maxpair.html),
 which given a pair of images find the
 pixel-wise max and min, and [`vips_clamp()`]({{ site.baseurl
-}}/API/8.16/libvips-arithmetic.html#vips-clamp), which constrains pixels
+}}/API/current/method.Image.clamp.html), which constrains pixels
 to a range.
 
 SDFs fit really well with libvips on-demand-evaluation. These things
@@ -97,9 +97,9 @@ File format support has been improved (again). Highlights this time are:
 
 * `rawsave` gets  streaming support with
   [`vips_rawsave_target()`]({{ site.baseurl
-  }}/API/8.16/VipsForeignSave.html#vips-rawsave-target) and
+  }}/API/current/method.Image.rawsave_target.html) and
   [`vips_rawsave_buffer()`]({{ site.baseurl
-  }}/API/8.16/VipsForeignSave.html#vips-rawsave-buffer).
+  }}/API/current/method.Image.rawsave_buffer.html).
 
 ## General improvements
 
@@ -107,10 +107,10 @@ There have been some smaller libvips additions and improvements too.
 
 * libvips used to limit image dimensions to 10 million pixels. This is now
   configurable, see [`vips_max_coord_get()`]({{ site.baseurl
-  }}/API/8.16/libvips-vips.html#vips-max-coord-get).
+  }}/API/current/func.max_coord_get.html).
 
 * There's a new (trivial) [`vips_addalpha()`]({{ site.baseurl
-  }}/API/8.16/libvips-conversion.html#vips-addalpha) operation.
+  }}/API/current/method.Image.addalpha.html) operation.
 
 * `vips_getpoint()` has a new `unpack_complex` option.
 

--- a/_posts/2024-10-10-What's-new-in-8.16.md
+++ b/_posts/2024-10-10-What's-new-in-8.16.md
@@ -9,7 +9,7 @@ if you need more details.
 ## Signed Distance Fields
 
 libvips has a new
-[`vips_sdf()`]({{ site.baseurl }}/API/current/ctor.Image.sdf.html)
+[`vips_sdf()`](/API/current/ctor.Image.sdf.html)
 operator. This can efficiently generate a range of basic shapes as Signed
 Distance Fields -- these are images where each pixel contains a signed value
 giving the distance to the closest edge. For example:
@@ -22,7 +22,7 @@ Makes a 512 x 512 pixel float image of a circle with radius 200, centered
 on 256 x 256. As you move out and away from the edge, values become
 increasingly positive, as you move within the circle, values become negative.
 
-![SDF circle]({{ site.baseurl }}/assets/images/sdf-circle.png)
+![SDF circle](/assets/images/sdf-circle.png)
 
 The great thing about SDFs is that they are quick to make and very easy to
 combine to make more complex shapes. For example, you could write:
@@ -58,15 +58,15 @@ sdf.clamp().linear(-255, 255, uchar=True).write_to_file(sys.argv[1])
 
 To make:
 
-![SDF boat]({{ site.baseurl }}/assets/images/sdf-boat.png)
+![SDF boat](/assets/images/sdf-boat.png)
 
 Hmmm, possibly a person rowing a boat. This uses three
-other new operators: [`vips_minpair()`]({{ site.baseurl
-}}/API/current/method.Image.minpair.html) and [`vips_maxpair()`]({{
-site.baseurl }}/API/current/method.Image.maxpair.html),
+other new operators: [`vips_minpair()`](
+/API/current/method.Image.minpair.html) and [`vips_maxpair()`](
+/API/current/method.Image.maxpair.html),
 which given a pair of images find the
-pixel-wise max and min, and [`vips_clamp()`]({{ site.baseurl
-}}/API/current/method.Image.clamp.html), which constrains pixels
+pixel-wise max and min, and [`vips_clamp()`](
+/API/current/method.Image.clamp.html), which constrains pixels
 to a range.
 
 SDFs fit really well with libvips on-demand-evaluation. These things
@@ -96,21 +96,21 @@ File format support has been improved (again). Highlights this time are:
 * PFM load and save now uses scRGB colourspace (ie. linear 0-1).
 
 * `rawsave` gets  streaming support with
-  [`vips_rawsave_target()`]({{ site.baseurl
-  }}/API/current/method.Image.rawsave_target.html) and
-  [`vips_rawsave_buffer()`]({{ site.baseurl
-  }}/API/current/method.Image.rawsave_buffer.html).
+  [`vips_rawsave_target()`](
+  /API/current/method.Image.rawsave_target.html) and
+  [`vips_rawsave_buffer()`](
+  /API/current/method.Image.rawsave_buffer.html).
 
 ## General improvements
 
 There have been some smaller libvips additions and improvements too.
 
 * libvips used to limit image dimensions to 10 million pixels. This is now
-  configurable, see [`vips_max_coord_get()`]({{ site.baseurl
-  }}/API/current/func.max_coord_get.html).
+  configurable, see [`vips_max_coord_get()`](
+  /API/current/func.max_coord_get.html).
 
-* There's a new (trivial) [`vips_addalpha()`]({{ site.baseurl
-  }}/API/current/method.Image.addalpha.html) operation.
+* There's a new (trivial) [`vips_addalpha()`](
+  /API/current/method.Image.addalpha.html) operation.
 
 * `vips_getpoint()` has a new `unpack_complex` option.
 

--- a/_posts/2025-01-31-nip4-January-progress.md
+++ b/_posts/2025-01-31-nip4-January-progress.md
@@ -9,11 +9,11 @@ pre-compiled binaries for flatpak and Windows by the end of February.
 Here's the per-voxel Patlak workspace I made for analyzing pulmonary FDG-PET
 scans:
 
-![FDG-PET workspace]({{ site.baseurl }}/assets/images/nip4-jan-1.png)
+![FDG-PET workspace](/assets/images/nip4-jan-1.png)
 
 The **About nip4** menu item shows some stats:
 
-![Workspace stats]({{ site.baseurl }}/assets/images/nip4-jan-2.png)
+![Workspace stats](/assets/images/nip4-jan-2.png)
 
 So this workspace has:
 
@@ -26,7 +26,7 @@ So this workspace has:
 Here's the [Charisma
 workspace](https://www.academia.edu/7276130/J_Dyer_G_Verri_and_J_Cupitt_Multispectral_Imaging_in_Reflectance_and_Photo_induced_Luminescence_modes_a_User_Manual_European_CHARISMA_Project):
 
-![Charisma workspace]({{ site.baseurl }}/assets/images/nip4-jan-3.png)
+![Charisma workspace](/assets/images/nip4-jan-3.png)
 
 This thing is for museum imaging: you give it images taken under visible,
 infrared, and UV light with various filters and it aligns them and computes
@@ -49,7 +49,7 @@ but if there's a crash (sadly inevitable in alpha software) they'll still
 be there when it restarts. Click on **Recover after crash** and you get
 this window:
 
-![Recover after crash]({{ site.baseurl }}/assets/images/nip4-jan-4.png)
+![Recover after crash](/assets/images/nip4-jan-4.png)
 
 You can see the saves from each nip4 workspace and select one to recover it.
 The **Delete all backups** button wipes the temp area if it's getting too big.
@@ -67,14 +67,14 @@ workspace background and select **Workspace definitions** and a panel opens on
 the right with all the local definitions. You can edit them and press the
 **Play** button to process your changes and update everything.
 
-![Workspace definitions]({{ site.baseurl }}/assets/images/nip4-jan-5.png)
+![Workspace definitions](/assets/images/nip4-jan-5.png)
 
 ### Edit toolkits
 
 Right-click on the workspace background, pick **Edit toolkits** and you get
 the programming window:
 
-![Programming window]({{ site.baseurl }}/assets/images/nip4-jan-6.png)
+![Programming window](/assets/images/nip4-jan-6.png)
 
 You can edit and compile any of the built-in toolkits, though it's a bit
 barebones for now. 

--- a/_posts/2025-03-12-nip4-for-nip2-users.md
+++ b/_posts/2025-03-12-nip4-for-nip2-users.md
@@ -21,7 +21,7 @@ corners everywhere.  And nip2 is a "kitchen sink" program --- it has lots
 of features which seemed like a good idea at the time, but which I never
 ended up using much. 
 
-![nip2]({{ site.baseurl }}/assets/images/nip2.png)
+![nip2](/assets/images/nip2.png)
 
 nip4 is a rewrite of nip2 with the following aims:
 
@@ -39,7 +39,7 @@ nip4 is a rewrite of nip2 with the following aims:
 
 And here is nip4, running the same very complex workspace:
 
-![nip4]({{ site.baseurl }}/assets/images/nip4-12-mar-25.png)
+![nip4](/assets/images/nip4-12-mar-25.png)
 
 ## New image window
 
@@ -81,7 +81,7 @@ pan, and so on.
 The big change in the main window is the new toolkit bar down the left,
 replacing the old Toolkits menu.
 
-![nip4]({{ site.baseurl }}/assets/images/nip4-toolkits.png)
+![nip4](/assets/images/nip4-toolkits.png)
 
 It slides left and right as you select items or go back, and it stays open
 after clicking on a tool, so you can use several related tools together, which
@@ -91,7 +91,7 @@ It also supports keyword search. Click on the magnifying glass at the
 top-left, then type something related to what you want. Entering "lab", for
 example, will show all the tools related to CIELAB colourspace, for example:
 
-![nip4]({{ site.baseurl }}/assets/images/nip4-toolkits-search.png)
+![nip4](/assets/images/nip4-toolkits-search.png)
 
 Searching is fuzzy, so you don't need to be exact.
 
@@ -111,7 +111,7 @@ back to the workspace and right-click on the row for that region. You can
 change region properties by opening the row a few times and editing the
 members:
 
-![nip4]({{ site.baseurl }}/assets/images/nip4-region.png)
+![nip4](/assets/images/nip4-region.png)
 
 This works for all objects: open the row, edit the members. 
 
@@ -122,14 +122,14 @@ crash ...** from the main burger menu and you see a table of recent
 workspace auto-backups, sorted by the process ID and time. Doubleclick one of
 them to restore it.
 
-![nip4]({{ site.baseurl }}/assets/images/nip4-recover.png)
+![nip4](/assets/images/nip4-recover.png)
 
 ## New graphing window
 
 The graphing window has been rewritten and [now uses
 kplot](https://github.com/kristapsdz/kplot).
 
-![nip4]({{ site.baseurl }}/assets/images/nip4-plot.png)
+![nip4](/assets/images/nip4-plot.png)
 
 It no longer supports bar plots, but everything else works, and it's very
 fast.

--- a/_posts/2025-03-20-introduction-to-nip4.md
+++ b/_posts/2025-03-20-introduction-to-nip4.md
@@ -7,7 +7,7 @@ so this post tries to introduce this strange tool for people who've not
 come across it before.
 
 If you used nip2, there's a [nip4 for nip2
-users](https://www.libvips.org/2025/03/12/nip4-for-nip2-users.html) post
+users](/2025/03/12/nip4-for-nip2-users.html) post
 which runs though the main differences.
 
 I'll write a "nip4 for nerds" post next week introducing nip4's programming
@@ -21,7 +21,7 @@ You can use it to build image processing pipelines and then execute them on
 large datasets. These pipelines can get quite complex --- I've made systems
 with over 10,000 operations chained together.
 
-![nip4]({{ site.baseurl }}/assets/images/nip4-12-mar-25.png)
+![nip4](/assets/images/nip4-12-mar-25.png)
 
 This workspace analyses pulmonary PET-CT scans. It fits a two compartment
 model to each lung voxel to estimate a rate constant for FDG uptake (a proxy
@@ -30,7 +30,7 @@ for inflammation).
 Here's [the workspace developed in the Charisma
 project](https://github.com/BritishMuseum/bm-charisma). 
 
-![nip4]({{ site.baseurl }}/assets/images/nip4-charisma.png)
+![nip4](/assets/images/nip4-charisma.png)
 
 This workspace standardises and automates technical imaging in museums. You
 can load visible, infrared, ultraviolet, UV-induced visible luminescence and
@@ -45,7 +45,7 @@ does not need a lot of memory. The Charisma workspace above, for example,
 loads in about 5s on this PC, manipulates almost 100GB of images, but runs
 in under 1GB of RAM:
 
-![nip4]({{ site.baseurl }}/assets/images/nip4-resources.png)
+![nip4](/assets/images/nip4-resources.png)
 
 Everything is live. You can open an image view window on any of the
 cells in the workspace and watch pixels change as you edit the formula.
@@ -66,7 +66,7 @@ When you start nip4 it looks something like this. I've loaded a test image
 (drag one in, use the folder button at the top left, or start nip4 from the
 command-line with `nip4 my-great-image.jpg`):
 
-![nip4]({{ site.baseurl }}/assets/images/nip4-main-window.png)
+![nip4](/assets/images/nip4-main-window.png)
 
 `A` is the current column, `A1` is a row for the image you loaded, this is all
 in `tab1`. The thing down the left is the set of loaded toolkits. 
@@ -77,7 +77,7 @@ click in the magnifying glass at the top and search for tools by keyword.
 
 If you select Filter > Photographic Negative you'll see:
 
-![nip4]({{ site.baseurl }}/assets/images/nip4-negative.png)
+![nip4](/assets/images/nip4-negative.png)
 
 Most tools take one argument, and they are applied to the bottom row 
 in the current column. If you want to apply a tool to a row other than the
@@ -86,12 +86,12 @@ bottom one, select it first by clicking on the row label.
 If you open up `A2` by clicking on the `V` down button next to the label,
 you'll see the cell formula:
 
-![nip4]({{ site.baseurl }}/assets/images/nip4-formula.png)
+![nip4](/assets/images/nip4-formula.png)
 
 So the function `Filter_negative_item.action` has been applied to the row `A1`.
 You can edit the formula --- click on it, enter `255 - A1`, and you should see:
 
-![nip4]({{ site.baseurl }}/assets/images/nip4-formula2.png)
+![nip4](/assets/images/nip4-formula2.png)
 
 Which computes almost the same result.
 
@@ -103,7 +103,7 @@ scale widget called `A3` to the workspace. Now edit the formula to be
 It looks a bit awkward with the result row `A2` positioned before the scale.
 You can reorder columns by dragging on the row label. 
 
-![nip4]({{ site.baseurl }}/assets/images/nip4-scale.png)
+![nip4](/assets/images/nip4-scale.png)
 
 nip4 does not have an undo operation, instead it has fast and easy duplicate,
 merge and delete. If you make a copy of column `A` before you start changing
@@ -112,7 +112,7 @@ it, you can't lose any of your current work.
 Duplicate column `A` by right-clicking on the column title and selecting
 Duplicate from the menu.  Right-click on `B3` and select Delete, so you have:
 
-![nip4]({{ site.baseurl }}/assets/images/nip4-duplicate.png)
+![nip4](/assets/images/nip4-duplicate.png)
 
 Now in the text box at the bottom of column `B`, enter this formula for
 [Solarization](https://en.wikipedia.org/wiki/Solarization_(photography)):
@@ -129,7 +129,7 @@ If you double-click on an image thumbnail, you'll open an image view window.
 These are all live, so as you drag scales, they'll all update. You can zoom
 in and watch the values of individual pixels change as you edit formula.
 
-![nip4]({{ site.baseurl }}/assets/images/nip4-solarise.png)
+![nip4](/assets/images/nip4-solarise.png)
 
 The main window has some other useful features. You can pan large workspaces
 by dragging on the background, the burger menu at the top-right has some
@@ -170,13 +170,13 @@ for each pixel (handy for scientific images), and a burger menu gives
 a set of useful visualisation options such as false colour, log scale,
 and colour management.
 
-![nip4]({{ site.baseurl }}/assets/images/nip4-image-window.png)
+![nip4](/assets/images/nip4-image-window.png)
 
 You can also mark features on images. If you hold down Ctrl and drag down and
 right, you'll create a rectangular region, if you drag up and left you'll mark
 an arrow, if you just Ctrl-click you'll mark a point.
 
-![nip4]({{ site.baseurl }}/assets/images/nip4-regions.png)
+![nip4](/assets/images/nip4-regions.png)
 
 ## Editing complex objects
 
@@ -184,7 +184,7 @@ All compound row objects can be edited. Back in the main window, try pressing
 the down arrow next to the region a few times. You should see something like
 this:
 
-![nip4]({{ site.baseurl }}/assets/images/nip4-compound.png)
+![nip4](/assets/images/nip4-compound.png)
 
 You can edit any of these member values. For example, try setting `top` to
 be a fixed value, like 900. Now go back to the image window and try dragging
@@ -236,7 +236,7 @@ two scales and the third will update.
 If you open up the new scale widget, you'll see that `from` and `to` have
 been set appropriately for the possible range:
 
-![nip4]({{ site.baseurl }}/assets/images/nip4-add-scale.png)
+![nip4](/assets/images/nip4-add-scale.png)
 
 Just as with regions, you can also set the formula for any of these members.
 

--- a/_posts/2025-06-05-What's-new-in-8.17.md
+++ b/_posts/2025-06-05-What's-new-in-8.17.md
@@ -9,23 +9,23 @@ if you need more details.
 ## New documentation system
 
 We were using gtk-doc for our documentation system. [We've switched to its
-newer replacement, gi-docgen](https://www.libvips.org/API/current), and it
+newer replacement, gi-docgen](/API/current), and it
 should be a lot better.
 
-![docs]({{ site.baseurl }}/assets/images/docs.png)
+![docs](/assets/images/docs.png)
 
 The most interesting improvements are:
 
 - A much better search system -- try typing in the search box at the top left!
 
 - Better and more consistent display of optional arguments, see for example
-  [`embed`](https://www.libvips.org/API/current/method.Image.embed.html).
+  [`embed`](/API/current/method.Image.embed.html).
 
-- The [class overview page](https://www.libvips.org/API/current/class.Image.html)
+- The [class overview page](/API/current/class.Image.html)
   includes a useful one-line description of each operator.
 
 - Revised and restructured [Additional
-  documentation](https://www.libvips.org/API/current/index.html#extra).
+  documentation](/API/current/index.html#extra).
 
 - Support for light and dark appearance.
 
@@ -36,51 +36,51 @@ The most interesting improvements are:
 
 To help compatibility, the old vips7 matrix multiply
 function is now available as a vips8 operator,
-[`matrixmultiply`](https://www.libvips.org/API/current/method.Image.matrixmultiply.html).
+[`matrixmultiply`](/API/current/method.Image.matrixmultiply.html).
 
 We rewrote the old vips7 `remosaic` function for vips8 years
 ago, but stupidly forgot to link it.  We've fixed this, and
-[`remosaic`](https://www.libvips.org/API/current/method.Image.remosaic.html)
+[`remosaic`](/API/current/method.Image.remosaic.html)
 is now proudly available. Similarly,
-[`quadratic`](https://www.libvips.org/API/current/method.Image.quadratic.html)
+[`quadratic`](/API/current/method.Image.quadratic.html)
 has been there for years, but never worked properly. It's been revised and
 should now (finally) be useful.
 
 The so-called [magic kernel](https://johncostella.com/magic) is [now
-supported](https://www.libvips.org/API/current/enum.Kernel.html#mks2021)
+supported](/API/current/enum.Kernel.html#mks2021)
 for image resize.
 
 ICC import and transform now has an
-[`auto`](https://www.libvips.org/API/current/enum.Intent.html#auto) option
+[`auto`](/API/current/enum.Intent.html#auto) option
 for rendering intent.
 
 ## Better file format support
 
 File format support has been improved (again). Highlights this time are:
 
-- [`gifsave`](https://www.libvips.org/API/current/method.Image.gifsave.html)
+- [`gifsave`](/API/current/method.Image.gifsave.html)
   has a new `keep_duplicate_frames` option
 
-- [`svgload`](https://www.libvips.org/API/current/ctor.Image.svgload.html)
+- [`svgload`](/API/current/ctor.Image.svgload.html)
   has a new `stylesheet` option for custom CSS, and a `high_bitdepth` option
   for scRGB output.
 
-- [`heifload`](https://www.libvips.org/API/current/ctor.Image.heifload.html)
+- [`heifload`](/API/current/ctor.Image.heifload.html)
   has a new `unlimited` flag to remove all load limits, has better alpha
   channel detection, and better detection of truncated files.
 
-- [`jp2kload`](https://www.libvips.org/API/current/ctor.Image.jp2kload.html)
+- [`jp2kload`](/API/current/ctor.Image.jp2kload.html)
   has a new `oneshot` flag which can improve compatibility for older
   jp2k files.
 
-- [`jxlsave`](https://www.libvips.org/API/current/method.Image.jxlsave.html)
+- [`jxlsave`](/API/current/method.Image.jxlsave.html)
   has much lower memory use for large images.
 
-- [`openslideload`](https://www.libvips.org/API/current/ctor.Image.openslideload.html)
+- [`openslideload`](/API/current/ctor.Image.openslideload.html)
   now shares and reuses connections to the underlying file format library,
   improving speed.
 
-- [`ppmload`](https://www.libvips.org/API/current/ctor.Image.ppmload.html)
+- [`ppmload`](/API/current/ctor.Image.ppmload.html)
   has a new buffer variant for convenience.
 
 - TIFF load and save has better error handling 
@@ -93,15 +93,15 @@ File format support has been improved (again). Highlights this time are:
 There have been some smaller libvips additions and improvements too.
 
 - The
-  [`hough_line`](https://www.libvips.org/API/current/method.Image.hough_line.html)
+  [`hough_line`](/API/current/method.Image.hough_line.html)
   operator has better scaling to Hough space.
 
-- [`shrink`](https://www.libvips.org/API/current/method.Image.shrink.html)
+- [`shrink`](/API/current/method.Image.shrink.html)
   is noticeably faster
 
 - The operation cache is a lot more reliable.
 
-- [`sink_screen`](https://www.libvips.org/API/current/method.Image.sink_screen.html)
+- [`sink_screen`](/API/current/method.Image.sink_screen.html)
   has better scheduling and should render thumbnails much more quickly.
 
 - The ICC operators are better at detecting and rejecting corrupt profiles.

--- a/_posts/2025-06-05-What's-new-in-8.17.md
+++ b/_posts/2025-06-05-What's-new-in-8.17.md
@@ -9,7 +9,7 @@ if you need more details.
 ## New documentation system
 
 We were using gtk-doc for our documentation system. [We've switched to its
-newer replacement, gi-docgen](https://www.libvips.org/API/8.17), and it
+newer replacement, gi-docgen](https://www.libvips.org/API/current), and it
 should be a lot better.
 
 ![docs]({{ site.baseurl }}/assets/images/docs.png)
@@ -19,13 +19,13 @@ The most interesting improvements are:
 - A much better search system -- try typing in the search box at the top left!
 
 - Better and more consistent display of optional arguments, see for example
-  [`embed`](https://www.libvips.org/API/8.17/method.Image.embed.html).
+  [`embed`](https://www.libvips.org/API/current/method.Image.embed.html).
 
-- The [class overview page](https://www.libvips.org/API/8.17/class.Image.html)
+- The [class overview page](https://www.libvips.org/API/current/class.Image.html)
   includes a useful one-line description of each operator.
 
 - Revised and restructured [Additional
-  documentation](https://www.libvips.org/API/8.17/index.html#extra).
+  documentation](https://www.libvips.org/API/current/index.html#extra).
 
 - Support for light and dark appearance.
 
@@ -36,51 +36,51 @@ The most interesting improvements are:
 
 To help compatibility, the old vips7 matrix multiply
 function is now available as a vips8 operator,
-[`matrixmultiply`](https://www.libvips.org/API/8.17/method.Image.matrixmultiply.html).
+[`matrixmultiply`](https://www.libvips.org/API/current/method.Image.matrixmultiply.html).
 
 We rewrote the old vips7 `remosaic` function for vips8 years
 ago, but stupidly forgot to link it.  We've fixed this, and
-[`remosaic`](https://www.libvips.org/API/8.17/method.Image.remosaic.html)
+[`remosaic`](https://www.libvips.org/API/current/method.Image.remosaic.html)
 is now proudly available. Similarly,
-[`quadratic`](https://www.libvips.org/API/8.17/method.Image.quadratic.html)
+[`quadratic`](https://www.libvips.org/API/current/method.Image.quadratic.html)
 has been there for years, but never worked properly. It's been revised and
 should now (finally) be useful.
 
 The so-called [magic kernel](https://johncostella.com/magic) is [now
-supported](https://www.libvips.org/API/8.17/enum.Kernel.html#mks2021)
+supported](https://www.libvips.org/API/current/enum.Kernel.html#mks2021)
 for image resize.
 
 ICC import and transform now has an
-[`auto`](https://www.libvips.org/API/8.17/enum.Intent.html#auto) option
+[`auto`](https://www.libvips.org/API/current/enum.Intent.html#auto) option
 for rendering intent.
 
 ## Better file format support
 
 File format support has been improved (again). Highlights this time are:
 
-- [`gifsave`](https://www.libvips.org/API/8.17/method.Image.gifsave.html)
+- [`gifsave`](https://www.libvips.org/API/current/method.Image.gifsave.html)
   has a new `keep_duplicate_frames` option
 
-- [`svgload`](https://www.libvips.org/API/8.17/ctor.Image.svgload.html)
+- [`svgload`](https://www.libvips.org/API/current/ctor.Image.svgload.html)
   has a new `stylesheet` option for custom CSS, and a `high_bitdepth` option
   for scRGB output.
 
-- [`heifload`](https://www.libvips.org/API/8.17/ctor.Image.heifload.html)
+- [`heifload`](https://www.libvips.org/API/current/ctor.Image.heifload.html)
   has a new `unlimited` flag to remove all load limits, has better alpha
   channel detection, and better detection of truncated files.
 
-- [`jp2kload`](https://www.libvips.org/API/8.17/ctor.Image.jp2kload.html)
+- [`jp2kload`](https://www.libvips.org/API/current/ctor.Image.jp2kload.html)
   has a new `oneshot` flag which can improve compatibility for older
   jp2k files.
 
-- [`jxlsave`](https://www.libvips.org/API/8.17/method.Image.jxlsave.html)
+- [`jxlsave`](https://www.libvips.org/API/current/method.Image.jxlsave.html)
   has much lower memory use for large images.
 
-- [`openslideload`](https://www.libvips.org/API/8.17/ctor.Image.openslideload.html)
+- [`openslideload`](https://www.libvips.org/API/current/ctor.Image.openslideload.html)
   now shares and reuses connections to the underlying file format library,
   improving speed.
 
-- [`ppmload`](https://www.libvips.org/API/8.17/ctor.Image.ppmload.html)
+- [`ppmload`](https://www.libvips.org/API/current/ctor.Image.ppmload.html)
   has a new buffer variant for convenience.
 
 - TIFF load and save has better error handling 
@@ -93,15 +93,15 @@ File format support has been improved (again). Highlights this time are:
 There have been some smaller libvips additions and improvements too.
 
 - The
-  [`hough_line`](https://www.libvips.org/API/8.17/method.Image.hough_line.html)
+  [`hough_line`](https://www.libvips.org/API/current/method.Image.hough_line.html)
   operator has better scaling to Hough space.
 
-- [`shrink`](https://www.libvips.org/API/8.17/method.Image.shrink.html)
+- [`shrink`](https://www.libvips.org/API/current/method.Image.shrink.html)
   is noticeably faster
 
 - The operation cache is a lot more reliable.
 
-- [`sink_screen`](https://www.libvips.org/API/8.17/method.Image.sink_screen.html)
+- [`sink_screen`](https://www.libvips.org/API/current/method.Image.sink_screen.html)
   has better scheduling and should render thumbnails much more quickly.
 
 - The ICC operators are better at detecting and rejecting corrupt profiles.


### PR DESCRIPTION
In preparation for PR #4457. 

Also, make all links in news posts relative. Note that some of them were already relative, see e.g.:
https://github.com/libvips/libvips/blob/4b693ddde72f92a751710ea18c2bc919898614d4/_posts/2023-10-10-What's-new-in-8.15.md#L140-L146