### PR TITLE
jpegload: deprecate "unlimited" argument

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -23,6 +23,7 @@ master
 - add "exact" to webpsave
 - add "uhdr2scRGB"
 - dzsave has gainmap support
+- jpegload: deprecate "unlimited" argument [kleisauke]
 
 8.17.4
 

--- a/libvips/deprecated/im_jpeg2vips.c
+++ b/libvips/deprecated/im_jpeg2vips.c
@@ -116,7 +116,7 @@ jpeg2vips(const char *name, IMAGE *out, gboolean header_only)
 		if (!(source = vips_source_new_from_file(filename)))
 			return -1;
 		if (vips__jpeg_read_source(source, out,
-				header_only, shrink, fail_on_warn, FALSE, FALSE)) {
+				header_only, shrink, fail_on_warn, FALSE)) {
 			VIPS_UNREF(source);
 			return -1;
 		}

--- a/libvips/foreign/jpeg.h
+++ b/libvips/foreign/jpeg.h
@@ -96,10 +96,6 @@ typedef struct _ReadJpeg {
 	 */
 	gboolean autorotate;
 
-	/* Remove DoS limits.
-	 */
-	gboolean unlimited;
-
 	/* cinfo->output_width and height can be larger than we want since
 	 * libjpeg rounds up on shrink-on-load. This is the real size we will
 	 * output, as opposed to the size we decompress to.
@@ -119,8 +115,7 @@ void vips__new_output_message(j_common_ptr cinfo);
 void vips__new_error_exit(j_common_ptr cinfo);
 
 ReadJpeg *vips__readjpeg_new(VipsSource *source, VipsImage *out,
-	int shrink, VipsFailOn fail_on, gboolean autorotate,
-	gboolean unlimited);
+	int shrink, VipsFailOn fail_on, gboolean autorotate);
 int vips__readjpeg_open_input(ReadJpeg *jpeg);
 
 #ifdef __cplusplus

--- a/libvips/foreign/jpeg2vips.c
+++ b/libvips/foreign/jpeg2vips.c
@@ -113,7 +113,9 @@
  * 24/7/21
  * 	- add fail_on support
  * 2/8/22
- *      - add "unlimited"
+ * 	- add "unlimited"
+ * 30/11/25
+ * 	- deprecate "unlimited"
  */
 
 /*
@@ -335,34 +337,6 @@ vips__readjpeg_open_input(ReadJpeg *jpeg)
 	return 0;
 }
 
-static void
-readjpeg_emit_message(j_common_ptr cinfo, int msg_level)
-{
-	ReadJpeg *jpeg = (ReadJpeg *) cinfo->client_data;
-
-	long num_warnings;
-
-	if (msg_level < 0) {
-		/* Always count warnings in num_warnings.
-		 */
-		num_warnings = ++cinfo->err->num_warnings;
-
-		/* Corrupt files may give many warnings, the policy here is to
-		 * show only the first warning and treat many warnings as fatal,
-		 * unless unlimited is set.
-		 */
-		if (num_warnings == 1)
-			(*cinfo->err->output_message)(cinfo);
-		else if (!jpeg ||
-			(!jpeg->unlimited && num_warnings >= 100))
-			cinfo->err->error_exit(cinfo);
-	}
-	else if (cinfo->err->trace_level >= msg_level)
-		/* It's a trace message. Show it if trace_level >= msg_level.
-		 */
-		(*cinfo->err->output_message)(cinfo);
-}
-
 /* This can be called many times.
  */
 static int
@@ -407,8 +381,7 @@ readjpeg_minimise_cb(VipsImage *image, ReadJpeg *jpeg)
  */
 ReadJpeg *
 vips__readjpeg_new(VipsSource *source, VipsImage *out,
-	int shrink, VipsFailOn fail_on, gboolean autorotate,
-	gboolean unlimited)
+	int shrink, VipsFailOn fail_on, gboolean autorotate)
 {
 	ReadJpeg *jpeg;
 
@@ -425,11 +398,9 @@ vips__readjpeg_new(VipsSource *source, VipsImage *out,
 	jpeg->cinfo.err->first_addon_message = 1000;
 	jpeg->cinfo.err->last_addon_message = 1001;
 	jpeg->eman.pub.error_exit = vips__new_error_exit;
-	jpeg->eman.pub.emit_message = readjpeg_emit_message;
 	jpeg->eman.pub.output_message = vips__new_output_message;
 	jpeg->eman.fp = NULL;
 	jpeg->autorotate = autorotate;
-	jpeg->unlimited = unlimited;
 	jpeg->cinfo.client_data = jpeg;
 
 	/* jpeg_create_decompress() can fail on some sanity checks. Don't
@@ -998,12 +969,12 @@ jpeg_read(ReadJpeg *jpeg, VipsImage *out, gboolean header_only)
 int
 vips__jpeg_read_source(VipsSource *source, VipsImage *out,
 	gboolean header_only, int shrink, VipsFailOn fail_on,
-	gboolean autorotate, gboolean unlimited)
+	gboolean autorotate)
 {
 	ReadJpeg *jpeg;
 
 	if (!(jpeg = vips__readjpeg_new(source, out, shrink, fail_on,
-			  autorotate, unlimited)))
+			  autorotate)))
 		return -1;
 
 	/* Here for longjmp() from vips__new_error_exit() during

--- a/libvips/foreign/jpegload.c
+++ b/libvips/foreign/jpegload.c
@@ -74,10 +74,6 @@ typedef struct _VipsForeignLoadJpeg {
 	 */
 	VipsSource *source;
 
-	/* Remove DoS limits.
-	 */
-	gboolean unlimited;
-
 	/* Shrink by this much during load.
 	 */
 	int shrink;
@@ -85,6 +81,12 @@ typedef struct _VipsForeignLoadJpeg {
 	/* Autorotate using exif orientation tag.
 	 */
 	gboolean autorotate;
+
+	/* Remove DoS limits.
+	 *
+	 * This is deprecated and does nothing.
+	 */
+	gboolean unlimited;
 
 } VipsForeignLoadJpeg;
 
@@ -140,7 +142,7 @@ vips_foreign_load_jpeg_header(VipsForeignLoad *load)
 
 	if (vips__jpeg_read_source(jpeg->source,
 			load->out, TRUE, jpeg->shrink, load->fail_on,
-			jpeg->autorotate, jpeg->unlimited))
+			jpeg->autorotate))
 		return -1;
 
 	return 0;
@@ -153,7 +155,7 @@ vips_foreign_load_jpeg_load(VipsForeignLoad *load)
 
 	if (vips__jpeg_read_source(jpeg->source,
 			load->real, FALSE, jpeg->shrink, load->fail_on,
-			jpeg->autorotate, jpeg->unlimited))
+			jpeg->autorotate))
 		return -1;
 
 	return 0;
@@ -199,14 +201,12 @@ vips_foreign_load_jpeg_class_init(VipsForeignLoadJpegClass *class)
 		G_STRUCT_OFFSET(VipsForeignLoadJpeg, autorotate),
 		FALSE);
 
-#ifndef FUZZING_BUILD_MODE_UNSAFE_FOR_PRODUCTION
 	VIPS_ARG_BOOL(class, "unlimited", 22,
 		_("Unlimited"),
 		_("Remove all denial of service limits"),
-		VIPS_ARGUMENT_OPTIONAL_INPUT,
+		VIPS_ARGUMENT_OPTIONAL_INPUT | VIPS_ARGUMENT_DEPRECATED,
 		G_STRUCT_OFFSET(VipsForeignLoadJpeg, unlimited),
 		FALSE);
-#endif
 }
 
 static void

--- a/libvips/foreign/pforeign.h
+++ b/libvips/foreign/pforeign.h
@@ -138,7 +138,7 @@ int vips__jpeg_region_write_target(VipsRegion *region, VipsRect *rect,
 
 int vips__jpeg_read_source(VipsSource *source, VipsImage *out,
 	gboolean header_only, int shrink, VipsFailOn fail_on,
-	gboolean autorotate, gboolean unlimited);
+	gboolean autorotate);
 int vips__isjpeg_source(VipsSource *source);
 
 int vips__png_ispng_source(VipsSource *source);

--- a/libvips/foreign/uhdrload.c
+++ b/libvips/foreign/uhdrload.c
@@ -111,7 +111,7 @@ vips_foreign_load_uhdr_is_a(VipsSource *source)
 
 	ReadJpeg *jpeg;
 	if (!(jpeg = vips__readjpeg_new(source, context, 1, VIPS_FAIL_ON_NONE,
-			  FALSE, FALSE))) {
+			  FALSE))) {
 		VIPS_UNREF(context);
 		return 0;
 	}


### PR DESCRIPTION
The security issue that motivated this argument has been fixed upstream in libjpeg-turbo v3.0.4.

This partially reverts commit 2c4c0390564da4acf4186663b6bcd1c4ccbe96d8 and df26bd1e46c67ed7745996627ca0d83e5a6d678d.

Marked as draft, as this might be a bit too early, see:
<details>
  <summary>libjpeg-turbo packaging status</summary>

[![libjpeg-turbo packaging status](https://repology.org/badge/vertical-allrepos/libjpeg-turbo.svg?minversion=3.0.4&exclude_unsupported=1&columns=3&exclude_sources=modules,site&header=libjpeg-turbo%20packaging%20status)](https://repology.org/project/libjpeg-turbo/versions)
</details>

Context: https://github.com/libvips/libvips/discussions/3289#discussioncomment-10441905