### PR TITLE
feat: add `scRGB2CICP`

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -23,6 +23,7 @@ date-tbd 8.19.0
 - csvload: add maximum limit on column count [lovell]
 - pdfload_buffer: only search the first few bytes in is_a [violetviolinist]
 - heifload: allow mif2 and mif3 "brand" images e.g. mini box [lovell]
+- add vips_scRGB2CICP [mertalev]
 
 6/6/26 8.18.3
 

--- a/doc/libvips-colour.md
+++ b/doc/libvips-colour.md
@@ -118,6 +118,7 @@ The colour spaces supported by libvips are:
 * [method@Image.XYZ2scRGB]
 * [method@Image.scRGB2sRGB]
 * [method@Image.scRGB2BW]
+* [method@Image.scRGB2CICP]
 * [method@Image.sRGB2scRGB]
 * [method@Image.scRGB2XYZ]
 * [method@Image.HSV2sRGB]

--- a/libvips/colour/CICP2scRGB.c
+++ b/libvips/colour/CICP2scRGB.c
@@ -78,17 +78,9 @@ typedef struct _VipsCICP2scRGB {
 
 } VipsCICP2scRGB;
 
-#define SDR_WHITE 80.0f
-
 typedef VipsColourClass VipsCICP2scRGBClass;
 
 G_DEFINE_TYPE(VipsCICP2scRGB, vips_CICP2scRGB, VIPS_TYPE_COLOUR);
-
-static const float BT709_to_BT709[9] = {
-	1.0f, 0.0f, 0.0f,
-	0.0f, 1.0f, 0.0f,
-	0.0f, 0.0f, 1.0f
-};
 
 static const float BT2020_to_BT709[9] = {
 	1.660491f, -0.58764114f, -0.07284986f,
@@ -146,128 +138,30 @@ static const float EBU3213_to_BT709[9] = {
 	-0.00176953f, -0.00144232f, 1.00321185f
 };
 
-/* Luminance coefficients (Y row of primaries-to-XYZ matrix) for
- * each set of colour primaries. Used by HLG OOTF to compute
- * scene luminance in the source primaries' colour space.
- *
- * These are the normalised Y chromaticities scaled so that the
- * white point has Y = 1. For standard illuminant D65 primaries:
- *   Y_r = yr * (xw/yw) / (xr/yr * (yw-yg) - xg * (yw-yr)/yg + xb * (yr-yg)/yb + ...)
- * In practice these come from the second row of the 3x3
- * chromaticity-to-XYZ matrix, normalised to sum to 1.
- */
-
-/* Luminance coefficients derived from H.273 Table 2 chromaticities.
- */
-
-/* BT.709 / sRGB (value 1)
- */
-static const float BT709_luminance[3] = { 0.2126f, 0.7152f, 0.0722f };
-
-/* BT.2020 / BT.2100 (value 9)
- */
-static const float BT2020_luminance[3] = { 0.2627f, 0.6780f, 0.0593f };
-
-/* DCI-P3 / SMPTE 431 (value 11, Illuminant DCI ~0.314/0.351)
- */
-static const float DCI_P3_luminance[3] = { 0.2095f, 0.7216f, 0.0689f };
-
-/* Display P3 / SMPTE 432 (value 12, D65 white)
- */
-static const float Display_P3_luminance[3] = { 0.2290f, 0.6917f, 0.0793f };
-
-/* BT.470M (value 4, Illuminant C)
- */
-static const float BT470M_luminance[3] = { 0.2990f, 0.5864f, 0.1146f };
-
-/* BT.470BG (value 5)
- */
-static const float BT470BG_luminance[3] = { 0.2220f, 0.7067f, 0.0713f };
-
-/* BT.601 / SMPTE 170M / SMPTE 240M (values 6, 7)
- */
-static const float BT601_luminance[3] = { 0.2124f, 0.7011f, 0.0866f };
-
-/* Generic Film (value 8, Illuminant C)
- */
-static const float GenericFilm_luminance[3] = { 0.2536f, 0.6783f, 0.0681f };
-
-/* EBU 3213 (value 22)
- */
-static const float EBU3213_luminance[3] = { 0.2318f, 0.6723f, 0.0960f };
-
-static void
-vips_CICP2scRGB_init_matrix(VipsCICP2scRGB *cicp)
+static const float *
+vips_CICP2scRGB_get_matrix(VipsCICPColourPrimaries primaries)
 {
-	const float *matrix;
-	const float *luminance;
-
-	switch (cicp->colour_primaries) {
-	case VIPS_CICP_COLOUR_PRIMARIES_BT709:
-		matrix = BT709_to_BT709;
-		luminance = BT709_luminance;
-		break;
-
+	switch (primaries) {
 	case VIPS_CICP_COLOUR_PRIMARIES_BT2020:
-		matrix = BT2020_to_BT709;
-		luminance = BT2020_luminance;
-		break;
-
+		return BT2020_to_BT709;
 	case VIPS_CICP_COLOUR_PRIMARIES_SMPTE431:
-		matrix = DCI_P3_to_BT709;
-		luminance = DCI_P3_luminance;
-		break;
-
+		return DCI_P3_to_BT709;
 	case VIPS_CICP_COLOUR_PRIMARIES_SMPTE432:
-		matrix = Display_P3_to_BT709;
-		luminance = Display_P3_luminance;
-		break;
-
+		return Display_P3_to_BT709;
 	case VIPS_CICP_COLOUR_PRIMARIES_BT470M:
-		matrix = BT470M_to_BT709;
-		luminance = BT470M_luminance;
-		break;
-
+		return BT470M_to_BT709;
 	case VIPS_CICP_COLOUR_PRIMARIES_BT470BG:
-		matrix = BT470BG_to_BT709;
-		luminance = BT470BG_luminance;
-		break;
-
+		return BT470BG_to_BT709;
 	case VIPS_CICP_COLOUR_PRIMARIES_BT601:
 	case VIPS_CICP_COLOUR_PRIMARIES_SMPTE240:
-		matrix = BT601_to_BT709;
-		luminance = BT601_luminance;
-		break;
-
+		return BT601_to_BT709;
 	case VIPS_CICP_COLOUR_PRIMARIES_GENERIC_FILM:
-		matrix = GenericFilm_to_BT709;
-		luminance = GenericFilm_luminance;
-		break;
-
+		return GenericFilm_to_BT709;
 	case VIPS_CICP_COLOUR_PRIMARIES_EBU3213:
-		matrix = EBU3213_to_BT709;
-		luminance = EBU3213_luminance;
-		break;
-
+		return EBU3213_to_BT709;
 	default:
-		/* For unspecified or unimplemented primaries, use identity.
-		 */
-		matrix = BT709_to_BT709;
-		luminance = BT709_luminance;
-		break;
+		return BT709_to_BT709;
 	}
-
-	memcpy(cicp->conversion_matrix, matrix, 9 * sizeof(float));
-	memcpy(cicp->luminance_coeffs, luminance, 3 * sizeof(float));
-}
-
-static inline void
-vips_apply_matrix(const float *matrix, float r, float g, float b,
-	float *out_r, float *out_g, float *out_b)
-{
-	*out_r = matrix[0] * r + matrix[1] * g + matrix[2] * b;
-	*out_g = matrix[3] * r + matrix[4] * g + matrix[5] * b;
-	*out_b = matrix[6] * r + matrix[7] * g + matrix[8] * b;
 }
 
 static inline float
@@ -331,24 +225,6 @@ vips_hlg_inverse_oetf(float E)
  * Uses a pre-computed LUT for powf(Y_s, gamma-1) with linear
  * interpolation. Y_s is in [0, 1] (scene-linear after inverse OETF).
  */
-#define OOTF_LUT_SIZE 4096
-
-static float *
-vips_hlg_ootf_build_lut(void)
-{
-	const float gamma_minus_1 = 0.2f;
-	const float scale = 1000.0f / SDR_WHITE;
-
-	float *lut = g_new(float, OOTF_LUT_SIZE);
-
-	lut[0] = 0.0f;
-	for (int i = 1; i < OOTF_LUT_SIZE; i++)
-		lut[i] = scale *
-			powf((float) i / (OOTF_LUT_SIZE - 1), gamma_minus_1);
-
-	return lut;
-}
-
 static inline void
 vips_hlg_ootf(float *r, float *g, float *b,
 	const float *luminance, const float *ootf_lut)
@@ -362,16 +238,7 @@ vips_hlg_ootf(float *r, float *g, float *b,
 		return;
 	}
 
-	/* Linearly interpolate the OOTF LUT. Y_s is in [0, 1].
-	 */
-	float idx = Y_s * (OOTF_LUT_SIZE - 1);
-	int lo = (int) idx;
-
-	if (lo >= OOTF_LUT_SIZE - 1)
-		lo = OOTF_LUT_SIZE - 2;
-
-	float frac = idx - lo;
-	float factor = ootf_lut[lo] + frac * (ootf_lut[lo + 1] - ootf_lut[lo]);
+	float factor = vips_cicp_lut_interpolate(ootf_lut, Y_s);
 
 	*r *= factor;
 	*g *= factor;
@@ -400,9 +267,10 @@ vips_bt709_inverse_oetf(float E)
 static inline float
 vips_sRGB_inverse_oetf(float E)
 {
-	const float signal_beta = 0.04045f;
+	const float linear_beta = 0.003041282560128f;
 	const float slope = 12.92f;
-	const float alpha = 1.055f;
+	const float signal_beta = slope * linear_beta;
+	const float alpha = 1.05501071894759f;
 	const float gamma = 2.4f;
 
 	if (E < 0.0f)
@@ -428,8 +296,8 @@ vips_CICP2scRGB_transfer(VipsCICPTransferCharacteristics transfer, float in)
 	case VIPS_CICP_TRANSFER_BT2020_12BIT:
 		return vips_bt709_inverse_oetf(in);
 	case VIPS_CICP_TRANSFER_SMPTE240: {
-		const float alpha = 1.1115f;
-		const float linear_beta = 0.0228f;
+		const float alpha = 1.11157219592173f;
+		const float linear_beta = 0.022821585529445f;
 		const float slope = 4.0f;
 
 		if (in < slope * linear_beta)
@@ -516,7 +384,7 @@ vips_CICP2scRGB_build_lut(VipsCICPTransferCharacteristics transfer, int n)
 		if (is_hlg) \
 			vips_hlg_ootf(&r, &g, &b, luminance, cicp->ootf_lut); \
 \
-		vips_apply_matrix(matrix, r, g, b, &q[0], &q[1], &q[2]); \
+		vips_cicp_apply_matrix(matrix, r, g, b, &q[0], &q[1], &q[2]); \
 \
 		q += 3; \
 	} \
@@ -564,7 +432,12 @@ vips_CICP2scRGB_build(VipsObject *object)
 		cicp->transfer_characteristics = transfer_characteristics;
 		cicp->matrix_coefficients = matrix_coefficients;
 
-		vips_CICP2scRGB_init_matrix(cicp);
+		memcpy(cicp->conversion_matrix,
+			vips_CICP2scRGB_get_matrix(cicp->colour_primaries),
+			9 * sizeof(float));
+		memcpy(cicp->luminance_coeffs,
+			vips_cicp_get_luminance(cicp->colour_primaries),
+			3 * sizeof(float));
 
 		cicp->lut_size = cicp->in->BandFmt == VIPS_FORMAT_UCHAR
 			? 256 : 65536;
@@ -572,7 +445,8 @@ vips_CICP2scRGB_build(VipsObject *object)
 			cicp->transfer_characteristics, cicp->lut_size);
 
 		if (cicp->transfer_characteristics == VIPS_CICP_TRANSFER_HLG)
-			cicp->ootf_lut = vips_hlg_ootf_build_lut();
+			cicp->ootf_lut = vips_cicp_build_power_lut(
+				0.2f, 1000.0f / SDR_WHITE);
 
 		colour->in[0] = cicp->in;
 		g_object_ref(cicp->in);

--- a/libvips/colour/CICP2scRGB.c
+++ b/libvips/colour/CICP2scRGB.c
@@ -71,11 +71,6 @@ typedef struct _VipsCICP2scRGB {
 	float *transfer_lut;
 	int lut_size;
 
-	/* LUT for HLG OOTF: maps Y_s in [0,1] to
-	 * scale * Y_s^(gamma-1), with linear interpolation.
-	 */
-	float *ootf_lut;
-
 } VipsCICP2scRGB;
 
 typedef VipsColourClass VipsCICP2scRGBClass;
@@ -221,14 +216,13 @@ vips_hlg_inverse_oetf(float E)
  *   Y_s = luminance using source primaries' coefficients
  *
  * Output scaled by 1/SDR_WHITE so that 1.0 = 80 nits.
- *
- * Uses a pre-computed LUT for powf(Y_s, gamma-1) with linear
- * interpolation. Y_s is in [0, 1] (scene-linear after inverse OETF).
  */
 static inline void
-vips_hlg_ootf(float *r, float *g, float *b,
-	const float *luminance, const float *ootf_lut)
+vips_hlg_ootf(float *r, float *g, float *b, const float *luminance)
 {
+	const float alpha = 1000.0f / SDR_WHITE;
+	const float gamma_minus_1 = 0.2f;
+
 	float Y_s = luminance[0] * *r + luminance[1] * *g + luminance[2] * *b;
 
 	if (Y_s <= 0.0f) {
@@ -238,7 +232,7 @@ vips_hlg_ootf(float *r, float *g, float *b,
 		return;
 	}
 
-	float factor = vips_cicp_lut_interpolate(ootf_lut, Y_s);
+	float factor = alpha * powf(Y_s, gamma_minus_1);
 
 	*r *= factor;
 	*g *= factor;
@@ -382,7 +376,7 @@ vips_CICP2scRGB_build_lut(VipsCICPTransferCharacteristics transfer, int n)
 		p += 3; \
 \
 		if (is_hlg) \
-			vips_hlg_ootf(&r, &g, &b, luminance, cicp->ootf_lut); \
+			vips_hlg_ootf(&r, &g, &b, luminance); \
 \
 		vips_cicp_apply_matrix(matrix, r, g, b, &q[0], &q[1], &q[2]); \
 \
@@ -444,10 +438,6 @@ vips_CICP2scRGB_build(VipsObject *object)
 		cicp->transfer_lut = vips_CICP2scRGB_build_lut(
 			cicp->transfer_characteristics, cicp->lut_size);
 
-		if (cicp->transfer_characteristics == VIPS_CICP_TRANSFER_HLG)
-			cicp->ootf_lut = vips_cicp_build_power_lut(
-				0.2f, 1000.0f / SDR_WHITE);
-
 		colour->in[0] = cicp->in;
 		g_object_ref(cicp->in);
 	}
@@ -472,7 +462,6 @@ vips_CICP2scRGB_dispose(GObject *gobject)
 	VipsCICP2scRGB *cicp = (VipsCICP2scRGB *) gobject;
 
 	VIPS_FREE(cicp->transfer_lut);
-	VIPS_FREE(cicp->ootf_lut);
 
 	G_OBJECT_CLASS(vips_CICP2scRGB_parent_class)->dispose(gobject);
 }

--- a/libvips/colour/colour.c
+++ b/libvips/colour/colour.c
@@ -642,6 +642,7 @@ vips_colour_operation_init(void)
 	extern GType vips_Oklch2Oklab_get_type(void);
 	extern GType vips_uhdr2scRGB_get_type(void);
 	extern GType vips_CICP2scRGB_get_type(void);
+	extern GType vips_scRGB2CICP_get_type(void);
 	extern GType vips_profile_load_get_type(void);
 #ifdef HAVE_LCMS2
 	extern GType vips_icc_import_get_type(void);
@@ -685,6 +686,7 @@ vips_colour_operation_init(void)
 	vips_XYZ2CMYK_get_type();
 	vips_uhdr2scRGB_get_type();
 	vips_CICP2scRGB_get_type();
+	vips_scRGB2CICP_get_type();
 	vips_profile_load_get_type();
 #ifdef HAVE_LCMS2
 	vips_icc_import_get_type();

--- a/libvips/colour/meson.build
+++ b/libvips/colour/meson.build
@@ -27,6 +27,7 @@ colour_sources = files(
     'profiles.c',
     'rad2float.c',
     'scRGB2BW.c',
+    'scRGB2CICP.c',
     'scRGB2sRGB.c',
     'scRGB2XYZ.c',
     'sRGB2HSV.c',

--- a/libvips/colour/pcolour.h
+++ b/libvips/colour/pcolour.h
@@ -219,6 +219,135 @@ typedef int (*VipsColourTransformFn)(VipsImage *in, VipsImage **out, ...);
 int vips__colourspace_process_n(const char *domain,
 	VipsImage *in, VipsImage **out, int n, VipsColourTransformFn fn);
 
+#define SDR_WHITE 80.0f
+
+/* Identity matrix (BT.709 -> BT.709). */
+static const float BT709_to_BT709[9] = {
+	1.0f, 0.0f, 0.0f,
+	0.0f, 1.0f, 0.0f,
+	0.0f, 0.0f, 1.0f
+};
+
+/* Luminance coefficients (Y row of primaries-to-XYZ matrix) for
+ * each set of colour primaries. Used by HLG OOTF / inverse OOTF
+ * to compute luminance in the source/target primaries' colour space.
+ *
+ * These are the normalised Y chromaticities scaled so that the
+ * white point has Y = 1. In practice these come from the second
+ * row of the 3x3 chromaticity-to-XYZ matrix, normalised to sum
+ * to 1.
+ *
+ * Derived from H.273 Table 2 chromaticities.
+ */
+
+/* BT.709 / sRGB (value 1) */
+static const float BT709_luminance[3] = { 0.2126f, 0.7152f, 0.0722f };
+
+/* BT.2020 / BT.2100 (value 9) */
+static const float BT2020_luminance[3] = { 0.2627f, 0.6780f, 0.0593f };
+
+/* DCI-P3 / SMPTE 431 (value 11, Illuminant DCI ~0.314/0.351) */
+static const float DCI_P3_luminance[3] = { 0.2095f, 0.7216f, 0.0689f };
+
+/* Display P3 / SMPTE 432 (value 12, D65 white) */
+static const float Display_P3_luminance[3] = { 0.2290f, 0.6917f, 0.0793f };
+
+/* BT.470M (value 4, Illuminant C) */
+static const float BT470M_luminance[3] = { 0.2990f, 0.5864f, 0.1146f };
+
+/* BT.470BG (value 5) */
+static const float BT470BG_luminance[3] = { 0.2220f, 0.7067f, 0.0713f };
+
+/* BT.601 / SMPTE 170M / SMPTE 240M (values 6, 7) */
+static const float BT601_luminance[3] = { 0.2124f, 0.7011f, 0.0866f };
+
+/* Generic Film (value 8, Illuminant C) */
+static const float GenericFilm_luminance[3] = { 0.2536f, 0.6783f, 0.0681f };
+
+/* EBU 3213 (value 22) */
+static const float EBU3213_luminance[3] = { 0.2318f, 0.6723f, 0.0960f };
+
+/* Look up luminance coefficients for a CICP colour primaries code. */
+static inline const float *
+vips_cicp_get_luminance(int colour_primaries)
+{
+	switch (colour_primaries) {
+	case VIPS_CICP_COLOUR_PRIMARIES_BT709:
+		return BT709_luminance;
+	case VIPS_CICP_COLOUR_PRIMARIES_BT2020:
+		return BT2020_luminance;
+	case VIPS_CICP_COLOUR_PRIMARIES_SMPTE431:
+		return DCI_P3_luminance;
+	case VIPS_CICP_COLOUR_PRIMARIES_SMPTE432:
+		return Display_P3_luminance;
+	case VIPS_CICP_COLOUR_PRIMARIES_BT470M:
+		return BT470M_luminance;
+	case VIPS_CICP_COLOUR_PRIMARIES_BT470BG:
+		return BT470BG_luminance;
+	case VIPS_CICP_COLOUR_PRIMARIES_BT601:
+	case VIPS_CICP_COLOUR_PRIMARIES_SMPTE240:
+		return BT601_luminance;
+	case VIPS_CICP_COLOUR_PRIMARIES_GENERIC_FILM:
+		return GenericFilm_luminance;
+	case VIPS_CICP_COLOUR_PRIMARIES_EBU3213:
+		return EBU3213_luminance;
+	default:
+		return BT709_luminance;
+	}
+}
+
+/* LUT size for CICP transfer / OOTF tables.
+ */
+#define VIPS_CICP_LUT_SIZE 4096
+
+/* Build a LUT for f(t) = scale * t^exponent, t in [0, 1].
+ * Used by HLG forward OOTF (exponent=0.2, scale=1000/80)
+ * and HLG inverse OOTF (exponent=1/1.2, scale=1).
+ */
+static inline float *
+vips_cicp_build_power_lut(float exponent, float scale)
+{
+	float *lut = g_new(float, VIPS_CICP_LUT_SIZE);
+
+	lut[0] = 0.0f;
+	for (int i = 1; i < VIPS_CICP_LUT_SIZE; i++)
+		lut[i] = scale *
+			powf((float) i / (VIPS_CICP_LUT_SIZE - 1), exponent);
+
+	return lut;
+}
+
+/* Linearly interpolate a LUT on the domain [0, 1].
+ * Returns lut[0] for t <= 0; extrapolates from the last
+ * segment for t slightly above 1.
+ */
+static inline float
+vips_cicp_lut_interpolate(const float *lut, float t)
+{
+	float idx = t * (VIPS_CICP_LUT_SIZE - 1);
+
+	if (idx <= 0.0f)
+		return lut[0];
+
+	int lo = (int) idx;
+
+	if (lo >= VIPS_CICP_LUT_SIZE - 1)
+		lo = VIPS_CICP_LUT_SIZE - 2;
+
+	float frac = idx - lo;
+
+	return lut[lo] + frac * (lut[lo + 1] - lut[lo]);
+}
+
+static inline void
+vips_cicp_apply_matrix(const float *matrix, float r, float g, float b,
+	float *out_r, float *out_g, float *out_b)
+{
+	*out_r = matrix[0] * r + matrix[1] * g + matrix[2] * b;
+	*out_g = matrix[3] * r + matrix[4] * g + matrix[5] * b;
+	*out_b = matrix[6] * r + matrix[7] * g + matrix[8] * b;
+}
+
 #ifdef __cplusplus
 }
 #endif /*__cplusplus*/

--- a/libvips/colour/pcolour.h
+++ b/libvips/colour/pcolour.h
@@ -296,49 +296,6 @@ vips_cicp_get_luminance(int colour_primaries)
 	}
 }
 
-/* LUT size for CICP transfer / OOTF tables.
- */
-#define VIPS_CICP_LUT_SIZE 4096
-
-/* Build a LUT for f(t) = scale * t^exponent, t in [0, 1].
- * Used by HLG forward OOTF (exponent=0.2, scale=1000/80)
- * and HLG inverse OOTF (exponent=1/1.2, scale=1).
- */
-static inline float *
-vips_cicp_build_power_lut(float exponent, float scale)
-{
-	float *lut = g_new(float, VIPS_CICP_LUT_SIZE);
-
-	lut[0] = 0.0f;
-	for (int i = 1; i < VIPS_CICP_LUT_SIZE; i++)
-		lut[i] = scale *
-			powf((float) i / (VIPS_CICP_LUT_SIZE - 1), exponent);
-
-	return lut;
-}
-
-/* Linearly interpolate a LUT on the domain [0, 1].
- * Returns lut[0] for t <= 0; extrapolates from the last
- * segment for t slightly above 1.
- */
-static inline float
-vips_cicp_lut_interpolate(const float *lut, float t)
-{
-	float idx = t * (VIPS_CICP_LUT_SIZE - 1);
-
-	if (idx <= 0.0f)
-		return lut[0];
-
-	int lo = (int) idx;
-
-	if (lo >= VIPS_CICP_LUT_SIZE - 1)
-		lo = VIPS_CICP_LUT_SIZE - 2;
-
-	float frac = idx - lo;
-
-	return lut[lo] + frac * (lut[lo + 1] - lut[lo]);
-}
-
 static inline void
 vips_cicp_apply_matrix(const float *matrix, float r, float g, float b,
 	float *out_r, float *out_g, float *out_b)

--- a/libvips/colour/scRGB2CICP.c
+++ b/libvips/colour/scRGB2CICP.c
@@ -1,0 +1,614 @@
+/* Turn scRGB image to CICP signal.
+ *
+ * 27/3/26
+ * 	- from CICP2scRGB.c
+ */
+
+/*
+
+	This file is part of VIPS.
+
+	VIPS is free software; you can redistribute it and/or modify
+	it under the terms of the GNU Lesser General Public License as published by
+	the Free Software Foundation; either version 2 of the License, or
+	(at your option) any later version.
+
+	This program is distributed in the hope that it will be useful,
+	but WITHOUT ANY WARRANTY; without even the implied warranty of
+	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+	GNU Lesser General Public License for more details.
+
+	You should have received a copy of the GNU Lesser General Public License
+	along with this program; if not, write to the Free Software
+	Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+	02110-1301  USA
+
+ */
+
+/*
+
+	These files are distributed with VIPS - https://github.com/libvips/libvips
+
+ */
+
+#ifdef HAVE_CONFIG_H
+#include <config.h>
+#endif /*HAVE_CONFIG_H*/
+#include <glib/gi18n-lib.h>
+
+#include <stdio.h>
+#include <math.h>
+
+#include <vips/vips.h>
+
+#include "pcolour.h"
+
+typedef struct _VipsscRGB2CICP {
+	VipsColourCode parent_instance;
+
+	int depth;
+
+	int colour_primaries;
+	int transfer_characteristics;
+	int matrix_coefficients;
+	int full_range_flag;
+
+	/* Conversion matrix from BT.709 (scRGB) to target primaries.
+	 */
+	float conversion_matrix[9];
+
+	/* Luminance coefficients for target primaries (Y row of
+	 * primaries-to-XYZ matrix), used by HLG inverse OOTF.
+	 */
+	float luminance_coeffs[3];
+
+	/* Pre-computed forward transfer function LUT. Maps
+	 * normalised linear [0, 1] to signal [0, 1], where
+	 * the normalisation factor is 1/max_linear.
+	 */
+	float *transfer_lut;
+	float max_linear;
+
+	/* LUT for HLG inverse OOTF: maps (Y_d/alpha) in [0, 1]
+	 * to (Y_d/alpha)^(1/gamma), with linear interpolation.
+	 */
+	float *ootf_lut;
+
+} VipsscRGB2CICP;
+
+typedef VipsColourCodeClass VipsscRGB2CICPClass;
+
+G_DEFINE_TYPE(VipsscRGB2CICP, vips_scRGB2CICP, VIPS_TYPE_COLOUR_CODE);
+
+/* Inverse matrices: BT.709 -> target primaries.
+ * Computed as the matrix inverse of the X_to_BT709 matrices in CICP2scRGB.c.
+ */
+
+static const float BT709_to_BT2020[9] = {
+	0.62740390f, 0.32928304f, 0.04331306f,
+	0.06909729f, 0.91954039f, 0.01136231f,
+	0.01639144f, 0.08801331f, 0.89559525f
+};
+
+static const float BT709_to_DCI_P3[9] = {
+	0.86857974f, 0.12891914f, 0.00250112f,
+	0.03454041f, 0.96181139f, 0.00364820f,
+	0.01677143f, 0.07104000f, 0.91218857f
+};
+
+static const float BT709_to_Display_P3[9] = {
+	0.82246197f, 0.17753803f, 0.00000000f,
+	0.03319420f, 0.96680581f, 0.00000000f,
+	0.01708263f, 0.07239744f, 0.91051993f
+};
+
+/* Bradford chromatic adaptation (D65 -> Illuminant C)
+ */
+static const float BT709_to_BT470M[9] = {
+	0.67835640f, 0.28847937f, 0.03316423f,
+	0.01651316f, 1.05200891f, -0.06852207f,
+	0.01791784f, 0.05063116f, 0.93145099f
+};
+
+static const float BT709_to_BT470BG[9] = {
+	0.95781476f, 0.04218524f, 0.00000000f,
+	0.00000000f, 1.00000000f, 0.00000000f,
+	0.00000000f, -0.01193412f, 1.01193412f
+};
+
+/* BT.601 / SMPTE 170M / SMPTE 240M share the same primaries
+ */
+static const float BT709_to_BT601[9] = {
+	1.06537904f, -0.05540088f, -0.00997816f,
+	-0.01963255f, 1.03636310f, -0.01673054f,
+	0.00163205f, 0.00441237f, 0.99395558f
+};
+
+/* Bradford chromatic adaptation (D65 -> Illuminant C)
+ */
+static const float BT709_to_GenericFilm[9] = {
+	0.75141736f, 0.23960166f, 0.00898097f,
+	0.03367299f, 0.94971067f, 0.01661635f,
+	0.01693851f, 0.05856136f, 0.92450013f
+};
+
+static const float BT709_to_EBU3213[9] = {
+	0.97484950f, 0.02729535f, -0.00214486f,
+	-0.02000029f, 1.05420904f, -0.03420875f,
+	0.00169075f, 0.00156378f, 0.99674547f
+};
+
+static const float *
+vips_scRGB2CICP_get_matrix(int primaries)
+{
+	switch (primaries) {
+	case VIPS_CICP_COLOUR_PRIMARIES_BT2020:
+		return BT709_to_BT2020;
+	case VIPS_CICP_COLOUR_PRIMARIES_SMPTE431:
+		return BT709_to_DCI_P3;
+	case VIPS_CICP_COLOUR_PRIMARIES_SMPTE432:
+		return BT709_to_Display_P3;
+	case VIPS_CICP_COLOUR_PRIMARIES_BT470M:
+		return BT709_to_BT470M;
+	case VIPS_CICP_COLOUR_PRIMARIES_BT470BG:
+		return BT709_to_BT470BG;
+	case VIPS_CICP_COLOUR_PRIMARIES_BT601:
+	case VIPS_CICP_COLOUR_PRIMARIES_SMPTE240:
+		return BT709_to_BT601;
+	case VIPS_CICP_COLOUR_PRIMARIES_GENERIC_FILM:
+		return BT709_to_GenericFilm;
+	case VIPS_CICP_COLOUR_PRIMARIES_EBU3213:
+		return BT709_to_EBU3213;
+	default:
+		return BT709_to_BT709;
+	}
+}
+
+/* Forward OETFs: linear-light -> signal.
+ * These are the mathematical inverses of the EOTF/inverse-OETF
+ * functions in CICP2scRGB.c, per ITU-T H.273 Table 3.
+ */
+
+/* BT.709 / BT.601 / BT.2020 OETF (H.273 Table 3, values 1, 6, 14, 15).
+ * V = alpha * Lc^0.45 - (alpha - 1), for Lc >= beta
+ * V = 4.5 * Lc, for Lc < beta
+ */
+static inline float
+vips_bt709_oetf(float L)
+{
+	const float alpha = 1.09929682680944f;
+	const float beta = 0.018053968510807f;
+
+	if (L < 0.0f)
+		return 0.0f;
+
+	if (L < beta)
+		return 4.5f * L;
+	else
+		return alpha * powf(L, 0.45f) - (alpha - 1.0f);
+}
+
+/* sRGB OETF (H.273 Table 3, value 13 with MatrixCoefficients == 0).
+ * V = alpha * Lc^(1/2.4) - (alpha - 1), for Lc >= beta
+ * V = 12.92 * Lc, for Lc < beta
+ */
+static inline float
+vips_sRGB_oetf(float L)
+{
+	const float alpha = 1.05501071894759f;
+	const float beta = 0.003041282560128f;
+
+	if (L < 0.0f)
+		return 0.0f;
+
+	if (L < beta)
+		return 12.92f * L;
+	else
+		return alpha * powf(L, 1.0f / 2.4f) - (alpha - 1.0f);
+}
+
+/* PQ inverse EOTF (H.273 Table 3, value 16).
+ * V = ((c1 + c2 * Lo^n) / (1 + c3 * Lo^n))^m
+ * Lo = L * SDR_WHITE / 10000 (normalize scRGB to [0, 1] display luminance)
+ */
+static inline float
+vips_pq_oetf(float L)
+{
+	const float m1 = 2610.0f / 16384.0f;
+	const float m2 = 2523.0f / 4096.0f * 128.0f;
+	const float c1 = 3424.0f / 4096.0f;
+	const float c2 = 2413.0f / 4096.0f * 32.0f;
+	const float c3 = 2392.0f / 4096.0f * 32.0f;
+
+	float Lo = fmaxf(L * (SDR_WHITE / 10000.0f), 0.0f);
+
+	float Lo_m1 = powf(Lo, m1);
+	float numerator = c1 + c2 * Lo_m1;
+	float denominator = 1.0f + c3 * Lo_m1;
+
+	return powf(numerator / denominator, m2);
+}
+
+/* HLG OETF (H.273 Table 3, value 18).
+ * V = a * Ln(12 * Lc - b) + c, for 1 >= Lc > 1/12
+ * V = Sqrt(3) * Lc^0.5, for 1/12 >= Lc >= 0
+ */
+static inline float
+vips_hlg_oetf(float L)
+{
+	const float a = 0.17883277f;
+	const float b = 0.28466892f;
+	const float c = 0.55991073f;
+
+	if (L <= 0.0f)
+		return 0.0f;
+
+	if (L <= 1.0f / 12.0f)
+		return sqrtf(3.0f * L);
+	else
+		return a * logf(12.0f * L - b) + c;
+}
+
+/* HLG inverse OOTF: display-linear -> scene-linear.
+ * Inverts the OOTF F_d = alpha * Y_s^(gamma-1) * E_s from BT.2100-2.
+ *
+ * The luminance transforms as Y_d = alpha * Y_s^gamma, so:
+ *   Y_s = (Y_d / alpha)^(1/gamma)
+ *   E_s = F_d * Y_s / Y_d
+ *
+ * Uses a pre-computed LUT for (Y_d/alpha)^(1/gamma) with linear
+ * interpolation. Y_d/alpha is in [0, 1] for well-formed content.
+ *
+ * Input/output are in target primaries (after BT.709 -> target matrix).
+ */
+static inline void
+vips_hlg_inverse_ootf(float *r, float *g, float *b,
+	const float *luminance, const float *ootf_lut)
+{
+	const float alpha = 1000.0f / SDR_WHITE;
+
+	float Y_d = luminance[0] * *r + luminance[1] * *g + luminance[2] * *b;
+
+	if (Y_d <= 0.0f) {
+		*r = 0.0f;
+		*g = 0.0f;
+		*b = 0.0f;
+		return;
+	}
+
+	float Y_s = vips_cicp_lut_interpolate(ootf_lut, Y_d / alpha);
+	float factor = Y_s / Y_d;
+
+	*r *= factor;
+	*g *= factor;
+	*b *= factor;
+}
+
+/* Dispatch to the appropriate forward OETF for the given transfer
+ * characteristic. Input is linear-light, output is signal in [0, 1].
+ */
+static inline float
+vips_scRGB2CICP_transfer(VipsCICPTransferCharacteristics transfer, float L)
+{
+	switch (transfer) {
+	case VIPS_CICP_TRANSFER_PQ:
+		return vips_pq_oetf(L);
+	case VIPS_CICP_TRANSFER_HLG:
+		return vips_hlg_oetf(L);
+	case VIPS_CICP_TRANSFER_BT709:
+	case VIPS_CICP_TRANSFER_BT601:
+	case VIPS_CICP_TRANSFER_BT2020_10BIT:
+	case VIPS_CICP_TRANSFER_BT2020_12BIT:
+		return vips_bt709_oetf(L);
+	case VIPS_CICP_TRANSFER_SMPTE240: {
+		const float alpha = 1.11157219592173f;
+		const float beta = 0.022821585529445f;
+
+		if (L < 0.0f)
+			return 0.0f;
+		if (L < beta)
+			return 4.0f * L;
+		return alpha * powf(L, 0.45f) - (alpha - 1.0f);
+	}
+	case VIPS_CICP_TRANSFER_SRGB:
+		return vips_sRGB_oetf(L);
+	case VIPS_CICP_TRANSFER_BT470M:
+		return powf(fmaxf(L, 0.0f), 1.0f / 2.2f);
+	case VIPS_CICP_TRANSFER_BT470BG:
+		return powf(fmaxf(L, 0.0f), 1.0f / 2.8f);
+	case VIPS_CICP_TRANSFER_LINEAR:
+		return L;
+	case VIPS_CICP_TRANSFER_LOG_100:
+		/* V = 1.0 + Log10(Lc) / 2 for Lc >= 0.01, else 0.
+		 */
+		return L >= 0.01f ? 1.0f + log10f(L) / 2.0f : 0.0f;
+	case VIPS_CICP_TRANSFER_LOG_100_SQRT10:
+		/* V = 1.0 + Log10(Lc) / 2.5 for Lc >= Sqrt(10)/1000, else 0.
+		 */
+		return L >= 3.16227766e-3f
+			? 1.0f + log10f(L) / 2.5f
+			: 0.0f;
+	case VIPS_CICP_TRANSFER_IEC61966:
+	case VIPS_CICP_TRANSFER_BT1361:
+		/* BT.709 curve extended to negative values via odd symmetry.
+		 */
+		if (L >= 0.0f)
+			return vips_bt709_oetf(L);
+		else
+			return -vips_bt709_oetf(-L);
+	case VIPS_CICP_TRANSFER_SMPTE428:
+		/* V = (48 * Lo / 52.37)^(1/2.6)
+		 * Lo = L * SDR_WHITE / 48 (scRGB to 48 cd/m² reference)
+		 * Simplifies to V = (L * SDR_WHITE / 52.37)^(1/2.6)
+		 */
+		return powf(fmaxf(L, 0.0f) * (SDR_WHITE / 52.37f),
+			1.0f / 2.6f);
+	default:
+		return L;
+	}
+}
+
+static inline float
+vips_scRGB2CICP_max_linear(VipsCICPTransferCharacteristics transfer)
+{
+	return transfer == VIPS_CICP_TRANSFER_PQ ? 10000.0f / SDR_WHITE : 1.0f;
+}
+
+/* Build a forward transfer function LUT that maps normalised
+ * linear [0, max_linear] to signal [0, 1].
+ */
+static float *
+vips_scRGB2CICP_build_lut(VipsCICPTransferCharacteristics transfer,
+	float max_linear)
+{
+	float *lut = g_new(float, VIPS_CICP_LUT_SIZE);
+	const float scale = max_linear / (VIPS_CICP_LUT_SIZE - 1);
+
+	for (int i = 0; i < VIPS_CICP_LUT_SIZE; i++)
+		lut[i] = vips_scRGB2CICP_transfer(transfer, i * scale);
+
+	return lut;
+}
+
+#define SCRGB2CICP_LOOP(TYPE, MAX_VAL) \
+{ \
+	float *restrict p = (float *) in[0]; \
+	TYPE *restrict q = (TYPE *) out; \
+	const float *matrix = cicp->conversion_matrix; \
+	const float *luminance = cicp->luminance_coeffs; \
+	const float *restrict transfer_lut = cicp->transfer_lut; \
+	const float *ootf_lut = cicp->ootf_lut; \
+	const gboolean is_hlg = \
+		(cicp->transfer_characteristics == VIPS_CICP_TRANSFER_HLG); \
+	const float norm = 1.0f / cicp->max_linear; \
+	const float scale = (float) MAX_VAL; \
+\
+	for (int i = 0; i < width; i++) { \
+		float r = p[0]; \
+		float g = p[1]; \
+		float b = p[2]; \
+		p += 3; \
+\
+		float tr, tg, tb; \
+		vips_cicp_apply_matrix(matrix, r, g, b, &tr, &tg, &tb); \
+\
+		if (is_hlg) \
+			vips_hlg_inverse_ootf(&tr, &tg, &tb, luminance, ootf_lut); \
+\
+		float vr = vips_cicp_lut_interpolate(transfer_lut, tr * norm); \
+		float vg = vips_cicp_lut_interpolate(transfer_lut, tg * norm); \
+		float vb = vips_cicp_lut_interpolate(transfer_lut, tb * norm); \
+\
+		int ir = (int) (vr * scale + 0.5f); \
+		int ig = (int) (vg * scale + 0.5f); \
+		int ib = (int) (vb * scale + 0.5f); \
+\
+		q[0] = (TYPE) VIPS_CLIP(0, ir, MAX_VAL); \
+		q[1] = (TYPE) VIPS_CLIP(0, ig, MAX_VAL); \
+		q[2] = (TYPE) VIPS_CLIP(0, ib, MAX_VAL); \
+		q += 3; \
+	} \
+}
+
+static void
+vips_scRGB2CICP_line(VipsColour *colour, VipsPel *out, VipsPel **in, int width)
+{
+	VipsscRGB2CICP *cicp = (VipsscRGB2CICP *) colour;
+
+	if (cicp->depth == 16)
+		SCRGB2CICP_LOOP(unsigned short, 65535)
+	else
+		SCRGB2CICP_LOOP(unsigned char, 255)
+}
+
+static int
+vips_scRGB2CICP_build(VipsObject *object)
+{
+	VipsObjectClass *class = VIPS_OBJECT_GET_CLASS(object);
+	VipsscRGB2CICP *cicp = (VipsscRGB2CICP *) object;
+	VipsColour *colour = (VipsColour *) object;
+	VipsColourCode *code = (VipsColourCode *) object;
+
+	code->input_format = VIPS_FORMAT_FLOAT;
+	colour->input_bands = 3;
+
+	switch (cicp->depth) {
+	case 16:
+		colour->interpretation = VIPS_INTERPRETATION_RGB16;
+		colour->format = VIPS_FORMAT_USHORT;
+		break;
+
+	case 8:
+		colour->interpretation = VIPS_INTERPRETATION_sRGB;
+		colour->format = VIPS_FORMAT_UCHAR;
+		break;
+
+	default:
+		vips_error(class->nickname, "%s", _("depth must be 8 or 16"));
+		return -1;
+	}
+
+	colour->bands = 3;
+
+	/* TODO: implement matrix coefficients and narrow-range
+	 * quantization. For now, only identity matrix (0) with
+	 * full range (1) is supported.
+	 */
+	if (cicp->matrix_coefficients != VIPS_CICP_MATRIX_RGB) {
+		vips_error(class->nickname, "%s",
+			_("only matrix-coefficients 0 (identity/RGB) "
+			  "is currently supported"));
+		return -1;
+	}
+
+	if (cicp->full_range_flag != 1) {
+		vips_error(class->nickname, "%s",
+			_("only full-range-flag 1 is currently supported"));
+		return -1;
+	}
+
+	memcpy(cicp->conversion_matrix,
+		vips_scRGB2CICP_get_matrix(cicp->colour_primaries),
+		9 * sizeof(float));
+	memcpy(cicp->luminance_coeffs,
+		vips_cicp_get_luminance(cicp->colour_primaries),
+		3 * sizeof(float));
+
+	cicp->max_linear = vips_scRGB2CICP_max_linear(
+		cicp->transfer_characteristics);
+	cicp->transfer_lut = vips_scRGB2CICP_build_lut(
+		cicp->transfer_characteristics, cicp->max_linear);
+
+	if (cicp->transfer_characteristics == VIPS_CICP_TRANSFER_HLG)
+		cicp->ootf_lut = vips_cicp_build_power_lut(
+			1.0f / 1.2f, 1.0f);
+
+	if (VIPS_OBJECT_CLASS(vips_scRGB2CICP_parent_class)->build(object))
+		return -1;
+
+	vips_image_set_int(colour->out,
+		"cicp-colour-primaries", cicp->colour_primaries);
+	vips_image_set_int(colour->out,
+		"cicp-transfer-characteristics", cicp->transfer_characteristics);
+	vips_image_set_int(colour->out,
+		"cicp-matrix-coefficients", cicp->matrix_coefficients);
+	vips_image_set_int(colour->out,
+		"cicp-full-range-flag", cicp->full_range_flag);
+
+	return 0;
+}
+
+static void
+vips_scRGB2CICP_dispose(GObject *gobject)
+{
+	VipsscRGB2CICP *cicp = (VipsscRGB2CICP *) gobject;
+
+	VIPS_FREE(cicp->transfer_lut);
+	VIPS_FREE(cicp->ootf_lut);
+
+	G_OBJECT_CLASS(vips_scRGB2CICP_parent_class)->dispose(gobject);
+}
+
+static void
+vips_scRGB2CICP_class_init(VipsscRGB2CICPClass *class)
+{
+	GObjectClass *gobject_class = G_OBJECT_CLASS(class);
+	VipsObjectClass *object_class = (VipsObjectClass *) class;
+	VipsColourClass *colour_class = VIPS_COLOUR_CLASS(class);
+
+	gobject_class->dispose = vips_scRGB2CICP_dispose;
+	gobject_class->set_property = vips_object_set_property;
+	gobject_class->get_property = vips_object_get_property;
+
+	object_class->nickname = "scRGB2CICP";
+	object_class->description = _("transform scRGB to CICP");
+	object_class->build = vips_scRGB2CICP_build;
+
+	colour_class->process_line = vips_scRGB2CICP_line;
+
+	VIPS_ARG_INT(class, "depth", 130,
+		_("Depth"),
+		_("Output device space depth in bits"),
+		VIPS_ARGUMENT_OPTIONAL_INPUT,
+		G_STRUCT_OFFSET(VipsscRGB2CICP, depth),
+		8, 16, 8);
+
+	VIPS_ARG_INT(class, "colour-primaries", 2,
+		_("Colour primaries"),
+		_("CICP colour primaries code (H.273 Table 2)"),
+		VIPS_ARGUMENT_REQUIRED_INPUT,
+		G_STRUCT_OFFSET(VipsscRGB2CICP, colour_primaries),
+		0, 255, VIPS_CICP_COLOUR_PRIMARIES_BT709);
+
+	VIPS_ARG_INT(class, "transfer-characteristics", 3,
+		_("Transfer characteristics"),
+		_("CICP transfer characteristics code (H.273 Table 3)"),
+		VIPS_ARGUMENT_REQUIRED_INPUT,
+		G_STRUCT_OFFSET(VipsscRGB2CICP, transfer_characteristics),
+		0, 255, VIPS_CICP_TRANSFER_SRGB);
+
+	VIPS_ARG_INT(class, "matrix-coefficients", 4,
+		_("Matrix coefficients"),
+		_("CICP matrix coefficients code (H.273 Table 4)"),
+		VIPS_ARGUMENT_REQUIRED_INPUT,
+		G_STRUCT_OFFSET(VipsscRGB2CICP, matrix_coefficients),
+		0, 255, VIPS_CICP_MATRIX_RGB);
+
+	VIPS_ARG_INT(class, "full-range-flag", 5,
+		_("Full range flag"),
+		_("CICP full range flag"),
+		VIPS_ARGUMENT_REQUIRED_INPUT,
+		G_STRUCT_OFFSET(VipsscRGB2CICP, full_range_flag),
+		0, 1, 1);
+}
+
+static void
+vips_scRGB2CICP_init(VipsscRGB2CICP *cicp)
+{
+	cicp->depth = 8;
+	cicp->colour_primaries = VIPS_CICP_COLOUR_PRIMARIES_BT709;
+	cicp->transfer_characteristics = VIPS_CICP_TRANSFER_SRGB;
+	cicp->matrix_coefficients = VIPS_CICP_MATRIX_RGB;
+	cicp->full_range_flag = 1;
+}
+
+/**
+ * vips_scRGB2CICP: (method)
+ * @in: input image
+ * @out: (out): output image
+ * @colour_primaries: CICP colour primaries code (H.273 Table 2)
+ * @transfer_characteristics: CICP transfer characteristics code (H.273 Table 3)
+ * @matrix_coefficients: CICP matrix coefficients code (H.273 Table 4)
+ * @full_range_flag: CICP full range flag (0 or 1)
+ * @...: `NULL`-terminated list of optional named arguments
+ *
+ * Transform an scRGB image to CICP signal. The target colour encoding
+ * is specified via the CICP code point arguments.
+ *
+ * Currently only @matrix_coefficients 0 (identity/RGB) and
+ * @full_range_flag 1 are supported.
+ *
+ * ::: tip "Optional arguments"
+ *     * @depth: `gint`, output depth in bits (8 or 16)
+ *
+ * ::: seealso
+ *     [method@Image.CICP2scRGB], [method@Image.scRGB2sRGB].
+ *
+ * Returns: 0 on success, -1 on error.
+ */
+int
+vips_scRGB2CICP(VipsImage *in, VipsImage **out,
+	int colour_primaries, int transfer_characteristics,
+	int matrix_coefficients, int full_range_flag, ...)
+{
+	va_list ap;
+	int result;
+
+	va_start(ap, full_range_flag);
+	result = vips_call_split("scRGB2CICP", ap, in, out,
+		colour_primaries, transfer_characteristics,
+		matrix_coefficients, full_range_flag);
+	va_end(ap);
+
+	return result;
+}

--- a/libvips/colour/scRGB2CICP.c
+++ b/libvips/colour/scRGB2CICP.c
@@ -62,18 +62,6 @@ typedef struct _VipsscRGB2CICP {
 	 */
 	float luminance_coeffs[3];
 
-	/* Pre-computed forward transfer function LUT. Maps
-	 * normalised linear [0, 1] to signal [0, 1], where
-	 * the normalisation factor is 1/max_linear.
-	 */
-	float *transfer_lut;
-	float max_linear;
-
-	/* LUT for HLG inverse OOTF: maps (Y_d/alpha) in [0, 1]
-	 * to (Y_d/alpha)^(1/gamma), with linear interpolation.
-	 */
-	float *ootf_lut;
-
 } VipsscRGB2CICP;
 
 typedef VipsColourCodeClass VipsscRGB2CICPClass;
@@ -256,16 +244,14 @@ vips_hlg_oetf(float L)
  *   Y_s = (Y_d / alpha)^(1/gamma)
  *   E_s = F_d * Y_s / Y_d
  *
- * Uses a pre-computed LUT for (Y_d/alpha)^(1/gamma) with linear
- * interpolation. Y_d/alpha is in [0, 1] for well-formed content.
- *
  * Input/output are in target primaries (after BT.709 -> target matrix).
  */
 static inline void
 vips_hlg_inverse_ootf(float *r, float *g, float *b,
-	const float *luminance, const float *ootf_lut)
+	const float *luminance)
 {
 	const float alpha = 1000.0f / SDR_WHITE;
+	const float inv_gamma = 1.0f / 1.2f;
 
 	float Y_d = luminance[0] * *r + luminance[1] * *g + luminance[2] * *b;
 
@@ -276,7 +262,7 @@ vips_hlg_inverse_ootf(float *r, float *g, float *b,
 		return;
 	}
 
-	float Y_s = vips_cicp_lut_interpolate(ootf_lut, Y_d / alpha);
+	float Y_s = powf(Y_d / alpha, inv_gamma);
 	float factor = Y_s / Y_d;
 
 	*r *= factor;
@@ -348,39 +334,15 @@ vips_scRGB2CICP_transfer(VipsCICPTransferCharacteristics transfer, float L)
 	}
 }
 
-static inline float
-vips_scRGB2CICP_max_linear(VipsCICPTransferCharacteristics transfer)
-{
-	return transfer == VIPS_CICP_TRANSFER_PQ ? 10000.0f / SDR_WHITE : 1.0f;
-}
-
-/* Build a forward transfer function LUT that maps normalised
- * linear [0, max_linear] to signal [0, 1].
- */
-static float *
-vips_scRGB2CICP_build_lut(VipsCICPTransferCharacteristics transfer,
-	float max_linear)
-{
-	float *lut = g_new(float, VIPS_CICP_LUT_SIZE);
-	const float scale = max_linear / (VIPS_CICP_LUT_SIZE - 1);
-
-	for (int i = 0; i < VIPS_CICP_LUT_SIZE; i++)
-		lut[i] = vips_scRGB2CICP_transfer(transfer, i * scale);
-
-	return lut;
-}
-
 #define SCRGB2CICP_LOOP(TYPE, MAX_VAL) \
 { \
 	float *restrict p = (float *) in[0]; \
 	TYPE *restrict q = (TYPE *) out; \
 	const float *matrix = cicp->conversion_matrix; \
 	const float *luminance = cicp->luminance_coeffs; \
-	const float *restrict transfer_lut = cicp->transfer_lut; \
-	const float *ootf_lut = cicp->ootf_lut; \
-	const gboolean is_hlg = \
-		(cicp->transfer_characteristics == VIPS_CICP_TRANSFER_HLG); \
-	const float norm = 1.0f / cicp->max_linear; \
+	const VipsCICPTransferCharacteristics transfer = \
+		cicp->transfer_characteristics; \
+	const gboolean is_hlg = (transfer == VIPS_CICP_TRANSFER_HLG); \
 	const float scale = (float) MAX_VAL; \
 \
 	for (int i = 0; i < width; i++) { \
@@ -393,11 +355,11 @@ vips_scRGB2CICP_build_lut(VipsCICPTransferCharacteristics transfer,
 		vips_cicp_apply_matrix(matrix, r, g, b, &tr, &tg, &tb); \
 \
 		if (is_hlg) \
-			vips_hlg_inverse_ootf(&tr, &tg, &tb, luminance, ootf_lut); \
+			vips_hlg_inverse_ootf(&tr, &tg, &tb, luminance); \
 \
-		float vr = vips_cicp_lut_interpolate(transfer_lut, tr * norm); \
-		float vg = vips_cicp_lut_interpolate(transfer_lut, tg * norm); \
-		float vb = vips_cicp_lut_interpolate(transfer_lut, tb * norm); \
+		float vr = vips_scRGB2CICP_transfer(transfer, tr); \
+		float vg = vips_scRGB2CICP_transfer(transfer, tg); \
+		float vb = vips_scRGB2CICP_transfer(transfer, tb); \
 \
 		int ir = (int) (vr * scale + 0.5f); \
 		int ig = (int) (vg * scale + 0.5f); \
@@ -474,15 +436,6 @@ vips_scRGB2CICP_build(VipsObject *object)
 		vips_cicp_get_luminance(cicp->colour_primaries),
 		3 * sizeof(float));
 
-	cicp->max_linear = vips_scRGB2CICP_max_linear(
-		cicp->transfer_characteristics);
-	cicp->transfer_lut = vips_scRGB2CICP_build_lut(
-		cicp->transfer_characteristics, cicp->max_linear);
-
-	if (cicp->transfer_characteristics == VIPS_CICP_TRANSFER_HLG)
-		cicp->ootf_lut = vips_cicp_build_power_lut(
-			1.0f / 1.2f, 1.0f);
-
 	if (VIPS_OBJECT_CLASS(vips_scRGB2CICP_parent_class)->build(object))
 		return -1;
 
@@ -499,24 +452,12 @@ vips_scRGB2CICP_build(VipsObject *object)
 }
 
 static void
-vips_scRGB2CICP_dispose(GObject *gobject)
-{
-	VipsscRGB2CICP *cicp = (VipsscRGB2CICP *) gobject;
-
-	VIPS_FREE(cicp->transfer_lut);
-	VIPS_FREE(cicp->ootf_lut);
-
-	G_OBJECT_CLASS(vips_scRGB2CICP_parent_class)->dispose(gobject);
-}
-
-static void
 vips_scRGB2CICP_class_init(VipsscRGB2CICPClass *class)
 {
 	GObjectClass *gobject_class = G_OBJECT_CLASS(class);
 	VipsObjectClass *object_class = (VipsObjectClass *) class;
 	VipsColourClass *colour_class = VIPS_COLOUR_CLASS(class);
 
-	gobject_class->dispose = vips_scRGB2CICP_dispose;
 	gobject_class->set_property = vips_object_set_property;
 	gobject_class->get_property = vips_object_get_property;
 

--- a/libvips/colour/scRGB2CICP.c
+++ b/libvips/colour/scRGB2CICP.c
@@ -51,7 +51,6 @@ typedef struct _VipsscRGB2CICP {
 	VipsCICPColourPrimaries colour_primaries;
 	VipsCICPTransferCharacteristics transfer_characteristics;
 	VipsCICPMatrixCoefficients matrix_coefficients;
-	gboolean full_range;
 
 	/* Conversion matrix from BT.709 (scRGB) to target primaries.
 	 */
@@ -414,18 +413,12 @@ vips_scRGB2CICP_build(VipsObject *object)
 
 	/* TODO: implement matrix coefficients and narrow-range
 	 * quantization. For now, only identity matrix (0) with
-	 * full range (1) is supported.
+	 * full range is supported.
 	 */
 	if (cicp->matrix_coefficients != VIPS_CICP_MATRIX_RGB) {
 		vips_error(class->nickname, "%s",
 			_("only matrix-coefficients 0 (identity/RGB) "
 			  "is currently supported"));
-		return -1;
-	}
-
-	if (!cicp->full_range) {
-		vips_error(class->nickname, "%s",
-			_("only full-range TRUE is currently supported"));
 		return -1;
 	}
 
@@ -445,8 +438,7 @@ vips_scRGB2CICP_build(VipsObject *object)
 		"cicp-transfer-characteristics", cicp->transfer_characteristics);
 	vips_image_set_int(colour->out,
 		"cicp-matrix-coefficients", cicp->matrix_coefficients);
-	vips_image_set_int(colour->out,
-		"cicp-full-range-flag", cicp->full_range ? 1 : 0);
+	vips_image_set_int(colour->out, "cicp-full-range-flag", 1);
 
 	return 0;
 }
@@ -491,13 +483,6 @@ vips_scRGB2CICP_class_init(VipsscRGB2CICPClass *class)
 		VIPS_TYPE_CICP_MATRIX_COEFFICIENTS,
 		VIPS_CICP_MATRIX_RGB);
 
-	VIPS_ARG_BOOL(class, "full_range", 5,
-		_("Full range flag"),
-		_("CICP full range flag"),
-		VIPS_ARGUMENT_OPTIONAL_INPUT,
-		G_STRUCT_OFFSET(VipsscRGB2CICP, full_range),
-		TRUE);
-
 	VIPS_ARG_INT(class, "depth", 130,
 		_("Depth"),
 		_("Output device space depth in bits"),
@@ -513,7 +498,6 @@ vips_scRGB2CICP_init(VipsscRGB2CICP *cicp)
 	cicp->colour_primaries = VIPS_CICP_COLOUR_PRIMARIES_BT709;
 	cicp->transfer_characteristics = VIPS_CICP_TRANSFER_SRGB;
 	cicp->matrix_coefficients = VIPS_CICP_MATRIX_RGB;
-	cicp->full_range = TRUE;
 }
 
 /**
@@ -526,13 +510,12 @@ vips_scRGB2CICP_init(VipsscRGB2CICP *cicp)
  * is specified via the optional CICP arguments.
  *
  * Currently only @matrix_coefficients %VIPS_CICP_MATRIX_RGB and
- * @full_range %TRUE are supported.
+ * full-range output is supported.
  *
  * ::: tip "Optional arguments"
  *     * @colour_primaries: #VipsCICPColourPrimaries, target primaries (default %VIPS_CICP_COLOUR_PRIMARIES_BT709)
  *     * @transfer_characteristics: #VipsCICPTransferCharacteristics, target transfer (default %VIPS_CICP_TRANSFER_SRGB)
  *     * @matrix_coefficients: #VipsCICPMatrixCoefficients, target matrix (default %VIPS_CICP_MATRIX_RGB)
- *     * @full_range: `gboolean`, full-range output (default %TRUE)
  *     * @depth: `gint`, output depth in bits, 8 or 16 (default 8)
  *
  * ::: seealso

--- a/libvips/colour/scRGB2CICP.c
+++ b/libvips/colour/scRGB2CICP.c
@@ -48,10 +48,10 @@ typedef struct _VipsscRGB2CICP {
 
 	int depth;
 
-	int colour_primaries;
-	int transfer_characteristics;
-	int matrix_coefficients;
-	int full_range_flag;
+	VipsCICPColourPrimaries colour_primaries;
+	VipsCICPTransferCharacteristics transfer_characteristics;
+	VipsCICPMatrixCoefficients matrix_coefficients;
+	gboolean full_range;
 
 	/* Conversion matrix from BT.709 (scRGB) to target primaries.
 	 */
@@ -139,7 +139,7 @@ static const float BT709_to_EBU3213[9] = {
 };
 
 static const float *
-vips_scRGB2CICP_get_matrix(int primaries)
+vips_scRGB2CICP_get_matrix(VipsCICPColourPrimaries primaries)
 {
 	switch (primaries) {
 	case VIPS_CICP_COLOUR_PRIMARIES_BT2020:
@@ -461,9 +461,9 @@ vips_scRGB2CICP_build(VipsObject *object)
 		return -1;
 	}
 
-	if (cicp->full_range_flag != 1) {
+	if (!cicp->full_range) {
 		vips_error(class->nickname, "%s",
-			_("only full-range-flag 1 is currently supported"));
+			_("only full-range TRUE is currently supported"));
 		return -1;
 	}
 
@@ -493,7 +493,7 @@ vips_scRGB2CICP_build(VipsObject *object)
 	vips_image_set_int(colour->out,
 		"cicp-matrix-coefficients", cicp->matrix_coefficients);
 	vips_image_set_int(colour->out,
-		"cicp-full-range-flag", cicp->full_range_flag);
+		"cicp-full-range-flag", cicp->full_range ? 1 : 0);
 
 	return 0;
 }
@@ -526,40 +526,43 @@ vips_scRGB2CICP_class_init(VipsscRGB2CICPClass *class)
 
 	colour_class->process_line = vips_scRGB2CICP_line;
 
+	VIPS_ARG_ENUM(class, "colour_primaries", 2,
+		_("Colour primaries"),
+		_("CICP colour primaries (H.273 Table 2)"),
+		VIPS_ARGUMENT_OPTIONAL_INPUT,
+		G_STRUCT_OFFSET(VipsscRGB2CICP, colour_primaries),
+		VIPS_TYPE_CICP_COLOUR_PRIMARIES,
+		VIPS_CICP_COLOUR_PRIMARIES_BT709);
+
+	VIPS_ARG_ENUM(class, "transfer_characteristics", 3,
+		_("Transfer characteristics"),
+		_("CICP transfer characteristics (H.273 Table 3)"),
+		VIPS_ARGUMENT_OPTIONAL_INPUT,
+		G_STRUCT_OFFSET(VipsscRGB2CICP, transfer_characteristics),
+		VIPS_TYPE_CICP_TRANSFER_CHARACTERISTICS,
+		VIPS_CICP_TRANSFER_SRGB);
+
+	VIPS_ARG_ENUM(class, "matrix_coefficients", 4,
+		_("Matrix coefficients"),
+		_("CICP matrix coefficients (H.273 Table 4)"),
+		VIPS_ARGUMENT_OPTIONAL_INPUT,
+		G_STRUCT_OFFSET(VipsscRGB2CICP, matrix_coefficients),
+		VIPS_TYPE_CICP_MATRIX_COEFFICIENTS,
+		VIPS_CICP_MATRIX_RGB);
+
+	VIPS_ARG_BOOL(class, "full_range", 5,
+		_("Full range flag"),
+		_("CICP full range flag"),
+		VIPS_ARGUMENT_OPTIONAL_INPUT,
+		G_STRUCT_OFFSET(VipsscRGB2CICP, full_range),
+		TRUE);
+
 	VIPS_ARG_INT(class, "depth", 130,
 		_("Depth"),
 		_("Output device space depth in bits"),
 		VIPS_ARGUMENT_OPTIONAL_INPUT,
 		G_STRUCT_OFFSET(VipsscRGB2CICP, depth),
 		8, 16, 8);
-
-	VIPS_ARG_INT(class, "colour-primaries", 2,
-		_("Colour primaries"),
-		_("CICP colour primaries code (H.273 Table 2)"),
-		VIPS_ARGUMENT_REQUIRED_INPUT,
-		G_STRUCT_OFFSET(VipsscRGB2CICP, colour_primaries),
-		0, 255, VIPS_CICP_COLOUR_PRIMARIES_BT709);
-
-	VIPS_ARG_INT(class, "transfer-characteristics", 3,
-		_("Transfer characteristics"),
-		_("CICP transfer characteristics code (H.273 Table 3)"),
-		VIPS_ARGUMENT_REQUIRED_INPUT,
-		G_STRUCT_OFFSET(VipsscRGB2CICP, transfer_characteristics),
-		0, 255, VIPS_CICP_TRANSFER_SRGB);
-
-	VIPS_ARG_INT(class, "matrix-coefficients", 4,
-		_("Matrix coefficients"),
-		_("CICP matrix coefficients code (H.273 Table 4)"),
-		VIPS_ARGUMENT_REQUIRED_INPUT,
-		G_STRUCT_OFFSET(VipsscRGB2CICP, matrix_coefficients),
-		0, 255, VIPS_CICP_MATRIX_RGB);
-
-	VIPS_ARG_INT(class, "full-range-flag", 5,
-		_("Full range flag"),
-		_("CICP full range flag"),
-		VIPS_ARGUMENT_REQUIRED_INPUT,
-		G_STRUCT_OFFSET(VipsscRGB2CICP, full_range_flag),
-		0, 1, 1);
 }
 
 static void
@@ -569,27 +572,27 @@ vips_scRGB2CICP_init(VipsscRGB2CICP *cicp)
 	cicp->colour_primaries = VIPS_CICP_COLOUR_PRIMARIES_BT709;
 	cicp->transfer_characteristics = VIPS_CICP_TRANSFER_SRGB;
 	cicp->matrix_coefficients = VIPS_CICP_MATRIX_RGB;
-	cicp->full_range_flag = 1;
+	cicp->full_range = TRUE;
 }
 
 /**
  * vips_scRGB2CICP: (method)
  * @in: input image
  * @out: (out): output image
- * @colour_primaries: CICP colour primaries code (H.273 Table 2)
- * @transfer_characteristics: CICP transfer characteristics code (H.273 Table 3)
- * @matrix_coefficients: CICP matrix coefficients code (H.273 Table 4)
- * @full_range_flag: CICP full range flag (0 or 1)
  * @...: `NULL`-terminated list of optional named arguments
  *
  * Transform an scRGB image to CICP signal. The target colour encoding
- * is specified via the CICP code point arguments.
+ * is specified via the optional CICP arguments.
  *
- * Currently only @matrix_coefficients 0 (identity/RGB) and
- * @full_range_flag 1 are supported.
+ * Currently only @matrix_coefficients %VIPS_CICP_MATRIX_RGB and
+ * @full_range %TRUE are supported.
  *
  * ::: tip "Optional arguments"
- *     * @depth: `gint`, output depth in bits (8 or 16)
+ *     * @colour_primaries: #VipsCICPColourPrimaries, target primaries (default %VIPS_CICP_COLOUR_PRIMARIES_BT709)
+ *     * @transfer_characteristics: #VipsCICPTransferCharacteristics, target transfer (default %VIPS_CICP_TRANSFER_SRGB)
+ *     * @matrix_coefficients: #VipsCICPMatrixCoefficients, target matrix (default %VIPS_CICP_MATRIX_RGB)
+ *     * @full_range: `gboolean`, full-range output (default %TRUE)
+ *     * @depth: `gint`, output depth in bits, 8 or 16 (default 8)
  *
  * ::: seealso
  *     [method@Image.CICP2scRGB], [method@Image.scRGB2sRGB].
@@ -597,17 +600,13 @@ vips_scRGB2CICP_init(VipsscRGB2CICP *cicp)
  * Returns: 0 on success, -1 on error.
  */
 int
-vips_scRGB2CICP(VipsImage *in, VipsImage **out,
-	int colour_primaries, int transfer_characteristics,
-	int matrix_coefficients, int full_range_flag, ...)
+vips_scRGB2CICP(VipsImage *in, VipsImage **out, ...)
 {
 	va_list ap;
 	int result;
 
-	va_start(ap, full_range_flag);
-	result = vips_call_split("scRGB2CICP", ap, in, out,
-		colour_primaries, transfer_characteristics,
-		matrix_coefficients, full_range_flag);
+	va_start(ap, out);
+	result = vips_call_split("scRGB2CICP", ap, in, out);
 	va_end(ap);
 
 	return result;

--- a/libvips/include/vips/colour.h
+++ b/libvips/include/vips/colour.h
@@ -280,6 +280,11 @@ int vips_uhdr2scRGB(VipsImage *in, VipsImage **out, ...)
 VIPS_API
 int vips_CICP2scRGB(VipsImage *in, VipsImage **out, ...)
 	G_GNUC_NULL_TERMINATED;
+VIPS_API
+int vips_scRGB2CICP(VipsImage *in, VipsImage **out,
+	int colour_primaries, int transfer_characteristics,
+	int matrix_coefficients, int full_range_flag, ...)
+	G_GNUC_NULL_TERMINATED;
 
 VIPS_API
 int vips_profile_load(const char *name, VipsBlob **profile, ...)

--- a/libvips/include/vips/colour.h
+++ b/libvips/include/vips/colour.h
@@ -281,9 +281,7 @@ VIPS_API
 int vips_CICP2scRGB(VipsImage *in, VipsImage **out, ...)
 	G_GNUC_NULL_TERMINATED;
 VIPS_API
-int vips_scRGB2CICP(VipsImage *in, VipsImage **out,
-	int colour_primaries, int transfer_characteristics,
-	int matrix_coefficients, int full_range_flag, ...)
+int vips_scRGB2CICP(VipsImage *in, VipsImage **out, ...)
 	G_GNUC_NULL_TERMINATED;
 
 VIPS_API

--- a/test/test-suite/test_cicp.py
+++ b/test/test-suite/test_cicp.py
@@ -223,6 +223,99 @@ class TestCICP:
         assert result.interpretation == "scrgb"
         assert result.bands == 3
 
+    @skip_if_no("scRGB2CICP")
+    @pytest.mark.parametrize("transfer,name,cases,tolerance", TRANSFER_CASES,
+                             ids=[c[1] for c in TRANSFER_CASES])
+    def test_transfer_roundtrip(self, transfer, name, cases, tolerance):
+        for val, _ in cases:
+            if val == 0:
+                continue
+            im = make_cicp_image(val, val, val, transfer=transfer)
+            scrgb = im.CICP2scRGB()
+            result = scrgb.scRGB2CICP(PRIMARIES_BT709, transfer, 0, 1)
+            pixel = result(0, 0)
+            assert abs(pixel[0] - val) <= 1, \
+                f"{name} at {val}: got {pixel[0]}, expected {val}"
+
+    @skip_if_no("scRGB2CICP")
+    @pytest.mark.parametrize("primaries,name,_expected,_tolerance",
+                             PRIMARIES_MATRIX_CASES,
+                             ids=[c[1] for c in PRIMARIES_MATRIX_CASES])
+    def test_primaries_roundtrip(self, primaries, name, _expected, _tolerance):
+        im = make_cicp_image(200, 100, 50, primaries=primaries,
+                             transfer=TRANSFER_LINEAR)
+        scrgb = im.CICP2scRGB()
+        result = scrgb.scRGB2CICP(primaries, TRANSFER_LINEAR, 0, 1)
+        pixel = result(0, 0)
+        assert abs(pixel[0] - 200) <= 1, \
+            f"{name} R: got {pixel[0]}, expected 200"
+        assert abs(pixel[1] - 100) <= 1, \
+            f"{name} G: got {pixel[1]}, expected 100"
+        assert abs(pixel[2] - 50) <= 1, \
+            f"{name} B: got {pixel[2]}, expected 50"
+
+    @skip_if_no("scRGB2CICP")
+    def test_scRGB2CICP_output_format_8bit(self):
+        im = pyvips.Image.black(1, 1, bands=3).copy(interpretation="scrgb") \
+            + [0.5, 0.5, 0.5]
+        result = im.scRGB2CICP(PRIMARIES_BT709, TRANSFER_SRGB, 0, 1)
+        assert result.format == "uchar"
+        assert result.bands == 3
+
+    @skip_if_no("scRGB2CICP")
+    def test_scRGB2CICP_output_format_16bit(self):
+        im = pyvips.Image.black(1, 1, bands=3).copy(interpretation="scrgb") \
+            + [0.5, 0.5, 0.5]
+        result = im.scRGB2CICP(PRIMARIES_BT709, TRANSFER_SRGB, 0, 1,
+                                depth=16)
+        assert result.format == "ushort"
+        assert result.bands == 3
+
+    @skip_if_no("scRGB2CICP")
+    def test_scRGB2CICP_metadata_set(self):
+        im = pyvips.Image.black(1, 1, bands=3).copy(interpretation="scrgb") \
+            + [0.5, 0.5, 0.5]
+        result = im.scRGB2CICP(PRIMARIES_BT2020, TRANSFER_PQ, 0, 1)
+        assert result.get("cicp-colour-primaries") == PRIMARIES_BT2020
+        assert result.get("cicp-transfer-characteristics") == TRANSFER_PQ
+        assert result.get("cicp-matrix-coefficients") == 0
+        assert result.get("cicp-full-range-flag") == 1
+
+    @skip_if_no("scRGB2CICP")
+    def test_scRGB2CICP_ushort_roundtrip(self):
+        ushort_val = round(128 / 255.0 * 65535)
+        im = make_cicp_image(ushort_val, ushort_val, ushort_val,
+                             transfer=TRANSFER_SRGB, fmt="ushort")
+        scrgb = im.CICP2scRGB()
+        result = scrgb.scRGB2CICP(PRIMARIES_BT709, TRANSFER_SRGB, 0, 1,
+                                   depth=16)
+        pixel = result(0, 0)
+        assert abs(pixel[0] - ushort_val) <= 1
+
+    @skip_if_no("scRGB2CICP")
+    def test_bt2020_pq_roundtrip(self):
+        im = make_cicp_image(128, 100, 80,
+                             primaries=PRIMARIES_BT2020,
+                             transfer=TRANSFER_PQ)
+        scrgb = im.CICP2scRGB()
+        result = scrgb.scRGB2CICP(PRIMARIES_BT2020, TRANSFER_PQ, 0, 1)
+        pixel = result(0, 0)
+        assert abs(pixel[0] - 128) <= 1
+        assert abs(pixel[1] - 100) <= 1
+        assert abs(pixel[2] - 80) <= 1
+
+    @skip_if_no("scRGB2CICP")
+    def test_display_p3_hlg_roundtrip(self):
+        im = make_cicp_image(180, 120, 60,
+                             primaries=PRIMARIES_DISPLAY_P3,
+                             transfer=TRANSFER_HLG)
+        scrgb = im.CICP2scRGB()
+        result = scrgb.scRGB2CICP(PRIMARIES_DISPLAY_P3, TRANSFER_HLG, 0, 1)
+        pixel = result(0, 0)
+        assert abs(pixel[0] - 180) <= 1
+        assert abs(pixel[1] - 120) <= 1
+        assert abs(pixel[2] - 60) <= 1
+
     # -- JXL round-trip tests --
 
     @skip_if_no("jxlsave")

--- a/test/test-suite/test_cicp.py
+++ b/test/test-suite/test_cicp.py
@@ -232,7 +232,7 @@ class TestCICP:
                 continue
             im = make_cicp_image(val, val, val, transfer=transfer)
             scrgb = im.CICP2scRGB()
-            result = scrgb.scRGB2CICP(PRIMARIES_BT709, transfer, 0, 1)
+            result = scrgb.scRGB2CICP(transfer_characteristics=transfer)
             pixel = result(0, 0)
             assert abs(pixel[0] - val) <= 1, \
                 f"{name} at {val}: got {pixel[0]}, expected {val}"
@@ -245,7 +245,8 @@ class TestCICP:
         im = make_cicp_image(200, 100, 50, primaries=primaries,
                              transfer=TRANSFER_LINEAR)
         scrgb = im.CICP2scRGB()
-        result = scrgb.scRGB2CICP(primaries, TRANSFER_LINEAR, 0, 1)
+        result = scrgb.scRGB2CICP(colour_primaries=primaries,
+                                   transfer_characteristics=TRANSFER_LINEAR)
         pixel = result(0, 0)
         assert abs(pixel[0] - 200) <= 1, \
             f"{name} R: got {pixel[0]}, expected 200"
@@ -258,7 +259,7 @@ class TestCICP:
     def test_scRGB2CICP_output_format_8bit(self):
         im = pyvips.Image.black(1, 1, bands=3).copy(interpretation="scrgb") \
             + [0.5, 0.5, 0.5]
-        result = im.scRGB2CICP(PRIMARIES_BT709, TRANSFER_SRGB, 0, 1)
+        result = im.scRGB2CICP()
         assert result.format == "uchar"
         assert result.bands == 3
 
@@ -266,8 +267,7 @@ class TestCICP:
     def test_scRGB2CICP_output_format_16bit(self):
         im = pyvips.Image.black(1, 1, bands=3).copy(interpretation="scrgb") \
             + [0.5, 0.5, 0.5]
-        result = im.scRGB2CICP(PRIMARIES_BT709, TRANSFER_SRGB, 0, 1,
-                                depth=16)
+        result = im.scRGB2CICP(depth=16)
         assert result.format == "ushort"
         assert result.bands == 3
 
@@ -275,7 +275,8 @@ class TestCICP:
     def test_scRGB2CICP_metadata_set(self):
         im = pyvips.Image.black(1, 1, bands=3).copy(interpretation="scrgb") \
             + [0.5, 0.5, 0.5]
-        result = im.scRGB2CICP(PRIMARIES_BT2020, TRANSFER_PQ, 0, 1)
+        result = im.scRGB2CICP(colour_primaries=PRIMARIES_BT2020,
+                                transfer_characteristics=TRANSFER_PQ)
         assert result.get("cicp-colour-primaries") == PRIMARIES_BT2020
         assert result.get("cicp-transfer-characteristics") == TRANSFER_PQ
         assert result.get("cicp-matrix-coefficients") == 0
@@ -287,8 +288,7 @@ class TestCICP:
         im = make_cicp_image(ushort_val, ushort_val, ushort_val,
                              transfer=TRANSFER_SRGB, fmt="ushort")
         scrgb = im.CICP2scRGB()
-        result = scrgb.scRGB2CICP(PRIMARIES_BT709, TRANSFER_SRGB, 0, 1,
-                                   depth=16)
+        result = scrgb.scRGB2CICP(depth=16)
         pixel = result(0, 0)
         assert abs(pixel[0] - ushort_val) <= 1
 
@@ -298,7 +298,8 @@ class TestCICP:
                              primaries=PRIMARIES_BT2020,
                              transfer=TRANSFER_PQ)
         scrgb = im.CICP2scRGB()
-        result = scrgb.scRGB2CICP(PRIMARIES_BT2020, TRANSFER_PQ, 0, 1)
+        result = scrgb.scRGB2CICP(colour_primaries=PRIMARIES_BT2020,
+                                   transfer_characteristics=TRANSFER_PQ)
         pixel = result(0, 0)
         assert abs(pixel[0] - 128) <= 1
         assert abs(pixel[1] - 100) <= 1
@@ -310,7 +311,8 @@ class TestCICP:
                              primaries=PRIMARIES_DISPLAY_P3,
                              transfer=TRANSFER_HLG)
         scrgb = im.CICP2scRGB()
-        result = scrgb.scRGB2CICP(PRIMARIES_DISPLAY_P3, TRANSFER_HLG, 0, 1)
+        result = scrgb.scRGB2CICP(colour_primaries=PRIMARIES_DISPLAY_P3,
+                                   transfer_characteristics=TRANSFER_HLG)
         pixel = result(0, 0)
         assert abs(pixel[0] - 180) <= 1
         assert abs(pixel[1] - 120) <= 1

--- a/test/test-suite/test_cicp.py
+++ b/test/test-suite/test_cicp.py
@@ -238,6 +238,23 @@ class TestCICP:
                 f"{name} at {val}: got {pixel[0]}, expected {val}"
 
     @skip_if_no("scRGB2CICP")
+    @pytest.mark.parametrize("transfer,name", [
+        (TRANSFER_PQ, "PQ"),
+        (TRANSFER_HLG, "HLG"),
+        (TRANSFER_SRGB, "sRGB"),
+    ])
+    def test_transfer_shadow_roundtrip(self, transfer, name):
+        for val in range(1, 4096, 37):
+            im = make_cicp_image(val, val, val, transfer=transfer,
+                                 fmt="ushort")
+            scrgb = im.CICP2scRGB()
+            result = scrgb.scRGB2CICP(transfer_characteristics=transfer,
+                                       depth=16)
+            got = result(0, 0)[0]
+            assert abs(got - val) <= 1, \
+                f"{name} shadow at {val}/65535: got {got}, expected {val}"
+
+    @skip_if_no("scRGB2CICP")
     @pytest.mark.parametrize("primaries,name,_expected,_tolerance",
                              PRIMARIES_MATRIX_CASES,
                              ids=[c[1] for c in PRIMARIES_MATRIX_CASES])


### PR DESCRIPTION
Following `CICP2scRGB`, this PR implements the reverse `scRGB2CICP` operation with parity. It isn't wired up to any saver or loader at the moment; it's just a manual operation you can run.

It requires the primary, transfer, matrix and range to be passed by the caller and sets this metadata on the image after transforming it. While it requires the matrix and range to be provided, only 0 and 1 are supported, respectively. The idea is that the API is explicit and later PRs can implement more of the codes as needed without a breaking change.

This API is especially useful when you have to linearize the input, but want to save with CICP metadata. For example, loading an Ultra HDR image and saving to AVIF currently gives an SDR output since the saver sees regular scRGB without any CICP metadata to speak of.