### PR TITLE
add vips__worker_exit

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -3,6 +3,7 @@ master
 - add dcrawload, dcrawload_source, dcrawload_buffer: load raw camera files
   using libraw [lxsameer]
 - add magickload_source: load from a source with imagemagick
+- add vips__worker_exit(): enables fast threadpool shutdown
 
 8.17.1
 

--- a/libvips/conversion/subsample.c
+++ b/libvips/conversion/subsample.c
@@ -53,6 +53,7 @@
 #include <stdlib.h>
 
 #include <vips/vips.h>
+#include <vips/internal.h>
 
 #include "pconversion.h"
 
@@ -102,7 +103,10 @@ vips_subsample_line_gen(VipsRegion *out_region,
 		VipsPel *q = VIPS_REGION_ADDR(out_region, le, y);
 		VipsPel *p;
 
-		/* Loop across the region, in owidth sized pieces.
+		if (vips__worker_exit())
+			return 0;
+
+		/* Loop across the region, in owidth-sized pieces.
 		 */
 		for (x = le; x < ri; x += owidth) {
 			/* How many pixels do we make this time?
@@ -165,11 +169,10 @@ vips_subsample_point_gen(VipsRegion *out_region,
 		VipsPel *q = VIPS_REGION_ADDR(out_region, le, y);
 		VipsPel *p;
 
-		/* Loop across the region, in owidth sized pieces.
-		 */
+		if (vips__worker_exit())
+			return 0;
+
 		for (x = le; x < ri; x++) {
-			/* Ask for input.
-			 */
 			s.left = x * subsample->xfac;
 			s.top = y * subsample->yfac;
 			s.width = 1;
@@ -177,8 +180,6 @@ vips_subsample_point_gen(VipsRegion *out_region,
 			if (vips_region_prepare(ir, &s))
 				return -1;
 
-			/* Append new pels to output.
-			 */
 			p = VIPS_REGION_ADDR(ir, s.left, s.top);
 			for (k = 0; k < ps; k++)
 				q[k] = p[k];

--- a/libvips/include/vips/internal.h
+++ b/libvips/include/vips/internal.h
@@ -166,6 +166,7 @@ void vips_threadset_free(VipsThreadset *set);
 
 VIPS_API void vips__worker_lock(GMutex *mutex);
 VIPS_API void vips__worker_cond_wait(GCond *cond, GMutex *mutex);
+gboolean vips__worker_exit(void);
 
 void vips__cache_init(void);
 

--- a/libvips/include/vips/threadpool.h
+++ b/libvips/include/vips/threadpool.h
@@ -96,7 +96,6 @@ typedef struct _VipsThreadState {
 	 * debugging race conditions.
 	 */
 	gboolean stall;
-
 } VipsThreadState;
 
 typedef struct _VipsThreadStateClass {

--- a/libvips/iofuncs/sinkscreen.c
+++ b/libvips/iofuncs/sinkscreen.c
@@ -115,10 +115,10 @@ typedef struct _Render {
 
 	/* Parameters.
 	 */
-	VipsImage *in;	 /* Image we render */
-	VipsImage *out;	 /* Write tiles here on demand */
-	VipsImage *mask; /* Set valid pixels here */
-	int tile_width;	 /* Tile size */
+	VipsImage *in;			/* Image we render */
+	VipsImage *out;			/* Write tiles here on demand */
+	VipsImage *mask;		/* Set valid pixels here */
+	int tile_width;			/* Tile size */
 	int tile_height;
 	int max_tiles;		   /* Maximum number of tiles */
 	int priority;		   /* Larger numbers done sooner */
@@ -139,9 +139,9 @@ typedef struct _Render {
 
 	/* Tile cache.
 	 */
-	GSList *all; /* All our tiles */
-	int ntiles;	 /* Number of tiles */
-	int ticks;	 /* Inc. on each access ... used for LRU */
+	GSList *all;			/* All our tiles */
+	int ntiles;				/* Number of tiles */
+	int ticks;				/* Inc. on each access ... used for LRU */
 
 	/* List of dirty tiles. Most recent at the front.
 	 */
@@ -193,6 +193,21 @@ static VipsSemaphore n_render_dirty_sem;
 /* Set this to make the bg thread stop and reschedule.
  */
 static gboolean render_reschedule = FALSE;
+
+/* Set this GPrivate to link a thread back to its Render struct.
+ */
+static GPrivate render_worker_key;
+
+gboolean
+vips__worker_exit(void)
+{
+	Render *render = (Render *) g_private_get(&render_worker_key);
+
+	if (render && render->shutdown)
+		printf("vips__worker_exit: early exit for render %p\n", render);
+
+	return render && render->shutdown;
+}
 
 static void
 render_thread_state_class_init(RenderThreadStateClass *class)
@@ -269,6 +284,7 @@ render_free(Render *render)
 
 #ifdef VIPS_DEBUG_AMBER
 	render_num_renders -= 1;
+	printf("%d active renders\n", render_num_renders);
 #endif /*VIPS_DEBUG_AMBER*/
 
 	return 0;
@@ -295,7 +311,7 @@ render_ref(Render *render)
 static int
 render_unref(Render *render)
 {
-	int kill;
+	gboolean kill;
 
 #if GLIB_CHECK_VERSION(2, 58, 0)
 	g_assert(!g_atomic_ref_count_compare(&render->ref_count, 0));
@@ -426,10 +442,16 @@ render_work(VipsThreadState *state, void *a)
 	VIPS_DEBUG_MSG("calculating tile %p %dx%d\n",
 		tile, tile->area.left, tile->area.top);
 
+	/* vips__worker_exit() uses this to find the render to check for
+	 * shutdown.
+	 */
+	g_private_set(&render_worker_key, render);
+
 	if (vips_region_prepare_to(state->reg, tile->region,
 			&tile->area, tile->area.left, tile->area.top)) {
 		VIPS_DEBUG_MSG_RED("render_work: vips_region_prepare_to() failed: %s\n",
 			vips_error_buffer());
+		g_private_set(&render_worker_key, NULL);
 		return -1;
 	}
 	tile->painted = TRUE;
@@ -437,6 +459,8 @@ render_work(VipsThreadState *state, void *a)
 	if (!render->shutdown &&
 		render->notify)
 		render->notify(render->out, &tile->area, render->a);
+
+	g_private_set(&render_worker_key, NULL);
 
 	return 0;
 }
@@ -620,6 +644,7 @@ render_new(VipsImage *in, VipsImage *out, VipsImage *mask,
 
 #ifdef VIPS_DEBUG_AMBER
 	render_num_renders += 1;
+	printf("%d active renders\n", render_num_renders);
 #endif /*VIPS_DEBUG_AMBER*/
 
 	return render;
@@ -1094,6 +1119,11 @@ render_work_private(void *data, void *null)
 
 	Render *render = (Render *) data;
 
+	/* vips__worker_exit() uses this to find the render to check for
+	 * shutdown.
+	 */
+	g_private_set(&render_worker_key, render);
+
 	// this will quit on ->shutdown == TRUE
 	if (vips_threadpool_run(render->in,
 			render_thread_state_new,
@@ -1102,6 +1132,8 @@ render_work_private(void *data, void *null)
 			NULL,
 			render))
 		VIPS_DEBUG_MSG_RED("render_work_private: threadpool_run failed\n");
+
+	g_private_set(&render_worker_key, NULL);
 
 	render_unref(render);
 
@@ -1144,11 +1176,11 @@ vips__sink_screen_once(void *data)
  * uchar image and has 255 for pixels which are currently in cache and 0
  * for uncalculated pixels.
  *
- * Renders with a positive priority are assumed to be large, gh-priority,
+ * Renders with a positive priority are assumed to be large, high-priority,
  * foreground images. Although there can be many of these, only one is ever
  * active, to avoid overcommitting threads.
  *
- * Renders with a negative priority are assumed to be small, thumbnail images
+ * Renders with a negative priority are assumed to be small, thumbnail images,
  * consisting of a single tile. Single tile images are effectively
  * single-threaded, so all these renders are evaluated together.
  *

--- a/libvips/iofuncs/threadpool.c
+++ b/libvips/iofuncs/threadpool.c
@@ -379,8 +379,6 @@ vips_thread_main_loop(void *a, void *b)
 	VipsWorker *worker = (VipsWorker *) a;
 	VipsThreadpool *pool = worker->pool;
 
-	g_assert(pool == worker->pool);
-
 	VIPS_GATE_START("vips_thread_main_loop: thread");
 
 	g_private_set(&worker_key, worker);
@@ -481,9 +479,6 @@ vips_threadpool_wait(VipsThreadpool *pool)
 static void
 vips_threadpool_free(VipsThreadpool *pool)
 {
-	VIPS_DEBUG_MSG("vips_threadpool_free: \"%s\" (%p)\n",
-		pool->im->filename, pool);
-
 	vips_threadpool_wait(pool);
 
 	g_mutex_clear(&pool->allocate_lock);
@@ -531,9 +526,6 @@ vips_threadpool_new(VipsImage *im)
 	 * concurrency.
 	 */
 	pool->max_workers = vips_image_get_concurrency(im, pool->max_workers);
-
-	VIPS_DEBUG_MSG("vips_threadpool_new: \"%s\" (%p), with %d threads\n",
-		im->filename, pool, pool->max_workers);
 
 	return pool;
 }


### PR DESCRIPTION
In interactive applications it's important to be able to shut down pipelines which are no longer needed as quickly as possible.

Right now, shutdown can be very slow. For example, vips_subsample() on a large image can maybe take 1 or 2 seconds per tile, so it can take 1 or 2 seconds between the start of shutdown and the exit of any threads. If the user is updating the operation graph faster than that, pipelines will start to back up and the system will lag badly.

This PR adds vips__worker_exit(), a fast test-for-shutdown that operations can call in their generate function.

It adds vips__worker_exit() to vips_subsample() and successfully stops pipelines lagging for nip4 previews. Some other slow operations should probably have calls added too (shrink, reduce, conv, perhaps others), but they can be added later as required.