### PR TITLE
fix trivial memleaks in "vips" driver prog

### DIFF
--- a/tools/vips.c
+++ b/tools/vips.c
@@ -560,7 +560,7 @@ static ActionEntry actions[] = {
 		&empty_options[0], print_help },
 };
 
-static void
+static int
 parse_options(GOptionContext *context, int *argc, char **argv)
 {
 	char txt[1024];
@@ -589,7 +589,7 @@ parse_options(GOptionContext *context, int *argc, char **argv)
 			g_error_free(error);
 		}
 
-		vips_error_exit(NULL);
+		return -1;
 	}
 
 	/* On Windows, argc will not have been updated by
@@ -610,6 +610,8 @@ parse_options(GOptionContext *context, int *argc, char **argv)
 
 			*argc -= 1;
 		}
+
+	return 0;
 }
 
 static GOptionGroup *
@@ -724,6 +726,7 @@ main(int argc, char **argv)
 		help = g_option_context_get_help(context, TRUE, NULL);
 		printf("%s", help);
 		g_free(help);
+		g_option_context_free(context);
 
 		exit(0);
 	}
@@ -744,6 +747,8 @@ main(int argc, char **argv)
 			g_error_free(error);
 		}
 
+		g_option_context_free(context);
+
 		vips_error_exit(NULL);
 	}
 
@@ -756,13 +761,16 @@ main(int argc, char **argv)
 	if (main_option_plugin) {
 #ifdef ENABLE_MODULES
 #ifdef ENABLE_DEPRECATED
-		if (!im_load_plugin(main_option_plugin))
+		if (!im_load_plugin(main_option_plugin)) {
+			g_option_context_free(context);
 			vips_error_exit(NULL);
+		}
 #else  /*!ENABLE_DEPRECATED*/
 		GModule *module;
 
 		module = g_module_open(main_option_plugin, G_MODULE_BIND_LAZY);
 		if (!module) {
+			g_option_context_free(context);
 			vips_error_exit(_("unable to load \"%s\" -- %s"),
 				main_option_plugin, g_module_error());
 		}
@@ -826,12 +834,13 @@ main(int argc, char **argv)
 		for (i = 0; i < VIPS_NUMBER(actions); i++)
 			if (strcmp(action, actions[i].name) == 0) {
 				group = add_operation_group(context, NULL);
-				g_option_group_add_entries(group,
-					actions[i].group);
+				g_option_group_add_entries(group, actions[i].group);
 				parse_options(context, &argc, argv);
 
-				if (actions[i].action(argc - 1, argv + 1))
+				if (actions[i].action(argc - 1, argv + 1)) {
+					g_option_context_free(context);
 					vips_error_exit("%s", action);
+				}
 
 				handled = TRUE;
 				break;
@@ -848,8 +857,10 @@ main(int argc, char **argv)
 		if (im_run_command(action, argc - 1, argv + 1)) {
 			if (argc == 1)
 				usage(fn);
-			else
+			else {
+				g_option_context_free(context);
 				vips_error_exit(NULL);
+			}
 		}
 
 		handled = TRUE;
@@ -869,7 +880,10 @@ main(int argc, char **argv)
 		(operation = vips_operation_new(action))) {
 		group = add_operation_group(context, operation);
 		vips_call_options(group, operation);
-		parse_options(context, &argc, argv);
+		if (parse_options(context, &argc, argv)) {
+			g_option_context_free(context);
+			vips_error_exit(NULL);
+		}
 
 		if (vips_call_argv(operation, argc - 1, argv + 1)) {
 			if (argc == 1)
@@ -878,6 +892,7 @@ main(int argc, char **argv)
 
 			vips_object_unref_outputs(VIPS_OBJECT(operation));
 			g_object_unref(operation);
+			g_option_context_free(context);
 
 			if (argc == 1)
 				/* We don't exit with an error for something
@@ -907,14 +922,18 @@ main(int argc, char **argv)
 
 	if (action &&
 		!handled) {
+		g_option_context_free(context);
 		vips_error_exit(_("unknown action \"%s\""), action);
 	}
 
 	/* Still not handled? We may not have called parse_options(), so
 	 * --help args may not have been processed.
 	 */
-	if (!handled)
-		parse_options(context, &argc, argv);
+	if (!handled &&
+		parse_options(context, &argc, argv)) {
+		g_option_context_free(context);
+		vips_error_exit(NULL);
+	}
 
 	g_option_context_free(context);
 


### PR DESCRIPTION
The "vips" driver program was not freeing the option parser on error. It doesn't matter at all, but fixing it makes valgrind output a little cleaner.

I now see:

```
$ valgrind --leak-check=full vips
==1207207== Memcheck, a memory error detector
==1207207== Copyright (C) 2002-2024, and GNU GPL'd, by Julian Seward et al.
==1207207== Using Valgrind-3.24.0 and LibVEX; rerun with -h for copyright info
==1207207== Command: vips
==1207207== 
Usage:
  vips [OPTION…] [ACTION] [OPTIONS] [PARAMETERS] - VIPS driver program

Help Options:
  -h, --help                     Show help options

Application Options:
  -t, --targets                  print vector targets
...
  --vips-pipe-read-limit         read at most this many bytes from a pipe

==1207207== 
==1207207== HEAP SUMMARY:
==1207207==     in use at exit: 290,250 bytes in 2,294 blocks
==1207207==   total heap usage: 5,929 allocs, 3,635 frees, 743,005 bytes allocated
==1207207== 
==1207207== LEAK SUMMARY:
==1207207==    definitely lost: 0 bytes in 0 blocks
==1207207==    indirectly lost: 0 bytes in 0 blocks
==1207207==      possibly lost: 0 bytes in 0 blocks
==1207207==    still reachable: 134,322 bytes in 173 blocks
==1207207==         suppressed: 154,024 bytes in 2,098 blocks
==1207207== Reachable blocks (those to which a pointer was found) are not shown.
==1207207== To see them, rerun with: --leak-check=full --show-leak-kinds=all
==1207207== 
==1207207== For lists of detected and suppressed errors, rerun with: -s
==1207207== ERROR SUMMARY: 0 errors from 0 contexts (suppressed: 0 from 0)
```