### PR TITLE
convi: guard against invalid shift

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -29,6 +29,7 @@ date-tbd 8.18.1
 - composite: fix UB (invalid-enum-value) in `->build()` [kleisauke]
 - multiply: prevent possible int overflow [kleisauke]
 - csvload: guard against negative index access [kleisauke]
+- convi: guard against invalid shift [kleisauke]
 
 17/12/25 8.18.0
 

--- a/libvips/convolution/convi.c
+++ b/libvips/convolution/convi.c
@@ -982,6 +982,10 @@ vips_convi_intize(VipsConvi *convi, VipsImage *M)
 	 * signed 8 bit.
 	 */
 	shift = ceil(log2(mx) + 1);
+	if (shift > 6 || shift < -24) {
+		g_info("vips_convi_intize: invalid shift");
+		return -1;
+	}
 
 #ifdef HAVE_HWY
 	/* Make sure we have enough range.
@@ -1100,10 +1104,7 @@ vips_convi_intize(VipsConvi *convi, VipsImage *M)
 
 		true_value = VIPS_CLIP(0, true_sum, 255);
 
-		if (convi->exp > 0)
-			int_value = (int_sum + (1 << (convi->exp - 1))) >> convi->exp;
-		else
-			int_value = VIPS_LSHIFT_INT(int_sum, convi->exp);
+		int_value = (int_sum + (1 << (convi->exp - 1))) >> convi->exp;
 		int_value = VIPS_CLIP(0, int_value, 255);
 
 		if (abs(true_value - int_value) > 2) {


### PR DESCRIPTION
<details>
  <summary>Reproducer</summary>

```console
$ printf 'P1\n1 1\n0' > min_uchar.pbm
$ vips convi min_uchar.pbm x.v min_uchar.pbm
../libvips/convolution/convi.c:1106:16: runtime error: shift exponent -2 is negative
    #0 0x7f59b05bd294 in vips_convi_intize /home/kleisauke/libvips/build/../libvips/convolution/convi.c:1106:16
    #1 0x7f59b05b5266 in vips_convi_build /home/kleisauke/libvips/build/../libvips/convolution/convi.c:1152:4
    #2 0x7f59b086c365 in vips_object_build /home/kleisauke/libvips/build/../libvips/iofuncs/object.c:372:6
    #3 0x7f59b092526d in vips_call_argv /home/kleisauke/libvips/build/../libvips/iofuncs/operation.c:1474:6
    #4 0x0000004eda5a in main /home/kleisauke/libvips/build/../tools/vips.c:888:7
    #5 0x7f59af4975b4 in __libc_start_call_main (/lib64/libc.so.6+0x35b4) (BuildId: ff0267465bc3d76e21003b3bc5598fd5ee63e261)
    #6 0x7f59af497667 in __libc_start_main@GLIBC_2.2.5 (/lib64/libc.so.6+0x3667) (BuildId: ff0267465bc3d76e21003b3bc5598fd5ee63e261)
    #7 0x000000400a94 in _start (/usr/bin/vips+0x400a94) (BuildId: faa38c405694c8f3e501fee5b4b2897861450fd0)

SUMMARY: UndefinedBehaviorSanitizer: undefined-behavior ../libvips/convolution/convi.c:1106:16 
Aborted                    vips convi min_uchar.pbm x.v min_uchar.pbm
```
</details>

Found using PR #4863.
Targets the 8.18 branch.