### PR TITLE
Fix build against GraphicsMagick

### DIFF
--- a/libvips/foreign/magick6load.c
+++ b/libvips/foreign/magick6load.c
@@ -1120,7 +1120,7 @@ vips_foreign_load_magick_source_header(VipsForeignLoad *load)
 		const char *filename =
 			vips_connection_filename(VIPS_CONNECTION(magick_source->source));
 
-		g_strlcpy(magick->image_info->filename, filename, MagickPathExtent);
+		g_strlcpy(magick->image_info->filename, filename, MaxPathExtent);
 		magick_sniff_file(magick->image_info, filename);
 		magick->image = ReadImage(magick->image_info, magick->exception);
 	}


### PR DESCRIPTION
GraphicsMagick does not provide the `MagickPathExtent` definition, use `MaxPathExtent` instead.

Resolves: #4796.

See also:
https://github.com/libvips/libvips/blob/fb923c8a360d8230b9d97f955d687e6b1590db78/libvips/foreign/magick.h#L35-L43
https://github.com/ImageMagick/ImageMagick6/blob/fab0592b552267bfe15184e3c39534a565760af7/magick/magick-type.h#L34-L36