### PR TITLE
draw_circle: prevent possible int overflow

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -37,6 +37,7 @@ date-tbd 8.18.1
 - convasep: prevent possible int overflow [kleisauke]
 - conva: prevent possible int overflow [kleisauke]
 - convi: prevent possible int overflow [kleisauke]
+- draw_circle: prevent possible int overflow [kleisauke]
 - csvload: guard against negative index access [kleisauke]
 - convi: guard against invalid shift [kleisauke]
 - nary: guard against empty input [kleisauke]

--- a/libvips/draw/draw_circle.c
+++ b/libvips/draw/draw_circle.c
@@ -54,6 +54,7 @@
 #include <glib/gi18n-lib.h>
 
 #include <string.h>
+#include <stdint.h>
 
 #include <vips/vips.h>
 #include <vips/internal.h>
@@ -81,7 +82,8 @@ void
 vips__draw_circle_direct(VipsImage *image, int cx, int cy, int r,
 	VipsDrawScanline draw_scanline, void *client)
 {
-	int x, y, d;
+	int x, y;
+	int64_t d;
 
 	y = r;
 	d = 3 - 2 * r;
@@ -93,9 +95,9 @@ vips__draw_circle_direct(VipsImage *image, int cx, int cy, int r,
 		draw_scanline(image, cy - x, cx - y, cx + y, 3, client);
 
 		if (d < 0)
-			d += 4 * x + 6;
+			d += (int64_t) 4 * x + 6;
 		else {
-			d += 4 * (x - y) + 10;
+			d += (int64_t) 4 * (x - y) + 10;
 			y--;
 		}
 	}


### PR DESCRIPTION
<details>
  <summary>Reproducer</summary>

```console
$ vips black x.v 1024 1024 --bands 3
$ vips draw_circle x.v "255 255 255" 1000000000 1000000000 1000000000
../libvips/draw/draw_circle.c:98:11: runtime error: signed integer overflow: 4 * -999968378 cannot be represented in type 'int'
    #0 0x7f19ab1ce303 in vips__draw_circle_direct /home/kleisauke/libvips/build/../libvips/draw/draw_circle.c:98:11
    #1 0x7f19ab1d0f99 in vips_draw_circle_build /home/kleisauke/libvips/build/../libvips/draw/draw_circle.c:213:2
    #2 0x7f19ab279cd5 in vips_object_build /home/kleisauke/libvips/build/../libvips/iofuncs/object.c:372:6
    #3 0x7f19ab33349d in vips_call_argv /home/kleisauke/libvips/build/../libvips/iofuncs/operation.c:1474:6
    #4 0x0000004eda5a in main /home/kleisauke/libvips/build/../tools/vips.c:888:7
    #5 0x7f19a9e595b4 in __libc_start_call_main (/lib64/libc.so.6+0x35b4) (BuildId: ff0267465bc3d76e21003b3bc5598fd5ee63e261)
    #6 0x7f19a9e59667 in __libc_start_main@GLIBC_2.2.5 (/lib64/libc.so.6+0x3667) (BuildId: ff0267465bc3d76e21003b3bc5598fd5ee63e261)
    #7 0x000000400a94 in _start (/usr/bin/vips+0x400a94) (BuildId: aaf856a0ed7ff9fe0e4544a9fa28a9aed1af42f2)

SUMMARY: UndefinedBehaviorSanitizer: undefined-behavior ../libvips/draw/draw_circle.c:98:11 
Aborted                    vips draw_circle x.v "255 255 255" 1000000000 1000000000 1000000000
```
</details>

Targets the 8.18 branch.