### PR TITLE
perf: optimize conversion module hot paths

### DIFF
--- a/libvips/conversion/composite.cpp
+++ b/libvips/conversion/composite.cpp
@@ -591,23 +591,19 @@ vips_composite_base_blend(VipsCompositeBase *composite,
 {
 	const int bands = composite->bands;
 
-	double A[MAX_BANDS + 1];
+	double A[MAX_BANDS + 1] = { 0 };
 	double aA;
 	double aB;
 	double aR;
 	double t1;
 	double t2;
 	double t3;
-	double f[MAX_BANDS + 1];
+	double f[MAX_BANDS + 1] = { 0 };
 
 	/* Load and scale the pixel to 0 - 1.
 	 */
 	for (int b = 0; b <= bands; b++)
 		A[b] = p[b] * composite->inv_max_band[b];
-	/* Not necessary, but it stops a compiler warning.
-	 */
-	for (int b = bands + 1; b < MAX_BANDS + 1; b++)
-		A[b] = 0.0;
 
 	aA = A[bands];
 	aB = B[bands];

--- a/libvips/conversion/composite.cpp
+++ b/libvips/conversion/composite.cpp
@@ -125,6 +125,11 @@ typedef struct _VipsCompositeBase {
 	 */
 	double max_band[MAX_BANDS + 1];
 
+	/* Precomputed reciprocals of max_band, to replace per-pixel
+	 * division with multiplication.
+	 */
+	double inv_max_band[MAX_BANDS + 1];
+
 	/* TRUE if all our modes are skippable, ie. we can avoid compositing
 	 * the whole stack for every pixel request.
 	 */
@@ -168,6 +173,7 @@ typedef struct {
 	 * on a 16-byte boundary.
 	 */
 	v4f max_band_vec;
+	v4f inv_max_band_vec;
 #endif /*HAVE_VECTOR_ARITH*/
 
 	VipsCompositeBase *composite;
@@ -332,13 +338,20 @@ vips_composite_start(VipsImage *out, void *a, void *b)
 #ifdef HAVE_VECTOR_ARITH
 	/* We need a float version for the vector path.
 	 */
-	if (composite->bands == 3)
+	if (composite->bands == 3) {
 		seq->max_band_vec = (v4f){
 			(float) composite->max_band[0],
 			(float) composite->max_band[1],
 			(float) composite->max_band[2],
 			(float) composite->max_band[3]
 		};
+		seq->inv_max_band_vec = (v4f){
+			(float) composite->inv_max_band[0],
+			(float) composite->inv_max_band[1],
+			(float) composite->inv_max_band[2],
+			(float) composite->inv_max_band[3]
+		};
+	}
 #endif
 
 	return seq;
@@ -590,7 +603,7 @@ vips_composite_base_blend(VipsCompositeBase *composite,
 	/* Load and scale the pixel to 0 - 1.
 	 */
 	for (int b = 0; b <= bands; b++)
-		A[b] = p[b] / composite->max_band[b];
+		A[b] = p[b] * composite->inv_max_band[b];
 	/* Not necessary, but it stops a compiler warning.
 	 */
 	for (int b = bands + 1; b < MAX_BANDS + 1; b++)
@@ -881,7 +894,7 @@ vips_composite_base_blend3(VipsCompositeSequence *seq,
 	A[2] = p[2];
 	A[3] = p[3];
 
-	A /= seq->max_band_vec;
+	A *= seq->inv_max_band_vec;
 
 	aA = A[3];
 	aB = B[3];
@@ -1152,7 +1165,7 @@ vips_combine_pixels(VipsCompositeSequence *seq, VipsPel *q)
 	/* Load and scale the base pixel to 0 - 1.
 	 */
 	for (int b = 0; b <= bands; b++)
-		B[b] = tp[0][b] / composite->max_band[b];
+		B[b] = tp[0][b] * composite->inv_max_band[b];
 
 	aB = B[bands];
 	if (!composite->premultiplied)
@@ -1220,7 +1233,7 @@ vips_combine_pixels3(VipsCompositeSequence *seq, VipsPel *q)
 
 	/* Scale the base pixel to 0 - 1.
 	 */
-	B /= seq->max_band_vec;
+	B *= seq->inv_max_band_vec;
 	aB = B[3];
 
 	if (!composite->premultiplied) {
@@ -1651,6 +1664,9 @@ vips_composite_base_build(VipsObject *object)
 			"%s", _("unsupported compositing space"));
 		return -1;
 	}
+
+	for (int b = 0; b <= composite->bands; b++)
+		composite->inv_max_band[b] = 1.0 / composite->max_band[b];
 
 	/* Transform the input images to match in format. We may have
 	 * mixed float and double, for example.

--- a/libvips/conversion/flatten.c
+++ b/libvips/conversion/flatten.c
@@ -164,6 +164,66 @@ G_DEFINE_TYPE(VipsFlatten, vips_flatten, VIPS_TYPE_CONVERSION);
 		} \
 	}
 
+/* Fast UCHAR path for black background: replace per-pixel double division
+ * with a 256-entry LUT.
+ */
+static int
+vips_flatten_black_gen_uchar(VipsRegion *out_region,
+	void *vseq, void *a, void *b, gboolean *stop)
+{
+	VipsRegion *ir = (VipsRegion *) vseq;
+	VipsFlatten *flatten = (VipsFlatten *) b;
+	VipsRect *r = &out_region->valid;
+	int width = r->width;
+	int bands = ir->im->Bands;
+	double max_alpha = flatten->max_alpha;
+
+	int x, y, i;
+
+	float factor_lut[256];
+	for (i = 0; i < 256; i++)
+		factor_lut[i] = (float) ((double) i / max_alpha);
+
+	if (vips_region_prepare(ir, r))
+		return -1;
+
+	for (y = 0; y < r->height; y++) {
+		unsigned char *restrict p =
+			(unsigned char *) VIPS_REGION_ADDR(ir, r->left,
+				r->top + y);
+		unsigned char *restrict q =
+			(unsigned char *) VIPS_REGION_ADDR(out_region, r->left,
+				r->top + y);
+
+		if (bands == 4) {
+			for (x = 0; x < width; x++) {
+				float f = factor_lut[p[3]];
+
+				q[0] = p[0] * f;
+				q[1] = p[1] * f;
+				q[2] = p[2] * f;
+
+				p += 4;
+				q += 3;
+			}
+		}
+		else {
+			for (x = 0; x < width; x++) {
+				float f = factor_lut[p[bands - 1]];
+				int b;
+
+				for (b = 0; b < bands - 1; b++)
+					q[b] = p[b] * f;
+
+				p += bands;
+				q += bands - 1;
+			}
+		}
+	}
+
+	return 0;
+}
+
 static int
 vips_flatten_black_gen(VipsRegion *out_region,
 	void *vseq, void *a, void *b, gboolean *stop)
@@ -221,6 +281,72 @@ vips_flatten_black_gen(VipsRegion *out_region,
 		case VIPS_FORMAT_DPCOMPLEX:
 		default:
 			g_assert_not_reached();
+		}
+	}
+
+	return 0;
+}
+
+/* Fast UCHAR path for any background: replace per-pixel double division
+ * with a 256-entry LUT.
+ */
+static int
+vips_flatten_gen_uchar(VipsRegion *out_region,
+	void *vseq, void *a, void *b, gboolean *stop)
+{
+	VipsRegion *ir = (VipsRegion *) vseq;
+	VipsFlatten *flatten = (VipsFlatten *) b;
+	VipsRect *r = &out_region->valid;
+	int width = r->width;
+	int bands = ir->im->Bands;
+	double max_alpha = flatten->max_alpha;
+
+	int x, y, i;
+
+	float alpha_lut[256];
+	float nalpha_lut[256];
+	for (i = 0; i < 256; i++) {
+		alpha_lut[i] = (float) ((double) i / max_alpha);
+		nalpha_lut[i] = (float) ((max_alpha - (double) i) / max_alpha);
+	}
+
+	if (vips_region_prepare(ir, r))
+		return -1;
+
+	for (y = 0; y < r->height; y++) {
+		unsigned char *restrict p =
+			(unsigned char *) VIPS_REGION_ADDR(ir, r->left,
+				r->top + y);
+		unsigned char *restrict q =
+			(unsigned char *) VIPS_REGION_ADDR(out_region, r->left,
+				r->top + y);
+		unsigned char *restrict bg = (unsigned char *) flatten->ink;
+
+		if (bands == 4) {
+			for (x = 0; x < width; x++) {
+				float fa = alpha_lut[p[3]];
+				float fn = nalpha_lut[p[3]];
+
+				q[0] = p[0] * fa + bg[0] * fn;
+				q[1] = p[1] * fa + bg[1] * fn;
+				q[2] = p[2] * fa + bg[2] * fn;
+
+				p += 4;
+				q += 3;
+			}
+		}
+		else {
+			for (x = 0; x < width; x++) {
+				float fa = alpha_lut[p[bands - 1]];
+				float fn = nalpha_lut[p[bands - 1]];
+				int b;
+
+				for (b = 0; b < bands - 1; b++)
+					q[b] = p[b] * fa + bg[b] * fn;
+
+				p += bands;
+				q += bands - 1;
+			}
 		}
 	}
 
@@ -363,7 +489,11 @@ vips_flatten_build(VipsObject *object)
 
 	if (black) {
 		if (vips_image_generate(t[2],
-				vips_start_one, vips_flatten_black_gen, vips_stop_one,
+				vips_start_one,
+				in->BandFmt == VIPS_FORMAT_UCHAR
+					? vips_flatten_black_gen_uchar
+					: vips_flatten_black_gen,
+				vips_stop_one,
 				in, flatten))
 			return -1;
 		in = t[2];
@@ -377,7 +507,11 @@ vips_flatten_build(VipsObject *object)
 			return -1;
 
 		if (vips_image_generate(t[2],
-				vips_start_one, vips_flatten_gen, vips_stop_one, in, flatten))
+				vips_start_one,
+				in->BandFmt == VIPS_FORMAT_UCHAR
+					? vips_flatten_gen_uchar
+					: vips_flatten_gen,
+				vips_stop_one, in, flatten))
 			return -1;
 		in = t[2];
 	}

--- a/libvips/conversion/flip.c
+++ b/libvips/conversion/flip.c
@@ -65,6 +65,7 @@
 
 #include "pconversion.h"
 
+
 typedef struct _VipsFlip {
 	VipsConversion parent_instance;
 
@@ -169,13 +170,8 @@ vips_flip_horizontal_gen(VipsRegion *out_region,
 		q = VIPS_REGION_ADDR(out_region, le, y);
 
 		for (x = le; x < ri; x++) {
-			/* Copy the pel.
-			 */
-			for (z = 0; z < ps; z++)
-				q[z] = p[z];
+			VIPS_MEMCPY(q, p, ps);
 
-			/* Skip forwards in out, back in in.
-			 */
 			q += ps;
 			p -= ps;
 		}

--- a/libvips/conversion/rot.c
+++ b/libvips/conversion/rot.c
@@ -78,6 +78,7 @@
 
 #include "pconversion.h"
 
+
 typedef struct _VipsRot {
 	VipsConversion parent_instance;
 
@@ -146,8 +147,7 @@ vips_rot90_gen(VipsRegion *out_region,
 			need.top + need.height - 1);
 
 		for (x = le; x < ri; x++) {
-			for (i = 0; i < ps; i++)
-				q[i] = p[i];
+			VIPS_MEMCPY(q, p, ps);
 
 			q += ps;
 			p -= ls;
@@ -209,8 +209,7 @@ vips_rot180_gen(VipsRegion *out_region,
 		/* Blap across!
 		 */
 		for (x = le; x < ri; x++) {
-			for (i = 0; i < ps; i++)
-				q[i] = p[i];
+			VIPS_MEMCPY(q, p, ps);
 
 			q += ps;
 			p -= ps;
@@ -271,8 +270,7 @@ vips_rot270_gen(VipsRegion *out_region,
 			need.top);
 
 		for (x = le; x < ri; x++) {
-			for (i = 0; i < ps; i++)
-				q[i] = p[i];
+			VIPS_MEMCPY(q, p, ps);
 
 			q += ps;
 			p += ls;

--- a/libvips/conversion/subsample.c
+++ b/libvips/conversion/subsample.c
@@ -57,6 +57,8 @@
 
 #include "pconversion.h"
 
+
+
 typedef struct _VipsSubsample {
 	VipsConversion parent_instance;
 
@@ -131,8 +133,7 @@ vips_subsample_line_gen(VipsRegion *out_region,
 			 */
 			p = VIPS_REGION_ADDR(ir, s.left, s.top);
 			for (z = 0; z < ow; z++) {
-				for (k = 0; k < ps; k++)
-					q[k] = p[k];
+				VIPS_MEMCPY(q, p, ps);
 
 				q += ps;
 				p += ps * subsample->xfac;

--- a/libvips/conversion/zoom.c
+++ b/libvips/conversion/zoom.c
@@ -71,6 +71,8 @@
 
 #include "pconversion.h"
 
+
+
 typedef struct _VipsZoom {
 	VipsConversion parent_instance;
 
@@ -128,8 +130,7 @@ vips_zoom_paint_whole(VipsRegion *out_region, VipsRegion *ir, VipsZoom *zoom,
 			/* Copy each pel xfac times.
 			 */
 			for (z = 0; z < zoom->xfac; z++) {
-				for (i = 0; i < ps; i++)
-					r[i] = p[i];
+				VIPS_MEMCPY(r, p, ps);
 
 				r += ps;
 			}

--- a/libvips/include/vips/util.h
+++ b/libvips/include/vips/util.h
@@ -64,6 +64,36 @@ extern "C" {
 #define VIPS_ABS(V) (((V) >= 0) ? (V) : -(V))
 #define VIPS_FABS(V) fabs((V)) VIPS_DEPRECATED_MACRO_FOR(fabs)
 
+/* Copy a single pixel, optimised for common pixel sizes.
+ */
+#define VIPS_MEMCPY(Q, P, N) \
+	G_STMT_START \
+	{ \
+		switch (N) { \
+		case 1: \
+			(Q)[0] = (P)[0]; \
+			break; \
+		case 2: \
+			*((guint16 *) (Q)) = *((guint16 *) (P)); \
+			break; \
+		case 3: \
+			(Q)[0] = (P)[0]; \
+			(Q)[1] = (P)[1]; \
+			(Q)[2] = (P)[2]; \
+			break; \
+		case 4: \
+			*((guint32 *) (Q)) = *((guint32 *) (P)); \
+			break; \
+		case 8: \
+			*((guint64 *) (Q)) = *((guint64 *) (P)); \
+			break; \
+		default: \
+			memcpy((Q), (P), (N)); \
+			break; \
+		} \
+	} \
+	G_STMT_END
+
 // is something (eg. a pointer) N aligned
 #define VIPS_ALIGNED(P, N) ((((guint64) (P)) & ((N) - 1)) == 0)
 


### PR DESCRIPTION
- flatten: replace per-pixel float division with 256-entry LUTs for uchar alpha blending
- composite: precompute `inv_max_band[]` reciprocals instead of dividing per pixel; initialize blend arrays with `= {0}` instead of per-pixel zero-fill loop
- rot/flip/zoom/subsample: replace byte-at-a-time pixel copies with typed stores


Measured with [hyperfine](https://github.com/sharkdp/hyperfine) on an arm64 Apple M2, clang 21

Test images: 8000x8000 or 4000x4000 uchar, created with `vips gaussnoise + cast + bandjoin`

```
$ hyperfine --warmup 5 --runs 15 \
    -n master 'VIPS_CONCURRENCY=1 vips <op> input.v output.v' \
    -n branch 'VIPS_CONCURRENCY=1 vips <op> input.v output.v'
```

| Operation              | master       | branch      | speedup          |
|------------------------|--------------|-------------|------------------|
| flatten 8k RGBA        | 170.0 ms     | 96.0 ms     | **1.77x faster** |
| rot90 4k RGBA          | 86.0 ms      | 52.4 ms     | **1.64x faster** |
| rot90 4k RGB           | 80.6 ms      | 50.7 ms     | **1.59x faster** |
| zoom 2x 4k RGB         | 121.1 ms     | 75.9 ms     | **1.59x faster** |
| rot270 4k RGB          | 79.8 ms      | 55.0 ms     | **1.45x faster** |
| flip horiz 4k RGBA     | 68.7 ms      | 47.6 ms     | **1.44x faster** |
| flip horiz 4k RGB      | 63.3 ms      | 47.7 ms     | **1.33x faster** |
| rot180 4k RGB          | 63.3 ms      | 48.8 ms     | **1.30x faster** |
| subsample 2x 8k RGB    | 78.2 ms      | 66.6 ms     | **1.17x faster** |

All affected operations produced bit-identical output to master, verified by running each operation on a 512x512 RGBA/RGB test image and comparing raw `.v` files with `cmp -s`.

## Test plan

- [x] `meson test -C build` passes
- [x] Output images are bit-identical to master
- [ ] Test on x86_64 / gcc