### PR TITLE
Meson custom_target name is mandatory prior to 0.60.0

### DIFF
--- a/doc/meson.build
+++ b/doc/meson.build
@@ -59,7 +59,7 @@ vips_toml = configure_file(
 
 fixup_gir_for_doc = find_program('fixup-gir-for-doc.py')
 
-vips_gir_doc = custom_target(
+vips_gir_doc = custom_target('vips-gir-docs',
   input: vips_gir[0],
   output: 'Vips-@0@.0-doc.gir'.format(version_major),
   command: [fixup_gir_for_doc, '@INPUT@', '@OUTPUT@'],


### PR DESCRIPTION
Fixes #4558

(Targets the master branch as 8.17 branch not yet created.)