### PR TITLE
Improve kill handling

### DIFF
--- a/libvips/iofuncs/image.c
+++ b/libvips/iofuncs/image.c
@@ -1607,8 +1607,9 @@ vips_image_set_progress(VipsImage *image, gboolean progress)
  * vips_image_iskilled:
  * @image: image to test
  *
- * If @image has been killed (see [method@Image.set_kill]), set an error message,
- * clear the [class@Image].kill flag and return `TRUE`. Otherwise return `FALSE`.
+ * If @image has been killed (see [method@Image.set_kill]), set an error
+ * message, clear the [class@Image].kill flag and return `TRUE`. Otherwise
+ * return `FALSE`.
  *
  * Handy for loops which need to run sets of threads which can fail.
  *
@@ -1631,10 +1632,10 @@ vips_image_iskilled(VipsImage *image)
 	/* Has kill been set for this image? If yes, abort evaluation.
 	 */
 	if (kill) {
-		VIPS_DEBUG_MSG("vips_image_iskilled: %s (%p) killed\n",
-			image->filename, image);
-		vips_error("VipsImage",
-			_("killed for image \"%s\""), image->filename);
+#ifdef VIPS_DEBUG
+		printf("vips_image_iskilled: %s (%p) killed\n", image->filename, image);
+#endif /*VIPS_DEBUG*/
+		vips_error("VipsImage", _("killed for image \"%s\""), image->filename);
 
 		/* We've picked up the kill message, it's now our caller's
 		 * responsibility to pass the message up the chain.

--- a/libvips/iofuncs/vips.c
+++ b/libvips/iofuncs/vips.c
@@ -178,10 +178,9 @@ vips__open_image_write(const char *filename, gboolean temp)
 		g_info("vips__open_image_write: opening with O_TMPFILE");
 		dirname = g_path_get_dirname(filename);
 		fd = vips_tracked_open(dirname, O_TMPFILE | O_RDWR, 0644);
-		g_free(dirname);
-
 		if (fd < 0)
 			g_info("vips__open_image_write: O_TMPFILE failed!");
+		g_free(dirname);
 	}
 #endif /*O_TMPFILE*/
 


### PR DESCRIPTION
Some small fixes found while improving load cancel behaviour in nip4:

- libvips was not setting `O_TMPFILE` on temp files on linux (the dir check in `vips__open()` was breaking it)
- in some cases `vips_foreign_load_start()` could fail without setting an error message, causing confusion in applications
- various tiny improvements