### PR TITLE
subtract: use 64-bits intermediate for int format

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -29,6 +29,7 @@ date-tbd 8.18.1
 - composite: fix UB (invalid-enum-value) in `->build()` [kleisauke]
 - add: prevent possible int overflow [kleisauke]
 - multiply: prevent possible int overflow [kleisauke]
+- subtract: prevent possible int overflow [kleisauke]
 - convasep: prevent possible int overflow [kleisauke]
 - conva: prevent possible int overflow [kleisauke]
 - convi: prevent possible int overflow [kleisauke]

--- a/libvips/arithmetic/subtract.c
+++ b/libvips/arithmetic/subtract.c
@@ -92,6 +92,18 @@ G_DEFINE_TYPE(VipsSubtract, vips_subtract, VIPS_TYPE_BINARY);
 			q[x] = left[x] - right[x]; \
 	}
 
+/* Special case for VIPS_FORMAT_INT, to prevent UB.
+ */
+#define LOOP_INT64(IN, OUT) \
+	{ \
+		IN *restrict left = (IN *) in[0]; \
+		IN *restrict right = (IN *) in[1]; \
+		OUT *restrict q = (OUT *) out; \
+\
+		for (x = 0; x < sz; x++) \
+			q[x] = (int64_t) left[x] - right[x]; \
+	}
+
 static void
 vips_subtract_buffer(VipsArithmetic *arithmetic,
 	VipsPel *out, VipsPel **in, int width)
@@ -122,7 +134,7 @@ vips_subtract_buffer(VipsArithmetic *arithmetic,
 		LOOP(unsigned short, signed int);
 		break;
 	case VIPS_FORMAT_INT:
-		LOOP(signed int, signed int);
+		LOOP_INT64(signed int, signed int);
 		break;
 	case VIPS_FORMAT_UINT:
 		LOOP(unsigned int, signed int);


### PR DESCRIPTION
Same as #4922, but for `vips_subtract()`.

<details>
  <summary>Reproducer</summary>

```console
$ printf 'P5\n1 1\n65536\n\x7F\xFF\xFF\xFF' > max_int.ppm
$ vips cast max_int.ppm max_int.v int
$ vips linear max_int.v x.v -- -1 0
$ vips cast x.v min_int.v int --shift
$ vips subtract max_int.v min_int.v x.v
../libvips/arithmetic/subtract.c:125:3: runtime error: signed integer overflow: 2147483647 - -2147483648 cannot be represented in type 'int'
    #0 0x7feabebc9930 in vips_subtract_buffer /home/kleisauke/libvips/build/../libvips/arithmetic/subtract.c:125:3
    #1 0x7feabe97298b in vips_arithmetic_gen /home/kleisauke/libvips/build/../libvips/arithmetic/arithmetic.c:421:3
    #2 0x7feabf549d62 in vips_region_generate /home/kleisauke/libvips/build/../libvips/iofuncs/region.c:1614:6
    #3 0x7feabf52bc23 in vips_region_fill /home/kleisauke/libvips/build/../libvips/iofuncs/region.c:867:7
    #4 0x7feabf54951c in vips_region_prepare /home/kleisauke/libvips/build/../libvips/iofuncs/region.c:1682:7
    #5 0x7feabef624e7 in vips_copy_gen /home/kleisauke/libvips/build/../libvips/conversion/copy.c:140:6
    #6 0x7feabf549d62 in vips_region_generate /home/kleisauke/libvips/build/../libvips/iofuncs/region.c:1614:6
    #7 0x7feabf52bc23 in vips_region_fill /home/kleisauke/libvips/build/../libvips/iofuncs/region.c:867:7
    #8 0x7feabf54951c in vips_region_prepare /home/kleisauke/libvips/build/../libvips/iofuncs/region.c:1682:7
    #9 0x7feabf49a767 in vips_image_write_gen /home/kleisauke/libvips/build/../libvips/iofuncs/image.c:2600:6
    #10 0x7feabf549d62 in vips_region_generate /home/kleisauke/libvips/build/../libvips/iofuncs/region.c:1614:6
    #11 0x7feabf54cd4b in vips_region_prepare_to_generate /home/kleisauke/libvips/build/../libvips/iofuncs/region.c:1737:6
    #12 0x7feabf54b99c in vips_region_prepare_to /home/kleisauke/libvips/build/../libvips/iofuncs/region.c:1854:7
    #13 0x7feabf4e4c4a in wbuffer_work_fn /home/kleisauke/libvips/build/../libvips/iofuncs/sinkdisc.c:438:11
    #14 0x7feabf41136c in vips_worker_work_unit /home/kleisauke/libvips/build/../libvips/iofuncs/threadpool.c:368:6
    #15 0x7feabf40fb70 in vips_thread_main_loop /home/kleisauke/libvips/build/../libvips/iofuncs/threadpool.c:393:3
    #16 0x7feabf40a9ae in vips_threadset_work /home/kleisauke/libvips/build/../libvips/iofuncs/threadset.c:187:3
    #17 0x7feabf405924 in vips_thread_run /home/kleisauke/libvips/build/../libvips/iofuncs/thread.c:108:11
    #18 0x7feabe51f741  (/lib64/libglib-2.0.so.0+0x75741) (BuildId: 2932f63ee7c53ae67d9b0b3ff877ece14c13edd5)
    #19 0x0000004a380a in asan_thread_start(void*) asan_interceptors.cpp.o
    #20 0x7feabe106463 in start_thread (/lib64/libc.so.6+0x72463) (BuildId: ff0267465bc3d76e21003b3bc5598fd5ee63e261)
    #21 0x7feabe1895eb in __GI___clone3 (/lib64/libc.so.6+0xf55eb) (BuildId: ff0267465bc3d76e21003b3bc5598fd5ee63e261)

SUMMARY: UndefinedBehaviorSanitizer: undefined-behavior ../libvips/arithmetic/subtract.c:125:3 
Aborted                    vips subtract max_int.v min_int.v x.v

```
</details>

Targets the 8.18 branch.