### PR TITLE
perf: specialize pixel replication in embed for common pixel sizes

### DIFF
--- a/libvips/conversion/embed.c
+++ b/libvips/conversion/embed.c
@@ -164,11 +164,39 @@ vips_embed_base_copy_pixel(VipsEmbedBase *base,
 {
 	const int bs = VIPS_IMAGE_SIZEOF_PEL(base->in);
 
-	int x, b;
+	int x;
 
-	for (x = 0; x < n; x++)
-		for (b = 0; b < bs; b++)
-			*q++ = p[b];
+	switch (bs) {
+	case 1:
+		memset(q, p[0], n);
+		break;
+	case 2:
+		for (x = 0; x < n; x++)
+			((guint16 *)q)[x] = *(guint16 *)p;
+		break;
+	case 3:
+		for (x = 0; x < n; x++) {
+			q[0] = p[0];
+			q[1] = p[1];
+			q[2] = p[2];
+			q += 3;
+		}
+		break;
+	case 4:
+		for (x = 0; x < n; x++)
+			((guint32 *)q)[x] = *(guint32 *)p;
+		break;
+	case 8:
+		for (x = 0; x < n; x++)
+			((guint64 *)q)[x] = *(guint64 *)p;
+		break;
+	default:
+		for (x = 0; x < n; x++) {
+			memcpy(q, p, bs);
+			q += bs;
+		}
+		break;
+	}
 }
 
 /* Paint r of region or. It's a border area, lying entirely within


### PR DESCRIPTION
Replace the byte-by-byte loop in `vips_embed_base_copy_pixel` with
type-specific stores for common pixel sizes:

- 1 byte (greyscale): memset
- 2 bytes (greyscale+alpha): guint16 store
- 3 bytes (RGB): explicit byte assignments
- 4 bytes (RGBA): guint32 store
- 8 bytes (RGBA double/complex): guint64 store
- other: memcpy per pixel

Benchmark: `vips embed x.v x2.v 0 0 10000 10000 --extend copy`,
VIPS_CONCURRENCY=1, median of 5 runs, arm64 Apple M-series, clang -O3:

| Bands | master | PR    | speedup |
|-------|--------|-------|---------|
| 1     | 0.030s | 0.020s | 33%   |
| 3     | 0.040s | 0.030s | 25%   |
| 4     | 0.040s | 0.030s | 25%   |
| 8     | 0.070s | 0.050s | 29%   |
| 16    | 0.120s | 0.100s | 17%   |
| 32    | 0.210s | 0.150s | 29%   |
| 48    | 0.330s | 0.240s | 27%   |