### PR TITLE
add: use 64-bits intermediate for int format

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -27,6 +27,7 @@ date-tbd 8.18.1
 - bandrank: check `index` is in range [Niebelungen-D] [lovell]
 - vips_window_take: prevent int underflow for small mapped images [jcupitt]
 - composite: fix UB (invalid-enum-value) in `->build()` [kleisauke]
+- add: prevent possible int overflow [kleisauke]
 - multiply: prevent possible int overflow [kleisauke]
 - convasep: prevent possible int overflow [kleisauke]
 - conva: prevent possible int overflow [kleisauke]

--- a/libvips/arithmetic/add.c
+++ b/libvips/arithmetic/add.c
@@ -99,6 +99,18 @@ G_DEFINE_TYPE(VipsAdd, vips_add, VIPS_TYPE_BINARY);
 			q[x] = left[x] + right[x]; \
 	}
 
+/* Special case for VIPS_FORMAT_INT, to prevent UB.
+ */
+#define LOOP_INT64(IN, OUT) \
+	{ \
+		IN *restrict left = (IN *) in[0]; \
+		IN *restrict right = (IN *) in[1]; \
+		OUT *restrict q = (OUT *) out; \
+\
+		for (x = 0; x < sz; x++) \
+			q[x] = (int64_t) left[x] + right[x]; \
+	}
+
 static void
 add_buffer(VipsArithmetic *arithmetic, VipsPel *out, VipsPel **in, int width)
 {
@@ -129,7 +141,7 @@ add_buffer(VipsArithmetic *arithmetic, VipsPel *out, VipsPel **in, int width)
 		LOOP(unsigned int, unsigned int);
 		break;
 	case VIPS_FORMAT_INT:
-		LOOP(signed int, signed int);
+		LOOP_INT64(signed int, signed int);
 		break;
 
 	case VIPS_FORMAT_FLOAT:


### PR DESCRIPTION
Same as #4922, but for `vips_add()`.

<details>
  <summary>Reproducer</summary>

```console
$ printf 'P5\n1 1\n65536\n\x7F\xFF\xFF\xFF' > max_int.ppm
$ vips cast max_int.ppm max_int.v int
$ vips add max_int.v max_int.v x.v
../libvips/arithmetic/add.c:132:3: runtime error: signed integer overflow: 2147483647 + 2147483647 cannot be represented in type 'int'
    #0 0x7fdb96b76d46 in add_buffer /home/kleisauke/libvips/build/../libvips/arithmetic/add.c:132:3
    #1 0x7fdb96b8533b in vips_arithmetic_gen /home/kleisauke/libvips/build/../libvips/arithmetic/arithmetic.c:421:3
    #2 0x7fdb9775c712 in vips_region_generate /home/kleisauke/libvips/build/../libvips/iofuncs/region.c:1614:6
    #3 0x7fdb9773e5d3 in vips_region_fill /home/kleisauke/libvips/build/../libvips/iofuncs/region.c:867:7
    #4 0x7fdb9775becc in vips_region_prepare /home/kleisauke/libvips/build/../libvips/iofuncs/region.c:1682:7
    #5 0x7fdb97174e97 in vips_copy_gen /home/kleisauke/libvips/build/../libvips/conversion/copy.c:140:6
    #6 0x7fdb9775c712 in vips_region_generate /home/kleisauke/libvips/build/../libvips/iofuncs/region.c:1614:6
    #7 0x7fdb9773e5d3 in vips_region_fill /home/kleisauke/libvips/build/../libvips/iofuncs/region.c:867:7
    #8 0x7fdb9775becc in vips_region_prepare /home/kleisauke/libvips/build/../libvips/iofuncs/region.c:1682:7
    #9 0x7fdb976ad117 in vips_image_write_gen /home/kleisauke/libvips/build/../libvips/iofuncs/image.c:2600:6
    #10 0x7fdb9775c712 in vips_region_generate /home/kleisauke/libvips/build/../libvips/iofuncs/region.c:1614:6
    #11 0x7fdb9775f6fb in vips_region_prepare_to_generate /home/kleisauke/libvips/build/../libvips/iofuncs/region.c:1737:6
    #12 0x7fdb9775e34c in vips_region_prepare_to /home/kleisauke/libvips/build/../libvips/iofuncs/region.c:1854:7
    #13 0x7fdb976f75fa in wbuffer_work_fn /home/kleisauke/libvips/build/../libvips/iofuncs/sinkdisc.c:438:11
    #14 0x7fdb97623d1c in vips_worker_work_unit /home/kleisauke/libvips/build/../libvips/iofuncs/threadpool.c:368:6
    #15 0x7fdb97622520 in vips_thread_main_loop /home/kleisauke/libvips/build/../libvips/iofuncs/threadpool.c:393:3
    #16 0x7fdb9761d35e in vips_threadset_work /home/kleisauke/libvips/build/../libvips/iofuncs/threadset.c:187:3
    #17 0x7fdb976182d4 in vips_thread_run /home/kleisauke/libvips/build/../libvips/iofuncs/thread.c:108:11
    #18 0x7fdb993e9741  (/lib64/libglib-2.0.so.0+0x75741) (BuildId: 2932f63ee7c53ae67d9b0b3ff877ece14c13edd5)
    #19 0x0000004a380a in asan_thread_start(void*) asan_interceptors.cpp.o
    #20 0x7fdb963d1463 in start_thread (/lib64/libc.so.6+0x72463) (BuildId: ff0267465bc3d76e21003b3bc5598fd5ee63e261)
    #21 0x7fdb964545eb in __GI___clone3 (/lib64/libc.so.6+0xf55eb) (BuildId: ff0267465bc3d76e21003b3bc5598fd5ee63e261)

SUMMARY: UndefinedBehaviorSanitizer: undefined-behavior ../libvips/arithmetic/add.c:132:3 
Aborted                    vips add max_int.v max_int.v x.v
```
</details>

Found using PR #4863 (+ that `ppmload` change).
Targets the 8.18 branch.