### PR TITLE
CI: run CIFuzz with both ASAN and UBSAN

### DIFF
--- a/.github/workflows/cifuzz.yml
+++ b/.github/workflows/cifuzz.yml
@@ -4,22 +4,26 @@ permissions: {}
 jobs:
   Fuzzing:
     runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        sanitizer: [address, undefined]
     steps:
     - name: Build Fuzzers
       id: build
       uses: google/oss-fuzz/infra/cifuzz/actions/build_fuzzers@master
       with:
         oss-fuzz-project-name: 'libvips'
-        dry-run: false
+        sanitizer: ${{ matrix.sanitizer }}
     - name: Run Fuzzers
       uses: google/oss-fuzz/infra/cifuzz/actions/run_fuzzers@master
       with:
         oss-fuzz-project-name: 'libvips'
+        sanitizer: ${{ matrix.sanitizer }}
         fuzz-seconds: 600
-        dry-run: false
     - name: Upload Crash
       uses: actions/upload-artifact@v6
       if: failure() && steps.build.outcome == 'success'
       with:
-        name: artifacts
+        name: artifacts-${{ matrix.sanitizer }}
         path: ./out/artifacts


### PR DESCRIPTION
Noticed while working on #4863: https://github.com/libvips/libvips/actions/runs/22092771573/job/64029163205#step:5:48
Previously, CIFuzz only ran with the default sanitizer (`address`). This adds a matrix strategy so that fuzzing is run separately with both ASAN and UBSAN.
For reference: https://google.github.io/oss-fuzz/getting-started/continuous-integration/