### PR TITLE
convolution: avoid using unsigned accumulators

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,7 @@
+date-tbd 8.18.2
+
+- convolution: avoid using unsigned accumulators [nakrovati]
+
 18/3/26 8.18.1
 
 - vector: mask supported Highway targets by builtin targets [kleisauke]

--- a/libvips/convolution/convasep.c
+++ b/libvips/convolution/convasep.c
@@ -455,7 +455,7 @@ vips_convasep_start(VipsImage *out, void *a, void *b)
 \
 			TYPE *q; \
 			TYPE *p; \
-			ACC sum; \
+			int64_t sum; \
 \
 			p = i + (TYPE *) VIPS_REGION_ADDR(ir, r->left, r->top + y); \
 			q = i + (TYPE *) VIPS_REGION_ADDR(out_region, r->left, r->top + y); \
@@ -465,7 +465,7 @@ vips_convasep_start(VipsImage *out, void *a, void *b)
 				isum[z] = 0; \
 				for (x = seq->start[z]; x < seq->end[z]; x += istride) \
 					isum[z] += p[x]; \
-				sum += convasep->factor[z] * isum[z]; \
+				sum += (int64_t) convasep->factor[z] * isum[z]; \
 			} \
 \
 			/* Don't add offset ... we only want to do that once, do it on \
@@ -481,7 +481,7 @@ vips_convasep_start(VipsImage *out, void *a, void *b)
 				for (z = 0; z < n_lines; z++) { \
 					isum[z] += p[seq->end[z]]; \
 					isum[z] -= p[seq->start[z]]; \
-					sum += convasep->factor[z] * isum[z]; \
+					sum += (int64_t) convasep->factor[z] * isum[z]; \
 				} \
 				p += istride; \
 				sum = (sum + convasep->rounding) / convasep->divisor; \
@@ -638,7 +638,7 @@ vips_convasep_generate_horizontal(VipsRegion *out_region,
 \
 			TYPE *q; \
 			TYPE *p; \
-			ACC sum; \
+			int64_t sum; \
 \
 			p = x + (TYPE *) VIPS_REGION_ADDR(ir, r->left, r->top); \
 			q = x + (TYPE *) VIPS_REGION_ADDR(out_region, r->left, r->top); \
@@ -648,7 +648,7 @@ vips_convasep_generate_horizontal(VipsRegion *out_region,
 				isum[z] = 0; \
 				for (y = seq->start[z]; y < seq->end[z]; y += istride) \
 					isum[z] += p[y]; \
-				sum += convasep->factor[z] * isum[z]; \
+				sum += (int64_t) convasep->factor[z] * isum[z]; \
 			} \
 			sum = (sum + convasep->rounding) / convasep->divisor + \
 				convasep->offset; \
@@ -661,7 +661,7 @@ vips_convasep_generate_horizontal(VipsRegion *out_region,
 				for (z = 0; z < n_lines; z++) { \
 					isum[z] += p[seq->end[z]]; \
 					isum[z] -= p[seq->start[z]]; \
-					sum += convasep->factor[z] * isum[z]; \
+					sum += (int64_t) convasep->factor[z] * isum[z]; \
 				} \
 				p += istride; \
 				sum = (sum + convasep->rounding) / convasep->divisor + \

--- a/libvips/convolution/convi.c
+++ b/libvips/convolution/convi.c
@@ -694,19 +694,19 @@ vips_convi_gen_vector(VipsRegion *out_region,
 
 /* INT inner loops.
  */
-#define CONV_INT(TYPE, STYPE, CLIP) \
+#define CONV_INT(TYPE, CLIP) \
 	{ \
 		TYPE *restrict p = (TYPE *) VIPS_REGION_ADDR(ir, le, y); \
 		TYPE *restrict q = (TYPE *) VIPS_REGION_ADDR(out_region, le, y); \
 		int *restrict offsets = seq->offsets; \
 \
 		for (x = 0; x < sz; x++) { \
-			STYPE sum; \
+			int64_t sum; \
 			int i; \
 \
 			sum = 0; \
 			for (i = 0; i < nnz; i++) \
-				sum += (STYPE) t[i] * p[offsets[i]]; \
+				sum += (int64_t) t[i] * p[offsets[i]]; \
 \
 			sum = CLIP(((sum + rounding) / scale) + offset); \
 \
@@ -805,27 +805,27 @@ vips_convi_gen(VipsRegion *out_region,
 	for (y = to; y < bo; y++) {
 		switch (in->BandFmt) {
 		case VIPS_FORMAT_UCHAR:
-			CONV_INT(unsigned char, unsigned int, CLIP_UCHAR);
+			CONV_INT(unsigned char, CLIP_UCHAR);
 			break;
 
 		case VIPS_FORMAT_CHAR:
-			CONV_INT(signed char, int, CLIP_CHAR);
+			CONV_INT(signed char, CLIP_CHAR);
 			break;
 
 		case VIPS_FORMAT_USHORT:
-			CONV_INT(unsigned short, unsigned int, CLIP_USHORT);
+			CONV_INT(unsigned short, CLIP_USHORT);
 			break;
 
 		case VIPS_FORMAT_SHORT:
-			CONV_INT(signed short, int, CLIP_SHORT);
+			CONV_INT(signed short, CLIP_SHORT);
 			break;
 
 		case VIPS_FORMAT_UINT:
-			CONV_INT(unsigned int, uint64_t, CLIP_NONE);
+			CONV_INT(unsigned int, CLIP_NONE);
 			break;
 
 		case VIPS_FORMAT_INT:
-			CONV_INT(signed int, int64_t, CLIP_NONE);
+			CONV_INT(signed int, CLIP_NONE);
 			break;
 
 		case VIPS_FORMAT_FLOAT:

--- a/meson.build
+++ b/meson.build
@@ -1,5 +1,5 @@
 project('vips', 'c', 'cpp',
-    version: '8.18.1',
+    version: '8.18.2',
     meson_version: '>=0.55',
     default_options: [
         # this is what glib uses (one of our required deps), so we use it too
@@ -23,7 +23,7 @@ version_patch = version_parts[2]
 # binary interface changed: increment current, reset revision to 0
 #   binary interface changes backwards compatible?: increment age
 #   binary interface changes not backwards compatible?: reset age to 0
-library_revision = 1
+library_revision = 2
 library_current = 62
 library_age = 20
 library_version = '@0@.@1@.@2@'.format(library_current - library_age, library_age, library_revision)

--- a/test/test-suite/test_convolution.py
+++ b/test/test-suite/test_convolution.py
@@ -79,6 +79,12 @@ class TestConvolution:
                     true = conv(im, msk, 49, 49)
                     assert_almost_equal_objects(result, true)
 
+        # https://github.com/libvips/libvips/issues/4955
+        # (cast to ushort to avoid vector path)
+        im = pyvips.Image.mask_ideal(100, 100, 0.5, reject=True, optical=True, uchar=True).cast('ushort')
+        convolved = im.conv(self.sharp, precision=pyvips.Precision.INTEGER)
+        assert convolved(24, 49) == [0]
+
     # don't test conva, it's still not done
     def dont_est_conva(self):
         for im in self.all_images:


### PR DESCRIPTION
Fixes a regression introduced in commit 6d09450 and b72df1e.

Resolves: #4955.
Targets the 8.18 branch.

Note: this would regress https://issues.oss-fuzz.com/issues/490824565, but it likely only affects {u,}int images, so let's track it in #4931 instead.