### PR TITLE
vector: mask supported Highway targets by builtin targets

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,7 @@
+date-tbd 8.18.1
+
+- vector: mask supported Highway targets by builtin targets [kleisauke]
+
 17/12/25 8.18.0
 
 - add dcrawload, dcrawload_source, dcrawload_buffer: load raw camera files

--- a/libvips/iofuncs/vector.cpp
+++ b/libvips/iofuncs/vector.cpp
@@ -132,7 +132,7 @@ vips_vector_get_builtin_targets()
 /**
  * vips_vector_get_supported_targets:
  *
- * Gets a bitfield of enabled targets that are supported on this CPU. The
+ * Gets a bitfield of builtin targets that are supported on this CPU. The
  * targets returned may change after calling [func@vector_disable_targets].
  *
  * Returns: a bitfield of supported CPU targets.
@@ -141,7 +141,7 @@ gint64
 vips_vector_get_supported_targets()
 {
 #ifdef HAVE_HWY
-	return hwy::SupportedTargets() & ~(HWY_EMU128 | HWY_SCALAR);
+	return hwy::SupportedTargets() & HWY_TARGETS & ~(HWY_EMU128 | HWY_SCALAR);
 #elif defined(HAVE_ORC)
 	return orc_target_get_default_flags(orc_target_get_default());
 #else


### PR DESCRIPTION
Ensure `vips_vector_get_supported_targets()` only reports targets that were actually compiled into libvips by intersecting the CPU supported targets with the builtin targets.

Resolves: #4815.