### PR TITLE
exif: add missing `entry->components == 0` check

### DIFF
--- a/libvips/foreign/exif.c
+++ b/libvips/foreign/exif.c
@@ -234,18 +234,28 @@ vips_exif_get_int(ExifData *ed,
 	size_t sizeof_component = entry->size / entry->components;
 	size_t offset = component * sizeof_component;
 
-	if (entry->format == EXIF_FORMAT_SHORT)
+	switch (entry->format) {
+	case EXIF_FORMAT_SHORT:
 		*out = exif_get_short(entry->data + offset, bo);
-	else if (entry->format == EXIF_FORMAT_SSHORT)
+		break;
+
+	case EXIF_FORMAT_SSHORT:
 		*out = exif_get_sshort(entry->data + offset, bo);
-	else if (entry->format == EXIF_FORMAT_LONG)
+		break;
+
+	case EXIF_FORMAT_LONG:
 		/* This won't work for huge values, but who cares.
 		 */
 		*out = (int) exif_get_long(entry->data + offset, bo);
-	else if (entry->format == EXIF_FORMAT_SLONG)
+		break;
+
+	case EXIF_FORMAT_SLONG:
 		*out = exif_get_slong(entry->data + offset, bo);
-	else
+		break;
+
+	default:
 		return -1;
+	}
 
 	return 0;
 }
@@ -327,29 +337,40 @@ vips_exif_to_s(ExifData *ed, ExifEntry *entry, VipsDbuf *buf)
 	ExifRational rv;
 	ExifSRational srv;
 
-	if (entry->components < 10 &&
-		!vips_exif_get_int(ed, entry, 0, &iv)) {
-		for (i = 0; i < entry->components; i++) {
-			vips_exif_get_int(ed, entry, i, &iv);
-			vips_dbuf_writef(buf, "%d ", iv);
-		}
-	}
-	else if (entry->components < 10 &&
-		!vips_exif_get_rational(ed, entry, 0, &rv)) {
-		for (i = 0; i < entry->components; i++) {
-			vips_exif_get_rational(ed, entry, i, &rv);
-			vips_dbuf_writef(buf, "%u/%u ", rv.numerator, rv.denominator);
-		}
-	}
-	else if (entry->components < 10 &&
-		!vips_exif_get_srational(ed, entry, 0, &srv)) {
-		for (i = 0; i < entry->components; i++) {
-			vips_exif_get_srational(ed, entry, i, &srv);
-			vips_dbuf_writef(buf, "%d/%d ", srv.numerator, srv.denominator);
-		}
-	}
-	else
+	if (entry->components == 0 || entry->components >= 10) {
 		vips_dbuf_writef(buf, "%s ", text);
+	}
+	else {
+		switch (entry->format) {
+		case EXIF_FORMAT_SHORT:
+		case EXIF_FORMAT_SSHORT:
+		case EXIF_FORMAT_LONG:
+		case EXIF_FORMAT_SLONG:
+			for (i = 0; i < entry->components; i++) {
+				vips_exif_get_int(ed, entry, i, &iv);
+				vips_dbuf_writef(buf, "%d ", iv);
+			}
+			break;
+
+		case EXIF_FORMAT_RATIONAL:
+			for (i = 0; i < entry->components; i++) {
+				vips_exif_get_rational(ed, entry, i, &rv);
+				vips_dbuf_writef(buf, "%u/%u ", rv.numerator, rv.denominator);
+			}
+			break;
+
+		case EXIF_FORMAT_SRATIONAL:
+			for (i = 0; i < entry->components; i++) {
+				vips_exif_get_srational(ed, entry, i, &srv);
+				vips_dbuf_writef(buf, "%d/%d ", srv.numerator, srv.denominator);
+			}
+			break;
+
+		default:
+			vips_dbuf_writef(buf, "%s ", text);
+			break;
+		}
+	}
 
 	vips_dbuf_writef(buf, "(%s, %s, %lu components, %d bytes)",
 		text,


### PR DESCRIPTION
Non-functional change to appease static analysis tools: libexif will never allow `entry->components == 0` unless you patch it like this:

<details>
  <summary>libexif patch to allow <code>entry->components == 0</code></summary>

```diff
--- a/libexif/exif-data.c
+++ b/libexif/exif-data.c
@@ -77,7 +77,7 @@ exif_data_alloc (ExifData *data, unsigned int i)
 {
 	void *d;
 
-	if (!data || !i) 
+	if (!data) 
 		return NULL;
 
 	d = exif_mem_alloc (data->priv->mem, i);
@@ -183,7 +183,7 @@ exif_data_load_data_entry (ExifData *data, ExifEntry *entry,
 	/* {0,1,2,4,8} x { 0x00000000 .. 0xffffffff } 
 	 *   -> { 0x000000000 .. 0x7fffffff8 } */
 	s = exif_format_get_size(entry->format) * entry->components;
-	if ((s < entry->components) || (s == 0)){
+	if ((s < entry->components)){
 		return 0;
 	}
 
```
(patch tested against libexif 0.6.25)

</details>

Targets the 8.18 branch without a ChangeLog entry.