### PR TITLE
Update ChangeLog ahead of v8.18.1

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,4 +1,4 @@
-date-tbd 8.18.1
+18/3/26 8.18.1
 
 - vector: mask supported Highway targets by builtin targets [kleisauke]
 - fix Highway paths on big-endian targets [kleisauke]


### PR DESCRIPTION
It's time for a formal patch release. Let's aim for Tuesday, unless OSS-Fuzz uncovers any new issues.

@jcupitt Could you merge the `8.18` branch back into `master`? That should make all recently reported OSS-Fuzz issues publicly visible.