### PR TITLE
openslideload_source: flag operation as "nocache"

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -5,6 +5,7 @@
 - pdfiumload: allow both dpi and scale to be set [kleisauke]
 - svgload: honor DPI when scaling elements with non-pixel units [kleisauke]
 - disable redundant Highway AVX512 targets [kleisauke]
+- openslideload_source: flag operation as "nocache" [kleisauke]
 
 7/7/25 8.17.1
 

--- a/libvips/foreign/openslideload.c
+++ b/libvips/foreign/openslideload.c
@@ -1155,6 +1155,7 @@ vips_foreign_load_openslide_source_class_init(
 {
 	GObjectClass *gobject_class = G_OBJECT_CLASS(class);
 	VipsObjectClass *object_class = (VipsObjectClass *) class;
+	VipsOperationClass *operation_class = VIPS_OPERATION_CLASS(class);
 	VipsForeignLoadClass *load_class = (VipsForeignLoadClass *) class;
 
 	gobject_class->set_property = vips_object_set_property;
@@ -1163,6 +1164,8 @@ vips_foreign_load_openslide_source_class_init(
 	object_class->nickname = "openslideload_source";
 	object_class->description = _("load source with OpenSlide");
 	object_class->build = vips_foreign_load_openslide_source_build;
+
+	operation_class->flags |= VIPS_OPERATION_NOCACHE;
 
 	load_class->is_a_source =
 		vips_foreign_load_openslide_source_is_a_source;


### PR DESCRIPTION
See commit cb58d7d9600282802d2d04a04254f6d9dfefe203 for rationale.

History:
Commit 1214f942f9397db25cfec19d5712b88480965a0f moved this flag to the base class, and commit 53db48d49cea96a699fb74c6713fe810e0ed805b later removed it, likely under the assumption that the `_source` class still had this flag set.

Targets the 8.17 branch.