### PR TITLE
Add missing `<stdint.h>` includes

### DIFF
--- a/libvips/arithmetic/add.c
+++ b/libvips/arithmetic/add.c
@@ -77,6 +77,7 @@
 #include <glib/gi18n-lib.h>
 
 #include <stdio.h>
+#include <stdint.h>
 #include <stdlib.h>
 #include <math.h>
 

--- a/libvips/arithmetic/multiply.c
+++ b/libvips/arithmetic/multiply.c
@@ -66,6 +66,7 @@
 #include <glib/gi18n-lib.h>
 
 #include <stdio.h>
+#include <stdint.h>
 #include <stdlib.h>
 #include <math.h>
 

--- a/libvips/arithmetic/subtract.c
+++ b/libvips/arithmetic/subtract.c
@@ -70,6 +70,7 @@
 #include <glib/gi18n-lib.h>
 
 #include <stdio.h>
+#include <stdint.h>
 #include <stdlib.h>
 #include <math.h>
 

--- a/libvips/convolution/conva.c
+++ b/libvips/convolution/conva.c
@@ -90,6 +90,7 @@ $ vips im_max abs.v
 
 #include <stdio.h>
 #include <string.h>
+#include <stdint.h>
 #include <stdlib.h>
 #include <limits.h>
 #include <math.h>

--- a/libvips/convolution/convasep.c
+++ b/libvips/convolution/convasep.c
@@ -78,6 +78,7 @@
 #include <glib/gi18n-lib.h>
 
 #include <stdio.h>
+#include <stdint.h>
 #include <stdlib.h>
 #include <limits.h>
 #include <math.h>

--- a/libvips/convolution/convi_hwy.cpp
+++ b/libvips/convolution/convi_hwy.cpp
@@ -41,6 +41,7 @@
 #include <glib/gi18n-lib.h>
 
 #include <cstdio>
+#include <cstdint>
 #include <cstdlib>
 #include <cmath>
 

--- a/libvips/foreign/jxlsave.c
+++ b/libvips/foreign/jxlsave.c
@@ -47,6 +47,7 @@
 #ifdef HAVE_LIBJXL
 
 #include <stdio.h>
+#include <stdint.h>
 #include <stdlib.h>
 #include <string.h>
 

--- a/libvips/foreign/spngsave.c
+++ b/libvips/foreign/spngsave.c
@@ -54,6 +54,7 @@
 #include <glib/gi18n-lib.h>
 
 #include <stdio.h>
+#include <stdint.h>
 #include <stdlib.h>
 #include <string.h>
 

--- a/libvips/histogram/hist_cum.c
+++ b/libvips/histogram/hist_cum.c
@@ -57,6 +57,7 @@
 #include <glib/gi18n-lib.h>
 
 #include <stdio.h>
+#include <stdint.h>
 
 #include <vips/vips.h>
 

--- a/libvips/morphology/morph_hwy.cpp
+++ b/libvips/morphology/morph_hwy.cpp
@@ -37,6 +37,7 @@
 #include <glib/gi18n-lib.h>
 
 #include <cstdio>
+#include <cstdint>
 #include <cstdlib>
 #include <cmath>
 

--- a/libvips/resample/reduceh_hwy.cpp
+++ b/libvips/resample/reduceh_hwy.cpp
@@ -37,6 +37,7 @@
 #include <glib/gi18n-lib.h>
 
 #include <cstdio>
+#include <cstdint>
 #include <cstdlib>
 #include <cmath>
 

--- a/libvips/resample/reducev_hwy.cpp
+++ b/libvips/resample/reducev_hwy.cpp
@@ -41,6 +41,7 @@
 #include <glib/gi18n-lib.h>
 
 #include <cstdio>
+#include <cstdint>
 #include <cstdlib>
 #include <cmath>
 

--- a/libvips/resample/shrinkh_hwy.cpp
+++ b/libvips/resample/shrinkh_hwy.cpp
@@ -35,6 +35,7 @@
 #include <glib/gi18n-lib.h>
 
 #include <cstdio>
+#include <cstdint>
 #include <cstdlib>
 #include <cmath>
 

--- a/libvips/resample/shrinkv_hwy.cpp
+++ b/libvips/resample/shrinkv_hwy.cpp
@@ -35,6 +35,7 @@
 #include <glib/gi18n-lib.h>
 
 #include <cstdio>
+#include <cstdint>
 #include <cstdlib>
 #include <cmath>
 


### PR DESCRIPTION
Non-functional change, it was already included via GLib.

As a possible follow-up, we could run [IWYU's analysis](https://github.com/include-what-you-use/include-what-you-use) on libvips, though in my experience with other projects it produces a LOT of output.

Context: https://github.com/libvips/libvips/pull/4937#discussion_r2917021106.
Targets the 8.18 branch.