### PR TITLE
Expose more libultrahdr arguments to uhdrsave

### DIFF
--- a/libvips/foreign/uhdrsave.c
+++ b/libvips/foreign/uhdrsave.c
@@ -78,6 +78,8 @@ typedef struct _VipsForeignSaveUhdr {
 	int Q;
 
 	int gainmap_scale_factor;
+	double target_display_peak_brightness;
+	double max_content_boost;
 
 	/* Base image options to pass to jpegsave.
 	 */
@@ -406,6 +408,14 @@ vips_foreign_save_uhdr_hdr(VipsForeignSaveUhdr *uhdr, VipsImage *image)
 	uhdr_enc_set_gainmap_scale_factor(uhdr->enc, uhdr->gainmap_scale_factor);
 	uhdr_enc_set_using_multi_channel_gainmap(uhdr->enc, 0);
 
+	if (uhdr->target_display_peak_brightness > 0) {
+		uhdr_enc_set_target_display_peak_brightness(uhdr->enc, (float) uhdr->target_display_peak_brightness);
+	}
+
+	if (uhdr->max_content_boost > 0) {
+		uhdr_enc_set_min_max_content_boost(uhdr->enc, -FLT_MIN, (float) uhdr->max_content_boost);
+	}
+
 	// attach the gainmap, if we have one
 	if (vips_image_get_typeof(image, "gainmap-data") &&
 		vips_foreign_save_uhdr_set_compressed_gainmap(uhdr, image))
@@ -650,6 +660,19 @@ vips_foreign_save_uhdr_class_init(VipsForeignSaveUhdrClass *class)
 		G_STRUCT_OFFSET(VipsForeignSaveUhdr, restart_interval),
 		0, INT_MAX, 0);
 
+	VIPS_ARG_DOUBLE(class, "target_display_peak_brightness", 12,
+			_("Target display peak brightness"),
+			_("Target display peak brightness in nits"),
+			VIPS_ARGUMENT_OPTIONAL_INPUT,
+			G_STRUCT_OFFSET(VipsForeignSaveUhdr, target_display_peak_brightness),
+			-1.0, 10000.0, -1.0);
+
+	VIPS_ARG_DOUBLE(class, "max_content_boost", 13,
+		_("Max content boost"),
+		_("Maximum content boost for the gainmap"),
+		VIPS_ARGUMENT_OPTIONAL_INPUT,
+		G_STRUCT_OFFSET(VipsForeignSaveUhdr, max_content_boost),
+		-1.0, 100.0, -1.0);
 }
 
 static void
@@ -665,6 +688,8 @@ vips_foreign_save_uhdr_init(VipsForeignSaveUhdr *uhdr)
 	uhdr->optimize_scans = FALSE;
 	uhdr->quant_table = 0;
 	uhdr->restart_interval = 0;
+	uhdr->target_display_peak_brightness = -1.0;
+	uhdr->max_content_boost = -1.0;
 }
 
 typedef struct _VipsForeignSaveUhdrFile {


### PR DESCRIPTION
libultrahdr accepts some arguments which were so far not possible to control through vips.

1.  `target_display_peak_brightness`
2. `max_content_boost`
3. `color_gamut`
4. `color_transfer`

Especially important is the last one, which makes it easy to convert any 16-bit HDR image data into ultrahdr.
Previously you had to go though scrgb and the result was never right for me (very desaturated and no hdr 'pop').

With this PR it's possible to do this:
```bash
vips uhdrsave --color-transfer 2 10bit.heic uhdr.jpg
```
The result is very close to the original (as long as you match the color transfer function).

Help output:
```
> vips uhdrsave
save image in UltraHDR format
usage:
   uhdrsave in filename [--option-name option-value ...]
where:
   in           - Image to save, input VipsImage
   filename     - Filename to save to, input gchararray
optional arguments:
   Q            - Q factor, input gint
                        default: 75
                        min: 1, max: 100
   gainmap-scale-factor - The scale factor of base image to gainmap image, input gint
                        default: 2
                        min: 1, max: 128
   target-display-peak-brightness - Target display peak brightness in nits, input gdouble
                        default: -1
                        min: -1, max: 10000
   max-content-boost - Maximum content boost for the gainmap, input gdouble
                        default: -1
                        min: -1, max: 100
   multi-channel-gainmap - Enable multi channel (RGB) gainmap, input gboolean
                        default: false
   color-gamut  - Color gamut: 0=BT709, 1=P3, 2=BT2100, input gint
                        default: 0
                        min: 0, max: 2
   color-transfer - Transfer characteristic: 0=Linear, 1=HLG, 2=PQ, 3=sRGB, input gint
                        default: 0
                        min: 0, max: 3
   keep         - Which metadata to retain, input VipsForeignKeep
                        default flags: exif:xmp:iptc:icc:other:gainmap:all
                        allowed flags: none, exif, xmp, iptc, icc, other, gainmap, all
   background   - Background value, input VipsArrayDouble
   page-height  - Set page height for multipage save, input gint
                        default: 0
                        min: 0, max: 100000000
   profile      - Filename of ICC profile to embed, input gchararray
operation flags: sequential nocache 
```

P.S. C is not my first language and this is partially inspired by what AI told me. Overall the changes are quite isolated and default parameter values are preserved. Let me know what can be improved.

