### PR TITLE
Silence a GCC warning

### DIFF
--- a/libvips/foreign/uhdrsave.c
+++ b/libvips/foreign/uhdrsave.c
@@ -271,6 +271,7 @@ vips_foreign_save_uhdr_set_compressed_gainmap(VipsForeignSaveUhdr *uhdr,
 	size_t length;
 	void *to_free;
 
+	data = NULL;
 	to_free = NULL;
 	if (vips_image_get_typeof(image, "gainmap")) {
 		VipsImage *gainmap;


### PR DESCRIPTION
<details>
  <summary>Details</summary>

```
[1/40] Compiling C object libvips/foreign/libforeign.a.p/uhdrsave.c.o
../libvips/foreign/uhdrsave.c:289:11: warning: variable 'data' is used uninitialized whenever '&&' condition is false [-Wsometimes-uninitialized]
  289 |         else if (vips_image_get_typeof(image, "gainmap-data") &&
      |                  ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
../libvips/foreign/uhdrsave.c:293:6: note: uninitialized use occurs here
  293 |         if (data) {
      |             ^~~~
../libvips/foreign/uhdrsave.c:289:11: note: remove the '&&' if its condition is always true
  289 |         else if (vips_image_get_typeof(image, "gainmap-data") &&
      |                  ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
../libvips/foreign/uhdrsave.c:270:18: note: initialize the variable 'data' to silence this warning
  270 |         const void *data;
      |                         ^
      |                          = NULL
1 warning generated.
```
</details>