### PR TITLE
Reformat .gitattributes

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,5 +1,5 @@
 # Shell scripts can't have CRLF line endings
-*.sh				eol=lf
+*.sh						eol=lf
 
 # Excluded from stats, hidden in diffs
 libvips/colour/profiles.c	linguist-generated
@@ -8,11 +8,11 @@ libvips/colour/profiles.c	linguist-generated
 libvips/foreign/libnsgif/*	linguist-vendored
 
 # Omit from release tarball
-.clang-format			export-ignore
-.codespellrc			export-ignore
-.editorconfig			export-ignore
+.clang-format				export-ignore
+.codespellrc				export-ignore
+.editorconfig				export-ignore
 .git-blame-ignore-revs		export-ignore
-.gitattributes			export-ignore
-.gitignore			export-ignore
-.gitkeep			export-ignore
-.github/			export-ignore
+.gitattributes				export-ignore
+.gitignore					export-ignore
+.gitkeep					export-ignore
+.github/					export-ignore


### PR DESCRIPTION
This was formatted in PR #4621 under the assumption that GitHub used 8-column tab stops by default, but that's no longer the case after:
https://github.blog/changelog/2025-08-07-default-tab-size-changed-from-eight-to-four/

(we could use spaces here, but tabs make it easier to confirm your tab size preference)