### PR TITLE
Make `_get_gainmap()` transfer ownership to caller

### DIFF
--- a/cplusplus/examples/uhdr.cpp
+++ b/cplusplus/examples/uhdr.cpp
@@ -32,11 +32,6 @@ main(int argc, char **argv)
 
 	VImage out = in.crop(left, top, width, height);
 
-	// vips_image_get_gainmap() can modify the metadata, so we need to make a
-	// unique copy of the image ... you can skip this step if you know your
-	// image is already unique
-	out = out.copy();
-
 	// also crop the gainmap, if there is one
 	VImage gainmap = out.gainmap();
 	if (!gainmap.is_null()) {
@@ -47,6 +42,11 @@ main(int argc, char **argv)
 
 		VImage x = gainmap.crop(left * hscale, top * vscale,
 			width * hscale, height * vscale);
+
+		// vips_image_set_image() modifies the metadata, so we need to make a
+		// unique copy of the image ... you can skip this step if you know your
+		// image is already unique
+		out = out.copy();
 
 		// update the gainmap
 		out.set("gainmap", x);

--- a/cplusplus/include/vips/VImage8.h
+++ b/cplusplus/include/vips/VImage8.h
@@ -554,7 +554,7 @@ public:
 	VImage
 	gainmap() const
 	{
-		return VImage(vips_image_get_gainmap(get_image()), NOSTEAL);
+		return VImage(vips_image_get_gainmap(get_image()));
 	}
 
 	/**

--- a/libvips/colour/uhdr2scRGB.c
+++ b/libvips/colour/uhdr2scRGB.c
@@ -238,6 +238,7 @@ vips_uhdr2scRGB_build(VipsObject *object)
 				"kernel", VIPS_KERNEL_LINEAR,
 				NULL))
 			return -1;
+		g_object_unref(gainmap);
 
 		colour->in[0] = uhdr->in;
 		g_object_ref(uhdr->in);

--- a/libvips/foreign/dzsave.c
+++ b/libvips/foreign/dzsave.c
@@ -2125,9 +2125,6 @@ vips_foreign_save_dz_build(VipsObject *object)
 	/* Load the gainmap, if any.
 	 */
 	if ((dz->gainmap = vips_image_get_gainmap(save->ready))) {
-		// we need a true reference
-		g_object_ref(dz->gainmap);
-
 		dz->gainmap_hscale = (double) dz->gainmap->Xsize / save->ready->Xsize;
 		dz->gainmap_vscale = (double) dz->gainmap->Ysize / save->ready->Ysize;
 

--- a/libvips/iofuncs/header.c
+++ b/libvips/iofuncs/header.c
@@ -1069,15 +1069,12 @@ vips_image_get_tile_height(VipsImage *image)
  * @image: image to get the gainmap from
  *
  * If the image has an attached `"gainmap"`, return that. If there's a
- * compressed `"gainmap-data"`, decompress, attach to the image, and return
- * it.
+ * compressed `"gainmap-data"`, decompress, and return it.
  *
- * Since this function can modify the image metadata, you must use
- * [method@Image.copy] to make a unique copy of the image first.
+ * You need to free the result with [method@GObject.Object.unref] when
+ * you're done with it.
  *
- * This function does not return a new reference -- do not unref the result.
- *
- * Returns: (nullable) (transfer none): the gainmap image, if present, or NULL.
+ * Returns: (nullable) (transfer full): the gainmap image, if present, or NULL.
  */
 VipsImage *
 vips_image_get_gainmap(VipsImage *image)
@@ -1096,12 +1093,7 @@ vips_image_get_gainmap(VipsImage *image)
 		if (vips_image_get_blob(image, "gainmap-data", &data, &length) ||
 			vips_jpegload_buffer((void *) data, length, &gainmap, NULL))
 			return NULL;
-
-		vips_image_set_image(image, "gainmap", gainmap);
 	}
-
-	if (gainmap)
-		g_object_unref(gainmap);
 
 	return gainmap;
 }

--- a/libvips/resample/thumbnail.c
+++ b/libvips/resample/thumbnail.c
@@ -840,17 +840,21 @@ vips_thumbnail_build(VipsObject *object)
 		return -1;
 	in = t[5];
 
-	/* Process the gainmap, if any. Make sure we don't have a shared image.
+	/* Also resize the gainmap, if any.
 	 */
-	if (vips_copy(in, &t[8], NULL))
-		return -1;
-	in = t[8];
 	if ((gainmap = vips_image_get_gainmap(in))) {
 		if (vips_resize(gainmap, &t[15], 1.0 / hshrink,
 			"vscale", 1.0 / vshrink,
 			"kernel", VIPS_KERNEL_LINEAR,
 			NULL))
 			return -1;
+		g_object_unref(gainmap);
+
+		/* Make sure we don't have a shared image.
+		 */
+		if (vips_copy(in, &t[8], NULL))
+			return -1;
+		in = t[8];
 
 		vips_image_set_image(in, "gainmap", t[15]);
 	}
@@ -868,6 +872,12 @@ vips_thumbnail_build(VipsObject *object)
 	 */
 	if (thumbnail->n_loaded_pages > 1) {
 		int output_page_height = rint(preshrunk_page_height / vshrink);
+
+		/* Make sure we don't have a shared image.
+		 */
+		if (vips_copy(in, &t[8], NULL))
+			return -1;
+		in = t[8];
 
 		vips_image_set_int(in, VIPS_META_PAGE_HEIGHT, output_page_height);
 	}
@@ -954,6 +964,7 @@ vips_thumbnail_build(VipsObject *object)
 				VIPS_META_ORIENTATION, thumbnail->orientation);
 			if (vips_autorot(gainmap, &t[17], NULL))
 				return -1;
+			g_object_unref(gainmap);
 
 			vips_image_set_image(in, "gainmap", t[17]);
 		}
@@ -997,6 +1008,7 @@ vips_thumbnail_build(VipsObject *object)
 					crop_width * xscale, crop_height * yscale,
 					NULL))
 				return -1;
+			g_object_unref(gainmap);
 
 			vips_image_set_image(in, "gainmap", t[16]);
 		}


### PR DESCRIPTION
`_get_gainmap()` now fully transfers ownership of the returned gainmap image to the caller, who is responsible for managing its lifecycle and setting the `"gainmap"` metadata.

Supersedes: #4782.