### PR TITLE
Discard existing RGB input profile for CMYK output

### DIFF
--- a/libvips/colour/icc_transform.c
+++ b/libvips/colour/icc_transform.c
@@ -558,7 +558,7 @@ vips_image_is_profile_compatible(VipsImage *image, int profile_bands)
 
 	// CMYK can mean more than 4 bands for eg. hexachrome
 	if (image->Type == VIPS_INTERPRETATION_CMYK)
-		return image->Bands >= 4;
+		return profile_bands >= 4;
 
 	if (bands > 0)
 		return bands == profile_bands;


### PR DESCRIPTION
Fixes a regression introduced in commit 1b88a00.

As noticed within sharp's test suite:
https://github.com/lovell/sharp/blob/3609c61a226760a4e9ce8524c1b42e136831b89e/test/unit/metadata.js#L666-L675