### PR TITLE
add magickload_source

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -2,6 +2,7 @@ master
 
 - add dcrawload, dcrawload_source, dcrawload_buffer: load raw camera files
   using libraw [lxsameer]
+- add magickload_source: load from a source with imagemagick
 
 8.17.1
 

--- a/libvips/foreign/foreign.c
+++ b/libvips/foreign/foreign.c
@@ -3000,8 +3000,10 @@ vips_foreign_operation_init(void)
 
 	extern GType vips_foreign_load_magick_file_get_type(void);
 	extern GType vips_foreign_load_magick_buffer_get_type(void);
+	extern GType vips_foreign_load_magick_source_get_type(void);
 	extern GType vips_foreign_load_magick7_file_get_type(void);
 	extern GType vips_foreign_load_magick7_buffer_get_type(void);
+	extern GType vips_foreign_load_magick7_source_get_type(void);
 
 	extern GType vips_foreign_save_magick_file_get_type(void);
 	extern GType vips_foreign_save_magick_buffer_get_type(void);
@@ -3234,11 +3236,13 @@ vips_foreign_operation_init(void)
 #ifdef HAVE_MAGICK6
 	vips_foreign_load_magick_file_get_type();
 	vips_foreign_load_magick_buffer_get_type();
+	vips_foreign_load_magick_source_get_type();
 #endif /*HAVE_MAGICK6*/
 
 #ifdef HAVE_MAGICK7
 	vips_foreign_load_magick7_file_get_type();
 	vips_foreign_load_magick7_buffer_get_type();
+	vips_foreign_load_magick7_source_get_type();
 #endif /*HAVE_MAGICK7*/
 #endif /*defined(ENABLE_MAGICKLOAD) && !defined(MAGICK_MODULE)*/
 

--- a/libvips/foreign/magick6load.c
+++ b/libvips/foreign/magick6load.c
@@ -1120,15 +1120,15 @@ vips_foreign_load_magick_source_header(VipsForeignLoad *load)
 		const char *filename =
 			vips_connection_filename(VIPS_CONNECTION(magick_source->source));
 
-		g_strlcpy(magick7->image_info->filename, filename, MagickPathExtent);
-		magick_sniff_file(magick7->image_info, filename);
-		magick7->image = ReadImage(magick7->image_info, magick7->exception);
+		g_strlcpy(magick->image_info->filename, filename, MagickPathExtent);
+		magick_sniff_file(magick->image_info, filename);
+		magick->image = ReadImage(magick->image_info, magick->exception);
 	}
 	else {
 		size_t length;
 		const void *data;
 
-		if (!(data = vips_source_map(raw->source, &length)))
+		if (!(data = vips_source_map(magick_source->source, &length)))
 			return -1;
 		magick_sniff_bytes(magick->image_info, data, length);
 		magick->image = BlobToImage(magick->image_info,

--- a/libvips/foreign/magick6load.c
+++ b/libvips/foreign/magick6load.c
@@ -1074,6 +1074,102 @@ vips_foreign_load_magick_buffer_init(VipsForeignLoadMagickBuffer *buffer)
 {
 }
 
+typedef struct _VipsForeignLoadMagickSource {
+	VipsForeignLoadMagick parent_object;
+
+	VipsSource *source;
+
+} VipsForeignLoadMagickSource;
+
+typedef VipsForeignLoadMagickClass VipsForeignLoadMagickSourceClass;
+
+G_DEFINE_TYPE(VipsForeignLoadMagickSource, vips_foreign_load_magick_source,
+	vips_foreign_load_magick_get_type());
+
+static gboolean
+vips_foreign_load_magick_source_is_a_source(VipsSource *source)
+{
+	const unsigned char *p;
+
+	// just use the first 100 byes, we don't want to force too much into
+	// memory
+	return (p = vips_source_sniff(source, 100)) &&
+		magick_ismagick(p, 100);
+}
+
+/* Unfortunately, libMagick does not support header-only reads very well. See
+ *
+ * http://www.imagemagick.org/discourse-server/viewtopic.php?f=1&t=20017
+ *
+ * Test especially with BMP, GIF, TGA. So we are forced to read the entire
+ * image in the @header() method.
+ */
+static int
+vips_foreign_load_magick_source_header(VipsForeignLoad *load)
+{
+	VipsForeignLoadMagick *magick = (VipsForeignLoadMagick *) load;
+	VipsForeignLoadMagickSource *magick_source =
+		(VipsForeignLoadMagickSource *) load;
+	VipsObjectClass *class = VIPS_OBJECT_GET_CLASS(magick);
+
+#ifdef DEBUG
+	printf("vips_foreign_load_magick_source_header: %p\n", load);
+#endif /*DEBUG*/
+
+	size_t length;
+	const void *data;
+	if (!(data = vips_source_map(magick_source->source, &length)))
+		return -1;
+
+	/* It would be great if we could PingImage and just read the header,
+	 * but sadly many IM coders do not support ping. The critical one for
+	 * us is DICOM. TGA also has issues.
+	 */
+	magick_sniff_bytes(magick->image_info, data, length);
+	magick->image = BlobToImage(magick->image_info,
+		data, length, magick->exception);
+	if (!magick->image) {
+		magick_vips_error(class->nickname, magick->exception);
+		vips_error(class->nickname, _("unable to read source"));
+		return -1;
+	}
+
+	if (vips_foreign_load_magick_load(magick))
+		return -1;
+
+	return 0;
+}
+
+static void
+vips_foreign_load_magick_source_class_init(
+	VipsForeignLoadMagickSourceClass *class)
+{
+	GObjectClass *gobject_class = G_OBJECT_CLASS(class);
+	VipsObjectClass *object_class = (VipsObjectClass *) class;
+	VipsForeignLoadClass *load_class = (VipsForeignLoadClass *) class;
+
+	gobject_class->set_property = vips_object_set_property;
+	gobject_class->get_property = vips_object_get_property;
+
+	object_class->nickname = "magickload_source";
+	object_class->description = _("load source with ImageMagick");
+
+	load_class->is_a_source = vips_foreign_load_magick_source_is_a_source;
+	load_class->header = vips_foreign_load_magick_source_header;
+
+	VIPS_ARG_OBJECT(class, "source", 1,
+		_("Source"),
+		_("Source to load from"),
+		VIPS_ARGUMENT_REQUIRED_INPUT,
+		G_STRUCT_OFFSET(VipsForeignLoadMagickSource, source),
+		VIPS_TYPE_SOURCE);
+}
+
+static void
+vips_foreign_load_magick_source_init(VipsForeignLoadMagickSource *source)
+{
+}
+
 #endif /*HAVE_MAGICK6*/
 
 #endif /*ENABLE_MAGICKLOAD*/

--- a/libvips/foreign/magickload.c
+++ b/libvips/foreign/magickload.c
@@ -156,3 +156,35 @@ vips_magickload_buffer(void *buf, size_t len, VipsImage **out, ...)
 
 	return result;
 }
+
+/**
+ * vips_magickload_source:
+ * @source: source to load
+ * @out: (out): image to write
+ * @...: `NULL`-terminated list of optional named arguments
+ *
+ * Exactly as [ctor@Image.magickload], but read from a source.
+ *
+ * ::: tip "Optional arguments"
+ *     * @page: `gint`, load from this page
+ *     * @n: `gint`, load this many pages
+ *     * @density: `gchararray`, canvas resolution for rendering vector formats
+ *       like SVG
+ *
+ * ::: seealso
+ *     [ctor@Image.magickload].
+ *
+ * Returns: 0 on success, -1 on error.
+ */
+int
+vips_magickload_source(VipsSource *source, VipsImage **out, ...)
+{
+	va_list ap;
+	int result;
+
+	va_start(ap, out);
+	result = vips_call_split("magickload_source", ap, source, out);
+	va_end(ap);
+
+	return result;
+}

--- a/libvips/include/vips/foreign.h
+++ b/libvips/include/vips/foreign.h
@@ -716,6 +716,9 @@ VIPS_API
 int vips_magickload_buffer(void *buf, size_t len, VipsImage **out, ...)
 	G_GNUC_NULL_TERMINATED;
 VIPS_API
+int vips_magickload_source(VipsSource *source, VipsImage **out, ...)
+	G_GNUC_NULL_TERMINATED;
+VIPS_API
 int vips_magicksave(VipsImage *in, const char *filename, ...)
 	G_GNUC_NULL_TERMINATED;
 VIPS_API

--- a/libvips/module/magick.c
+++ b/libvips/module/magick.c
@@ -60,8 +60,10 @@ g_module_check_init(GModule *module)
 
 	extern GType vips_foreign_load_magick_file_get_type(void);
 	extern GType vips_foreign_load_magick_buffer_get_type(void);
+	extern GType vips_foreign_load_magick_source_get_type(void);
 	extern GType vips_foreign_load_magick7_file_get_type(void);
 	extern GType vips_foreign_load_magick7_buffer_get_type(void);
+	extern GType vips_foreign_load_magick7_source_get_type(void);
 	extern GType vips_foreign_save_magick_file_get_type(void);
 	extern GType vips_foreign_save_magick_bmp_file_get_type(void);
 	extern GType vips_foreign_save_magick_buffer_get_type(void);
@@ -71,11 +73,13 @@ g_module_check_init(GModule *module)
 #ifdef HAVE_MAGICK6
 	vips_foreign_load_magick_file_get_type();
 	vips_foreign_load_magick_buffer_get_type();
+	vips_foreign_load_magick_source_get_type();
 #endif /*HAVE_MAGICK6*/
 
 #ifdef HAVE_MAGICK7
 	vips_foreign_load_magick7_file_get_type();
 	vips_foreign_load_magick7_buffer_get_type();
+	vips_foreign_load_magick7_source_get_type();
 #endif /*HAVE_MAGICK7*/
 #endif /*ENABLE_MAGICKLOAD*/
 

--- a/test/test-suite/test_foreign.py
+++ b/test/test-suite/test_foreign.py
@@ -806,6 +806,9 @@ class TestForeign:
 
         self.file_loader("magickload", BMP_FILE, bmp_valid)
         self.buffer_loader("magickload_buffer", BMP_FILE, bmp_valid)
+        source = pyvips.Source.new_from_file(BMP_FILE)
+        x = pyvips.Image.new_from_source(source, "")
+        bmp_valid(x)
 
         # we should have rgb or rgba for svg files ... different versions of
         # IM handle this differently. GM even gives 1 band.
@@ -877,10 +880,11 @@ class TestForeign:
         assert im.width == 433
         assert im.height == 433
 
-
         # load should see metadata like eg. icc profiles
         im = pyvips.Image.magickload(JPEG_FILE)
         assert len(im.get("icc-profile-data")) == 564
+
+        im = pyvips.Image.magickload(JPEG_FILE)
 
     # added in 8.7
     @skip_if_no("magicksave")


### PR DESCRIPTION
test with eg.:

```
$ cat MARBLES.BMP | vips magickload_source "[descriptor=0]" x.v
$ cat MARBLES.BMP | vipsthumbnail stdin -o x.jpg
```

ImageMagick doesn't support generic IO, so it just maps the source into memory and uses the buffer interface.

magick6 and magick7.

See https://github.com/libvips/libvips/issues/4530