### PR TITLE
fix vipsthumbnail pyr layer selection

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,7 @@
+8.17.4
+
+- vipsthumbnail: fix pyramidal image layer selection [esiqveland]
+
 30/10/25 8.17.3
 
 - tiffsave: fix saved resolution with a non-default resolution-unit metadata

--- a/meson.build
+++ b/meson.build
@@ -1,5 +1,5 @@
 project('vips', 'c', 'cpp',
-    version: '8.17.3',
+    version: '8.17.4',
     meson_version: '>=0.55',
     default_options: [
         # this is what glib uses (one of our required deps), so we use it too
@@ -23,7 +23,7 @@ version_patch = version_parts[2]
 # binary interface changed: increment current, reset revision to 0
 #   binary interface changes backwards compatible?: increment age
 #   binary interface changes not backwards compatible?: reset age to 0
-library_revision = 3
+library_revision = 4
 library_current = 61
 library_age = 19
 library_version = '@0@.@1@.@2@'.format(library_current - library_age, library_age, library_revision)


### PR DESCRIPTION
A >= rather than > meant we were always picking the smallest pyramid layer, not the best.

Test with:

```
vips copy any-image.jpg x.tif[tile,pyramid,compression=jpeg]
vipsthumbnail x.tif --size=1920 -o x.jpg --vips-info
```

Before you'll see eg.:

```
VIPS-INFO: 16:19:40.970: loading with factor 6 pre-shrink
VIPS-INFO: 16:19:40.970: pre-shrunk size is 68 x 45
```

After perhaps:

```
VIPS-INFO: 16:38:23.060: input size is 4368 x 2912
VIPS-INFO: 16:38:23.076: loading pyramid page 1
VIPS-INFO: 16:38:23.076: pre-shrunk size is 2184 x 1456
```

ie. it's now selecting the correct pyr level.

See https://github.com/libvips/libvips/issues/4692

Thanks @esiqveland