### PR TITLE
use much larger mmap windows

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -3,7 +3,8 @@ master
 - add dcrawload, dcrawload_source, dcrawload_buffer: load raw camera files
   using libraw [lxsameer]
 - add magickload_source: load from a source with imagemagick
-- improve random access mode for many file formats by adding fully mapped images
+- larger mmap windows on 64-bit machines improve random access mode for many
+  file formats
 
 8.17.1
 

--- a/ChangeLog
+++ b/ChangeLog
@@ -3,6 +3,7 @@ master
 - add dcrawload, dcrawload_source, dcrawload_buffer: load raw camera files
   using libraw [lxsameer]
 - add magickload_source: load from a source with imagemagick
+- use much larger mmap windows to limit scrolling
 
 8.17.1
 

--- a/ChangeLog
+++ b/ChangeLog
@@ -3,7 +3,7 @@ master
 - add dcrawload, dcrawload_source, dcrawload_buffer: load raw camera files
   using libraw [lxsameer]
 - add magickload_source: load from a source with imagemagick
-- use much larger mmap windows to limit scrolling
+- improve random access mode for many file formats by adding fully mapped images
 
 8.17.1
 

--- a/libvips/foreign/foreign.c
+++ b/libvips/foreign/foreign.c
@@ -1021,13 +1021,6 @@ vips_foreign_load_start(VipsImage *out, void *a, void *b)
 		 */
 		load->real->progress_signal = load->out;
 
-		/* If we rewind the image, we want to reopen in random access mode.
-		 *
-		 * Lazy open is always used to get RANDOM images, and the random hint
-		 * on a vips image enables fully mmaped files.
-		 */
-		vips__image_set_access(load->real, VIPS_ACCESS_RANDOM);
-
 		/* Note the load object on the image. Loaders can use
 		 * this to signal invalidate if they hit a load error. See
 		 * vips_foreign_load_invalidate() below.

--- a/libvips/foreign/foreign.c
+++ b/libvips/foreign/foreign.c
@@ -357,19 +357,19 @@ static GQuark vips__foreign_load_operation = 0;
  *
  * Some hints about the image loader.
  *
- * [flags@Vips.ForeignFlags.PARTIAL] means that the image can be read directly from the
- * file without needing to be unpacked to a temporary image first.
+ * [flags@Vips.ForeignFlags.PARTIAL] means that the image can be read directly
+ * from the file without needing to be unpacked to a temporary image first.
  *
- * [flags@Vips.ForeignFlags.SEQUENTIAL] means that the loader supports lazy reading, but
- * only top-to-bottom (sequential) access. Formats like PNG can read sets of
- * scanlines, for example, but only in order.
+ * [flags@Vips.ForeignFlags.SEQUENTIAL] means that the loader supports lazy
+ * reading, but only top-to-bottom (sequential) access. Formats like PNG can
+ * read sets of scanlines, for example, but only in order.
  *
  * If neither PARTIAL or SEQUENTIAL is set, the loader only supports whole
  * image read. Setting both PARTIAL and SEQUENTIAL is an error.
  *
- * [flags@Vips.ForeignFlags.BIGENDIAN] means that image pixels are most-significant byte
- * first. Depending on the native byte order of the host machine, you may
- * need to swap bytes. See [method@Image.copy].
+ * [flags@Vips.ForeignFlags.BIGENDIAN] means that image pixels are
+ * most-significant byte first. Depending on the native byte order of the
+ * host machine, you may need to swap bytes. See [method@Image.copy].
  */
 
 G_DEFINE_ABSTRACT_TYPE(VipsForeign, vips_foreign, VIPS_TYPE_OPERATION);
@@ -1020,6 +1020,13 @@ vips_foreign_load_start(VipsImage *out, void *a, void *b)
 		 * @out, so eval signals on ->real need to appear on ->out.
 		 */
 		load->real->progress_signal = load->out;
+
+		/* If we rewind the image, we want to reopen in random access mode.
+		 *
+		 * Lazy open is always used to get RANDOM iamges, and the random hint
+		 * on a vips image enables fully mmaped files.
+		 */
+		vips__image_set_access(load->real, VIPS_ACCESS_RANDOM);
 
 		/* Note the load object on the image. Loaders can use
 		 * this to signal invalidate if they hit a load error. See

--- a/libvips/foreign/foreign.c
+++ b/libvips/foreign/foreign.c
@@ -1023,7 +1023,7 @@ vips_foreign_load_start(VipsImage *out, void *a, void *b)
 
 		/* If we rewind the image, we want to reopen in random access mode.
 		 *
-		 * Lazy open is always used to get RANDOM iamges, and the random hint
+		 * Lazy open is always used to get RANDOM images, and the random hint
 		 * on a vips image enables fully mmaped files.
 		 */
 		vips__image_set_access(load->real, VIPS_ACCESS_RANDOM);

--- a/libvips/include/vips/internal.h
+++ b/libvips/include/vips/internal.h
@@ -239,6 +239,9 @@ extern GMutex vips__global_lock;
 
 int vips_image_written(VipsImage *image);
 
+void vips__image_set_access(VipsImage *image, VipsAccess access);
+VipsAccess vips__image_get_access(VipsImage *image);
+
 /* Defined in `vips.h`, unless building with `-Ddeprecated=false`
  */
 #if !VIPS_ENABLE_DEPRECATED

--- a/libvips/include/vips/internal.h
+++ b/libvips/include/vips/internal.h
@@ -239,9 +239,6 @@ extern GMutex vips__global_lock;
 
 int vips_image_written(VipsImage *image);
 
-void vips__image_set_access(VipsImage *image, VipsAccess access);
-VipsAccess vips__image_get_access(VipsImage *image);
-
 /* Defined in `vips.h`, unless building with `-Ddeprecated=false`
  */
 #if !VIPS_ENABLE_DEPRECATED

--- a/libvips/include/vips/private.h
+++ b/libvips/include/vips/private.h
@@ -44,16 +44,6 @@ extern "C" {
 
 #define VIPS_SPARE (8)
 
-/* Private to iofuncs: the minimum number of scanlines we add above and below
- * the window as a margin for slop.
- */
-#define VIPS__WINDOW_MARGIN_PIXELS (128)
-
-/* Private to iofuncs: add at least this many bytes above and below the window.
- * There's no point mapping just a few KB of a small image.
- */
-#define VIPS__WINDOW_MARGIN_BYTES (1024 * 1024 * 10)
-
 /* sizeof() a VIPS header on disc.
  */
 #define VIPS_SIZEOF_HEADER (64)

--- a/libvips/iofuncs/image.c
+++ b/libvips/iofuncs/image.c
@@ -377,10 +377,6 @@ char *vips__disc_threshold = NULL;
  */
 static GMutex vips__minimise_lock;
 
-/* Set to hint access mode.
- */
-static GQuark vips_image_access_quark = 0;
-
 static guint vips_image_signals[SIG_LAST] = { 0 };
 
 G_DEFINE_TYPE(VipsImage, vips_image, VIPS_TYPE_OBJECT);
@@ -1307,8 +1303,6 @@ vips_image_class_init(VipsImageClass *class)
 		NULL, NULL,
 		g_cclosure_marshal_VOID__VOID,
 		G_TYPE_NONE, 0);
-
-	vips_image_access_quark = g_quark_from_static_string("vips-image-access");
 }
 
 static void
@@ -3927,25 +3921,4 @@ vips__view_image(VipsImage *image)
 	vips_area_unref(VIPS_AREA(array));
 
 	return result;
-}
-
-/* Set and get the vips image access hint. -1 for no hint set.
- *
- * This is used by foreign.c to enable large mmap windows.
- */
-
-void
-vips__image_set_access(VipsImage *image, VipsAccess access)
-{
-	void *data = GINT_TO_POINTER(access + 1);
-
-	g_object_set_qdata(G_OBJECT(image), vips_image_access_quark, data);
-}
-
-VipsAccess
-vips__image_get_access(VipsImage *image)
-{
-	void *data = g_object_get_qdata(G_OBJECT(image), vips_image_access_quark);
-
-	return (VipsAccess) (GPOINTER_TO_INT(data) - 1);
 }

--- a/libvips/iofuncs/vips.c
+++ b/libvips/iofuncs/vips.c
@@ -1022,8 +1022,7 @@ vips_image_open_input(VipsImage *image)
 			VIPS_SIZEOF_HEADER ||
 		vips__read_header_bytes(image, header)) {
 		vips_error_system(errno, "VipsImage",
-			_("unable to read header for \"%s\""),
-			image->filename);
+			_("unable to read header for \"%s\""), image->filename);
 		return -1;
 	}
 
@@ -1048,8 +1047,7 @@ vips_image_open_input(VipsImage *image)
 	 * harmless.
 	 */
 	if (readhist(image)) {
-		g_warning("error reading vips image metadata: %s",
-			vips_error_buffer());
+		g_warning("error reading vips image metadata: %s", vips_error_buffer());
 		vips_error_clear();
 	}
 

--- a/libvips/iofuncs/window.c
+++ b/libvips/iofuncs/window.c
@@ -399,7 +399,9 @@ vips_window_take(VipsWindow *window, VipsImage *im, int top, int height)
 	top = VIPS_CLIP(0, top, im->Ysize - 1);
 	height = VIPS_CLIP(0, height, im->Ysize - top);
 
+#ifdef DEBUG
 	printf("vips_window_take: top = %d, height = %d\n", top, height);
+#endif /*DEBUG*/
 
 	if (!(window = vips_window_new(im, top, height))) {
 		g_mutex_unlock(&im->sslock);


### PR DESCRIPTION
At the moment, formats like JPEG will convert to uncompressed `.v` images in tmp and then be mapped into memory for processing.  In order to limit VMEM usage, this mapping is windowed, so only a few 100 scanlines are mapped at once.

However, this can cause severe performance issues with applications needing random pixel access, for example, image viewers. A viewer which is updating the screen in parallel will make scattered reads to the image, and each read will force the mmap window to scroll. With a large image, almost all time will be spent blocked on ioctl().

This PR makes the mmap window *much* larger, up to about 20,000 scanlines. Modern machines have much more VMEM available, so I think this will be OK.

Performance of interactive applications can improve by several 100 times.