### PR TITLE
handle rotated images in dcrawload

### DIFF
--- a/README.md
+++ b/README.md
@@ -143,6 +143,11 @@ If available, libvips adds support for EXIF metadata in JPEG files.
 The usual SVG loader. If this is not present, vips will try to load SVGs
 via imagemagick instead.
 
+### libraw
+
+The usual camera RAW loader. If this is not present, vips will try to load raw
+camera images via imagemagick instead.
+
 ### PDFium
 
 If present, libvips will attempt to load PDFs with PDFium. Download the


### PR DESCRIPTION
If we let dcrawload do auto-orientation, header and load may not match, making read fail. Disable dcraload orientation and set the orientation tag instead.

Thanks dvdkon

See https://github.com/libvips/libvips/issues/4626