### PR TITLE
jpegsave: fix assert fail when saving 2-band image

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -34,6 +34,7 @@ date-tbd 8.18.1
 - csvload: guard against negative index access [kleisauke]
 - convi: guard against invalid shift [kleisauke]
 - nary: guard against empty input [kleisauke]
+- jpegsave: fix assert fail when saving 2-band image [kleisauke]
 
 17/12/25 8.18.0
 

--- a/libvips/foreign/vips2jpeg.c
+++ b/libvips/foreign/vips2jpeg.c
@@ -736,9 +736,6 @@ write_vips(Write *write, VipsImage *in, int Q, const char *profile,
 	 */
 	g_assert(in->BandFmt == VIPS_FORMAT_UCHAR);
 	g_assert(in->Coding == VIPS_CODING_NONE);
-	g_assert(in->Bands == 1 ||
-		in->Bands == 3 ||
-		in->Bands == 4);
 
 	/* Check input image.
 	 */


### PR DESCRIPTION
<details>
  <summary>Reproducer</summary>

```console
$ vips black x.v 1 1 --bands 2
$ vips cast x.v x2.v char
$ vips copy x2.v x.jpg
**
VIPS:ERROR:../libvips/foreign/vips2jpeg.c:741:write_vips: assertion failed: (in->Bands == 1 || in->Bands == 3 || in->Bands == 4)
Bail out! VIPS:ERROR:../libvips/foreign/vips2jpeg.c:741:write_vips: assertion failed: (in->Bands == 1 || in->Bands == 3 || in->Bands == 4)
Aborted                    vips copy x2.v x.jpg

```
</details>

See also:
https://github.com/libvips/libvips/blob/580d786804d355862873d91e0d3f475900cdd196/libvips/foreign/foreign.c#L1443-L1451


Found in PR #4916.
Targets the 8.18 branch.