### PR TITLE
Add link to funding via GitHub sponsors

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,1 +1,2 @@
+github: libvips
 open_collective: libvips


### PR DESCRIPTION
This should add a link to https://github.com/sponsors/libvips alongside the existing OpenCollective funding option.