### PR TITLE
pngsave: cast to target format when colourspace is unsupported

### DIFF
--- a/libvips/foreign/pngsave.c
+++ b/libvips/foreign/pngsave.c
@@ -147,9 +147,20 @@ vips_foreign_save_png_build(VipsObject *object)
 			g_object_unref(in);
 			return -1;
 		}
-		g_object_unref(in);
-		in = x;
 	}
+	else {
+		VipsBandFormat target_format =
+			png->bitdepth > 8 ? VIPS_FORMAT_USHORT : VIPS_FORMAT_UCHAR;
+
+		/* Cast in down to target format if we can.
+		 */
+		if (vips_cast(in, &x, target_format, NULL)) {
+			g_object_unref(in);
+			return -1;
+		}
+	}
+	g_object_unref(in);
+	in = x;
 
 	/* If this is a RGB or RGBA image and a low bit depth has been
 	 * requested, enable palettization.

--- a/libvips/foreign/spngsave.c
+++ b/libvips/foreign/spngsave.c
@@ -639,9 +639,20 @@ vips_foreign_save_spng_build(VipsObject *object)
 			g_object_unref(in);
 			return -1;
 		}
-		g_object_unref(in);
-		in = x;
 	}
+	else {
+		VipsBandFormat target_format =
+			spng->bitdepth > 8 ? VIPS_FORMAT_USHORT : VIPS_FORMAT_UCHAR;
+
+		/* Cast in down to target format if we can.
+		 */
+		if (vips_cast(in, &x, target_format, NULL)) {
+			g_object_unref(in);
+			return -1;
+		}
+	}
+	g_object_unref(in);
+	in = x;
 
 	/* If this is a RGB or RGBA image and a low bit depth has been
 	 * requested, enable palettisation.


### PR DESCRIPTION
Similar to #4744, but for `pngsave`. Test case:
```python
#!/usr/bin/env python3
import pyvips

im = pyvips.Image.new_from_array([1, 2, 3, 4])
buf = im.pngsave_buffer()
im2 = pyvips.Image.new_from_buffer(buf, "")

assert im.avg() == im2.avg()
```

Targets the 8.17 branch.