### PR TITLE
source: replace sniff length overflow check with `g_assert()`

### DIFF
--- a/libvips/iofuncs/source.c
+++ b/libvips/iofuncs/source.c
@@ -1338,6 +1338,10 @@ vips_source_length(VipsSource *source)
  * read is returned -- it may be less than @length if the file is shorter than
  * @length. A negative number indicates a read error.
  *
+ * Do not use it if @length is greater than `UINT_MAX`.
+ * [struct@GLib.ByteArray] stores the length of its data in `guint`, which
+ * may be shorter than `size_t`.
+ *
  * Returns: number of bytes read, or -1 on error.
  */
 gint64
@@ -1349,12 +1353,7 @@ vips_source_sniff_at_most(VipsSource *source,
 
 	VIPS_DEBUG_MSG("vips_source_sniff_at_most: %zd bytes\n", length);
 
-	if (G_UNLIKELY(length > UINT_MAX)) {
-		vips_error(vips_connection_nick(VIPS_CONNECTION(source)),
-			"%s", _("length overflow"));
-		return -1;
-	}
-
+	g_assert(length <= UINT_MAX);
 	SANITY(source);
 
 	if (vips_source_test_features(source) ||


### PR DESCRIPTION
This check was added in commit a56feec, but it is only relevant for `vips_source_read_to_memory()`, not `vips_source_sniff_at_most()`.

Document the `UINT_MAX` constraint and replace the runtime error with a `g_assert()`, since exceeding this limit indicates a programming error rather than a recoverable runtime condition.

Targets the 8.18 branch.