### PR TITLE
Fix `-Wunused-function` warning

### DIFF
--- a/libvips/iofuncs/cache.c
+++ b/libvips/iofuncs/cache.c
@@ -456,6 +456,7 @@ vips_operation_copy_argument(VipsObject *object,
 	return NULL;
 }
 
+#ifdef DEBUG_LEAK
 static VipsOperation *
 vips_operation_copy(VipsOperation *operation)
 {
@@ -467,6 +468,7 @@ vips_operation_copy(VipsOperation *operation)
 
 	return new;
 }
+#endif /*DEBUG_LEAK*/
 
 static void *
 vips_object_unref_arg(VipsObject *object,

--- a/libvips/iofuncs/cache.c
+++ b/libvips/iofuncs/cache.c
@@ -431,6 +431,7 @@ vips_operation_equal(VipsOperation *a, VipsOperation *b)
 	return FALSE;
 }
 
+#ifdef DEBUG_LEAK
 static void *
 vips_operation_copy_argument(VipsObject *object,
 	GParamSpec *pspec,
@@ -456,7 +457,6 @@ vips_operation_copy_argument(VipsObject *object,
 	return NULL;
 }
 
-#ifdef DEBUG_LEAK
 static VipsOperation *
 vips_operation_copy(VipsOperation *operation)
 {


### PR DESCRIPTION
Trivial backport of ee262ff45d1fc870e38091e04d0861537f0e302c to [`8.17`](https://github.com/libvips/libvips/tree/8.17), plus extended to guard `vips_operation_copy_argument()` as well.

Note: rebase merge, don't squash.