### PR TITLE
fix the metadata change warning in tiffsave

### DIFF
--- a/libvips/foreign/vips2tiff.c
+++ b/libvips/foreign/vips2tiff.c
@@ -1980,20 +1980,26 @@ wtiff_layer_write_tiles(Wtiff *wtiff, Layer *layer, VipsRegion *strip)
 		 */
 		WtiffRow row = { wtiff, strip, layer, 0 };
 
+		VipsImage *x;
+		if (vips_copy(im, &x, NULL))
+			return -1;
+
 		/* We don't want threadpool_run to minimise on completion -- we need to
 		 * keep the cache on the pipeline before us.
 		 */
 		vips_image_set_int(im, "vips-no-minimise", 1);
 
-		if (vips_threadpool_run(im,
+		if (vips_threadpool_run(x,
 				vips_thread_state_new,
 				wtiff_layer_row_allocate,
 				wtiff_layer_row_work,
 				NULL,
 				&row)) {
+			VIPS_UNREF(x);
 			wtiff_row_free(&row);
 			return -1;
 		}
+		VIPS_UNREF(x);
 
 		if (wtiff_row_write(&row, layer->tif)) {
 			wtiff_row_free(&row);


### PR DESCRIPTION
Very like the dzsave change -- we need to make a private image to signal the minimise behaviour we want to the thraedpool.

See https://github.com/libvips/libvips/pull/4783