### PR TITLE
semaphore: simplify `GCond` initialization

### DIFF
--- a/libvips/include/vips/semaphore.h
+++ b/libvips/include/vips/semaphore.h
@@ -53,11 +53,7 @@ typedef struct {
 	int v;
 
 	GMutex mutex;
-
-	/* FIXME: sizeof(GCond) != sizeof(GCond *)
-	 * https://gitlab.gnome.org/GNOME/glib/-/issues/1256
-	 */
-	GCond *cond;
+	GCond cond;
 } VipsSemaphore;
 
 VIPS_API


### PR DESCRIPTION
This member is marked as `/*< private >*/` and is never allocated statically or on the stack, something the API disallows anyway. Therefore, we can simply use `GCond` directly here.

The `abi-compliance-checker` results are available at:
https://kleisauke.nl/compat_reports/vips/master_to_semaphore-simplify-gcond-init/compat_report.html

Context: https://github.com/libvips/libvips/pull/4249#issuecomment-2740143439.