### PR TITLE
Update ChangeLog ahead of v8.17.1

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,6 +1,4 @@
-master
-
-8.17.1
+7/7/25 8.17.1
 
 - fix API docs build with meson < 0.60 [lovell]
 - improve function checks in meson [kleisauke]


### PR DESCRIPTION
I think it's time for a formal patch release.

We might also consider including a variant of PR #4599 in v8.17.1, although I think most users are already using the latest PDFium releases, i.e. similar to our approach in OSS-Fuzz:
https://github.com/google/oss-fuzz/blob/76d5d6351e09fc2a9da9e057001cd5daecb1b6a2/projects/libvips/Dockerfile#L37