### PR TITLE
Silence a clang warning

### DIFF
--- a/libvips/iofuncs/header.c
+++ b/libvips/iofuncs/header.c
@@ -743,16 +743,13 @@ vips_image_guess_interpretation(const VipsImage *image)
 		break;
 
 	case VIPS_INTERPRETATION_RGB16:
-		if (vips_band_format_is8bit(image->BandFmt))
-			sane = FALSE;
-		break;
-
 	case VIPS_INTERPRETATION_GREY16:
 		if (vips_band_format_is8bit(image->BandFmt))
 			sane = FALSE;
 		break;
 
 	default:
+		break;
 	}
 
 	if (sane)


### PR DESCRIPTION
```console
[290/461] Compiling C object libvips/iofuncs/libiofuncs.a.p/header.c.obj
../vips-8.18.0/libvips/iofuncs/header.c:756:2: warning: label at end of compound statement is a C23 extension [-Wc23-extensions]
  756 |         }
      |         ^
1 warning generated.
```

While we're here, merge 2 consecutive identical branches.