### PR TITLE
colourspace: treat `MATRIX` as `B_W` when resolving routes

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -6,6 +6,7 @@ date-tbd 8.18.1
 - fix compatibility with glibc 2.43 [mtasaka]
 - pngload: avoid an expensive check during header read [kleisauke]
 - improve vips7 JPEG load compatibility [kleisauke]
+- fix saving 3-band MATRIX images [kleisauke]
 
 17/12/25 8.18.0
 

--- a/libvips/colour/colourspace.c
+++ b/libvips/colour/colourspace.c
@@ -503,7 +503,8 @@ static VipsColourRoute vips_colour_routes[] = {
  * vips_colourspace_issupported: (method)
  * @image: input image
  *
- * Test if @image is in a colourspace that [method@Image.colourspace] can process.
+ * Test if @image is in a colourspace that [method@Image.colourspace] can
+ * process.
  *
  * Returns: `TRUE` if @image is in a supported colourspace.
  */
@@ -513,12 +514,18 @@ vips_colourspace_issupported(const VipsImage *image)
 	VipsInterpretation interpretation;
 	int i;
 
+	interpretation = vips_image_guess_interpretation(image);
+
 	/* Treat RGB as sRGB. If you want some other treatment,
 	 * you'll need to use the icc funcs.
 	 */
-	interpretation = vips_image_guess_interpretation(image);
 	if (interpretation == VIPS_INTERPRETATION_RGB)
 		interpretation = VIPS_INTERPRETATION_sRGB;
+
+	/* Treat MATRIX as B_W.
+	 */
+	if (interpretation == VIPS_INTERPRETATION_MATRIX)
+		interpretation = VIPS_INTERPRETATION_B_W;
 
 	for (i = 0; i < VIPS_NUMBER(vips_colour_routes); i++)
 		if (vips_colour_routes[i].from == interpretation)
@@ -579,6 +586,11 @@ vips_colourspace_build(VipsObject *object)
 	 */
 	if (interpretation == VIPS_INTERPRETATION_RGB)
 		interpretation = VIPS_INTERPRETATION_sRGB;
+
+	/* Treat MATRIX as B_W.
+	 */
+	if (interpretation == VIPS_INTERPRETATION_MATRIX)
+		interpretation = VIPS_INTERPRETATION_B_W;
 
 	for (i = 0; i < VIPS_NUMBER(vips_colour_routes); i++)
 		if (vips_colour_routes[i].from == interpretation &&

--- a/libvips/foreign/pngsave.c
+++ b/libvips/foreign/pngsave.c
@@ -125,39 +125,24 @@ vips_foreign_save_png_build(VipsObject *object)
 	if (vips_object_argument_isset(object, "colours"))
 		png->bitdepth = ceil(log2(png->colours));
 
-	if (vips_colourspace_issupported(in)) {
-		VipsInterpretation interpretation;
-
-		/* The bitdepth param can change the interpretation.
-		 */
-		if (in->Bands > 2) {
-		   if (png->bitdepth > 8)
-			   interpretation = VIPS_INTERPRETATION_RGB16;
-		   else
-			   interpretation = VIPS_INTERPRETATION_sRGB;
-		}
-		else {
-		   if (png->bitdepth > 8)
-			   interpretation = VIPS_INTERPRETATION_GREY16;
-		   else
-			   interpretation = VIPS_INTERPRETATION_B_W;
-		}
-
-		if (vips_colourspace(in, &x, interpretation, NULL)) {
-			g_object_unref(in);
-			return -1;
-		}
+	/* The bitdepth param can change the interpretation.
+	 */
+	VipsInterpretation interpretation;
+	if (in->Bands > 2) {
+	   if (png->bitdepth > 8)
+		   interpretation = VIPS_INTERPRETATION_RGB16;
+	   else
+		   interpretation = VIPS_INTERPRETATION_sRGB;
 	}
 	else {
-		VipsBandFormat target_format =
-			png->bitdepth > 8 ? VIPS_FORMAT_USHORT : VIPS_FORMAT_UCHAR;
-
-		/* Cast in down to target format if we can.
-		 */
-		if (vips_cast(in, &x, target_format, NULL)) {
-			g_object_unref(in);
-			return -1;
-		}
+	   if (png->bitdepth > 8)
+		   interpretation = VIPS_INTERPRETATION_GREY16;
+	   else
+		   interpretation = VIPS_INTERPRETATION_B_W;
+	}
+	if (vips_colourspace(in, &x, interpretation, NULL)) {
+		g_object_unref(in);
+		return -1;
 	}
 	g_object_unref(in);
 	in = x;

--- a/libvips/foreign/ppmsave.c
+++ b/libvips/foreign/ppmsave.c
@@ -223,7 +223,6 @@ vips_foreign_save_ppm_build(VipsObject *object)
 	VipsImage *image;
 	char *magic;
 	char *date;
-	VipsBandFormat target_format;
 	VipsInterpretation target_interpretation;
 	int target_bands;
 
@@ -254,37 +253,27 @@ vips_foreign_save_ppm_build(VipsObject *object)
 	case VIPS_FOREIGN_PPM_FORMAT_PBM:
 		if (!vips_object_argument_isset(object, "bitdepth"))
 			ppm->bitdepth = 1;
-		target_format = VIPS_FORMAT_UCHAR;
 		target_interpretation = VIPS_INTERPRETATION_B_W;
 		target_bands = 1;
 		break;
 
 	case VIPS_FOREIGN_PPM_FORMAT_PGM:
-		if (image->BandFmt == VIPS_FORMAT_USHORT) {
+		if (image->BandFmt == VIPS_FORMAT_USHORT)
 			target_interpretation = VIPS_INTERPRETATION_GREY16;
-			target_format = VIPS_FORMAT_USHORT;
-		}
-		else {
+		else
 			target_interpretation = VIPS_INTERPRETATION_B_W;
-			target_format = VIPS_FORMAT_UCHAR;
-		}
 		target_bands = 1;
 		break;
 
 	case VIPS_FOREIGN_PPM_FORMAT_PPM:
-		if (image->BandFmt == VIPS_FORMAT_USHORT) {
+		if (image->BandFmt == VIPS_FORMAT_USHORT)
 			target_interpretation = VIPS_INTERPRETATION_RGB16;
-			target_format = VIPS_FORMAT_USHORT;
-		}
-		else {
+		else
 			target_interpretation = VIPS_INTERPRETATION_sRGB;
-			target_format = VIPS_FORMAT_UCHAR;
-		}
 		target_bands = 3;
 		break;
 
 	case VIPS_FOREIGN_PPM_FORMAT_PFM:
-		target_format = VIPS_FORMAT_FLOAT;
 		target_interpretation = VIPS_INTERPRETATION_scRGB;
 		if (image->Bands > 1)
 			target_bands = 3;
@@ -295,19 +284,14 @@ vips_foreign_save_ppm_build(VipsObject *object)
 
 	case VIPS_FOREIGN_PPM_FORMAT_PNM:
 	default:
-		/* Just use the input format, interpretation and bands.
+		/* Just use the input interpretation and bands.
 		 */
-		target_format = image->BandFmt;
 		target_interpretation = image->Type;
 		target_bands = image->Bands;
 		break;
 	}
 
-	if (vips_colourspace_issupported(image)) {
-		if (vips_colourspace(image, &t[1], target_interpretation, NULL))
-			return -1;
-	}
-	else if (vips_cast(image, &t[1], target_format, NULL))
+	if (vips_colourspace(image, &t[1], target_interpretation, NULL))
 		return -1;
 	image = t[1];
 

--- a/libvips/foreign/spngsave.c
+++ b/libvips/foreign/spngsave.c
@@ -617,39 +617,24 @@ vips_foreign_save_spng_build(VipsObject *object)
 	if (vips_object_argument_isset(object, "colours"))
 		spng->bitdepth = ceil(log2(spng->colours));
 
-	if (vips_colourspace_issupported(in)) {
-		VipsInterpretation interpretation;
-
-		/* The bitdepth param can change the interpretation.
-		 */
-		if (in->Bands > 2) {
-		   if (spng->bitdepth > 8)
-			   interpretation = VIPS_INTERPRETATION_RGB16;
-		   else
-			   interpretation = VIPS_INTERPRETATION_sRGB;
-		}
-		else {
-		   if (spng->bitdepth > 8)
-			   interpretation = VIPS_INTERPRETATION_GREY16;
-		   else
-			   interpretation = VIPS_INTERPRETATION_B_W;
-		}
-
-		if (vips_colourspace(in, &x, interpretation, NULL)) {
-			g_object_unref(in);
-			return -1;
-		}
+	/* The bitdepth param can change the interpretation.
+	 */
+	VipsInterpretation interpretation;
+	if (in->Bands > 2) {
+	   if (spng->bitdepth > 8)
+		   interpretation = VIPS_INTERPRETATION_RGB16;
+	   else
+		   interpretation = VIPS_INTERPRETATION_sRGB;
 	}
 	else {
-		VipsBandFormat target_format =
-			spng->bitdepth > 8 ? VIPS_FORMAT_USHORT : VIPS_FORMAT_UCHAR;
-
-		/* Cast in down to target format if we can.
-		 */
-		if (vips_cast(in, &x, target_format, NULL)) {
-			g_object_unref(in);
-			return -1;
-		}
+	   if (spng->bitdepth > 8)
+		   interpretation = VIPS_INTERPRETATION_GREY16;
+	   else
+		   interpretation = VIPS_INTERPRETATION_B_W;
+	}
+	if (vips_colourspace(in, &x, interpretation, NULL)) {
+		g_object_unref(in);
+		return -1;
 	}
 	g_object_unref(in);
 	in = x;

--- a/test/test-suite/test_foreign.py
+++ b/test/test-suite/test_foreign.py
@@ -658,6 +658,27 @@ class TestForeign:
             # https://github.com/libvips/libvips/issues/4568
             assert (self.colour - rgb).abs().max() == 0
 
+        # sanity-check MULTIBAND save, this will be remapped
+        # to its standard RGB-like or greyscale equivalent
+        for i in range(1, 5):
+            im = pyvips.Image.black(16, 16, bands=i)
+            im.pngsave_buffer()
+
+        # https://github.com/libvips/lua-vips/issues/93
+        im = pyvips.Image.new_from_array([1, 2, 3, 4])
+        buf = im.pngsave_buffer()
+        im2 = pyvips.Image.new_from_buffer(buf, "")
+
+        assert im.avg() == im2.avg()
+
+        # https://github.com/libvips/ruby-vips/issues/431
+        im = pyvips.Image.new_from_array([1, 2, 3, 4])
+        im = im.bandjoin([im, im]).cast("uchar")
+        buf = im.pngsave_buffer(bitdepth=1)
+        im2 = pyvips.Image.new_from_buffer(buf, "")
+
+        assert im.avg() == im2.avg()
+
     @skip_if_no("tiffload")
     def test_tiff(self):
         def tiff_valid(im):


### PR DESCRIPTION
This simplifies colourspace handling by treating `MATRIX` images as `B_W`, removing the need for conditional casts in save paths.

This reverts commit 59cccb3, 522b418, 1ee29c9 and 64b1455.

Resolves: https://github.com/libvips/ruby-vips/issues/431.
Targets the 8.18 branch.

(h/t to @jcupitt for the idea: https://github.com/libvips/lua-vips/issues/93#issuecomment-3566915533)