### PR TITLE
Silence a clang warning

### DIFF
--- a/cplusplus/include/vips/VError8.h
+++ b/cplusplus/include/vips/VError8.h
@@ -72,8 +72,9 @@ private:
 	/**
 	 * ABI padding to preserve original VError size.
 	 */
+	// TODO: Migrate to [[maybe_unused]] once we require C++17.
 	char _abi_padding[sizeof(std::exception) + sizeof(std::string) -
-		sizeof(std::runtime_error)] = {};
+		sizeof(std::runtime_error)] G_GNUC_UNUSED = {};
 };
 
 VIPS_NAMESPACE_END


### PR DESCRIPTION
```console
[404/458] Compiling C++ object cplusplus/libvips-cpp.so.42.20.0.p/VError.cpp.o
In file included from ../cplusplus/VError.cpp:34:
In file included from ../cplusplus/include/vips/vips8:55:
../cplusplus/include/vips/VError8.h:76:7: warning: private field '_abi_padding' is not used [-Wunused-private-field]
   76 |         char _abi_padding[sizeof(std::exception) + sizeof(std::string) -
      |              ^
1 warning generated.
```