### PR TITLE
sign: use ready image instead of `unary->in`

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -46,6 +46,7 @@ date-tbd 8.18.1
 - max: fix possible OOB read with complex images [kleisauke]
 - guard against dimension overflow [ElhananHaenel] [kleisauke]
 - gifload: prevent int overflow on 32-bit platforms [ElhananHaenel] [kleisauke]
+- sign: use ready image instead of `unary->in` [kleisauke]
 
 17/12/25 8.18.0
 

--- a/libvips/arithmetic/sign.c
+++ b/libvips/arithmetic/sign.c
@@ -105,11 +105,11 @@ static void
 vips_sign_buffer(VipsArithmetic *arithmetic,
 	VipsPel *out, VipsPel **in, int width)
 {
-	VipsUnary *unary = VIPS_UNARY(arithmetic);
-	const int bands = vips_image_get_bands(unary->in);
+	VipsImage *im = arithmetic->ready[0];
+	const int bands = vips_image_get_bands(im);
 	int sz = width * bands;
 
-	switch (vips_image_get_format(unary->in)) {
+	switch (vips_image_get_format(im)) {
 	case VIPS_FORMAT_UCHAR:
 		SIGN(unsigned char);
 		break;


### PR DESCRIPTION
Buffer functions should operate on the ready images provided by the arithmetic operation rather than the original input stored on the `VipsUnary` base struct.

Resolves: https://issues.oss-fuzz.com/issues/490707025.
Targets the 8.18 branch.