### PR TITLE
Disable redundant Highway AVX512 targets

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -3,6 +3,7 @@
 - rank: fix an off-by-one error [larsmaxfield]
 - popplerload, svgload: validate page size [Yang Luo]
 - pdfiumload: allow both dpi and scale to be set [kleisauke]
+- disable redundant Highway AVX512 targets [kleisauke]
 
 7/7/25 8.17.1
 

--- a/meson.build
+++ b/meson.build
@@ -447,10 +447,15 @@ if libhwy_dep.found()
     cfg_var.set('HAVE_HWY_1_1_0', libhwy_dep.version().version_compare('>=1.1.0'))
     # Always disable SSSE3 since it is rare to have SSSE3 but not SSE4
     disabled_targets = ['HWY_SSSE3']
+    # Avoid disabling the AVX3_DL target, see: https://github.com/google/highway/pull/1356
+    #disabled_targets += ['HWY_AVX3_DL']
+    # Always disable special AVX512 targets since the FP16/BF16 ops they introduce are unused.
+    disabled_targets += ['HWY_AVX3_ZEN4', 'HWY_AVX3_SPR']
+    if libhwy_dep.version().version_compare('>=1.3.0')
+        disabled_targets += ['HWY_AVX10_2']
+    endif
     # Optionally, build without AVX512 support (helps to reduce binary size at the cost of performance)
     #disabled_targets += ['HWY_AVX3']
-    #disabled_targets += ['HWY_AVX3_ZEN4']
-    #disabled_targets += ['HWY_AVX3_SPR']
     add_project_arguments('-DHWY_DISABLED_TARGETS=@0@'.format('|'.join(disabled_targets)), language: ['cpp'])
     simd_package = libhwy_dep
 endif
@@ -524,9 +529,7 @@ if libjxl_found
     endif
     cfg_var.set('HAVE_LIBJXL', true)
     # need v0.9+ for chunked write
-    if libjxl_dep.version().version_compare('>=0.9')
-        cfg_var.set('HAVE_LIBJXL_0_9', '1')
-    endif
+    cfg_var.set('HAVE_LIBJXL_0_9', libjxl_dep.version().version_compare('>=0.9'))
 endif
 
 # only if pdfium not found


### PR DESCRIPTION
The FP16/BF16 ops that these targets introduce are unused by us.

`vips --targets` diff:
```diff
@@ -1,4 +1,4 @@
 $ vips --targets
-builtin targets:   AVX10_2 AVX3_SPR AVX3_ZEN4 AVX3_DL AVX3 AVX2 SSE4 SSE2
+builtin targets:   AVX3_DL AVX3 AVX2 SSE4 SSE2
 supported targets: AVX3_ZEN4 AVX3_DL AVX3 AVX2 SSE4 SSSE3 SSE2
 
```

Context: https://github.com/lovell/sharp-libvips/commit/7f16f4eb9d8c5696748636df4a1c50db49d107b2#commitcomment-164146435.

Targets the 8.17 branch.