### PR TITLE
uhdrload: expose gainmap-downsample-factor metadata

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -7,6 +7,7 @@ date-tbd 8.18.1
 - pngload: avoid an expensive check during header read [kleisauke]
 - improve vips7 JPEG load compatibility [kleisauke]
 - fix saving 3-band MATRIX images [kleisauke]
+- uhdrload: expose original gainmap scale factor [lovell]
 
 17/12/25 8.18.0
 

--- a/libvips/foreign/uhdrload.c
+++ b/libvips/foreign/uhdrload.c
@@ -475,6 +475,12 @@ vips_foreign_load_uhdr_set_metadata(VipsForeignLoadUhdr *uhdr, VipsImage *out)
 			"gainmap-use-base-cg", gainmap_metadata->use_base_cg);
 	}
 
+	const int gainmap_width = uhdr_dec_get_gainmap_width(uhdr->dec);
+	if (gainmap_width > 0) {
+		vips_image_set_int(out, "gainmap-downsample-factor", VIPS_MAX(1,
+			uhdr_dec_get_image_width(uhdr->dec) / gainmap_width));
+	}
+
 	return 0;
 }
 

--- a/test/test-suite/test_foreign.py
+++ b/test/test-suite/test_foreign.py
@@ -442,6 +442,8 @@ class TestForeign:
             value = im.get(name)
             assert isinstance(value, (int, float))
 
+        assert im.get("gainmap-downsample-factor") == 4
+
         value = im.get("gainmap-data")
         assert len(value) > 10000
 


### PR DESCRIPTION
I've started integrating all the excellent work on gain maps into sharp and I suspect a few PRs might fall out of this work.

In addition to exposing gain map dimensions from the input metadata, control over the output gain map scale factor might be useful too as this is currently fixed at 2 but most sample images I've been working with appear to use a factor of 4.