### PR TITLE
make cpp's get_gainmap return a true ref

### DIFF
--- a/cplusplus/include/vips/VImage8.h
+++ b/cplusplus/include/vips/VImage8.h
@@ -549,7 +549,7 @@ public:
 	}
 
 	/**
-	 * The associated gainmap image. nullptr for no gainmap.
+	 * The associated gainmap image, if any.
 	 */
 	VImage
 	gainmap() const


### PR DESCRIPTION
This PR makes get_gainmap return a VImage which holds a true reference to the gainmap image. This makes it safer to use, while being no more complex for the caller.