### PR TITLE
convi: prevent possible int overflow

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -28,6 +28,7 @@ date-tbd 8.18.1
 - vips_window_take: prevent int underflow for small mapped images [jcupitt]
 - composite: fix UB (invalid-enum-value) in `->build()` [kleisauke]
 - multiply: prevent possible int overflow [kleisauke]
+- convi: prevent possible int overflow [kleisauke]
 - csvload: guard against negative index access [kleisauke]
 
 17/12/25 8.18.0

--- a/libvips/convolution/convi.c
+++ b/libvips/convolution/convi.c
@@ -700,12 +700,12 @@ vips_convi_gen_vector(VipsRegion *out_region,
 		int *restrict offsets = seq->offsets; \
 \
 		for (x = 0; x < sz; x++) { \
-			int sum; \
+			int64_t sum; \
 			int i; \
 \
 			sum = 0; \
 			for (i = 0; i < nnz; i++) \
-				sum += t[i] * p[offsets[i]]; \
+				sum += (int64_t) t[i] * p[offsets[i]]; \
 \
 			sum = CLIP(((sum + rounding) / scale) + offset); \
 \


### PR DESCRIPTION
<details>
  <summary>Reproducer</summary>

```console
$ printf 'P5\n1 1\n65535\n\xFF\xFF' > max_ushort.pgm
$ vips convi max_ushort.pgm x.v max_ushort.pgm
../libvips/convolution/convi.c:815:4: runtime error: signed integer overflow: 65535 * 65535 cannot be represented in type 'int'
    #0 0x7fd4bbfcaab5 in vips_convi_gen /home/kleisauke/libvips/build/../libvips/convolution/convi.c:815:4
    #1 0x7fd4bc359bd2 in vips_region_generate /home/kleisauke/libvips/build/../libvips/iofuncs/region.c:1614:6
    #2 0x7fd4bc33ba93 in vips_region_fill /home/kleisauke/libvips/build/../libvips/iofuncs/region.c:867:7
    #3 0x7fd4bc35938c in vips_region_prepare /home/kleisauke/libvips/build/../libvips/iofuncs/region.c:1682:7
    #4 0x7fd4bbd74ff7 in vips_copy_gen /home/kleisauke/libvips/build/../libvips/conversion/copy.c:140:6
    #5 0x7fd4bc359bd2 in vips_region_generate /home/kleisauke/libvips/build/../libvips/iofuncs/region.c:1614:6
    #6 0x7fd4bc33ba93 in vips_region_fill /home/kleisauke/libvips/build/../libvips/iofuncs/region.c:867:7
    #7 0x7fd4bc35938c in vips_region_prepare /home/kleisauke/libvips/build/../libvips/iofuncs/region.c:1682:7
    #8 0x7fd4bc2aa5d7 in vips_image_write_gen /home/kleisauke/libvips/build/../libvips/iofuncs/image.c:2600:6
    #9 0x7fd4bc359bd2 in vips_region_generate /home/kleisauke/libvips/build/../libvips/iofuncs/region.c:1614:6
    #10 0x7fd4bc35cbbb in vips_region_prepare_to_generate /home/kleisauke/libvips/build/../libvips/iofuncs/region.c:1737:6
    #11 0x7fd4bc35b80c in vips_region_prepare_to /home/kleisauke/libvips/build/../libvips/iofuncs/region.c:1854:7
    #12 0x7fd4bc2f4aba in wbuffer_work_fn /home/kleisauke/libvips/build/../libvips/iofuncs/sinkdisc.c:438:11
    #13 0x7fd4bc2211dc in vips_worker_work_unit /home/kleisauke/libvips/build/../libvips/iofuncs/threadpool.c:368:6
    #14 0x7fd4bc21f9e0 in vips_thread_main_loop /home/kleisauke/libvips/build/../libvips/iofuncs/threadpool.c:393:3
    #15 0x7fd4bc21a81e in vips_threadset_work /home/kleisauke/libvips/build/../libvips/iofuncs/threadset.c:187:3
    #16 0x7fd4bc215794 in vips_thread_run /home/kleisauke/libvips/build/../libvips/iofuncs/thread.c:108:11
    #17 0x7fd4bb31f741  (/lib64/libglib-2.0.so.0+0x75741) (BuildId: 2932f63ee7c53ae67d9b0b3ff877ece14c13edd5)
    #18 0x0000004a380a in asan_thread_start(void*) asan_interceptors.cpp.o
    #19 0x7fd4bae69463 in start_thread (/lib64/libc.so.6+0x72463) (BuildId: ff0267465bc3d76e21003b3bc5598fd5ee63e261)
    #20 0x7fd4baeec5eb in __GI___clone3 (/lib64/libc.so.6+0xf55eb) (BuildId: ff0267465bc3d76e21003b3bc5598fd5ee63e261)

SUMMARY: UndefinedBehaviorSanitizer: undefined-behavior ../libvips/convolution/convi.c:815:4 
Aborted                    vips convi max_ushort.pgm x.v max_ushort.pgm
```
</details>

Found using PR #4863.
Targets the 8.18 branch.