### PR TITLE
cache: suppress invalidation errors in release builds

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -8,6 +8,7 @@ master
 - shift 16-bit output down to 8-bit when unsupported by saver [kleisauke]
 - text: prevent use of rgba subpixel anti-aliasing [lovell]
 - tiffsave: always apply resolution unit conversion [kleisauke]
+- cache: suppress invalidation errors in release builds [kleisauke]
 
 5/6/25 8.17.0
 

--- a/libvips/iofuncs/cache.c
+++ b/libvips/iofuncs/cache.c
@@ -890,6 +890,7 @@ vips_cache_operation_buildp(VipsOperation **operation)
 	 * it to the cache, if appropriate.
 	 */
 	if (!hit) {
+#ifdef DEBUG_LEAK
 		unsigned int hash_before = 0;
 		VipsOperation *operation_before = NULL;
 
@@ -900,10 +901,12 @@ vips_cache_operation_buildp(VipsOperation **operation)
 			hash_before = vips_operation_hash(*operation);
 			operation_before = vips_operation_copy(*operation);
 		}
+#endif /*DEBUG_LEAK*/
 
 		if (vips_object_build(VIPS_OBJECT(*operation)))
 			return -1;
 
+#ifdef DEBUG_LEAK
 		if (vips__leak &&
 			!(flags & VIPS_OPERATION_NOCACHE) &&
 			hash_before != vips_operation_hash(*operation)) {
@@ -929,6 +932,7 @@ vips_cache_operation_buildp(VipsOperation **operation)
 		}
 
 		VIPS_UNREF(operation_before);
+#endif /*DEBUG_LEAK*/
 
 		/* Retrieve the flags again, as vips_foreign_load_build() may
 		 * set load->nocache.


### PR DESCRIPTION
These diagnostics are only useful during development and debugging.

See: #4595.
Targets the 8.17 branch.