### PR TITLE
maplut: ensure lookup table index is unsigned #4871

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -16,6 +16,7 @@ date-tbd 8.18.1
 - extract: check bounds using unsigned arithmetic [Niebelungen-D] [lovell]
 - matrixload: guard against empty and very large inputs [Niebelungen-D] [lovell]
 - unpremultiply: check `alpha_band` is in range [Niebelungen-D] [lovell]
+- maplut: ensure lookup table index is unsigned [dloebl] [lovell]
 
 17/12/25 8.18.0
 

--- a/libvips/histogram/maplut.c
+++ b/libvips/histogram/maplut.c
@@ -191,7 +191,7 @@ vips_maplut_start(VipsImage *out, void *a, void *b)
 				OUT *tlut = (OUT *) maplut->table[z]; \
 \
 				for (x = z; x < ne; x += b) { \
-					int index = p[x]; \
+					unsigned int index = p[x]; \
 \
 					if (index > maplut->clp) { \
 						index = maplut->clp; \
@@ -215,7 +215,7 @@ vips_maplut_start(VipsImage *out, void *a, void *b)
 				OUT *tlut = (OUT *) maplut->table[z]; \
 \
 				for (x = 0; x < ne; x += b) { \
-					int index = p[x]; \
+					unsigned int index = p[x]; \
 \
 					if (index > maplut->clp) { \
 						index = maplut->clp; \
@@ -278,7 +278,7 @@ vips_maplut_start(VipsImage *out, void *a, void *b)
 			IN *p = (IN *) VIPS_REGION_ADDR(ir, le, y); \
 \
 			for (x = 0; x < ne; x++) { \
-				int index = p[x]; \
+				unsigned int index = p[x]; \
 \
 				if (index > maplut->clp) { \
 					index = maplut->clp; \
@@ -299,7 +299,7 @@ vips_maplut_start(VipsImage *out, void *a, void *b)
 			IN *p = (IN *) VIPS_REGION_ADDR(ir, le, y); \
 \
 			for (x = 0; x < ne; x++) { \
-				int index = p[x]; \
+				unsigned int index = p[x]; \
 \
 				if (index > maplut->clp) { \
 					index = maplut->clp; \
@@ -365,7 +365,7 @@ vips_maplut_start(VipsImage *out, void *a, void *b)
 			OUT *q = (OUT *) VIPS_REGION_ADDR(out_region, le, y); \
 \
 			for (i = 0, x = 0; x < np; x++) { \
-				int n = p[x]; \
+				unsigned int n = p[x]; \
 \
 				if (n > maplut->clp) { \
 					n = maplut->clp; \
@@ -389,7 +389,7 @@ vips_maplut_start(VipsImage *out, void *a, void *b)
 			OUT *q = (OUT *) VIPS_REGION_ADDR(out_region, le, y); \
 \
 			for (x = 0; x < np; x++) { \
-				int n = p[x]; \
+				unsigned int n = p[x]; \
 \
 				if (n > maplut->clp) { \
 					n = maplut->clp; \


### PR DESCRIPTION
This is a possible fix for #4871 and related code paths that deal with LUT indexes.

This change relies on the existing overflow check to clip the index to the LUT size. An alternative might be to continue to use a signed int but add an underflow check. (There are probably other solutions too.)