### PR TITLE
improve uhdr detection

### DIFF
--- a/libvips/foreign/jpeg2vips.c
+++ b/libvips/foreign/jpeg2vips.c
@@ -662,9 +662,21 @@ read_jpeg_header(ReadJpeg *jpeg, VipsImage *out)
 				p->data_length,
 				p->marker - JPEG_APP0);
 
-			for (i = 0; i < 10; i++)
-				printf("\t%d) '%c' (%d)\n",
-					i, p->data[i], p->data[i]);
+			i = 0;
+			for (int row = 0; i < VIPS_MIN(100, p->data_length); row++) {
+				printf(" 0x%02x)", i);
+
+				for (int col = 0; col < 8 &&
+						i < VIPS_MIN(100, p->data_length); col++, i++) {
+					printf(" %02x", p->data[i]);
+					if (p->data[i] > 32 && p->data[i] < 127)
+						printf(" '%c'", p->data[i]);
+					else
+						printf("    ");
+				}
+
+				printf("\n");
+			}
 		}
 #endif /*DEBUG*/
 


### PR DESCRIPTION
Some JPEGs really do use MPF and are not uhdr. Detect uhdr images by first looking for an MPF block, and only then calling is_uhdr_image().

Thanks @ri-char

See https://github.com/libvips/libvips/issues/4780