### PR TITLE
Revise sequential access in resampling operations

### DIFF
--- a/libvips/resample/reducev.cpp
+++ b/libvips/resample/reducev.cpp
@@ -23,6 +23,8 @@
  * 	- speed up the mask construction for uchar/ushort images
  * 22/4/22 kleisauke
  * 	- add @gap option
+ * 22/8/25 kleisauke
+ * 	- remove seq hint and line cache
  */
 
 /*
@@ -830,7 +832,7 @@ vips_reducev_build(VipsObject *object)
 	VipsResample *resample = VIPS_RESAMPLE(object);
 	VipsReducev *reducev = (VipsReducev *) object;
 	VipsImage **t = (VipsImage **)
-		vips_object_local_array(object, 5);
+		vips_object_local_array(object, 3);
 
 	VipsImage *in;
 	VipsGenerateFn generate;
@@ -983,8 +985,7 @@ vips_reducev_build(VipsObject *object)
 		 */
 		generate = vips_reducev_gen;
 
-	t[3] = vips_image_new();
-	if (vips_image_pipelinev(t[3],
+	if (vips_image_pipelinev(resample->out,
 			VIPS_DEMAND_STYLE_FATSTRIP, in, nullptr))
 		return -1;
 
@@ -995,8 +996,8 @@ vips_reducev_build(VipsObject *object)
 	 * example, vipsthumbnail knows the true reduce factor (including the
 	 * fractional part), we just see the integer part here.
 	 */
-	t[3]->Ysize = height;
-	if (t[3]->Ysize <= 0) {
+	resample->out->Ysize = height;
+	if (resample->out->Ysize <= 0) {
 		vips_error(object_class->nickname,
 			"%s", _("image has shrunk to nothing"));
 		return -1;
@@ -1005,41 +1006,15 @@ vips_reducev_build(VipsObject *object)
 #ifdef DEBUG
 	printf("vips_reducev_build: reducing %d x %d image to %d x %d\n",
 		in->Xsize, in->Ysize,
-		t[3]->Xsize, t[3]->Ysize);
+		resample->out->Xsize, resample->out->Ysize);
 #endif /*DEBUG*/
 
-	if (vips_image_generate(t[3],
+	if (vips_image_generate(resample->out,
 			vips_reducev_start, generate, vips_reducev_stop,
 			in, reducev))
 		return -1;
 
-	in = t[3];
-
-	vips_reorder_margin_hint(in, reducev->n_point);
-
-	/* Large reducev will throw off sequential mode. Suppose thread1 is
-	 * generating tile (0, 0), but stalls. thread2 generates tile
-	 * (0, 1), 128 lines further down the output. After it has done,
-	 * thread1 tries to generate (0, 0), but by then the pixels it needs
-	 * have gone from the input image line cache if the reducev is large.
-	 *
-	 * To fix this, put another seq on the output of reducev. Now we'll
-	 * always have the previous XX lines of the shrunk image, and we won't
-	 * fetch out of order.
-	 */
-	if (vips_image_is_sequential(in)) {
-		g_info("reducev sequential line cache");
-
-		if (vips_sequential(in, &t[4],
-				"tile_height", 10,
-				// "trace", TRUE,
-				nullptr))
-			return -1;
-		in = t[4];
-	}
-
-	if (vips_image_write(in, resample->out))
-		return -1;
+	vips_reorder_margin_hint(resample->out, reducev->n_point);
 
 	return 0;
 }
@@ -1049,8 +1024,6 @@ vips_reducev_class_init(VipsReducevClass *reducev_class)
 {
 	GObjectClass *gobject_class = G_OBJECT_CLASS(reducev_class);
 	VipsObjectClass *vobject_class = VIPS_OBJECT_CLASS(reducev_class);
-	VipsOperationClass *operation_class =
-		VIPS_OPERATION_CLASS(reducev_class);
 
 	VIPS_DEBUG_MSG("vips_reducev_class_init\n");
 
@@ -1063,8 +1036,6 @@ vips_reducev_class_init(VipsReducevClass *reducev_class)
 	vobject_class->nickname = "reducev";
 	vobject_class->description = _("shrink an image vertically");
 	vobject_class->build = vips_reducev_build;
-
-	operation_class->flags = VIPS_OPERATION_SEQUENTIAL;
 
 	VIPS_ARG_DOUBLE(reducev_class, "vshrink", 3,
 		_("Vshrink"),

--- a/libvips/resample/shrinkv.c
+++ b/libvips/resample/shrinkv.c
@@ -49,6 +49,8 @@
  * 	- use a double sum buffer for int32 types
  * 22/4/22 kleisauke
  * 	- add @ceil option
+ * 22/8/25 kleisauke
+ * 	- remove seq hint and line cache
  */
 
 /*
@@ -469,7 +471,7 @@ vips_shrinkv_build(VipsObject *object)
 	VipsObjectClass *class = VIPS_OBJECT_GET_CLASS(object);
 	VipsResample *resample = VIPS_RESAMPLE(object);
 	VipsShrinkv *shrink = (VipsShrinkv *) object;
-	VipsImage **t = (VipsImage **) vips_object_local_array(object, 4);
+	VipsImage **t = (VipsImage **) vips_object_local_array(object, 2);
 
 	VipsImage *in;
 	VipsGenerateFn generate;
@@ -543,8 +545,7 @@ vips_shrinkv_build(VipsObject *object)
 	/* SMALLTILE or we'll need huge input areas for our output. In seq
 	 * mode, the linecache above will keep us sequential.
 	 */
-	t[2] = vips_image_new();
-	if (vips_image_pipelinev(t[2],
+	if (vips_image_pipelinev(resample->out,
 			VIPS_DEMAND_STYLE_SMALLTILE, in, NULL))
 		return -1;
 
@@ -554,10 +555,10 @@ vips_shrinkv_build(VipsObject *object)
 	 * example, vipsthumbnail knows the true shrink factor (including the
 	 * fractional part), we just see the integer part here.
 	 */
-	t[2]->Ysize = shrink->ceil
+	resample->out->Ysize = shrink->ceil
 		? ceil((double) resample->in->Ysize / shrink->vshrink)
 		: VIPS_ROUND_UINT((double) resample->in->Ysize / shrink->vshrink);
-	if (t[2]->Ysize <= 0) {
+	if (resample->out->Ysize <= 0) {
 		vips_error(class->nickname,
 			"%s", _("image has shrunk to nothing"));
 		return -1;
@@ -567,37 +568,12 @@ vips_shrinkv_build(VipsObject *object)
 	printf("vips_shrinkv_build: vshrink = %d\n", shrink->vshrink);
 	printf("vips_shrinkv_build: shrinking %d x %d image to %d x %d\n",
 		in->Xsize, in->Ysize,
-		t[2]->Xsize, t[2]->Ysize);
+		resample->out->Xsize, resample->out->Ysize);
 #endif /*DEBUG*/
 
-	if (vips_image_generate(t[2],
+	if (vips_image_generate(resample->out,
 			vips_shrinkv_start, generate, vips_shrinkv_stop,
 			in, shrink))
-		return -1;
-
-	in = t[2];
-
-	/* Large vshrinks will throw off sequential mode. Suppose thread1 is
-	 * generating tile (0, 0), but stalls. thread2 generates tile
-	 * (0, 1), 128 lines further down the output. After it has done,
-	 * thread1 tries to generate (0, 0), but by then the pixels it needs
-	 * have gone from the input image line cache if the vshrink is large.
-	 *
-	 * To fix this, put another seq on the output of vshrink. Now we'll
-	 * always have the previous XX lines of the shrunk image, and we won't
-	 * fetch out of order.
-	 */
-	if (vips_image_is_sequential(in)) {
-		g_info("shrinkv sequential line cache");
-
-		if (vips_sequential(in, &t[3],
-				"tile_height", 10,
-				NULL))
-			return -1;
-		in = t[3];
-	}
-
-	if (vips_image_write(in, resample->out))
 		return -1;
 
 	return 0;
@@ -608,7 +584,6 @@ vips_shrinkv_class_init(VipsShrinkvClass *class)
 {
 	GObjectClass *gobject_class = G_OBJECT_CLASS(class);
 	VipsObjectClass *vobject_class = VIPS_OBJECT_CLASS(class);
-	VipsOperationClass *operation_class = VIPS_OPERATION_CLASS(class);
 
 	VIPS_DEBUG_MSG("vips_shrinkv_class_init\n");
 
@@ -618,8 +593,6 @@ vips_shrinkv_class_init(VipsShrinkvClass *class)
 	vobject_class->nickname = "shrinkv";
 	vobject_class->description = _("shrink an image vertically");
 	vobject_class->build = vips_shrinkv_build;
-
-	operation_class->flags = VIPS_OPERATION_SEQUENTIAL;
 
 	VIPS_ARG_INT(class, "vshrink", 9,
 		_("Vshrink"),

--- a/libvips/resample/thumbnail.c
+++ b/libvips/resample/thumbnail.c
@@ -42,7 +42,7 @@
  * 27/1/24
  *	- make icc profile transforms always write 8 bits
  * 22/8/25 kleisauke
- *	- remove seq line cache from thumbnail_image
+ *	- remove seq line cache from thumbnail_image, use hint instead
  */
 
 /*
@@ -1782,6 +1782,7 @@ vips_thumbnail_image_class_init(VipsThumbnailClass *class)
 {
 	GObjectClass *gobject_class = G_OBJECT_CLASS(class);
 	VipsObjectClass *vobject_class = VIPS_OBJECT_CLASS(class);
+	VipsOperationClass *operation_class = VIPS_OPERATION_CLASS(class);
 	VipsThumbnailClass *thumbnail_class = VIPS_THUMBNAIL_CLASS(class);
 
 	gobject_class->set_property = vips_object_set_property;
@@ -1789,6 +1790,8 @@ vips_thumbnail_image_class_init(VipsThumbnailClass *class)
 
 	vobject_class->nickname = "thumbnail_image";
 	vobject_class->description = _("generate thumbnail from image");
+
+	operation_class->flags = VIPS_OPERATION_SEQUENTIAL;
 
 	thumbnail_class->get_info = vips_thumbnail_image_get_info;
 	thumbnail_class->open = vips_thumbnail_image_open;

--- a/libvips/resample/thumbnail.c
+++ b/libvips/resample/thumbnail.c
@@ -41,6 +41,8 @@
  *	- skip colourspace conversion when needed
  * 27/1/24
  *	- make icc profile transforms always write 8 bits
+ * 22/8/25 kleisauke
+ *	- remove seq line cache from thumbnail_image
  */
 
 /*
@@ -1769,18 +1771,10 @@ static VipsImage *
 vips_thumbnail_image_open(VipsThumbnail *thumbnail, double factor)
 {
 	VipsThumbnailImage *image = (VipsThumbnailImage *) thumbnail;
-	VipsImage **t = (VipsImage **)
-		vips_object_local_array(VIPS_OBJECT(thumbnail), 1);
 
-	/* We want thumbnail to run in sequential mode on this image, or we
-	 * may get horrible cache thrashing.
-	 */
-	if (vips_sequential(image->in, &t[0], "tile-height", 16, NULL))
-		return NULL;
+	g_object_ref(image->in);
 
-	g_object_ref(t[0]);
-
-	return t[0];
+	return image->in;
 }
 
 static void


### PR DESCRIPTION
More testing is needed, so opened as a draft.

Resolves: #2757.

Context regarding the change to `thumbnail_image`:
https://app.gitter.im/#/room/#libvips_devchat:gitter.im/$x6M0KbuEpkdFjKFVmdRDf0V6m6NvPMD9Q4kwJevRrT8