### PR TITLE
uhdrsave: prevent early unref of image with alpha

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,6 +1,7 @@
 date-tbd 8.18.2
 
 - convolution: avoid using unsigned accumulators [nakrovati]
+- uhdrsave: prevent early unref of image with alpha channel [lovell]
 
 18/3/26 8.18.1
 

--- a/libvips/foreign/uhdrsave.c
+++ b/libvips/foreign/uhdrsave.c
@@ -480,13 +480,14 @@ vips_foreign_save_uhdr_build(VipsObject *object)
 		image = x;
 
 		// libuhdr needs RGBA
-		if (!vips_image_hasalpha(image) &&
-			vips_addalpha(image, &x, NULL)) {
+		if (!vips_image_hasalpha(image)) {
+			if (vips_addalpha(image, &x, NULL)) {
+				VIPS_UNREF(image);
+				return -1;
+			}
 			VIPS_UNREF(image);
-			return -1;
+			image = x;
 		}
-		VIPS_UNREF(image);
-		image = x;
 
 		if (vips_foreign_save_uhdr_hdr(uhdr, image)) {
 			VIPS_UNREF(image);


### PR DESCRIPTION
Should fix https://issues.oss-fuzz.com/issues/495086775, targets 8.18 branch.