### PR TITLE
validate poppler page size

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,6 +1,7 @@
 8.17.2
 
 - rank: fix an off-by-one error [larsmaxfield]
+- popplerload: check page size [Yang Luo]
 
 7/7/25 8.17.1
 

--- a/libvips/foreign/popplerload.c
+++ b/libvips/foreign/popplerload.c
@@ -312,7 +312,6 @@ vips_foreign_load_pdf_header(VipsForeignLoad *load)
 	VipsForeignLoadPdf *pdf = VIPS_FOREIGN_LOAD_PDF(load);
 
 	int top;
-	int i;
 
 #ifdef DEBUG
 	printf("vips_foreign_load_pdf_header: %p\n", pdf);
@@ -342,15 +341,20 @@ vips_foreign_load_pdf_header(VipsForeignLoad *load)
 	pdf->image.top = 0;
 	pdf->image.width = 0;
 	pdf->image.height = 0;
-	for (i = 0; i < pdf->n; i++) {
+	for (int i = 0; i < pdf->n; i++) {
 		double width;
 		double height;
 
 		if (vips_foreign_load_pdf_get_page(pdf, pdf->page_no + i))
 			return -1;
+
+		/* Poppler can set width and height to less than 1, see page size test
+		 * below.
+		 */
 		poppler_page_get_size(pdf->page, &width, &height);
 		pdf->pages[i].left = 0;
 		pdf->pages[i].top = top;
+
 		/* We do round to nearest, in the same way that vips_resize()
 		 * does round to nearest. Without this, things like
 		 * shrink-on-load will break.
@@ -368,9 +372,18 @@ vips_foreign_load_pdf_header(VipsForeignLoad *load)
 	/* If all pages are the same height, we can tag this as a toilet roll
 	 * image.
 	 */
-	for (i = 1; i < pdf->n; i++)
+	for (int i = 1; i < pdf->n; i++)
 		if (pdf->pages[i].height != pdf->pages[0].height)
 			break;
+
+	/* Bad PDFs can have empty pages.
+	 */
+	for (int i = 0; i < pdf->n; i++)
+		if (pdf->pages[i].width <= 0 ||
+			pdf->pages[i].height <= 0) {
+			vips_error(class->nickname, "%s", _("empty page"));
+			return -1;
+		}
 
 	/* Only set page-height if we have more than one page, or this could
 	 * accidentally turn into an animated image later.


### PR DESCRIPTION
Poppler can return pages less than 1 pixel wide or high. Check for this and flag an error.

Thanks Yang Luo