### PR TITLE
lsan: suppress leak warnings for 10-bit HEIC save

### DIFF
--- a/suppressions/lsan.supp
+++ b/suppressions/lsan.supp
@@ -21,4 +21,5 @@ leak:___kmp_allocate
 # https://github.com/strukturag/libheif/pull/1061
 # TODO: Does this requires calling heif_deinit()?
 leak:x265::x265_malloc
+leak:x265_10bit::x265_malloc
 leak:x265_12bit::x265_malloc


### PR DESCRIPTION
As noticed in PR #4928, see:
https://github.com/libvips/libvips/actions/runs/23099043328/job/67118449573#step:16:884