### PR TITLE
Include sample format when copying tiff data

### DIFF
--- a/libvips/foreign/vips2tiff.c
+++ b/libvips/foreign/vips2tiff.c
@@ -2370,6 +2370,7 @@ wtiff_copy_tiff(Wtiff *wtiff, TIFF *out, TIFF *in)
 	CopyField(TIFFTAG_ROWSPERSTRIP, ui32);
 	CopyField(TIFFTAG_SUBFILETYPE, ui32);
 	CopyField(TIFFTAG_PREDICTOR, ui16);
+	CopyField(TIFFTAG_SAMPLEFORMAT, ui16);
 
 	if (TIFFGetField(in, TIFFTAG_EXTRASAMPLES, &ui16, &a))
 		TIFFSetField(out, TIFFTAG_EXTRASAMPLES, ui16, a);


### PR DESCRIPTION
When making pyramidal tiffs, the lower resolutions need to have the sample format set or some readers rightly don't interpret the data correctly.  See #4638 

