### PR TITLE
CI: set `GITHUB_TOKEN` env to avoid API rate limits

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -11,6 +11,8 @@ jobs:
       - uses: actions/checkout@v5
       - uses: cpp-linter/cpp-linter-action@v2
         id: linter
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           style: file
           version: 19 # Ubuntu 24.04 provides clang-format-19


### PR DESCRIPTION
Prevents `cpp-linter/cpp-linter-action` from hitting GitHub API rate limits when detecting the changed files in a PR.

Example failing job:
https://github.com/libvips/libvips/actions/runs/19987506829/job/57323559286


See also:
https://docs.github.com/en/rest/using-the-rest-api/rate-limits-for-the-rest-api#primary-rate-limit-for-github_token-in-github-actions