### PR TITLE
csvload: check whitespace and separator are ASCII

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -19,6 +19,7 @@ date-tbd 8.18.1
 - unpremultiply: check `alpha_band` is in range [Niebelungen-D] [lovell]
 - maplut: ensure lookup table index is unsigned [dloebl] [lovell]
 - draw_flood: reject out-of-bounds start point [dloebl]
+- csvload: check whitespace and separator are ASCII [Niebelungen-D] [lovell]
 
 17/12/25 8.18.0
 

--- a/libvips/foreign/csvload.c
+++ b/libvips/foreign/csvload.c
@@ -121,6 +121,13 @@ vips_foreign_load_csv_build(VipsObject *object)
 	int i;
 	const char *p;
 
+	if (!g_str_is_ascii(csv->whitespace) ||
+		!g_str_is_ascii(csv->separator)) {
+		vips_error("csvload", "%s",
+			_("whitespace and separator must be ASCII"));
+		return -1;
+	}
+
 	if (!(csv->sbuf = vips_sbuf_new_from_source(csv->source)))
 		return -1;
 


### PR DESCRIPTION
A possible quick fix for https://github.com/libvips/libvips/issues/4874
