### PR TITLE
uhdrsave: expose control over gain map scale factor

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -8,6 +8,7 @@ date-tbd 8.18.1
 - improve vips7 JPEG load compatibility [kleisauke]
 - fix saving 3-band MATRIX images [kleisauke]
 - uhdrload: expose original gainmap scale factor [lovell]
+- uhdrsave: control generated gainmap scale factor [lovell]
 
 17/12/25 8.18.0
 

--- a/libvips/foreign/uhdrsave.c
+++ b/libvips/foreign/uhdrsave.c
@@ -77,6 +77,8 @@ typedef struct _VipsForeignSaveUhdr {
 
 	int Q;
 
+	int gainmap_scale_factor;
+
 	uhdr_codec_private_t *enc;
 
 } VipsForeignSaveUhdr;
@@ -373,7 +375,7 @@ vips_foreign_save_uhdr_hdr(VipsForeignSaveUhdr *uhdr, VipsImage *image)
 	g_info("saving scRGB as UltraHDR");
 
 	uhdr_enc_set_output_format(uhdr->enc, UHDR_CODEC_JPG);
-	uhdr_enc_set_gainmap_scale_factor(uhdr->enc, 2);
+	uhdr_enc_set_gainmap_scale_factor(uhdr->enc, uhdr->gainmap_scale_factor);
 	uhdr_enc_set_using_multi_channel_gainmap(uhdr->enc, 0);
 
 	// attach the gainmap, if we have one
@@ -542,12 +544,20 @@ vips_foreign_save_uhdr_class_init(VipsForeignSaveUhdrClass *class)
 		G_STRUCT_OFFSET(VipsForeignSaveUhdr, Q),
 		1, 100, 75);
 
+	VIPS_ARG_INT(class, "gainmap_scale_factor", 11,
+		_("Gainmap scale factor"),
+		_("The scale factor of base image to gainmap image"),
+		VIPS_ARGUMENT_OPTIONAL_INPUT,
+		G_STRUCT_OFFSET(VipsForeignSaveUhdr, gainmap_scale_factor),
+		1, 128, 2);
+
 }
 
 static void
 vips_foreign_save_uhdr_init(VipsForeignSaveUhdr *uhdr)
 {
 	uhdr->Q = 75;
+	uhdr->gainmap_scale_factor = 2;
 }
 
 typedef struct _VipsForeignSaveUhdrFile {
@@ -742,8 +752,13 @@ vips_foreign_save_uhdr_target_init(VipsForeignSaveUhdrTarget *target)
  * If the image is scRGB and has a gainmap, a base image will be computed
  * and it will be saved as UltraHDR.
  *
- * If the image is scRGB and has no gainmap, one will be computed.
+ * If the image is scRGB and has no gainmap, one will be computed at a
+ * `gainmap_scale_factor` of the base image.
  * This is slow and takes a lot of memory.
+ *
+ * ::: tip "Optional arguments"
+ *     * @Q: `gint`, quality factor
+ *     * @gainmap_scale_factor: `gint`, scale factor of base image to gainmap
  *
  * ::: seealso
  *     [method@Image.write_to_file], [ctor@Image.uhdrload].
@@ -771,6 +786,10 @@ vips_uhdrsave(VipsImage *in, const char *filename, ...)
  * @...: `NULL`-terminated list of optional named arguments
  *
  * As [method@Image.uhdrsave], but save to a memory buffer.
+ *
+ * ::: tip "Optional arguments"
+ *     * @Q: `gint`, quality factor
+ *     * @gainmap_scale_factor: `gint`, scale factor of base image to gainmap
  *
  * ::: seealso
  *     [method@Image.uhdrsave], [method@Image.write_to_file].
@@ -812,6 +831,10 @@ vips_uhdrsave_buffer(VipsImage *in, void **buf, size_t *len, ...)
  * @...: `NULL`-terminated list of optional named arguments
  *
  * As [method@Image.uhdrsave], but save to a target.
+ *
+ * ::: tip "Optional arguments"
+ *     * @Q: `gint`, quality factor
+ *     * @gainmap_scale_factor: `gint`, scale factor of base image to gainmap
  *
  * ::: seealso
  *     [method@Image.uhdrsave], [method@Image.write_to_target].

--- a/test/test-suite/test_foreign.py
+++ b/test/test-suite/test_foreign.py
@@ -481,6 +481,18 @@ class TestForeign:
 
         assert (im2 - im).abs().avg() < 0.05
 
+    @skip_if_no("uhdrsave")
+    def test_uhdrsave_gainmap_scale_factor(self):
+        scrgb = self.colour.colourspace("scrgb")
+
+        data = scrgb.uhdrsave_buffer()
+        im = pyvips.Image.uhdrload_buffer(data)
+        assert im.get("gainmap-scale-factor") == 2
+
+        data = scrgb.uhdrsave_buffer(gainmap_scale_factor=4)
+        im = pyvips.Image.uhdrload_buffer(data)
+        assert im.get("gainmap-scale-factor") == 4
+
     @skip_if_no("uhdrload")
     def test_uhdr_thumbnail(self):
         im = pyvips.Image.uhdrload(UHDR_FILE)


### PR DESCRIPTION
A follow-up to #4839 for the encoding side, plus adds some docs and tests as well.