### PR TITLE
LabS2LabQ: fix UB (undefined-shift)

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -36,6 +36,7 @@ date-tbd 8.18.1
 - nary: guard against empty input [kleisauke]
 - maplut: add missing overflow checks [kleisauke]
 - jpegsave: fix assert fail when saving 2-band image [kleisauke]
+- LabS2LabQ: fix UB (undefined-shift) [kleisauke]
 
 17/12/25 8.18.0
 

--- a/libvips/colour/LabS2LabQ.c
+++ b/libvips/colour/LabS2LabQ.c
@@ -52,6 +52,7 @@
 #include <stdio.h>
 
 #include <vips/vips.h>
+#include <vips/internal.h>
 
 #include "pcolour.h"
 
@@ -108,8 +109,8 @@ vips_LabS2LabQ_line(VipsColour *colour, VipsPel *out, VipsPel **in, int width)
 
 		/* Form extension byte.
 		 */
-		ext = (l << 6) & 0xc0;
-		ext |= (a << 3) & 0x38;
+		ext = VIPS_LSHIFT_INT(l, 6) & 0xc0;
+		ext |= VIPS_LSHIFT_INT(a, 3) & 0x38;
 		ext |= b & 0x7;
 		q[3] = ext;
 


### PR DESCRIPTION
<details>
  <summary>Reproducer</summary>

```console
$ printf "P6\n1 1\n65536\n" > max_uint.ppm
$ printf "\xFF\xFF\xFF\xFF%.0s" {1..3} >> max_uint.ppm
$ vips LabS2LabQ max_uint.ppm x.v
../libvips/colour/LabS2LabQ.c:112:13: runtime error: left shift of negative value -1
    #0 0x7fc156deac97 in vips_LabS2LabQ_line /home/kleisauke/libvips/build/../libvips/colour/LabS2LabQ.c:112:13
    #1 0x7fc156da90d9 in vips_colour_gen /home/kleisauke/libvips/build/../libvips/colour/colour.c:148:3
    #2 0x7fc15755e702 in vips_region_generate /home/kleisauke/libvips/build/../libvips/iofuncs/region.c:1614:6
    #3 0x7fc1575405c3 in vips_region_fill /home/kleisauke/libvips/build/../libvips/iofuncs/region.c:867:7
    #4 0x7fc15755debc in vips_region_prepare /home/kleisauke/libvips/build/../libvips/iofuncs/region.c:1682:7
    #5 0x7fc156f74f37 in vips_copy_gen /home/kleisauke/libvips/build/../libvips/conversion/copy.c:140:6
    #6 0x7fc15755e702 in vips_region_generate /home/kleisauke/libvips/build/../libvips/iofuncs/region.c:1614:6
    #7 0x7fc1575405c3 in vips_region_fill /home/kleisauke/libvips/build/../libvips/iofuncs/region.c:867:7
    #8 0x7fc15755debc in vips_region_prepare /home/kleisauke/libvips/build/../libvips/iofuncs/region.c:1682:7
    #9 0x7fc1574af107 in vips_image_write_gen /home/kleisauke/libvips/build/../libvips/iofuncs/image.c:2600:6
    #10 0x7fc15755e702 in vips_region_generate /home/kleisauke/libvips/build/../libvips/iofuncs/region.c:1614:6
    #11 0x7fc1575616eb in vips_region_prepare_to_generate /home/kleisauke/libvips/build/../libvips/iofuncs/region.c:1737:6
    #12 0x7fc15756033c in vips_region_prepare_to /home/kleisauke/libvips/build/../libvips/iofuncs/region.c:1854:7
    #13 0x7fc1574f95ea in wbuffer_work_fn /home/kleisauke/libvips/build/../libvips/iofuncs/sinkdisc.c:438:11
    #14 0x7fc157425d0c in vips_worker_work_unit /home/kleisauke/libvips/build/../libvips/iofuncs/threadpool.c:368:6
    #15 0x7fc157424510 in vips_thread_main_loop /home/kleisauke/libvips/build/../libvips/iofuncs/threadpool.c:393:3
    #16 0x7fc15741f34e in vips_threadset_work /home/kleisauke/libvips/build/../libvips/iofuncs/threadset.c:187:3
    #17 0x7fc15741a2c4 in vips_thread_run /home/kleisauke/libvips/build/../libvips/iofuncs/thread.c:108:11
    #18 0x7fc15651f741  (/lib64/libglib-2.0.so.0+0x75741) (BuildId: 2932f63ee7c53ae67d9b0b3ff877ece14c13edd5)
    #19 0x0000004a380a in asan_thread_start(void*) asan_interceptors.cpp.o
    #20 0x7fc1560a7463 in start_thread (/lib64/libc.so.6+0x72463) (BuildId: ff0267465bc3d76e21003b3bc5598fd5ee63e261)
    #21 0x7fc15612a5eb in __GI___clone3 (/lib64/libc.so.6+0xf55eb) (BuildId: ff0267465bc3d76e21003b3bc5598fd5ee63e261)

SUMMARY: UndefinedBehaviorSanitizer: undefined-behavior ../libvips/colour/LabS2LabQ.c:112:13 
Aborted                    vips LabS2LabQ max_uint.ppm x.v
```
</details>

Found using PR #4863.
Targets the 8.18 branch.