### PR TITLE
uhdrload: return early if source is not JPEG

### DIFF
--- a/libvips/foreign/uhdrload.c
+++ b/libvips/foreign/uhdrload.c
@@ -108,6 +108,9 @@ G_DEFINE_ABSTRACT_TYPE(VipsForeignLoadUhdr, vips_foreign_load_uhdr,
 static int
 vips_foreign_load_uhdr_is_a(VipsSource *source)
 {
+	if (!vips__isjpeg_source(source))
+		return 0;
+
 	VipsImage *context = vips_image_new();
 
 	ReadJpeg *jpeg;
@@ -738,7 +741,7 @@ vips_foreign_load_uhdr_class_init(VipsForeignLoadUhdrClass *class)
 	object_class->description = _("load a UHDR image");
 	object_class->build = vips_foreign_load_uhdr_build;
 
-	/* We need to be higher poriority than jpegload.
+	/* We need to be higher priority than jpegload.
 	 */
 	foreign_class->priority = 100;
 


### PR DESCRIPTION
Test case:
```c
/* Compile with:
 *   gcc -g -Wall test.c `pkg-config vips --cflags --libs`
 */

#include <vips/vips.h>

int
main(int argc, char *argv[])
{
	if (VIPS_INIT(argv[0]))
		vips_error_exit(NULL);

	VipsSource *source;
	if (!(source = vips_source_new_from_file("/dev/null")))
		return 0;

	vips_foreign_find_load_source(source);

	return 0;
}
```

Before:
```console
$ gcc -g -Wall test.c `pkg-config vips --cflags --libs`
$ ./a.out

(process:301493): VIPS-WARNING **: 11:39:52.417: read gave 1 warnings

(process:301493): VIPS-WARNING **: 11:39:52.417: vips_mapfile: unable to mmap
system error: Invalid argument
VipsJpeg: premature end of JPEG image
VipsJpeg: Not a JPEG file: starts with 0xff 0xd9
```

After:
```console
$ gcc -g -Wall test.c `pkg-config vips --cflags --libs`
$ ./a.out
<EMPTY OUTPUT />
```
