### PR TITLE
Add ChangeLog note for 4fab094

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -30,6 +30,7 @@ master
 - add vips_interpretation_bands()
 - heifsave: add "tune" parameter
 - require C++14 as a minimum standard [kleisauke]
+- prefer libpng over spng
 
 8.17.4
 


### PR DESCRIPTION
This change may affect distros that build with `-Dauto_features=enabled` (see e.g. rule 3 in [this blog post](https://blogs.gnome.org/mcatanzaro/2022/07/15/best-practices-for-build-options/)), so it's worth adding a note to the ChangeLog.