### PR TITLE
Fix pdfiumload.c vips_foreign_load_pdf_generate()

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -3,6 +3,7 @@ master
 - add dcrawload, dcrawload_source, dcrawload_buffer: load raw camera files
   using libraw [lxsameer]
 - add magickload_source: load from a source with imagemagick
+- fix pdfiumload.c vips_foreign_load_pdf_generate(): crash risk when pdfium < 6633 [daniel]
 
 8.17.1
 

--- a/libvips/foreign/pdfiumload.c
+++ b/libvips/foreign/pdfiumload.c
@@ -582,6 +582,11 @@ vips_foreign_load_pdf_generate(VipsRegion *out_region,
 	 */
 	vips_region_black(out_region);
 
+    /*
+     * Same with popperload
+     */
+    vips_region_paint_pel(out_region, r, pdf->ink);
+
 	top = r->top;
 	while (top < VIPS_RECT_BOTTOM(r)) {
 		VipsRect rect;
@@ -592,39 +597,43 @@ vips_foreign_load_pdf_generate(VipsRegion *out_region,
 		if (vips_foreign_load_pdf_get_page(pdf, pdf->page_no + i))
 			return -1;
 
-		vips__worker_lock(&vips_pdfium_mutex);
+        if (rect.width > 0 && rect.height > 0) {
+            // Ensure rect not empty
 
-		/* 4 means RGBA.
-		 */
-		bitmap = FPDFBitmap_CreateEx(rect.width, rect.height, 4,
-			VIPS_REGION_ADDR(out_region, rect.left, rect.top),
-			VIPS_REGION_LSKIP(out_region));
+            vips__worker_lock(&vips_pdfium_mutex);
 
-		/* Only paint the background if there's no transparency.
-		 */
-		if (!FPDFPage_HasTransparency(pdf->page)) {
-			FPDF_DWORD ink = *((guint32 *) pdf->ink);
+            /* 4 means RGBA.
+             */
+            bitmap = FPDFBitmap_CreateEx(rect.width, rect.height, 4,
+                VIPS_REGION_ADDR(out_region, rect.left, rect.top),
+                VIPS_REGION_LSKIP(out_region));
 
-			FPDFBitmap_FillRect(bitmap,
-				0, 0, rect.width, rect.height, ink);
-		}
+            /* Only paint the background if there's no transparency.
+             */
+            if (!FPDFPage_HasTransparency(pdf->page)) {
+                FPDF_DWORD ink = *((guint32 *) pdf->ink);
 
-		// pdfium writes bgra by default, we need rgba
-		FPDF_RenderPageBitmap(bitmap, pdf->page,
-			pdf->pages[i].left - rect.left,
-			pdf->pages[i].top - rect.top,
-			pdf->pages[i].width, pdf->pages[i].height,
-			0, FPDF_ANNOT | FPDF_REVERSE_BYTE_ORDER);
+                FPDFBitmap_FillRect(bitmap,
+                    0, 0, rect.width, rect.height, ink);
+            }
 
-		FPDF_FFLDraw(pdf->form, bitmap, pdf->page,
-			pdf->pages[i].left - rect.left,
-			pdf->pages[i].top - rect.top,
-			pdf->pages[i].width, pdf->pages[i].height,
-			0, FPDF_ANNOT | FPDF_REVERSE_BYTE_ORDER);
+            // pdfium writes bgra by default, we need rgba
+            FPDF_RenderPageBitmap(bitmap, pdf->page,
+                pdf->pages[i].left - rect.left,
+                pdf->pages[i].top - rect.top,
+                pdf->pages[i].width, pdf->pages[i].height,
+                0, FPDF_ANNOT | FPDF_REVERSE_BYTE_ORDER);
 
-		FPDFBitmap_Destroy(bitmap);
+            FPDF_FFLDraw(pdf->form, bitmap, pdf->page,
+                pdf->pages[i].left - rect.left,
+                pdf->pages[i].top - rect.top,
+                pdf->pages[i].width, pdf->pages[i].height,
+                0, FPDF_ANNOT | FPDF_REVERSE_BYTE_ORDER);
 
-		g_mutex_unlock(&vips_pdfium_mutex);
+            FPDFBitmap_Destroy(bitmap);
+
+            g_mutex_unlock(&vips_pdfium_mutex);
+        }
 
 		top += rect.height;
 		i += 1;


### PR DESCRIPTION
- Fix pdfiumload.c vips_foreign_load_pdf_generate(). Inconsistent PDF page dimensions (varying width/height) may generate empty Bitmaps, leading to crashes in PDFium versions prior to 6633.

- Draw a background color on outRegion to maintain consistency with Poppler's rendering behavior.