### PR TITLE
Avoid implicit bool-to-enum conversions

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -5,6 +5,7 @@ date-tbd 8.18.1
 - fix build with MSVC [star-hengxing]
 - fix compatibility with glibc 2.43 [mtasaka]
 - pngload: avoid an expensive check during header read [kleisauke]
+- improve vips7 JPEG load compatibility [kleisauke]
 
 17/12/25 8.18.0
 

--- a/libvips/deprecated/im_jpeg2vips.c
+++ b/libvips/deprecated/im_jpeg2vips.c
@@ -58,12 +58,12 @@ jpeg2vips(const char *name, IMAGE *out, gboolean header_only)
 	char *p, *q;
 	int shrink;
 	int seq;
-	gboolean fail_on_warn;
+	VipsFailOn fail_on;
 
 	/* By default, we ignore any warnings. We want to get as much of
 	 * the user's data as we can.
 	 */
-	fail_on_warn = FALSE;
+	fail_on = VIPS_FAIL_ON_NONE;
 
 	/* Parse the filename.
 	 */
@@ -83,7 +83,7 @@ jpeg2vips(const char *name, IMAGE *out, gboolean header_only)
 	}
 	if ((q = im_getnextoption(&p))) {
 		if (im_isprefix("fail", q))
-			fail_on_warn = TRUE;
+			fail_on = VIPS_FAIL_ON_WARNING;
 	}
 	if ((q = im_getnextoption(&p))) {
 		if (im_isprefix("seq", q))
@@ -116,7 +116,7 @@ jpeg2vips(const char *name, IMAGE *out, gboolean header_only)
 		if (!(source = vips_source_new_from_file(filename)))
 			return -1;
 		if (vips__jpeg_read_source(source, out,
-				header_only, shrink, fail_on_warn, FALSE, FALSE)) {
+				header_only, shrink, fail_on, FALSE, FALSE)) {
 			VIPS_UNREF(source);
 			return -1;
 		}

--- a/libvips/foreign/vipspng.c
+++ b/libvips/foreign/vipspng.c
@@ -820,7 +820,7 @@ vips__png_header_source(VipsSource *source, VipsImage *out,
 {
 	Read *read;
 
-	if (!(read = read_new(source, out, TRUE, unlimited)) ||
+	if (!(read = read_new(source, out, VIPS_FAIL_ON_NONE, unlimited)) ||
 		png2vips_header(read, out, TRUE))
 		return -1;
 
@@ -855,7 +855,7 @@ vips__png_isinterlaced_source(VipsSource *source)
 
 	image = vips_image_new();
 
-	if (!(read = read_new(source, image, TRUE, FALSE))) {
+	if (!(read = read_new(source, image, VIPS_FAIL_ON_NONE, FALSE))) {
 		g_object_unref(image);
 		return -1;
 	}


### PR DESCRIPTION
Only the changes to `im_jpeg2vips.c` are noted in the `ChangeLog`. The `vipspng.c` changes are non-functional, since `VipsFailOn` is no-op during header-only reads.

Targets the 8.18 branch.