### PR TITLE
min: fix possible OOB read with complex images

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -41,6 +41,7 @@ date-tbd 8.18.1
 - jpegsave: fix assert fail when saving 2-band image [kleisauke]
 - LabS2LabQ: fix UB (undefined-shift) [kleisauke]
 - convasep: use unsigned accumulator where appropriate [kleisauke]
+- min: fix possible OOB read with complex images [kleisauke]
 
 17/12/25 8.18.0
 

--- a/libvips/arithmetic/min.c
+++ b/libvips/arithmetic/min.c
@@ -359,7 +359,7 @@ vips_min_stop(VipsStatistic *statistic, void *seq)
 			TYPE mod2 = p[0] * p[0] + p[1] * p[1]; \
 \
 			if (!isnan(mod2)) \
-				vips_values_add(values, p[i], x + i / bands, y); \
+				vips_values_add(values, mod2, x + i / bands, y); \
 \
 			p += 2; \
 		} \


### PR DESCRIPTION
<details>
  <summary>Reproducer</summary>

```console
$ printf 'complex\npolar\n' > repro
$ printf 'PF\n1 3\n-1.0\n' >> repro
$ printf '\xFF\xFF\xFF\xFF%.0s' {1..8} >> repro
$ printf '\x7A\x67\x2E\xFF' >> repro
$ ./build/fuzz/vips_fuzzer -rss_limit_mb=2560 -timeout=60 -runs=100 repro
INFO: Running with entropic power schedule (0xFF, 100).
INFO: Seed: 1551465937
INFO: Loaded 2 modules   (271573 inline 8-bit counters): 271106 [0x7fb401bdd0e8, 0x7fb401c1f3ea), 467 [0x62a638, 0x62a80b), 
INFO: Loaded 2 PC tables (271573 PCs): 271106 [0x7fb401c1f3f0,0x7fb402042410), 467 [0x5e0258,0x5e1f88), 
./build/fuzz/vips_fuzzer: Running 1 inputs 100 time(s) each.
Running: repro
=================================================================
==553502==ERROR: AddressSanitizer: heap-buffer-overflow on address 0x7c33f9be8470 at pc 0x7fb3ffcf667d bp 0x7bb3f4bac630 sp 0x7bb3f4bac628
READ of size 4 at 0x7c33f9be8470 thread T2
    #0 0x7fb3ffcf667c in vips_min_scan /home/kleisauke/libvips/build/../libvips/arithmetic/min.c:420:3
    #1 0x7fb3ffda46bd in vips_statistic_scan /home/kleisauke/libvips/build/../libvips/arithmetic/statistic.c:86:7
    #2 0x7fb4006d9180 in sink_work /home/kleisauke/libvips/build/../libvips/iofuncs/sink.c:417:12
    #3 0x7fb40061136c in vips_worker_work_unit /home/kleisauke/libvips/build/../libvips/iofuncs/threadpool.c:368:6
    #4 0x7fb40060fb70 in vips_thread_main_loop /home/kleisauke/libvips/build/../libvips/iofuncs/threadpool.c:393:3
    #5 0x7fb40060a9ae in vips_threadset_work /home/kleisauke/libvips/build/../libvips/iofuncs/threadset.c:187:3
    #6 0x7fb400605924 in vips_thread_run /home/kleisauke/libvips/build/../libvips/iofuncs/thread.c:108:11
    #7 0x7fb3ff71f741  (/lib64/libglib-2.0.so.0+0x75741) (BuildId: 2932f63ee7c53ae67d9b0b3ff877ece14c13edd5)
    #8 0x000000543fea in asan_thread_start(void*) asan_interceptors.cpp.o
    #9 0x7fb3ff306463 in start_thread (/lib64/libc.so.6+0x72463) (BuildId: ff0267465bc3d76e21003b3bc5598fd5ee63e261)
    #10 0x7fb3ff3895eb in __GI___clone3 (/lib64/libc.so.6+0xf55eb) (BuildId: ff0267465bc3d76e21003b3bc5598fd5ee63e261)

0x7c33f9be8470 is located 0 bytes after 80-byte region [0x7c33f9be8420,0x7c33f9be8470)
allocated by thread T2 here:
    #0 0x00000054725b in posix_memalign (/home/kleisauke/libvips/build/fuzz/vips_fuzzer+0x54725b) (BuildId: 063cff614ed799dde39890daeaf09c8e09e01d4c)
    #1 0x7fb4006f78df in vips_tracked_aligned_alloc /home/kleisauke/libvips/build/../libvips/iofuncs/memory.c:383:6
    #2 0x7fb4007fa13a in buffer_move /home/kleisauke/libvips/build/../libvips/iofuncs/buffer.c:500:23
    #3 0x7fb4007f92f0 in vips_buffer_new /home/kleisauke/libvips/build/../libvips/iofuncs/buffer.c:546:6
    #4 0x7fb4007fb7e7 in vips_buffer_unref_ref /home/kleisauke/libvips/build/../libvips/iofuncs/buffer.c:654:17
    #5 0x7fb400724903 in vips_region_buffer /home/kleisauke/libvips/build/../libvips/iofuncs/region.c:574:6
    #6 0x7fb40072ba00 in vips_region_fill /home/kleisauke/libvips/build/../libvips/iofuncs/region.c:861:6
    #7 0x7fb40074951c in vips_region_prepare /home/kleisauke/libvips/build/../libvips/iofuncs/region.c:1682:7
    #8 0x7fb4001624e7 in vips_copy_gen /home/kleisauke/libvips/build/../libvips/conversion/copy.c:140:6
    #9 0x7fb400749d62 in vips_region_generate /home/kleisauke/libvips/build/../libvips/iofuncs/region.c:1614:6
    #10 0x7fb40072bc23 in vips_region_fill /home/kleisauke/libvips/build/../libvips/iofuncs/region.c:867:7
    #11 0x7fb40074951c in vips_region_prepare /home/kleisauke/libvips/build/../libvips/iofuncs/region.c:1682:7
    #12 0x7fb40069a767 in vips_image_write_gen /home/kleisauke/libvips/build/../libvips/iofuncs/image.c:2600:6
    #13 0x7fb400749d62 in vips_region_generate /home/kleisauke/libvips/build/../libvips/iofuncs/region.c:1614:6
    #14 0x7fb40072bc23 in vips_region_fill /home/kleisauke/libvips/build/../libvips/iofuncs/region.c:867:7
    #15 0x7fb40074951c in vips_region_prepare /home/kleisauke/libvips/build/../libvips/iofuncs/region.c:1682:7
    #16 0x7fb4006d8d19 in sink_work /home/kleisauke/libvips/build/../libvips/iofuncs/sink.c:415:11
    #17 0x7fb40061136c in vips_worker_work_unit /home/kleisauke/libvips/build/../libvips/iofuncs/threadpool.c:368:6
    #18 0x7fb40060fb70 in vips_thread_main_loop /home/kleisauke/libvips/build/../libvips/iofuncs/threadpool.c:393:3
    #19 0x7fb40060a9ae in vips_threadset_work /home/kleisauke/libvips/build/../libvips/iofuncs/threadset.c:187:3
    #20 0x7fb400605924 in vips_thread_run /home/kleisauke/libvips/build/../libvips/iofuncs/thread.c:108:11
    #21 0x7fb3ff71f741  (/lib64/libglib-2.0.so.0+0x75741) (BuildId: 2932f63ee7c53ae67d9b0b3ff877ece14c13edd5)
    #22 0x000000543fea in asan_thread_start(void*) asan_interceptors.cpp.o
    #23 0x7fb3ff306463 in start_thread (/lib64/libc.so.6+0x72463) (BuildId: ff0267465bc3d76e21003b3bc5598fd5ee63e261)
    #24 0x7fb3ff3895eb in __GI___clone3 (/lib64/libc.so.6+0xf55eb) (BuildId: ff0267465bc3d76e21003b3bc5598fd5ee63e261)

Thread T2 created by T0 here:
    #0 0x00000052a925 in pthread_create (/home/kleisauke/libvips/build/fuzz/vips_fuzzer+0x52a925) (BuildId: 063cff614ed799dde39890daeaf09c8e09e01d4c)
    #1 0x7fb3ff71f910  (/lib64/libglib-2.0.so.0+0x75910) (BuildId: 2932f63ee7c53ae67d9b0b3ff877ece14c13edd5)
    #2 0x7fb40060567b in vips_g_thread_new /home/kleisauke/libvips/build/../libvips/iofuncs/thread.c:140:11
    #3 0x7fb40060837d in vips_threadset_add_thread /home/kleisauke/libvips/build/../libvips/iofuncs/threadset.c:238:18
    #4 0x7fb4006096f7 in vips_threadset_run /home/kleisauke/libvips/build/../libvips/iofuncs/threadset.c:320:8
    #5 0x7fb40060b347 in vips_thread_execute /home/kleisauke/libvips/build/../libvips/iofuncs/threadpool.c:151:9
    #6 0x7fb40060e5d9 in vips_worker_new /home/kleisauke/libvips/build/../libvips/iofuncs/threadpool.c:434:6
    #7 0x7fb40060c39d in vips_threadpool_run /home/kleisauke/libvips/build/../libvips/iofuncs/threadpool.c:654:7
    #8 0x7fb4006d4e8b in vips_sink_tile /home/kleisauke/libvips/build/../libvips/iofuncs/sink.c:499:11
    #9 0x7fb4006d9933 in vips_sink /home/kleisauke/libvips/build/../libvips/iofuncs/sink.c:542:9
    #10 0x7fb3ffda316b in vips_statistic_build /home/kleisauke/libvips/build/../libvips/arithmetic/statistic.c:140:6
    #11 0x7fb3ffcec87f in vips_min_build /home/kleisauke/libvips/build/../libvips/arithmetic/min.c:207:6
    #12 0x7fb40065c4f5 in vips_object_build /home/kleisauke/libvips/build/../libvips/iofuncs/object.c:372:6
    #13 0x7fb4006c74ea in vips_cache_operation_buildp /home/kleisauke/libvips/build/../libvips/iofuncs/cache.c:1062:7
    #14 0x7fb40070a494 in vips_call_required_optional /home/kleisauke/libvips/build/../libvips/iofuncs/operation.c:974:6
    #15 0x7fb400713895 in vips_call_by_name /home/kleisauke/libvips/build/../libvips/iofuncs/operation.c:1014:11
    #16 0x7fb400713b41 in vips_call_split /home/kleisauke/libvips/build/../libvips/iofuncs/operation.c:1121:11
    #17 0x7fb3ffceb4d6 in vips_min /home/kleisauke/libvips/build/../libvips/arithmetic/min.c:555:11
    #18 0x000000593c48 in EvalRequiredOutput(_VipsObject*, _GParamSpec*, _VipsArgumentClass*, _VipsArgumentInstance*, void*, void*) /home/kleisauke/libvips/build/../fuzz/vips_fuzzer.cc:220:5
    #19 0x7fb40065cb45 in vips_argument_map /home/kleisauke/libvips/build/../libvips/iofuncs/object.c:607:17
    #20 0x00000058f063 in LLVMFuzzerTestOneInput /home/kleisauke/libvips/build/../fuzz/vips_fuzzer.cc:359:4
    #21 0x00000041e9ef in fuzzer::Fuzzer::ExecuteCallback(unsigned char const*, unsigned long) fuzzer.o
    #22 0x000000409416 in fuzzer::RunOneTest(fuzzer::Fuzzer*, char const*, unsigned long) fuzzer.o
    #23 0x00000040f2e9 in fuzzer::FuzzerDriver(int*, char***, int (*)(unsigned char const*, unsigned long)) fuzzer.o
    #24 0x00000043b526 in main (/home/kleisauke/libvips/build/fuzz/vips_fuzzer+0x43b526) (BuildId: 063cff614ed799dde39890daeaf09c8e09e01d4c)
    #25 0x7fb3ff2975b4 in __libc_start_call_main (/lib64/libc.so.6+0x35b4) (BuildId: ff0267465bc3d76e21003b3bc5598fd5ee63e261)
    #26 0x7fb3ff297667 in __libc_start_main@GLIBC_2.2.5 (/lib64/libc.so.6+0x3667) (BuildId: ff0267465bc3d76e21003b3bc5598fd5ee63e261)
    #27 0x0000004022f4 in _start (/home/kleisauke/libvips/build/fuzz/vips_fuzzer+0x4022f4) (BuildId: 063cff614ed799dde39890daeaf09c8e09e01d4c)

SUMMARY: AddressSanitizer: heap-buffer-overflow /home/kleisauke/libvips/build/../libvips/arithmetic/min.c:420:3 in vips_min_scan
Shadow bytes around the buggy address:
  0x7c33f9be8180: fa fa fa fa 00 00 00 00 00 00 00 00 00 00 00 00
  0x7c33f9be8200: fa fa fa fa 00 00 00 00 00 00 00 00 00 00 fa fa
  0x7c33f9be8280: fa fa fa fa 00 00 00 00 00 00 00 00 00 00 00 00
  0x7c33f9be8300: fa fa fa fa 00 00 00 00 00 00 00 00 00 00 fa fa
  0x7c33f9be8380: fa fa fa fa 00 00 00 00 00 00 00 00 00 00 00 00
=>0x7c33f9be8400: fa fa fa fa 00 00 00 00 00 00 00 00 00 00[fa]fa
  0x7c33f9be8480: fa fa fa fa 00 00 00 00 00 00 00 00 00 00 00 00
  0x7c33f9be8500: fa fa fa fa 00 00 00 00 00 00 00 00 00 00 00 00
  0x7c33f9be8580: fa fa fa fa 00 00 00 00 00 00 00 00 00 00 00 00
  0x7c33f9be8600: fa fa fa fa 00 00 00 00 00 00 00 00 00 00 00 00
  0x7c33f9be8680: fa fa fa fa 00 00 00 00 00 00 00 00 00 00 00 00
Shadow byte legend (one shadow byte represents 8 application bytes):
  Addressable:           00
  Partially addressable: 01 02 03 04 05 06 07 
  Heap left redzone:       fa
  Freed heap region:       fd
  Stack left redzone:      f1
  Stack mid redzone:       f2
  Stack right redzone:     f3
  Stack after return:      f5
  Stack use after scope:   f8
  Global redzone:          f9
  Global init order:       f6
  Poisoned by user:        f7
  Container overflow:      fc
  Array cookie:            ac
  Intra object redzone:    bb
  ASan internal:           fe
  Left alloca redzone:     ca
  Right alloca redzone:    cb
==553502==ABORTING
Aborted                    ./build/fuzz/vips_fuzzer -rss_limit_mb=2560 -timeout=60 -runs=100 repro
```
(it only seems to reproduce with `vips_fuzzer`, not when writing the `VIPS_FORMAT_COMPLEX` image to a `.v` intermediate)

</details>

Found using PR #4863.
Targets the 8.18 branch.