### PR TITLE
fix a cpp binding leak

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -14,6 +14,7 @@ master
   UltraHDR image
 - add vips_uhdrsave(), vips_uhdrsave_buffer(), vips_uhdrsave_target(): save an
   UltraHDR image
+- fix cpp binding leak [VivitionDeveloper]
 
 8.17.2
 


### PR DESCRIPTION
The cpp binding could leak references for uncollected optional output images.

See https://github.com/libvips/libvips/issues/4662

Thanks @VivitionDeveloper