### PR TITLE
OSS-Fuzz: remove spng build

### DIFF
--- a/fuzz/oss_fuzz_build.sh
+++ b/fuzz/oss_fuzz_build.sh
@@ -100,13 +100,6 @@ cmake \
 cmake --build . --target install
 popd
 
-# libspng
-pushd $SRC/libspng
-meson setup build --prefix=$WORK --libdir=lib --default-library=static --buildtype=debugoptimized \
-  -Dstatic_zlib=true -Dbuild_examples=false
-meson install -C build --tag devel
-popd
-
 # libwebp
 pushd $SRC/libwebp
 autoreconf -fi


### PR DESCRIPTION
See: lovell/sharp-libvips#300

Targets the 8.17 branch to ensure that CIFuzz continues to work after OSS-Fuzz's Dockerfile was updated to use libpng.