### PR TITLE
csvload: guard against negative index access

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -21,6 +21,7 @@ date-tbd 8.18.1
 - draw_flood: reject out-of-bounds start point [dloebl]
 - csvload: check whitespace and separator are ASCII [Niebelungen-D] [lovell]
 - bandrank: check `index` is in range [Niebelungen-D] [lovell]
+- csvload: guard against negative index access [kleisauke]
 
 17/12/25 8.18.0
 

--- a/libvips/foreign/csvload.c
+++ b/libvips/foreign/csvload.c
@@ -251,7 +251,8 @@ vips_foreign_load_csv_fetch_item(VipsForeignLoadCsv *csv)
 
 	/* We've (probably) read the end of item character. Push it back.
 	 */
-	if (ch == '\n' ||
+	if (ch == -1 ||
+		ch == '\n' ||
 		csv->whitemap[ch] ||
 		csv->sepmap[ch])
 		VIPS_SBUF_UNGETC(csv->sbuf);


### PR DESCRIPTION
<details>
  <summary>Reproducer</summary>

```console
$ printf '\x00' | vips csvload_source [descriptor=0] x.v
../libvips/foreign/csvload.c:255:3: runtime error: index -1 out of bounds for type 'char[256]'
    #0 0x7ff983e3322a in vips_foreign_load_csv_fetch_item /home/kleisauke/libvips/build/../libvips/foreign/csvload.c:255:3
    #1 0x7ff983e3322a in vips_foreign_load_csv_read_double /home/kleisauke/libvips/build/../libvips/foreign/csvload.c:298:10
    #2 0x7ff983e2eced in vips_foreign_load_csv_header /home/kleisauke/libvips/build/../libvips/foreign/csvload.c:356:8
    #3 0x7ff983e71bdf in vips_foreign_load_build /home/kleisauke/libvips/build/../libvips/foreign/foreign.c:1154:7
    #4 0x7ff98447b7e3 in vips_object_build /home/kleisauke/libvips/build/../libvips/iofuncs/object.c:372:6
    #5 0x7ff9844d5867 in vips_call_argv /home/kleisauke/libvips/build/../libvips/iofuncs/operation.c:1474:6
    #6 0x0000004ec187 in main /home/kleisauke/libvips/build/../tools/vips.c:888:7
    #7 0x7ff98380c5b4 in __libc_start_call_main (/lib64/libc.so.6+0x35b4) (BuildId: ff0267465bc3d76e21003b3bc5598fd5ee63e261)
    #8 0x7ff98380c667 in __libc_start_main@GLIBC_2.2.5 (/lib64/libc.so.6+0x3667) (BuildId: ff0267465bc3d76e21003b3bc5598fd5ee63e261)
    #9 0x000000400a74 in _start (/usr/bin/vips+0x400a74) (BuildId: f9ecb8b21e0799f39c470f19cb8672829ad7ead6)

SUMMARY: UndefinedBehaviorSanitizer: undefined-behavior ../libvips/foreign/csvload.c:255:3 
Aborted                    printf '\x00' | vips csvload_source [descriptor=0] x.v
```
</details>

Found using PR #4863.
Targets the 8.18 branch.