### PR TITLE
Ensure compatibility with libraw < 0.21

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -455,7 +455,8 @@ if openexr_dep.found()
     cfg_var.set('HAVE_OPENEXR', true)
 endif
 
-libraw_dep = dependency('libraw_r', required: get_option('raw'))
+# require 0.14 for LIBRAW_COMPILE_CHECK_VERSION_NOTLESS
+libraw_dep = dependency('libraw_r', version: '>=0.14', required: get_option('raw'))
 if libraw_dep.found()
     external_deps += libraw_dep
     cfg_var.set('HAVE_LIBRAW', true)


### PR DESCRIPTION
Resolves: #4795.

Tested locally with libraw 0.14, I only see this warning:
```console
[67/458] Compiling C object libvips/foreign/libforeign.a.p/dcrawload.c.o
../libvips/foreign/dcrawload.c: In function ‘vips_foreign_load_dcraw_header’:
../libvips/foreign/dcrawload.c:324:65: warning: passing argument 2 of ‘libraw_open_buffer’ discards ‘const’ qualifier from pointer target type [-Wdiscarded-qualifiers]
  324 |                 result = libraw_open_buffer(raw->raw_processor, data, length);
      |                                                                 ^~~~
In file included from ../libvips/foreign/dcrawload.c:50:
/home/kleisauke/libraw-0.14/include/libraw/libraw.h:56:73: note: expected ‘void *’ but argument is of type ‘const void *’
   56 | DllDef    int                 libraw_open_buffer(libraw_data_t*, void * buffer, size_t size);
      |                                                                  ~~~~~~~^~~~~~
```