### PR TITLE
OSS-Fuzz: add libpng dependency

### DIFF
--- a/fuzz/oss_fuzz_build.sh
+++ b/fuzz/oss_fuzz_build.sh
@@ -100,6 +100,19 @@ cmake \
 cmake --build . --target install
 popd
 
+# libpng
+pushd $SRC/libpng
+autoreconf -fi
+./configure \
+  --prefix=$WORK \
+  --disable-shared \
+  --disable-tools \
+  --without-binconfigs \
+  --disable-unversioned-libpng-config \
+  --disable-dependency-tracking
+make install dist_man_MANS=
+popd
+
 # libwebp
 pushd $SRC/libwebp
 autoreconf -fi


### PR DESCRIPTION
This reverts commit 009afbc00388eb46320187f3b556afaf1236f151.

See companion PR: https://github.com/google/oss-fuzz/pull/14323.
Targets the 8.17 branch.