### PR TITLE
hist_cum: use 64-bits intermediate for int format

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -30,6 +30,7 @@ date-tbd 8.18.1
 - add: prevent possible int overflow [kleisauke]
 - multiply: prevent possible int overflow [kleisauke]
 - subtract: prevent possible int overflow [kleisauke]
+- hist_cum: prevent possible int overflow [kleisauke]
 - convasep: prevent possible int overflow [kleisauke]
 - conva: prevent possible int overflow [kleisauke]
 - convi: prevent possible int overflow [kleisauke]

--- a/libvips/histogram/hist_cum.c
+++ b/libvips/histogram/hist_cum.c
@@ -83,6 +83,23 @@ G_DEFINE_TYPE(VipsHistCum, vips_hist_cum, VIPS_TYPE_HIST_UNARY);
 		} \
 	}
 
+/* Special case for VIPS_FORMAT_INT, to prevent UB.
+ */
+#define ACCUMULATE_INT64(ITYPE, OTYPE) \
+	{ \
+		for (b = 0; b < nb; b++) { \
+			ITYPE *p = (ITYPE *) in[0]; \
+			OTYPE *q = (OTYPE *) out; \
+			int64_t total; \
+\
+			total = 0; \
+			for (x = b; x < mx; x += nb) { \
+				total += p[x]; \
+				q[x] = total; \
+			} \
+		} \
+	}
+
 static void
 vips_hist_cum_process(VipsHistogram *histogram,
 	VipsPel *out, VipsPel **in, int width)
@@ -110,7 +127,7 @@ vips_hist_cum_process(VipsHistogram *histogram,
 		ACCUMULATE(unsigned short, unsigned int);
 		break;
 	case VIPS_FORMAT_INT:
-		ACCUMULATE(signed int, signed int);
+		ACCUMULATE_INT64(signed int, signed int);
 		break;
 	case VIPS_FORMAT_UINT:
 		ACCUMULATE(unsigned int, unsigned int);


### PR DESCRIPTION
Same as #4922, but for `vips_hist_cum()`.

<details>
  <summary>Reproducer</summary>

```console
$ printf 'P5\n2 1\n65536\n\x7F\xFF\xFF\xFF\x7F\xFF\xFF\xFF' > max_int_2x1.ppm
$ vips cast max_int_2x1.ppm max_int_2x1.v int
$ vips hist_cum max_int_2x1.v x.v
../libvips/histogram/hist_cum.c:113:3: runtime error: signed integer overflow: 2147483647 + 2147483647 cannot be represented in type 'int'
    #0 0x7f5c46978e1b in vips_hist_cum_process /home/kleisauke/libvips/build/../libvips/histogram/hist_cum.c:113:3
    #1 0x7f5c46894ae5 in vips_histogram_build /home/kleisauke/libvips/build/../libvips/histogram/histogram.c:177:2
    #2 0x7f5c469765a8 in vips_hist_unary_build /home/kleisauke/libvips/build/../libvips/histogram/hist_unary.c:68:6
    #3 0x7f5c46a5c4f5 in vips_object_build /home/kleisauke/libvips/build/../libvips/iofuncs/object.c:372:6
    #4 0x7f5c46b153fd in vips_call_argv /home/kleisauke/libvips/build/../libvips/iofuncs/operation.c:1474:6
    #5 0x0000004eda5a in main /home/kleisauke/libvips/build/../tools/vips.c:888:7
    #6 0x7f5c456975b4 in __libc_start_call_main (/lib64/libc.so.6+0x35b4) (BuildId: ff0267465bc3d76e21003b3bc5598fd5ee63e261)
    #7 0x7f5c45697667 in __libc_start_main@GLIBC_2.2.5 (/lib64/libc.so.6+0x3667) (BuildId: ff0267465bc3d76e21003b3bc5598fd5ee63e261)
    #8 0x000000400a94 in _start (/usr/bin/vips+0x400a94) (BuildId: faa38c405694c8f3e501fee5b4b2897861450fd0)

SUMMARY: UndefinedBehaviorSanitizer: undefined-behavior ../libvips/histogram/hist_cum.c:113:3 
Aborted                    vips hist_cum max_int_2x1.v x.v
```
</details>

Note: not needed for `VIPS_FORMAT_SHORT`, as histograms can't have more than 65536 elements:
https://github.com/libvips/libvips/blob/6a5c05111655d7454eebee4781b4cbcd9c5bc96e/libvips/iofuncs/error.c#L1165-L1169

Targets the 8.18 branch.