### PR TITLE
pngload: avoid an expensive check during header read

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -4,6 +4,7 @@ date-tbd 8.18.1
 - fix Highway paths on big-endian targets [kleisauke]
 - fix build with MSVC [star-hengxing]
 - fix compatibility with glibc 2.43 [mtasaka]
+- pngload: avoid an expensive check during header read [kleisauke]
 
 17/12/25 8.18.0
 

--- a/libvips/foreign/vipspng.c
+++ b/libvips/foreign/vipspng.c
@@ -390,7 +390,7 @@ vips__set_text(VipsImage *out, int i, const char *key, const char *text)
 /* Read a png header.
  */
 static int
-png2vips_header(Read *read, VipsImage *out)
+png2vips_header(Read *read, VipsImage *out, gboolean header_only)
 {
 	png_uint_32 width, height;
 	int bitdepth, color_type;
@@ -556,13 +556,18 @@ png2vips_header(Read *read, VipsImage *out)
 #endif
 
 	/* Sanity-check line size.
+	 *
+	 * Don't do this for header read, since we don't want to force a
+	 * malloc if all we are doing is looking at fields.
 	 */
-	png_read_update_info(read->pPng, read->pInfo);
-	if (png_get_rowbytes(read->pPng, read->pInfo) !=
-		VIPS_IMAGE_SIZEOF_LINE(out)) {
-		vips_error("vipspng",
-			"%s", _("unable to read PNG header"));
-		return -1;
+	if (!header_only) {
+		png_read_update_info(read->pPng, read->pInfo);
+		if (png_get_rowbytes(read->pPng, read->pInfo) !=
+			VIPS_IMAGE_SIZEOF_LINE(out)) {
+			vips_error("vipspng",
+				"%s", _("unable to read PNG header"));
+			return -1;
+		}
 	}
 
 	/* Let our caller know. These are very expensive to decode.
@@ -776,14 +781,14 @@ png2vips_image(Read *read, VipsImage *out)
 		 * buffer, then copy to out.
 		 */
 		t[0] = vips_image_new_memory();
-		if (png2vips_header(read, t[0]) ||
+		if (png2vips_header(read, t[0], FALSE) ||
 			png2vips_interlace(read, t[0]) ||
 			vips_image_write(t[0], out))
 			return -1;
 	}
 	else {
 		t[0] = vips_image_new();
-		if (png2vips_header(read, t[0]) ||
+		if (png2vips_header(read, t[0], FALSE) ||
 			vips_image_generate(t[0],
 				NULL, png2vips_generate, NULL,
 				read, NULL) ||
@@ -816,7 +821,7 @@ vips__png_header_source(VipsSource *source, VipsImage *out,
 	Read *read;
 
 	if (!(read = read_new(source, out, TRUE, unlimited)) ||
-		png2vips_header(read, out))
+		png2vips_header(read, out, TRUE))
 		return -1;
 
 	vips_source_minimise(source);


### PR DESCRIPTION
Before:
```console
$ /usr/bin/time -f %M:%e vipsheader clusterfuzz-testcase-minimized-jxlsave_buffer_fuzzer-6015797127610368
clusterfuzz-testcase-minimized-jxlsave_buffer_fuzzer-6015797127610368: 83886171x85 uchar, 4 bands, srgb, pngload
695400:0.24
```

After:
```console
$ /usr/bin/time -f %M:%e vipsheader clusterfuzz-testcase-minimized-jxlsave_buffer_fuzzer-6015797127610368
clusterfuzz-testcase-minimized-jxlsave_buffer_fuzzer-6015797127610368: 83886171x85 uchar, 4 bands, srgb, pngload
45732:0.03
```

Resolves https://issues.oss-fuzz.com/issues/470453247, https://issues.oss-fuzz.com/issues/471768114 and https://issues.oss-fuzz.com/issues/474401010.
Targets the 8.18 branch.