### PR TITLE
jpegload: minor cleanups

### DIFF
--- a/libvips/foreign/vips2jpeg.c
+++ b/libvips/foreign/vips2jpeg.c
@@ -809,7 +809,7 @@ typedef struct {
 /* Buffer full method. This is only called when the output area is exactly
  * full.
  */
-static jboolean
+static boolean
 empty_output_buffer(j_compress_ptr cinfo)
 {
 	Dest *dest = (Dest *) cinfo->dest;


### PR DESCRIPTION
- Change `attach_blob()` and `attach_xmp_blob()` to return `void`.
- Remove redundant data check in `attach_xmp_blob()`.
- Use `memchr()` instead of manual scanning.
- Comment out `jpeg_save_markers()` call for APP14 marker.