### PR TITLE
allow effort=10 for jxlsave

### DIFF
--- a/libvips/foreign/jxlsave.c
+++ b/libvips/foreign/jxlsave.c
@@ -1129,7 +1129,7 @@ vips_foreign_save_jxl_class_init(VipsForeignSaveJxlClass *class)
 		_("Encoding effort"),
 		VIPS_ARGUMENT_OPTIONAL_INPUT,
 		G_STRUCT_OFFSET(VipsForeignSaveJxl, effort),
-		1, 9, 7);
+		1, 10, 7);
 
 	VIPS_ARG_BOOL(class, "lossless", 13,
 		_("Lossless"),


### PR DESCRIPTION
libjxl 0.10 allows effort=10, and 11 in expert mode

allow effort 10, but don't try to implement expert mode encoding

See https://github.com/libvips/libvips/issues/4616