### PR TITLE
memory: fix `VIPS_FREEF` for expression-like macros

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -3,6 +3,7 @@ date-tbd 8.18.1
 - vector: mask supported Highway targets by builtin targets [kleisauke]
 - fix Highway paths on big-endian targets [kleisauke]
 - fix build with MSVC [star-hengxing]
+- fix compatibility with glibc 2.43 [mtasaka]
 
 17/12/25 8.18.0
 

--- a/libvips/include/vips/memory.h
+++ b/libvips/include/vips/memory.h
@@ -41,7 +41,7 @@ extern "C" {
 	G_STMT_START \
 	{ \
 		if (S) { \
-			(void) F((S)); \
+			(void) (F((S))); \
 			(S) = 0; \
 		} \
 	} \


### PR DESCRIPTION
Ensure the macro works correctly when F expands to an expression, such as `g_free()` using `free_sized()` (as available in the upcoming glibc 2.43).

Resolves: #4835.
Targets the 8.18 branch.