### PR TITLE
thumbnail: add original image size to metadata

### DIFF
--- a/libvips/resample/thumbnail.c
+++ b/libvips/resample/thumbnail.c
@@ -659,9 +659,9 @@ vips_thumbnail_open(VipsThumbnail *thumbnail)
 	if (!(im = class->open(thumbnail, factor)))
 		return NULL;
 
-	vips_image_set_int(im, "orig-width", thumbnail->input_width);
-	vips_image_set_int(im, "orig-height", thumbnail->input_height);
-	vips_image_set_int(im, "orig-orientation", thumbnail->orientation);
+	vips_image_set_int(im, "original-width", thumbnail->input_width);
+	vips_image_set_int(im, "original-height", thumbnail->input_height);
+	vips_image_set_int(im, "original-orientation", thumbnail->orientation);
 	g_info("pre-shrunk size is %d x %d", im->Xsize, im->Ysize);
 
 	return im;


### PR DESCRIPTION
The original image size is lost due to the shrink-on-load feature. This PR stores it in the image metadata.