### PR TITLE
dzsave: Zoomify: ensure correct tile count in ImageProperties.xml

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -3,6 +3,7 @@
 - tiffsave: fix saved resolution with a non-default resolution-unit metadata
   item [machur]
 - svgload: ensure short/malformed compressed input is ignored [kleisauke,lovell]
+- dzsave: Zoomify: ensure correct tile count in ImageProperties.xml [kleisauke]
 
 8.17.2
 

--- a/libvips/foreign/dzsave.c
+++ b/libvips/foreign/dzsave.c
@@ -303,7 +303,7 @@ struct _VipsForeignSaveDz {
 
 	/* Count zoomify tiles we write.
 	 */
-	int tile_count;
+	int tile_count; // (atomic)
 
 	/* Where we write ... can be the filesystem, or a zip.
 	 */
@@ -623,7 +623,7 @@ write_properties(VipsForeignSaveDz *dz)
 							"TILESIZE=\"%d\" />\n",
 		dz->level->width,
 		dz->level->height,
-		dz->tile_count,
+		g_atomic_int_get(&dz->tile_count),
 		dz->tile_size);
 
 	if ((buf = vips_dbuf_steal(&dbuf, &len))) {
@@ -1183,7 +1183,7 @@ tile_name(Level *level, int x, int y)
 
 		/* Used at the end in ImageProperties.xml
 		 */
-		dz->tile_count += 1;
+		g_atomic_int_inc(&dz->tile_count);
 
 		break;
 

--- a/test/test-suite/test_foreign.py
+++ b/test/test-suite/test_foreign.py
@@ -1416,6 +1416,11 @@ class TestForeign:
 
         # 256x256 tiles, no overlap
         assert os.path.exists(filename + "/ImageProperties.xml")
+        with open(filename + "/ImageProperties.xml", 'rb') as f:
+            buf = f.read()
+        assert buf == (b'<IMAGE_PROPERTIES WIDTH="290" HEIGHT="442" '
+                       b'NUMTILES="5" NUMIMAGES="1" VERSION="1.8" '
+                       b'TILESIZE="256" />\n')
         x = pyvips.Image.new_from_file(filename + "/TileGroup0/1-0-0.jpg")
         assert x.width == 256
         assert x.height == 256


### PR DESCRIPTION
Resolves: #4702.

Targets the 8.17 branch.