### PR TITLE
Bilinear interpolation: replace loop unroller with for loop

### DIFF
--- a/libvips/resample/interpolate.c
+++ b/libvips/resample/interpolate.c
@@ -428,45 +428,31 @@ G_DEFINE_TYPE(VipsInterpolateBilinear, vips_interpolate_bilinear,
  * p3  p4
  */
 
-#define BILINEAR_INT_INNER \
-	{ \
-		tq[z] = (c1 * tp1[z] + c2 * tp2[z] + \
-					c3 * tp3[z] + c4 * tp4[z] + \
-					(1 << VIPS_INTERPOLATE_SHIFT) / 2) >> \
-			VIPS_INTERPOLATE_SHIFT; \
-		z += 1; \
-	}
-
 /* Fixed-point arithmetic, no tables.
  */
 #define BILINEAR_INT(TYPE) \
 	{ \
 		TYPE *restrict tq = (TYPE *) out; \
 \
-		int X = (x - ix) * VIPS_INTERPOLATE_SCALE; \
-		int Y = (y - iy) * VIPS_INTERPOLATE_SCALE; \
+		const int X = (x - ix) * VIPS_INTERPOLATE_SCALE; \
+		const int Y = (y - iy) * VIPS_INTERPOLATE_SCALE; \
 \
-		int Yd = VIPS_INTERPOLATE_SCALE - Y; \
+		const int Yd = VIPS_INTERPOLATE_SCALE - Y; \
 \
-		int c4 = (Y * X) >> VIPS_INTERPOLATE_SHIFT; \
-		int c2 = (Yd * X) >> VIPS_INTERPOLATE_SHIFT; \
-		int c3 = Y - c4; \
-		int c1 = Yd - c2; \
+		const int c4 = (Y * X) >> VIPS_INTERPOLATE_SHIFT; \
+		const int c2 = (Yd * X) >> VIPS_INTERPOLATE_SHIFT; \
+		const int c3 = Y - c4; \
+		const int c1 = Yd - c2; \
 \
 		const TYPE *restrict tp1 = (TYPE *) p1; \
 		const TYPE *restrict tp2 = (TYPE *) p2; \
 		const TYPE *restrict tp3 = (TYPE *) p3; \
 		const TYPE *restrict tp4 = (TYPE *) p4; \
 \
-		z = 0; \
-		VIPS_UNROLL(b, BILINEAR_INT_INNER); \
-	}
-
-#define BILINEAR_FLOAT_INNER \
-	{ \
-		tq[z] = c1 * tp1[z] + c2 * tp2[z] + \
-			c3 * tp3[z] + c4 * tp4[z]; \
-		z += 1; \
+		for (z = 0; z < b; z++) { \
+			tq[z] = (c1 * tp1[z] + c2 * tp2[z] + c3 * tp3[z] + c4 * tp4[z] + \
+				(1 << VIPS_INTERPOLATE_SHIFT) / 2) >> VIPS_INTERPOLATE_SHIFT; \
+		} \
 	}
 
 /* Interpolate a pel ... int16, int32 and float types, no tables, float
@@ -477,23 +463,24 @@ G_DEFINE_TYPE(VipsInterpolateBilinear, vips_interpolate_bilinear,
 	{ \
 		TYPE *restrict tq = (TYPE *) out; \
 \
-		double X = x - ix; \
-		double Y = y - iy; \
+		const double X = x - ix; \
+		const double Y = y - iy; \
 \
-		double Yd = 1.0f - Y; \
+		const double Yd = 1.0f - Y; \
 \
-		double c4 = Y * X; \
-		double c2 = Yd * X; \
-		double c3 = Y - c4; \
-		double c1 = Yd - c2; \
+		const double c4 = Y * X; \
+		const double c2 = Yd * X; \
+		const double c3 = Y - c4; \
+		const double c1 = Yd - c2; \
 \
 		const TYPE *restrict tp1 = (TYPE *) p1; \
 		const TYPE *restrict tp2 = (TYPE *) p2; \
 		const TYPE *restrict tp3 = (TYPE *) p3; \
 		const TYPE *restrict tp4 = (TYPE *) p4; \
 \
-		z = 0; \
-		VIPS_UNROLL(b, BILINEAR_FLOAT_INNER); \
+		for (z = 0; z < b; z++) { \
+			tq[z] = c1 * tp1[z] + c2 * tp2[z] + c3 * tp3[z] + c4 * tp4[z]; \
+		} \
 	}
 
 /* The fixed-point path is fine for uchar pixels, but it'll be inaccurate for


### PR DESCRIPTION
As most images only have 1-4 bands, replacing the use of Duff's Device with a simple for loop is ~10% faster with modern compilers.

Before:
```
$ vips resize 500x500.png out.v 4 --kernel=linear

real	0m0.102s
user	0m0.294s
sys		0m0.062s
```
```
712,000,000 (61.63%)  ???:vips_interpolate_bilinear_interpolate [build/libvips/libvips.so.42.21.0]
236,182,625 (20.44%)  ???:vips_affine_gen [build/libvips/libvips.so.42.21.0]
 40,076,920 ( 3.47%)  ???:vips_format_sizeof_unsafe [build/libvips/libvips.so.42.21.0]
 40,000,000 ( 3.46%)  ???:vips_band_format_iscomplex [build/libvips/libvips.so.42.21.0]
```
After:
```
$ vips resize 500x500.png out.v 4 --kernel=linear

real	0m0.098s
user	0m0.261s
sys		0m0.058s
```
```
620,000,000 (58.25%)  ???:vips_interpolate_bilinear_interpolate [build/libvips/libvips.so.42.21.0]
236,182,625 (22.19%)  ???:vips_affine_gen [build/libvips/libvips.so.42.21.0]
 40,076,920 ( 3.77%)  ???:vips_format_sizeof_unsafe [build/libvips/libvips.so.42.21.0]
 40,000,000 ( 3.76%)  ???:vips_band_format_iscomplex [build/libvips/libvips.so.42.21.0]
```

I've been working with gain maps and spotted that `vips_interpolate_bilinear_interpolate` is on the hot path when upscaling these. It's possible to make further small performance gains by creating specific 1, 3 and 4 band paths without any for loop, but these would complicate the logic so I've left this out.
