### PR TITLE
Conditionally use C++14 for Highway sources

### DIFF
--- a/fuzz/oss_fuzz_build.sh
+++ b/fuzz/oss_fuzz_build.sh
@@ -168,6 +168,8 @@ EOF
 
 # highway
 pushd $SRC/highway
+# FIXME: Remove once Highway 1.4.0 is released.
+sed -i '/^project(hwy VERSION/s/1.3.0/1.4.0/' CMakeLists.txt
 cmake \
   -GNinja \
   -DCMAKE_BUILD_TYPE=RelWithDebInfo \

--- a/libvips/convolution/meson.build
+++ b/libvips/convolution/meson.build
@@ -29,6 +29,7 @@ convolution_lib = static_library('convolution',
     convolution_headers,
     dependencies: libvips_deps,
     gnu_symbol_visibility: 'hidden',
+    override_options: libhwy_overrides,
 )
 
 libvips_components += convolution_lib

--- a/libvips/iofuncs/meson.build
+++ b/libvips/iofuncs/meson.build
@@ -58,6 +58,7 @@ iofuncs_lib = static_library('iofuncs',
     vipsmarshal,
     dependencies: libvips_deps,
     gnu_symbol_visibility: 'hidden',
+    override_options: libhwy_overrides,
 )
 
 libvips_components += iofuncs_lib

--- a/libvips/morphology/meson.build
+++ b/libvips/morphology/meson.build
@@ -19,6 +19,7 @@ morphology_lib = static_library('morphology',
     morphology_headers,
     dependencies: libvips_deps,
     gnu_symbol_visibility: 'hidden',
+    override_options: libhwy_overrides,
 )
 
 libvips_components += morphology_lib

--- a/libvips/resample/meson.build
+++ b/libvips/resample/meson.build
@@ -36,6 +36,7 @@ resample_lib = static_library('resample',
     resample_headers,
     dependencies: libvips_deps,
     gnu_symbol_visibility: 'hidden',
+    override_options: libhwy_overrides,
 )
 
 libvips_components += resample_lib

--- a/meson.build
+++ b/meson.build
@@ -474,6 +474,7 @@ simd_package = disabler()
 # Require 1.0.5 to support the `ReorderDemote2To(u8, i16, i16)` operation
 # See: https://github.com/google/highway/pull/1247
 libhwy_dep = dependency('libhwy', version: '>=1.0.5', required: get_option('highway'))
+libhwy_overrides = []
 if libhwy_dep.found()
     external_deps += libhwy_dep
     cfg_var.set('HAVE_HWY', true)
@@ -487,6 +488,11 @@ if libhwy_dep.found()
     disabled_targets += ['HWY_AVX3_ZEN4', 'HWY_AVX3_SPR']
     if libhwy_dep.version().version_compare('>=1.3.0')
         disabled_targets += ['HWY_AVX10_2']
+    endif
+    # Use C++14 for libraries compiling Highway sources (required from v1.4.0)
+    # See: https://github.com/google/highway/pull/2805
+    if libhwy_dep.version().version_compare('>=1.4.0') and get_option('cpp_std') == 'c++11'
+        libhwy_overrides = ['cpp_std=c++14']
     endif
     # Optionally, build without AVX512 support (helps to reduce binary size at the cost of performance)
     #disabled_targets += ['HWY_AVX3']


### PR DESCRIPTION
Highway requires at least C++14 starting from version 1.4.0.

See: https://github.com/google/highway/pull/2805