### PR TITLE
lsan: suppress leak warnings for libgomp

### DIFF
--- a/suppressions/lsan.supp
+++ b/suppressions/lsan.supp
@@ -14,6 +14,7 @@ leak:FcValueSave
 
 # Freed on exit, see:
 # https://gcc.gnu.org/bugzilla/show_bug.cgi?id=36298#c1
+leak:GOMP_parallel
 leak:___kmp_allocate
 
 # Fixed in libheif >= v1.18.0, see:


### PR DESCRIPTION
The `___kmp_allocate` suppression applies to libomp (LLVM's OpenMP runtime library), but we also need to suppress `GOMP_parallel` when libgomp (GCC's OpenMP runtime library) is transitively used.

I noticed this while attempting to remove `-fopenmp` and `-fopenmp=libomp` from the CI configuration, since libvips itself doesn't use OpenMP, see:
https://github.com/kleisauke/libvips/actions/runs/16810815668/job/47616673957