### PR TITLE
multiply: use 64-bits intermediate for int format

### DIFF
--- a/libvips/arithmetic/multiply.c
+++ b/libvips/arithmetic/multiply.c
@@ -114,6 +114,18 @@ G_DEFINE_TYPE(VipsMultiply, vips_multiply, VIPS_TYPE_BINARY);
 			q[x] = (OUT) left[x] * right[x]; \
 	}
 
+/* Special case for VIPS_FORMAT_INT, to prevent UB.
+ */
+#define RLOOP_INT64(IN, OUT) \
+	{ \
+		IN *restrict left = (IN *) in[0]; \
+		IN *restrict right = (IN *) in[1]; \
+		OUT *restrict q = (OUT *) out; \
+\
+		for (x = 0; x < sz; x++) \
+			q[x] = (int64_t) left[x] * right[x]; \
+	}
+
 static void
 vips_multiply_buffer(VipsArithmetic *arithmetic,
 	VipsPel *out, VipsPel **in, int width)
@@ -140,7 +152,7 @@ vips_multiply_buffer(VipsArithmetic *arithmetic,
 		RLOOP(unsigned short, unsigned int);
 		break;
 	case VIPS_FORMAT_INT:
-		RLOOP(signed int, signed int);
+		RLOOP_INT64(signed int, signed int);
 		break;
 	case VIPS_FORMAT_UINT:
 		RLOOP(unsigned int, unsigned int);


### PR DESCRIPTION
Follow-up to #4900 and in line with:
https://github.com/libvips/libvips/blob/6d09450d6ad6db31713504dc4c1e945cccc65961/libvips/resample/templates.h#L527-L540

<details>
  <summary>Reproducer</summary>

```console
$ printf 'P5\n1 1\n65536\n\x7F\xFF\xFF\xFF' > max_int.ppm
$ vips cast max_int.ppm max_int.v int
$ vips multiply max_int.v max_int.v x.v
../libvips/arithmetic/multiply.c:143:3: runtime error: signed integer overflow: 2147483647 * 2147483647 cannot be represented in type 'int'
    #0 0x7f7804119a75 in vips_multiply_buffer /home/kleisauke/libvips/build/../libvips/arithmetic/multiply.c:143:3
    #1 0x7f7803f8533b in vips_arithmetic_gen /home/kleisauke/libvips/build/../libvips/arithmetic/arithmetic.c:421:3
    #2 0x7f7804b5c702 in vips_region_generate /home/kleisauke/libvips/build/../libvips/iofuncs/region.c:1614:6
    #3 0x7f7804b3e5c3 in vips_region_fill /home/kleisauke/libvips/build/../libvips/iofuncs/region.c:867:7
    #4 0x7f7804b5bebc in vips_region_prepare /home/kleisauke/libvips/build/../libvips/iofuncs/region.c:1682:7
    #5 0x7f7804574e87 in vips_copy_gen /home/kleisauke/libvips/build/../libvips/conversion/copy.c:140:6
    #6 0x7f7804b5c702 in vips_region_generate /home/kleisauke/libvips/build/../libvips/iofuncs/region.c:1614:6
    #7 0x7f7804b3e5c3 in vips_region_fill /home/kleisauke/libvips/build/../libvips/iofuncs/region.c:867:7
    #8 0x7f7804b5bebc in vips_region_prepare /home/kleisauke/libvips/build/../libvips/iofuncs/region.c:1682:7
    #9 0x7f7804aad107 in vips_image_write_gen /home/kleisauke/libvips/build/../libvips/iofuncs/image.c:2600:6
    #10 0x7f7804b5c702 in vips_region_generate /home/kleisauke/libvips/build/../libvips/iofuncs/region.c:1614:6
    #11 0x7f7804b5f6eb in vips_region_prepare_to_generate /home/kleisauke/libvips/build/../libvips/iofuncs/region.c:1737:6
    #12 0x7f7804b5e33c in vips_region_prepare_to /home/kleisauke/libvips/build/../libvips/iofuncs/region.c:1854:7
    #13 0x7f7804af75ea in wbuffer_work_fn /home/kleisauke/libvips/build/../libvips/iofuncs/sinkdisc.c:438:11
    #14 0x7f7804a23d0c in vips_worker_work_unit /home/kleisauke/libvips/build/../libvips/iofuncs/threadpool.c:368:6
    #15 0x7f7804a22510 in vips_thread_main_loop /home/kleisauke/libvips/build/../libvips/iofuncs/threadpool.c:393:3
    #16 0x7f7804a1d34e in vips_threadset_work /home/kleisauke/libvips/build/../libvips/iofuncs/threadset.c:187:3
    #17 0x7f7804a182c4 in vips_thread_run /home/kleisauke/libvips/build/../libvips/iofuncs/thread.c:108:11
    #18 0x7f7803b1f741  (/lib64/libglib-2.0.so.0+0x75741) (BuildId: 2932f63ee7c53ae67d9b0b3ff877ece14c13edd5)
    #19 0x0000004a380a in asan_thread_start(void*) asan_interceptors.cpp.o
    #20 0x7f7803706463 in start_thread (/lib64/libc.so.6+0x72463) (BuildId: ff0267465bc3d76e21003b3bc5598fd5ee63e261)
    #21 0x7f78037895eb in __GI___clone3 (/lib64/libc.so.6+0xf55eb) (BuildId: ff0267465bc3d76e21003b3bc5598fd5ee63e261)

SUMMARY: UndefinedBehaviorSanitizer: undefined-behavior ../libvips/arithmetic/multiply.c:143:3 
Aborted                    vips multiply max_int.v max_int.v x.v
```
</details>

Found using PR #4863 and by applying the following change:
```console
$ sed -i "/VIPS_FORMAT_/s/U//" libvips/foreign/ppmload.c
```
which makes `ppmload` to produce signed-format images, making such issues faster to detect (as overflow of signed integers invokes UB, whereas unsigned integer overflow is well defined).

Targets the 8.18 branch.