### PR TITLE
Fix vapi build

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -9,7 +9,7 @@
 - remove `vipsprofile.1` man page from install [kleisauke]
 - tiffload: ensure processing halts for memory-related errors [lovell]
 - tiffload: increase memory limit from 20MB to 50MB [lovell]
-- fix vapi build [jcupitt]
+- fix vapi build [stydxm]
 
 7/7/25 8.17.1
 

--- a/ChangeLog
+++ b/ChangeLog
@@ -9,6 +9,7 @@
 - remove `vipsprofile.1` man page from install [kleisauke]
 - tiffload: ensure processing halts for memory-related errors [lovell]
 - tiffload: increase memory limit from 20MB to 50MB [lovell]
+- fix vapi build [jcupitt]
 
 7/7/25 8.17.1
 

--- a/libvips/include/vips/connection.h
+++ b/libvips/include/vips/connection.h
@@ -317,6 +317,7 @@ typedef struct _VipsGInputStream {
 } VipsGInputStream;
 
 typedef struct _VipsGInputStreamClass {
+	/*< private >*/
 	GInputStreamClass parent_class;
 
 } VipsGInputStreamClass;
@@ -362,6 +363,7 @@ typedef struct _VipsSourceGInputStream {
 } VipsSourceGInputStream;
 
 typedef struct _VipsSourceGInputStreamClass {
+	/*< private >*/
 	VipsSourceClass parent_class;
 
 } VipsSourceGInputStreamClass;


### PR DESCRIPTION
It looks like Gio.gir is not wrapping GInputStreamClass, so we can't include it in stuff we wrap. Marking the whole of the class private seems to fix this.

I've not tested the .vapi file we make.

See https://github.com/libvips/libvips/issues/4654

Thanks to @stydxm for the clear report.