### PR TITLE
invertlut: check height before interpolating values #4872

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -12,6 +12,7 @@ date-tbd 8.18.1
 - source: guard against length truncation [Niebelungen-D]
 - string_to_array_double: ensure delimiter list is consistent [dloebl] [lovell]
 - fix loading/saving of non-8-bit JXL images [DarthSim]
+- invertlut: check height before interpolating values [dloebl] [lovell]
 
 17/12/25 8.18.0
 

--- a/libvips/create/invertlut.c
+++ b/libvips/create/invertlut.c
@@ -229,14 +229,19 @@ vips_invertlut_build_create(VipsInvertlut *lut)
 			if (j == -1)
 				j = 0;
 
-			/* Interpolate k as being between row data[j] and row
-			 * data[j + 1].
-			 */
-			irange = lut->data[j + 1][b + 1] - lut->data[j][b + 1];
-			orange = lut->data[j + 1][0] - lut->data[j][0];
+			if (height > 1) {
+				/* Interpolate k as being between row data[j] and row
+				 * data[j + 1].
+				 */
+				irange = lut->data[j + 1][b + 1] - lut->data[j][b + 1];
+				orange = lut->data[j + 1][0] - lut->data[j][0];
 
-			lut->buf[b + k * bands] = lut->data[j][0] +
-				orange * ((ki - lut->data[j][b + 1]) / irange);
+				lut->buf[b + k * bands] = lut->data[j][0] +
+					orange * ((ki - lut->data[j][b + 1]) / irange);
+			}
+			else {
+				lut->buf[b + k * bands] = lut->data[j][0];
+			}
 		}
 	}
 


### PR DESCRIPTION
A (not particularly useful) lookup table with only 1 row cannot use interpolation so instead copy the single value.

Fixes https://github.com/libvips/libvips/issues/4872