### PR TITLE
call terminateprocess to exit

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,6 +1,7 @@
 8.17.4
 
 - vipsthumbnail: fix pyramidal image layer selection [esiqveland]
+- tools: fix possible deadlock during process exit on win32
 
 30/10/25 8.17.3
 

--- a/libvips/include/vips/private.h
+++ b/libvips/include/vips/private.h
@@ -275,6 +275,11 @@ void vips__filename_split8(const char *name,
 VIPS_API
 char *vips__temp_name(const char *format);
 
+/* Used by libvips tools.
+ */
+VIPS_API
+void vips__win32_terminate(int ret);
+
 #ifdef __cplusplus
 }
 #endif /*__cplusplus*/

--- a/tools/vips.c
+++ b/tools/vips.c
@@ -930,5 +930,6 @@ main(int argc, char **argv)
 
 	vips_shutdown();
 
+	vips__win32_terminate(0);
 	return 0;
 }

--- a/tools/vipsedit.c
+++ b/tools/vipsedit.c
@@ -298,5 +298,6 @@ main(int argc, char **argv)
 
 	vips_shutdown();
 
+	vips__win32_terminate(0);
 	return 0;
 }

--- a/tools/vipsheader.c
+++ b/tools/vipsheader.c
@@ -287,5 +287,6 @@ main(int argc, char *argv[])
 
 	vips_shutdown();
 
+	vips__win32_terminate(result);
 	return result;
 }

--- a/tools/vipsthumbnail.c
+++ b/tools/vipsthumbnail.c
@@ -592,5 +592,6 @@ main(int argc, char **argv)
 
 	vips_shutdown();
 
+	vips__win32_terminate(result);
 	return result;
 }


### PR DESCRIPTION
clang on win10 can generate exes which occasionally deadlock on process exit, see https://github.com/llvm/llvm-project/issues/110954

on windows, call TerminateProcess instead to bypass orderly shutdown