### PR TITLE
Backport #4639 to 8.17

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -10,6 +10,7 @@
 - tiffload: ensure processing halts for memory-related errors [lovell]
 - tiffload: increase memory limit from 20MB to 50MB [lovell]
 - fix vapi build [stydxm]
+- tiffsave: include sample format when copying tiff data [manthey]
 
 7/7/25 8.17.1
 

--- a/libvips/foreign/vips2tiff.c
+++ b/libvips/foreign/vips2tiff.c
@@ -2370,6 +2370,7 @@ wtiff_copy_tiff(Wtiff *wtiff, TIFF *out, TIFF *in)
 	CopyField(TIFFTAG_ROWSPERSTRIP, ui32);
 	CopyField(TIFFTAG_SUBFILETYPE, ui32);
 	CopyField(TIFFTAG_PREDICTOR, ui16);
+	CopyField(TIFFTAG_SAMPLEFORMAT, ui16);
 
 	if (TIFFGetField(in, TIFFTAG_EXTRASAMPLES, &ui16, &a))
 		TIFFSetField(out, TIFFTAG_EXTRASAMPLES, ui16, a);


### PR DESCRIPTION
Trivial backport of #4639 to [`8.17`](https://github.com/libvips/libvips/tree/8.17).

Note: rebase merge, don't squash.