### PR TITLE
tiffsave: always apply resolution unit conversion

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -7,6 +7,7 @@ master
 - tiff: use correct log domain in threadsafe warning handlers [kleisauke]
 - shift 16-bit output down to 8-bit when unsupported by saver [kleisauke]
 - text: prevent use of rgba subpixel anti-aliasing [lovell]
+- tiffsave: always apply resolution unit conversion [kleisauke]
 
 5/6/25 8.17.0
 

--- a/libvips/foreign/tiffsave.c
+++ b/libvips/foreign/tiffsave.c
@@ -186,22 +186,21 @@ vips_foreign_save_tiff_build(VipsObject *object)
 		vips_isprefix("in", p))
 		resunit = VIPS_FOREIGN_TIFF_RESUNIT_INCH;
 
-	double xres;
-	xres = ready->Xres;
-	if (vips_object_argument_isset(object, "xres")) {
-		if (resunit == VIPS_FOREIGN_TIFF_RESUNIT_INCH)
-			xres = tiff->xres * 25.4;
-		else
-			xres = tiff->xres * 10.0;
-	}
+	double xres = vips_object_argument_isset(object, "xres")
+		? tiff->xres
+		: ready->Xres;
 
-	double yres;
-	yres = ready->Yres;
-	if (vips_object_argument_isset(object, "yres")) {
-		if (resunit == VIPS_FOREIGN_TIFF_RESUNIT_INCH)
-			yres = tiff->yres * 25.4;
-		else
-			yres = tiff->yres * 10.0;
+	double yres = vips_object_argument_isset(object, "yres")
+		? tiff->yres
+		: ready->Yres;
+
+	if (tiff->resunit == VIPS_FOREIGN_TIFF_RESUNIT_INCH) {
+		xres *= 25.4;
+		yres *= 25.4;
+	}
+	else {
+		xres *= 10.0;
+		yres *= 10.0;
 	}
 
 	if (vips__tiff_write_target(ready, tiff->target,


### PR DESCRIPTION
Originally reported at https://github.com/kleisauke/net-vips/issues/257.

Reproducer:
```python
#!/usr/bin/env python3
import pyvips

dpi = 300 / 25.4

im = pyvips.Image.Black(2560, 3300, bands=1).Copy(xres=dpi, yres=dpi)
im.tiffsave('x.tiff', resunit='inch')
```

Expected:
```console
$ tiffinfo x.tiff | grep pixels
  Resolution: 300, 300 pixels/inch
```

Actual:
```console
$ tiffinfo x.tiff | grep pixels
  Resolution: 11.811, 11.811 pixels/inch
```

Regressed since 22f68e86f5a4f902ecfa022dc6525e293e90dbbf.
Targets the 8.17 branch.