### PR TITLE
tiffload: improve handling of memory-related errors

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -7,6 +7,7 @@
 - disable redundant Highway AVX512 targets [kleisauke]
 - openslideload_source: flag operation as "nocache" [kleisauke]
 - remove `vipsprofile.1` man page from install [kleisauke]
+- tiffload: ensure processing halts for memory-related errors [lovell]
 
 7/7/25 8.17.1
 

--- a/ChangeLog
+++ b/ChangeLog
@@ -8,6 +8,7 @@
 - openslideload_source: flag operation as "nocache" [kleisauke]
 - remove `vipsprofile.1` man page from install [kleisauke]
 - tiffload: ensure processing halts for memory-related errors [lovell]
+- tiffload: increase memory limit from 20MB to 50MB [lovell]
 
 7/7/25 8.17.1
 

--- a/libvips/foreign/tiff.c
+++ b/libvips/foreign/tiff.c
@@ -206,7 +206,7 @@ vips__tiff_openin_source(VipsSource *source, VipsTiffErrorHandler error_fn,
 	TIFFOpenOptionsSetWarningHandlerExtR(opts, warning_fn, user_data);
 #ifdef HAVE_TIFF_OPEN_OPTIONS_SET_MAX_CUMULATED_MEM_ALLOC
 	if (!unlimited) {
-		TIFFOpenOptionsSetMaxCumulatedMemAlloc(opts, 20 * 1024 * 1024);
+		TIFFOpenOptionsSetMaxCumulatedMemAlloc(opts, 50 * 1024 * 1024);
 	}
 #endif /*HAVE_TIFF_OPEN_OPTIONS_SET_MAX_CUMULATED_MEM_ALLOC*/
 	if (!(tiff = TIFFClientOpenExt("source input", "rmC",

--- a/libvips/foreign/tiff2vips.c
+++ b/libvips/foreign/tiff2vips.c
@@ -612,6 +612,19 @@ static int
 rtiff_handler_error(TIFF *tiff, void* user_data,
 	const char *module, const char *fmt, va_list ap)
 {
+	if (user_data) {
+		Rtiff *rtiff = (Rtiff*) user_data;
+		if (rtiff->fail_on >= VIPS_FAIL_ON_ERROR) {
+			rtiff->failed = TRUE;
+		} else if (fmt) {
+			/* Inspect message for always-fatal errors.
+			*/
+			if (strncmp(fmt, "Cumulated memory", 16) == 0) {
+				rtiff->failed = TRUE;
+			}
+		}
+	}
+
 	vips_verror("tiff2vips", fmt, ap);
 	return 1;
 }


### PR DESCRIPTION
Ensures TIFF processing halts:
- for known-fatal errors relating to memory allocation
- for all other errors when `fail_on` is set to the `error` level or higher

Also, in a separate commit, increases the memory limit from 20MB to 50MB.

Fixes https://github.com/libvips/libvips/issues/4649
