### PR TITLE
tiff: use correct log domain in threadsafe warning handlers

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -4,6 +4,7 @@ master
 
 - fix API docs build with meson < 0.60 [lovell]
 - improve function checks in meson [kleisauke]
+- tiff: use correct log domain in threadsafe warning handlers [kleisauke]
 
 5/6/25 8.17.0
 

--- a/libvips/foreign/tiff2vips.c
+++ b/libvips/foreign/tiff2vips.c
@@ -626,7 +626,8 @@ rtiff_handler_warning(TIFF *tiff, void* user_data,
 			rtiff->failed = TRUE;
 		}
 	}
-	g_logv("tiff2vips", G_LOG_LEVEL_WARNING, fmt, ap);
+
+	g_logv(G_LOG_DOMAIN, G_LOG_LEVEL_WARNING, fmt, ap);
 	return 1;
 }
 

--- a/libvips/foreign/vips2tiff.c
+++ b/libvips/foreign/vips2tiff.c
@@ -459,7 +459,7 @@ static int
 wtiff_handler_warning(TIFF *tiff, void* user_data,
 	const char *module, const char *fmt, va_list ap)
 {
-	g_logv("vips2tiff", G_LOG_LEVEL_WARNING, fmt, ap);
+	g_logv(G_LOG_DOMAIN, G_LOG_LEVEL_WARNING, fmt, ap);
 	return 1;
 }
 


### PR DESCRIPTION
This ensures that warnings emitted from these handles can still be suppressed via the `VIPS_WARNING=0` env variable.