### PR TITLE
add a fast uhdr detector

### DIFF
--- a/libvips/foreign/jpeg.h
+++ b/libvips/foreign/jpeg.h
@@ -74,10 +74,54 @@ typedef struct {
 	FILE *fp;	 /* fclose() if non-NULL */
 } ErrorManager;
 
+/* Stuff we track during a read.
+ */
+typedef struct _ReadJpeg {
+	VipsImage *out;
+
+	/* Shrink by this much during load. 1, 2, 4, 8.
+	 */
+	int shrink;
+
+	/* Types of error to cause failure.
+	 */
+	VipsFailOn fail_on;
+
+	struct jpeg_decompress_struct cinfo;
+	ErrorManager eman;
+	gboolean invert_pels;
+
+	/* Use orientation tag to automatically rotate and flip image
+	 * during load.
+	 */
+	gboolean autorotate;
+
+	/* Remove DoS limits.
+	 */
+	gboolean unlimited;
+
+	/* cinfo->output_width and height can be larger than we want since
+	 * libjpeg rounds up on shrink-on-load. This is the real size we will
+	 * output, as opposed to the size we decompress to.
+	 */
+	int output_width;
+	int output_height;
+
+	/* The source we read from.
+	 */
+	VipsSource *source;
+
+} ReadJpeg;
+
 extern const char *vips__jpeg_message_table[];
 
 void vips__new_output_message(j_common_ptr cinfo);
 void vips__new_error_exit(j_common_ptr cinfo);
+
+ReadJpeg *vips__readjpeg_new(VipsSource *source, VipsImage *out,
+	int shrink, VipsFailOn fail_on, gboolean autorotate,
+	gboolean unlimited);
+int vips__readjpeg_open_input(ReadJpeg *jpeg);
 
 #ifdef __cplusplus
 }

--- a/libvips/foreign/jpegload.c
+++ b/libvips/foreign/jpegload.c
@@ -313,14 +313,13 @@ static gboolean
 vips_foreign_load_jpeg_file_is_a(const char *filename)
 {
 	VipsSource *source;
-	gboolean result;
 
 	if (!(source = vips_source_new_from_file(filename)))
 		return FALSE;
-	result = vips_foreign_load_jpeg_source_is_a_source(source);
+	gboolean is_a = vips_foreign_load_jpeg_source_is_a_source(source);
 	VIPS_UNREF(source);
 
-	return result;
+	return is_a;
 }
 
 static void

--- a/libvips/foreign/pforeign.h
+++ b/libvips/foreign/pforeign.h
@@ -220,8 +220,6 @@ gboolean vips__pdf_is_a_buffer(const void *buf, size_t len);
 gboolean vips__pdf_is_a_file(const char *filename);
 gboolean vips__pdf_is_a_source(VipsSource *source);
 
-extern const char *vips__uhdr_suffs[];
-
 #ifdef __cplusplus
 }
 #endif /*__cplusplus*/

--- a/libvips/foreign/uhdrsave.c
+++ b/libvips/foreign/uhdrsave.c
@@ -48,11 +48,14 @@
 #include <vips/vips.h>
 #include <vips/internal.h>
 
-#include "pforeign.h"
-
 #ifdef HAVE_UHDR
 
+#include "pforeign.h"
+
 #include <ultrahdr_api.h>
+
+// no suffs, we don't want to trigger directly for jpeg save
+const char *vips__uhdr_suffs[] = { NULL };
 
 const char *vips__uhdr_error_str(uhdr_codec_err_t err);
 void vips__uhdr_error(uhdr_error_info_t *error);


### PR DESCRIPTION
Add a quick ultrahdr detector (just looks for an MPF block in APP2) and use it to select `uhdrload`.

With this PR I see:

```
$ vipsheader -a ultra-hdr.jpg 
ultra-hdr.jpg: 3840x2160 uchar, 3 bands, srgb, uhdrload
width: 3840
height: 2160
bands: 3
format: uchar
coding: none
interpretation: srgb
xoffset: 0
yoffset: 0
xres: 1
yres: 1
filename: ultra-hdr.jpg
vips-loader: uhdrload
icc-profile-data: 588 bytes of binary data
gainmap: 31738 bytes of binary data
gainmap-max-content-boost: 100 100 100 
gainmap-min-content-boost: 1 1 1 
gainmap-gamma: 1 1 1 
gainmap-offset-sdr: 0 0 0 
gainmap-offset-hdr: 0 0 0 
gainmap-hdr-capacity-min: 1
gainmap-hdr-capacity-max: 100
gainmap-use-base-cg: 1

$ vipsheader -a ../k2.jpg 
../k2.jpg: 1450x2048 uchar, 3 bands, srgb, jpegload
width: 1450
height: 2048
bands: 3
format: uchar
coding: none
interpretation: srgb
xoffset: 0
yoffset: 0
xres: 2.835
yres: 2.835
filename: ../k2.jpg
vips-loader: jpegload
jpeg-multiscan: 0
jpeg-chroma-subsample: 4:2:0
exif-data: 186 bytes of binary data
resolution-unit: in
exif-ifd0-Orientation: 1 (Top-left, Short, 1 components, 2 bytes)
exif-ifd0-XResolution: 72009/1000 (72.009, Rational, 1 components, 8 bytes)
exif-ifd0-YResolution: 72009/1000 (72.009, Rational, 1 components, 8 bytes)
exif-ifd0-ResolutionUnit: 2 (Inch, Short, 1 components, 2 bytes)
exif-ifd0-YCbCrPositioning: 1 (Centred, Short, 1 components, 2 bytes)
exif-ifd2-ExifVersion: Exif Version 2.1 (Exif Version 2.1, Undefined, 4 components, 4 bytes)
exif-ifd2-ComponentsConfiguration: Y Cb Cr - (Y Cb Cr -, Undefined, 4 components, 4 bytes)
exif-ifd2-FlashpixVersion: FlashPix Version 1.0 (FlashPix Version 1.0, Undefined, 4 components, 4 bytes)
exif-ifd2-ColorSpace: 65535 (Uncalibrated, Short, 1 components, 2 bytes)
exif-ifd2-PixelXDimension: 1450 (1450, Long, 1 components, 4 bytes)
exif-ifd2-PixelYDimension: 2048 (2048, Long, 1 components, 4 bytes)
orientation: 1
```

So it successfully detects a uhdr JPG and route the load the the specialist uhdr loader. I'm not sure why the uhdr image is missing EXIF, I suppose that needs checking.

I also tried doing the routing to `uhdrload` during the `jpegload` header parse, but having a fast select function was a lot cleaner.

We'll need another PR to automatically route uhdr images to `uhdrsave` based on metadata.