### PR TITLE
fix metadata change warning for heifsave

### DIFF
--- a/libvips/foreign/heifsave.c
+++ b/libvips/foreign/heifsave.c
@@ -315,24 +315,19 @@ vips_foreign_save_heif_write_page(VipsForeignSaveHeif *heif, int page)
 	 * Orientation is defined using irot and imir transformations.
 	 */
 	options->image_orientation = vips_image_get_orientation(save->ready);
-	vips_autorot_remove_angle(save->ready);
 #endif
 
-
 #ifdef DEBUG
-	{
-		GTimer *timer = g_timer_new();
-
-		printf("calling heif_context_encode_image() ...\n");
+	GTimer *timer = g_timer_new();
+	printf("calling heif_context_encode_image() ...\n");
 #endif /*DEBUG*/
 
-		error = heif_context_encode_image(heif->ctx,
-			heif->img, heif->encoder, options, &heif->handle);
+	error = heif_context_encode_image(heif->ctx,
+		heif->img, heif->encoder, options, &heif->handle);
 
 #ifdef DEBUG
-		printf("... libheif took %.2g seconds\n", g_timer_elapsed(timer, NULL));
-		g_timer_destroy(timer);
-	}
+	printf("... libheif took %.2g seconds\n", g_timer_elapsed(timer, NULL));
+	g_timer_destroy(timer);
 #endif /*DEBUG*/
 
 	heif_encoding_options_free(options);


### PR DESCRIPTION
We were removing the orientation tag from the image during save, and this triggered a warning about a shared image pointer.

This PR removes the metadata change -- we were removing the libvips metadata orientation fields, but not regenerating the exif data block, which is what we we were actually writing, so the removal had no effect.

We could call `vips__exif_update()` to rebuild the exif block, but that's not part of the libvips API, so isn't available when heifsave is a module.

See https://github.com/libvips/libvips/pull/4783 for reporting PR.