### PR TITLE
convasep: use unsigned accumulator where appropriate

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -37,6 +37,7 @@ date-tbd 8.18.1
 - maplut: add missing overflow checks [kleisauke]
 - jpegsave: fix assert fail when saving 2-band image [kleisauke]
 - LabS2LabQ: fix UB (undefined-shift) [kleisauke]
+- convasep: use unsigned accumulator where appropriate [kleisauke]
 
 17/12/25 8.18.0
 

--- a/libvips/convolution/convasep.c
+++ b/libvips/convolution/convasep.c
@@ -342,8 +342,7 @@ typedef struct {
 	/* The sums for each line. int for integer types, double for floating
 	 * point types.
 	 */
-	int *isum;
-	double *dsum;
+	void *sum;
 
 	int last_stride; /* Avoid recalcing offsets, if we can */
 } VipsConvasepSeq;
@@ -358,8 +357,7 @@ vips_convasep_stop(void *vseq, void *a, void *b)
 	VIPS_UNREF(seq->ir);
 	VIPS_FREE(seq->start);
 	VIPS_FREE(seq->end);
-	VIPS_FREE(seq->isum);
-	VIPS_FREE(seq->dsum);
+	VIPS_FREE(seq->sum);
 
 	return 0;
 }
@@ -383,18 +381,17 @@ vips_convasep_start(VipsImage *out, void *a, void *b)
 	seq->ir = vips_region_new(in);
 	seq->start = VIPS_ARRAY(NULL, convasep->n_lines, int);
 	seq->end = VIPS_ARRAY(NULL, convasep->n_lines, int);
-	seq->isum = NULL;
-	seq->dsum = NULL;
+
 	if (vips_band_format_isint(out->BandFmt))
-		seq->isum = VIPS_ARRAY(NULL, convasep->n_lines, int);
+		seq->sum = VIPS_ARRAY(NULL, convasep->n_lines, int);
 	else
-		seq->dsum = VIPS_ARRAY(NULL, convasep->n_lines, double);
+		seq->sum = VIPS_ARRAY(NULL, convasep->n_lines, double);
 	seq->last_stride = -1;
 
 	if (!seq->ir ||
 		!seq->start ||
 		!seq->end ||
-		(!seq->isum && !seq->dsum)) {
+		!seq->sum) {
 		vips_convasep_stop(seq, in, convasep);
 		return NULL;
 	}
@@ -450,14 +447,14 @@ vips_convasep_start(VipsImage *out, void *a, void *b)
  * them separate for easy debugging.
  */
 
-#define HCONV_INT(TYPE, CLIP) \
+#define HCONV_INT(ACC, TYPE, CLIP) \
 	{ \
 		for (i = 0; i < bands; i++) { \
-			int *isum = seq->isum; \
+			ACC *isum = (ACC *) seq->sum; \
 \
 			TYPE *q; \
 			TYPE *p; \
-			int sum; \
+			ACC sum; \
 \
 			p = i + (TYPE *) VIPS_REGION_ADDR(ir, r->left, r->top + y); \
 			q = i + (TYPE *) VIPS_REGION_ADDR(out_region, r->left, r->top + y); \
@@ -497,7 +494,7 @@ vips_convasep_start(VipsImage *out, void *a, void *b)
 #define HCONV_FLOAT(TYPE) \
 	{ \
 		for (i = 0; i < bands; i++) { \
-			double *dsum = seq->dsum; \
+			double *dsum = (double *) seq->sum; \
 \
 			TYPE *q; \
 			TYPE *p; \
@@ -592,27 +589,27 @@ vips_convasep_generate_horizontal(VipsRegion *out_region,
 	for (y = 0; y < r->height; y++) {
 		switch (in->BandFmt) {
 		case VIPS_FORMAT_UCHAR:
-			HCONV_INT(unsigned char, CLIP_UCHAR);
+			HCONV_INT(unsigned int, unsigned char, CLIP_UCHAR);
 			break;
 
 		case VIPS_FORMAT_CHAR:
-			HCONV_INT(signed char, CLIP_CHAR);
+			HCONV_INT(signed int, signed char, CLIP_CHAR);
 			break;
 
 		case VIPS_FORMAT_USHORT:
-			HCONV_INT(unsigned short, CLIP_USHORT);
+			HCONV_INT(unsigned int, unsigned short, CLIP_USHORT);
 			break;
 
 		case VIPS_FORMAT_SHORT:
-			HCONV_INT(signed short, CLIP_SHORT);
+			HCONV_INT(signed int, signed short, CLIP_SHORT);
 			break;
 
 		case VIPS_FORMAT_UINT:
-			HCONV_INT(unsigned int, CLIP_NONE);
+			HCONV_INT(unsigned int, unsigned int, CLIP_NONE);
 			break;
 
 		case VIPS_FORMAT_INT:
-			HCONV_INT(signed int, CLIP_NONE);
+			HCONV_INT(signed int, signed int, CLIP_NONE);
 			break;
 
 		case VIPS_FORMAT_FLOAT:
@@ -633,14 +630,14 @@ vips_convasep_generate_horizontal(VipsRegion *out_region,
 	return 0;
 }
 
-#define VCONV_INT(TYPE, CLIP) \
+#define VCONV_INT(ACC, TYPE, CLIP) \
 	{ \
 		for (x = 0; x < sz; x++) { \
-			int *isum = seq->isum; \
+			ACC *isum = (ACC *) seq->sum; \
 \
 			TYPE *q; \
 			TYPE *p; \
-			int sum; \
+			ACC sum; \
 \
 			p = x + (TYPE *) VIPS_REGION_ADDR(ir, r->left, r->top); \
 			q = x + (TYPE *) VIPS_REGION_ADDR(out_region, r->left, r->top); \
@@ -678,7 +675,7 @@ vips_convasep_generate_horizontal(VipsRegion *out_region,
 #define VCONV_FLOAT(TYPE) \
 	{ \
 		for (x = 0; x < sz; x++) { \
-			double *dsum = seq->dsum; \
+			double *dsum = (double *) seq->sum; \
 \
 			TYPE *q; \
 			TYPE *p; \
@@ -768,27 +765,27 @@ vips_convasep_generate_vertical(VipsRegion *out_region,
 
 	switch (in->BandFmt) {
 	case VIPS_FORMAT_UCHAR:
-		VCONV_INT(unsigned char, CLIP_UCHAR);
+		VCONV_INT(unsigned int, unsigned char, CLIP_UCHAR);
 		break;
 
 	case VIPS_FORMAT_CHAR:
-		VCONV_INT(signed char, CLIP_CHAR);
+		VCONV_INT(signed int, signed char, CLIP_CHAR);
 		break;
 
 	case VIPS_FORMAT_USHORT:
-		VCONV_INT(unsigned short, CLIP_USHORT);
+		VCONV_INT(unsigned int, unsigned short, CLIP_USHORT);
 		break;
 
 	case VIPS_FORMAT_SHORT:
-		VCONV_INT(signed short, CLIP_SHORT);
+		VCONV_INT(signed int, signed short, CLIP_SHORT);
 		break;
 
 	case VIPS_FORMAT_UINT:
-		VCONV_INT(unsigned int, CLIP_NONE);
+		VCONV_INT(unsigned int, unsigned int, CLIP_NONE);
 		break;
 
 	case VIPS_FORMAT_INT:
-		VCONV_INT(signed int, CLIP_NONE);
+		VCONV_INT(signed int, signed int, CLIP_NONE);
 		break;
 
 	case VIPS_FORMAT_FLOAT:


### PR DESCRIPTION
In line with `vips_conva()`.

<details>
  <summary>Reproducer</summary>

```console
$ printf "P5\n1 2\n65536\n\xFF\xFF\xFF\xFF\x7F\xFF\xFF\xFF" > repro.pgm
$ vips convasep repro.pgm x.v repro.pgm
../libvips/convolution/convasep.c:611:4: runtime error: signed integer overflow: 3 * 2147483647 cannot be represented in type 'int'
    #0 0x7fbe0e420b29 in vips_convasep_generate_horizontal /home/kleisauke/libvips/build/../libvips/convolution/convasep.c:611:4
    #1 0x7fbe0e75e652 in vips_region_generate /home/kleisauke/libvips/build/../libvips/iofuncs/region.c:1614:6
    #2 0x7fbe0e740513 in vips_region_fill /home/kleisauke/libvips/build/../libvips/iofuncs/region.c:867:7
    #3 0x7fbe0e75de0c in vips_region_prepare /home/kleisauke/libvips/build/../libvips/iofuncs/region.c:1682:7
    #4 0x7fbe0e430f11 in vips_convasep_generate_vertical /home/kleisauke/libvips/build/../libvips/convolution/convasep.c:748:6
    #5 0x7fbe0e75e652 in vips_region_generate /home/kleisauke/libvips/build/../libvips/iofuncs/region.c:1614:6
    #6 0x7fbe0e740513 in vips_region_fill /home/kleisauke/libvips/build/../libvips/iofuncs/region.c:867:7
    #7 0x7fbe0e75de0c in vips_region_prepare /home/kleisauke/libvips/build/../libvips/iofuncs/region.c:1682:7
    #8 0x7fbe0e6af057 in vips_image_write_gen /home/kleisauke/libvips/build/../libvips/iofuncs/image.c:2600:6
    #9 0x7fbe0e75e652 in vips_region_generate /home/kleisauke/libvips/build/../libvips/iofuncs/region.c:1614:6
    #10 0x7fbe0e740513 in vips_region_fill /home/kleisauke/libvips/build/../libvips/iofuncs/region.c:867:7
    #11 0x7fbe0e75de0c in vips_region_prepare /home/kleisauke/libvips/build/../libvips/iofuncs/region.c:1682:7
    #12 0x7fbe0e174e87 in vips_copy_gen /home/kleisauke/libvips/build/../libvips/conversion/copy.c:140:6
    #13 0x7fbe0e75e652 in vips_region_generate /home/kleisauke/libvips/build/../libvips/iofuncs/region.c:1614:6
    #14 0x7fbe0e740513 in vips_region_fill /home/kleisauke/libvips/build/../libvips/iofuncs/region.c:867:7
    #15 0x7fbe0e75de0c in vips_region_prepare /home/kleisauke/libvips/build/../libvips/iofuncs/region.c:1682:7
    #16 0x7fbe0e6af057 in vips_image_write_gen /home/kleisauke/libvips/build/../libvips/iofuncs/image.c:2600:6
    #17 0x7fbe0e75e652 in vips_region_generate /home/kleisauke/libvips/build/../libvips/iofuncs/region.c:1614:6
    #18 0x7fbe0e76163b in vips_region_prepare_to_generate /home/kleisauke/libvips/build/../libvips/iofuncs/region.c:1737:6
    #19 0x7fbe0e76028c in vips_region_prepare_to /home/kleisauke/libvips/build/../libvips/iofuncs/region.c:1854:7
    #20 0x7fbe0e6f953a in wbuffer_work_fn /home/kleisauke/libvips/build/../libvips/iofuncs/sinkdisc.c:438:11
    #21 0x7fbe0e625c5c in vips_worker_work_unit /home/kleisauke/libvips/build/../libvips/iofuncs/threadpool.c:368:6
    #22 0x7fbe0e624460 in vips_thread_main_loop /home/kleisauke/libvips/build/../libvips/iofuncs/threadpool.c:393:3
    #23 0x7fbe0e61f29e in vips_threadset_work /home/kleisauke/libvips/build/../libvips/iofuncs/threadset.c:187:3
    #24 0x7fbe0e61a214 in vips_thread_run /home/kleisauke/libvips/build/../libvips/iofuncs/thread.c:108:11
    #25 0x7fbe0d71f741  (/lib64/libglib-2.0.so.0+0x75741) (BuildId: 2932f63ee7c53ae67d9b0b3ff877ece14c13edd5)
    #26 0x0000004a380a in asan_thread_start(void*) asan_interceptors.cpp.o
    #27 0x7fbe0d306463 in start_thread (/lib64/libc.so.6+0x72463) (BuildId: ff0267465bc3d76e21003b3bc5598fd5ee63e261)
    #28 0x7fbe0d3895eb in __GI___clone3 (/lib64/libc.so.6+0xf55eb) (BuildId: ff0267465bc3d76e21003b3bc5598fd5ee63e261)

SUMMARY: UndefinedBehaviorSanitizer: undefined-behavior ../libvips/convolution/convasep.c:611:4 
Aborted                    vips convasep repro.pgm x.v repro.pgm

```
</details>

Found using PR #4863.
Targets the 8.18 branch.