### PR TITLE
Fix build with `-Djpeg=disabled`

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -318,6 +318,7 @@ if libjpeg_dep.found()
 endif
 
 # we need libjpeg for uhdrload and save
+libuhdr_dep = disabler()
 if libjpeg_dep.found()
   libuhdr_dep = dependency('libuhdr', required: get_option('uhdr'))
   if libuhdr_dep.found()


### PR DESCRIPTION
```console
$ meson setup build -Djpeg=disabled
...
meson.build:704:35: ERROR: Unknown variable "libuhdr_dep".
```