### PR TITLE
more work on dcrawload

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,6 +1,7 @@
 master
 
-- add dcrawload: load raw camera files using libraw [lxsameer]
+- add dcrawload, dcrawload_source, dcrawload_buffer: load raw camera files
+  using libraw [lxsameer]
 
 8.17.1
 

--- a/libvips/foreign/dcrawload.c
+++ b/libvips/foreign/dcrawload.c
@@ -422,6 +422,12 @@ vips_foreign_load_dcraw_source_build(VipsObject *object)
 		->build(object);
 }
 
+static gboolean
+vips_foreign_load_dcrawload_source_is_a_source(VipsSource *source)
+{
+	return FALSE;
+}
+
 static void
 vips_foreign_load_dcraw_source_class_init(
 	VipsForeignLoadDcRawSourceClass *class)
@@ -429,6 +435,7 @@ vips_foreign_load_dcraw_source_class_init(
 	GObjectClass *gobject_class = G_OBJECT_CLASS(class);
 	VipsObjectClass *object_class = (VipsObjectClass *) class;
 	VipsOperationClass *operation_class = VIPS_OPERATION_CLASS(class);
+	VipsForeignLoadClass *load_class = (VipsForeignLoadClass *) class;
 
 	gobject_class->set_property = vips_object_set_property;
 	gobject_class->get_property = vips_object_get_property;
@@ -437,6 +444,8 @@ vips_foreign_load_dcraw_source_class_init(
 	object_class->build = vips_foreign_load_dcraw_source_build;
 
 	operation_class->flags |= VIPS_OPERATION_NOCACHE;
+
+	load_class->is_a_source = vips_foreign_load_dcrawload_source_is_a_source;
 
 	VIPS_ARG_OBJECT(class, "source", 1,
 		_("Source"),
@@ -547,18 +556,27 @@ vips_foreign_load_dcraw_buffer_build(VipsObject *object)
 		->build(object);
 }
 
+static gboolean
+vips_foreign_load_dcrawload_buffer_is_a_buffer(const void *buf, size_t len)
+{
+	return FALSE;
+}
+
 static void
 vips_foreign_load_dcraw_buffer_class_init(
 	VipsForeignLoadDcRawBufferClass *class)
 {
 	GObjectClass *gobject_class = G_OBJECT_CLASS(class);
 	VipsObjectClass *object_class = (VipsObjectClass *) class;
+	VipsForeignLoadClass *load_class = (VipsForeignLoadClass *) class;
 
 	gobject_class->set_property = vips_object_set_property;
 	gobject_class->get_property = vips_object_get_property;
 
 	object_class->nickname = "dcrawload_buffer";
 	object_class->build = vips_foreign_load_dcraw_buffer_build;
+
+	load_class->is_a_buffer = vips_foreign_load_dcrawload_buffer_is_a_buffer;
 
 	VIPS_ARG_BOXED(class, "buffer", 1,
 		_("Buffer"),

--- a/libvips/foreign/dcrawload.c
+++ b/libvips/foreign/dcrawload.c
@@ -162,6 +162,11 @@ vips_foreign_load_dcraw_set_metadata(VipsForeignLoadDcRaw *raw,
 	vips_image_set_string(image, "raw-lens",
 		raw->raw_processor->lens.Lens);
 
+	if (raw->raw_processor->color.profile)
+		vips_image_set_blob_copy(image, VIPS_META_ICC_NAME,
+			raw->raw_processor->color.profile,
+			raw->raw_processor->color.profile_length);
+
 }
 
 static int

--- a/libvips/foreign/dcrawload.c
+++ b/libvips/foreign/dcrawload.c
@@ -557,7 +557,7 @@ vips_foreign_load_dcraw_buffer_class_init(
 	gobject_class->set_property = vips_object_set_property;
 	gobject_class->get_property = vips_object_get_property;
 
-	object_class->nickname = "rawload_buffer";
+	object_class->nickname = "dcrawload_buffer";
 	object_class->build = vips_foreign_load_dcraw_buffer_build;
 
 	VIPS_ARG_BOXED(class, "buffer", 1,

--- a/libvips/foreign/dcrawload.c
+++ b/libvips/foreign/dcrawload.c
@@ -154,14 +154,13 @@ vips_foreign_load_dcraw_set_metadata(VipsForeignLoadDcRaw *raw,
 		g_date_time_unref(dt);
 	}
 
-	if (raw->raw_processor->idata.xmpdata) {
-		unsigned int len = raw->raw_processor->idata.xmplen;
-		char *data = vips_malloc(image, len);
+	if (raw->raw_processor->idata.xmpdata)
+		vips_image_set_blob_copy(image, VIPS_META_XMP_NAME,
+			raw->raw_processor->idata.xmpdata,
+			raw->raw_processor->idata.xmplen);
 
-		memcpy(data, raw->raw_processor->idata.xmpdata, len);
-		vips_image_set_blob(image, VIPS_META_XMP_NAME,
-			(VipsCallbackFn) g_free, data, len);
-	}
+	vips_image_set_string(image, "raw-lens",
+		raw->raw_processor->lens.Lens);
 
 }
 

--- a/libvips/foreign/dcrawload.c
+++ b/libvips/foreign/dcrawload.c
@@ -130,6 +130,8 @@ vips_foreign_load_dcraw_set_metadata(VipsForeignLoadDcRaw *raw,
 		raw->raw_processor->idata.make);
 	vips_image_set_string(image, "raw-model",
 		raw->raw_processor->idata.model);
+	vips_image_set_string(image, "raw-software",
+		raw->raw_processor->idata.software);
 	vips_image_set_double(image, "raw-iso",
 		raw->raw_processor->other.iso_speed);
 	vips_image_set_double(image, "raw-shutter",
@@ -151,6 +153,16 @@ vips_foreign_load_dcraw_set_metadata(VipsForeignLoadDcRaw *raw,
 
 		g_date_time_unref(dt);
 	}
+
+	if (raw->raw_processor->idata.xmpdata) {
+		unsigned int len = raw->raw_processor->idata.xmplen;
+		char *data = vips_malloc(image, len);
+
+		memcpy(data, raw->raw_processor->idata.xmpdata, len);
+		vips_image_set_blob(image, VIPS_META_XMP_NAME,
+			(VipsCallbackFn) g_free, data, len);
+	}
+
 }
 
 static int
@@ -202,7 +214,9 @@ vips_foreign_load_dcraw_header(VipsForeignLoad *load)
 	}
 
 	vips_image_init_fields(load->out,
-		raw->raw_processor->sizes.iwidth, raw->raw_processor->sizes.iheight, 3,
+		raw->raw_processor->sizes.iwidth,
+		raw->raw_processor->sizes.iheight,
+		raw->raw_processor->idata.colors,
 		raw->bitdepth > 8 ?
 			VIPS_FORMAT_USHORT : VIPS_FORMAT_UCHAR,
 		VIPS_CODING_NONE,

--- a/libvips/foreign/foreign.c
+++ b/libvips/foreign/foreign.c
@@ -3065,6 +3065,8 @@ vips_foreign_operation_init(void)
 	extern GType vips_foreign_save_cgif_target_get_type(void);
 
 	extern GType vips_foreign_load_dcraw_file_get_type(void);
+	extern GType vips_foreign_load_dcraw_buffer_get_type(void);
+	extern GType vips_foreign_load_dcraw_source_get_type(void);
 
 	vips_foreign_load_csv_file_get_type();
 	vips_foreign_load_csv_source_get_type();
@@ -3156,6 +3158,8 @@ vips_foreign_operation_init(void)
 
 #ifdef HAVE_LIBRAW
 	vips_foreign_load_dcraw_file_get_type();
+	vips_foreign_load_dcraw_buffer_get_type();
+	vips_foreign_load_dcraw_source_get_type();
 #endif /*HAVE_LIBRAW*/
 
 #ifdef HAVE_CGIF

--- a/libvips/include/vips/foreign.h
+++ b/libvips/include/vips/foreign.h
@@ -878,6 +878,12 @@ int vips_gifsave_target(VipsImage *in, VipsTarget *target, ...)
 VIPS_API
 int vips_dcrawload(const char *filename, VipsImage **out, ...)
 	G_GNUC_NULL_TERMINATED;
+VIPS_API
+int vips_dcrawload_source(VipsSource *source, VipsImage **out, ...)
+	G_GNUC_NULL_TERMINATED;
+VIPS_API
+int vips_dcrawload_buffer(void *buf, size_t len, VipsImage **out, ...)
+	G_GNUC_NULL_TERMINATED;
 
 VIPS_API
 int vips_heifload(const char *filename, VipsImage **out, ...)

--- a/libvips/include/vips/foreign.h
+++ b/libvips/include/vips/foreign.h
@@ -879,10 +879,10 @@ VIPS_API
 int vips_dcrawload(const char *filename, VipsImage **out, ...)
 	G_GNUC_NULL_TERMINATED;
 VIPS_API
-int vips_dcrawload_source(VipsSource *source, VipsImage **out, ...)
+int vips_dcrawload_buffer(void *buf, size_t len, VipsImage **out, ...)
 	G_GNUC_NULL_TERMINATED;
 VIPS_API
-int vips_dcrawload_buffer(void *buf, size_t len, VipsImage **out, ...)
+int vips_dcrawload_source(VipsSource *source, VipsImage **out, ...)
 	G_GNUC_NULL_TERMINATED;
 
 VIPS_API


### PR DESCRIPTION
libraw has a buffer and a file interface. If you use the file interface, it's able to read secondary files and extract more metadata.

TODO

- [x] add `dcrawload_source` and `_buffer`
- [ ] tests and a sample file
- [x] support more metadata
- [x] add options for bitdepth and whitebalance control, others?
- [x] thumbnail support