### PR TITLE
CIFuzz: integrate ThreadSanitizer

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -16,3 +16,4 @@ libvips/foreign/libnsgif/*	linguist-vendored
 .gitignore					export-ignore
 .gitkeep					export-ignore
 .github/					export-ignore
+subprojects/				export-ignore

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,19 +14,24 @@ jobs:
         include:
           - name: "Linux x64 (Ubuntu 24.04) - GCC 14"
             os: ubuntu-24.04
-            build: { cc: gcc-14, cxx: g++-14, linker: ld, docs: true }
+            build: { cc: gcc-14, cxx: g++-14, linker: ld }
+            extra_meson_args: -Ddocs=true
 
           - name: "Linux x64 (Ubuntu 24.04) - Clang 19 with ASan and UBSan"
             os: ubuntu-24.04
             build: { cc: clang-19, cxx: clang++-19, linker: ld.lld-19, sanitize: 'address,undefined' }
+            extra_meson_args: -Dintrospection=disabled
 
-          - name: "Linux x64 (Ubuntu 24.04) - Clang 19 with TSan"
-            os: ubuntu-24.04
-            build: { cc: clang-19, cxx: clang++-19, linker: ld.lld-19, sanitize: 'thread' }
+          # We cannot reliably test this if GLib is built without TSan instrumentation.
+          #- name: "Linux x64 (Ubuntu 24.04) - Clang 19 with TSan"
+          #  os: ubuntu-24.04
+          #  build: { cc: clang-19, cxx: clang++-19, linker: ld.lld-19, sanitize: 'thread' }
+          #  extra_meson_args: -Dintrospection=disabled
 
           - name: "macOS arm64 (15) - Xcode 16"
             os: macos-15
             build: { cc: clang, cxx: clang++, linker: ld.lld }
+            extra_meson_args: -Dintrospection=disabled
 
     env:
       CC: ${{ matrix.build.cc }}
@@ -113,8 +118,7 @@ jobs:
           meson setup build
             -Ddebug=true
             -Dmagick=disabled
-            -Ddocs=${{ matrix.build.docs || 'false' }}
-            -Dintrospection=${{ matrix.build.docs && 'enabled' || 'disabled' }}
+            ${{ matrix.extra_meson_args }}
             -Db_sanitize=${{ matrix.build.sanitize || 'none' }}
             -Db_lundef=${{ matrix.build.sanitize && 'false' || 'true' }}
           || (cat build/meson-logs/meson-log.txt && exit 1)

--- a/.github/workflows/cifuzz.yml
+++ b/.github/workflows/cifuzz.yml
@@ -7,8 +7,14 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        sanitizer: [address, undefined]
+        # Note: MSan requires all libraries to be built from source, see:
+        # https://github.com/google/oss-fuzz/issues/6294
+        sanitizer: [address, undefined, thread]
     steps:
+    # https://github.com/google/oss-fuzz/pull/15235
+    - name: Fix TSan on CIFuzz
+      if: matrix.sanitizer == 'thread'
+      run: echo "CIFUZZ_TEST=1" >> $GITHUB_ENV
     - name: Build Fuzzers
       id: build
       uses: google/oss-fuzz/infra/cifuzz/actions/build_fuzzers@master

--- a/fuzz/config.h
+++ b/fuzz/config.h
@@ -31,7 +31,7 @@ __lsan_default_suppressions()
 extern "C" const char *
 __tsan_default_options()
 {
-	return "halt_on_error=1";
+	return "halt_on_error=1:ignore_noninstrumented_modules=1";
 }
 
 extern "C" const char *

--- a/fuzz/config.h
+++ b/fuzz/config.h
@@ -29,6 +29,12 @@ __lsan_default_suppressions()
 }
 
 extern "C" const char *
+__tsan_default_options()
+{
+	return "halt_on_error=1";
+}
+
+extern "C" const char *
 __tsan_default_suppressions()
 {
 	static const char tsan_suppressions[] = {

--- a/fuzz/oss_fuzz_build.sh
+++ b/fuzz/oss_fuzz_build.sh
@@ -234,6 +234,7 @@ cmake \
 cmake --build . --target install
 popd
 
+TSAN_ARGS=""
 if [ "$SANITIZER" = "undefined" ]; then
   # Allow UBSan shift errors to be recoverable to ensure our suppression rules
   # are enforced. OSS-Fuzz uses `-fno-sanitize-recover=shift` by default.
@@ -243,11 +244,17 @@ if [ "$SANITIZER" = "undefined" ]; then
   # and available in OSS-Fuzz we can re-enable the above flags instead.
   export CFLAGS+=" -fsanitize-ignorelist=$PWD/suppressions/ubsan_ignorelist.txt"
   export CXXFLAGS+=" -fsanitize-ignorelist=$PWD/suppressions/ubsan_ignorelist.txt"
+elif [ "$SANITIZER" = "thread" ]; then
+  # TSan may report false positives when callbacks cross boundaries between
+  # instrumented and non-instrumented code. To avoid this, built GLib with
+  # TSan instrumentation as well.
+  # https://github.com/google/sanitizers/wiki/threadsanitizercppmanual#non-instrumented-code
+  TSAN_ARGS="--force-fallback-for=glib -Dglib:glib_debug=disabled -Dglib:nls=disabled -Dglib:sysprof=disabled -Dglib:tests=false"
 fi
 
 # libvips
 # Disable building man pages, gettext po files, tools, and tests
-meson setup build --prefix=$WORK --libdir=lib --prefer-static --default-library=static --buildtype=debug \
+meson setup build --prefix=$WORK --libdir=lib --prefer-static --default-library=static --buildtype=debug $TSAN_ARGS \
   -Dbackend_max_links=4 -Dexamples=false -Dman=false -Dpo=false \
   -Dtests=false -Dtools=false -Dcplusplus=false -Dmodules=disabled -Dfuzz=true \
   -Dfuzzing_engine=oss-fuzz -Dfuzzer_ldflags="$LIB_FUZZING_ENGINE" \

--- a/subprojects/.gitignore
+++ b/subprojects/.gitignore
@@ -1,0 +1,3 @@
+glib-*/
+packagecache/
+.wraplock

--- a/subprojects/glib.wrap
+++ b/subprojects/glib.wrap
@@ -1,0 +1,11 @@
+[wrap-file]
+directory = glib-2.88.1
+source_url = https://download.gnome.org/sources/glib/2.88/glib-2.88.1.tar.xz
+source_fallback_url = https://wrapdb.mesonbuild.com/v2/glib_2.88.1-1/get_source/glib-2.88.1.tar.xz
+source_filename = glib-2.88.1.tar.xz
+source_hash = 51ab804c56f6eab3e5045c774d1290ac5e4c923d4f9a3d8e33123bee45c1840e
+wrapdb_version = 2.88.1-1
+
+[provide]
+dependency_names = gthread-2.0, gobject-2.0, gmodule-no-export-2.0, gmodule-export-2.0, gmodule-2.0, glib-2.0, gio-2.0, gio-windows-2.0, gio-unix-2.0
+program_names = glib-genmarshal, glib-mkenums, glib-compile-schemas, glib-compile-resources, gio-querymodules, gdbus-codegen

--- a/suppressions/tsan.supp
+++ b/suppressions/tsan.supp
@@ -1,224 +1,58 @@
+### These suppressions assume that GLib was built with TSan instrumentation ###
+
 ## The suppressions below match only the top frame of report stacks
 
-# dispose() may run multiple times, but always serially, so non-racy
-race_top:vips_*_dispose
-
-# using thread-local regions in generate functions is fine
-race_top:vips_*_gen
-
-# these helpers are used by the above generate functions
-race_top:make_firstlast
-race_top:reduce_sum
-race_top:vips_combine_pixels3
-race_top:vips_composite_base_select
-race_top:vips_convi_uchar_hwy
-race_top:vips_embed_base_find_edge
-race_top:vips_embed_base_paint_edge
-race_top:vips_rect_includesrect
-race_top:vips_rect_intersectrect
-race_top:vips_reduceh_uchar_hwy
-race_top:vips_reducev_uchar_hwy
-race_top:vips_region_paint_pel
-race_top:vips__transform_invert_point
-
-# unlocked access to image/region fields, which is fine
-race_top:buffer_move
-race_top:vips_buffer_unref_ref
-race_top:vips_image_decode_predict
-race_top:vips_image_iskilled
-race_top:vips_region_buffer
-race_top:vips_region_copy
-race_top:vips_region_image
-race_top:vips_region_prepare
-race_top:vips__image_copy_fields_array
-race_top:vips__region_check_ownership
-
-# unlocked access/assignment to ->read_position, which is fine
-race_top:vips_source_read
-race_top:vips_source_seek
-
-# an unlocked FALSE/TRUE assignment, which is fine
-race_top:vips_image_set_kill
-race_top:vips_object_set_property
-race_top:vips_region_region
-race_top:vips_source_decode
-race_top:vips_source_rewind
-race_top:vips__demand_hint_array
-
-# an unlocked NULL assignment, which is fine
-race_top:vips_image_pio_input
-race_top:vips_image_wio_input
-
-# an unlocked singleton init of ->argument_table, which is fine
-race_top:vips_argument_init
-
-# an unlocked increment of ->local_memory, which is fine
-race_top:vips_malloc
-
-# buffers are thread-local (held in a GPrivate), so non-racy
-race_top:vips_buffer_free
-race_top:vips_buffer_undone
-
-# local static variables ought to be non-racy
-race_top:vips_getpagesize
-race_top:vips_get_disc_threshold
-
-# callers are expected to call this once during startup, so non-racy
-race_top:vips_cache_set_max
-race_top:vips_cache_set_max_files
-race_top:vips_cache_set_max_mem
-race_top:vips_concurrency_set
-race_top:vips_vector_set_enabled
-
-# guarded with vips_tracked_mutex, so it should be fine
-race_top:vips_tracked_aligned_alloc
-race_top:vips_tracked_aligned_free
-race_top:vips_tracked_close
-race_top:vips_tracked_get_files
-race_top:vips_tracked_get_mem
-race_top:vips_tracked_malloc
-race_top:vips_tracked_open
-
-# guarded with vips__meta_lock, so it should be fine
-race_top:meta_init
-race_top:meta_new
-
-# guarded with g_async_queue_lock(), so it should be fine
-race_top:vips_threadset_add_thread
-race_top:vips_threadset_reuse_wait
-
-# task is popped from the queue locked, then executed and freed
-# unlocked, which is fine
-race_top:vips_threadset_work
-
-# guarded with vips__global_lock, so it should be fine
-race_top:vips_area_new
-race_top:vips_buf_all
-race_top:vips_buf_rewind
-race_top:vips_buf_vappendf
-race_top:vips_error_freeze
-race_top:vips_image_sanity
-race_top:vips__link_make
-race_top:vips__link_map
-race_top:vips__region_count_pixels
-
-# guarded with vips_cache_lock, so it should be fine
-race_top:vips_cache_drop_all
-race_top:vips_cache_get_lru
-race_top:vips_cache_insert
-race_top:vips_cache_trim
-race_top:vips_entry_ref
-race_top:vips_entry_touch
-race_top:vips_object_ref_arg
-race_top:vips_operation_equal
-race_top:vips_operation_hash
-
-# use of pool->stop is unlocked, but fine
+# Unsynchronized read/write of pool->stop and pool->error
+race_top:vips_threadpool_run
+race_top:vips_threadpool_wait
 race_top:vips_thread_main_loop
+race_top:vips_worker_work_unit
 
-# quarks (i.e. GQuark) are likely non-racy
-race_top:vips_reorder_free
-race_top:vips_reorder_prepare_many
-race_top:vips__reorder_set_input
-
-# attaching/updating the time struct of an image is likely safe
+# Unsynchronized write of image->time
+race_top:g_timer_elapsed
+race_top:g_timer_start
 race_top:vips_progress_add
 race_top:vips_progress_update
 
-# semaphores are likely non-racy
-race_top:vips_*semaphore_*
+# Unsynchronized TRUE assignment to statistic->stop
+race_top:vips_max_scan
+race_top:vips_min_scan
 
-# pool->exit is atomically updated, so it should be fine
-race_top:vips_worker_work_unit
+# Unsynchronized TRUE assignment to wbuffer->kill
+race_top:wbuffer_free
 
-# guarded with area->lock, so it should be fine
-race_top:vips_area_copy
-race_top:vips_area_free
-race_top:vips_area_unref
+# Unsynchronized FALSE assignment to dest->invalid
+race_top:vips_region_prepare_to
 
-# guarded with cache->lock, so it should be fine
-race_top:vips_rect_equal
-race_top:vips_rect_hash
-race_top:vips_tile_cache_ref
-race_top:vips_tile_find
-race_top:vips_tile_new
-race_top:vips_tile_ref
-race_top:vips_tile_search
-race_top:vips_tile_unref
+# Unsynchronized FALSE/TRUE assignment
+race_top:vips_image_set_kill
 
-# guarded with pool->allocate_lock, so it should be fine
-race_top:direct_strip_allocate
-race_top:image_strip_allocate
-race_top:sink_area_allocate_fn
-race_top:sink_area_position
-race_top:sink_memory_area_allocate_fn
-race_top:sink_memory_area_position
-race_top:vips_maplut_stop
-race_top:vips_worker_allocate
-race_top:wbuffer_allocate_fn
-race_top:wtiff_layer_row_allocate
+# Unsynchronized singleton init of a local static variable
+race_top:vips_getpagesize
+race_top:vips_get_disc_threshold
 
-# thread-local state work functions are non-racy
-race_top:sink_memory_area_work_fn
-race_top:sink_work
-race_top:wbuffer_work_fn
+# Unsynchronized read of sink_base->processed
+race_top:vips_sink_base_progress
 
-# guarded with image->sslock, so it should be fine
-race_top:rtiff_seq_start
-race_top:vips_arithmetic_start
-race_top:vips_bandary_start
-race_top:vips_composite_start
-race_top:vips_convasep_start
-race_top:vips_convf_start
-race_top:vips_convi_start
-race_top:vips_foreign_load_start
-race_top:vips_foreign_load_temp
-race_top:vips_hist_local_start
-race_top:vips_morph_start
-race_top:vips_rank_start
-race_top:vips_region_build
-race_top:vips_region_dispose
-race_top:vips_shrinkv_start
-race_top:vips_start_many
-race_top:vips_window_find
-race_top:vips_window_fits
-race_top:vips_window_new
-race_top:vips_window_set
-race_top:vips_window_take
-race_top:vips_window_unref
-race_top:vips__region_start
-race_top:vips__region_stop
-race_top:vips__start_merge
+# Unsynchronized read of write->buf->write_errno
+race_top:write_check_error
+
+# Unsynchronized read of image fields
+race_top:vips__image_copy_fields_array
+race_top:vips__link_make
+
+# GClosure mixes atomic compare and exchange with non atomic reads
+# (read of cl->n_guards and cl->derivative_flag is non atomic)
+# https://gitlab.gnome.org/GNOME/glib/-/issues/1672
+race_top:closure_invoke_notifiers
+race_top:g_cclosure_marshal_VOID__POINTER
+race_top:vips_INT__VOID
 
 ## The suppressions below match all frames of report stacks
 
-# foreign generate functions ought to be non-racy
-race:direct_strip_work
-race:image_strip_work
-race:png2vips_generate
-race:rad2vips_generate
-race:read_jpeg_generate
-race:read_webp_generate
-race:rtiff_fill_region
-race:rtiff_stripwise_generate
-race:vips_fits_generate
-race:vips_foreign_load_heif_generate
-race:vips_foreign_load_jp2k_generate_tiled
-race:vips_foreign_load_jp2k_generate_untiled
-race:vips_foreign_load_jxl_generate
-race:vips_foreign_load_magick7_fill_region
-race:vips_foreign_load_magick_fill_region
-race:vips_foreign_load_nsgif_generate
-race:vips_foreign_load_pdf_generate
-race:vips_foreign_load_png_generate
-race:vips_foreign_load_ppm_generate_1bit_ascii
-race:vips_foreign_load_ppm_generate_1bit_binary
-race:vips_foreign_load_ppm_generate_ascii_int
-race:vips_foreign_load_ppm_generate_binary
-race:vips_foreign_load_svg_generate
-race:vips__openexr_generate
-race:vips__openslide_generate
-race:wtiff_layer_row_work
+# Unsynchronized read of once->status from g_once
+# https://gitlab.gnome.org/GNOME/glib/-/issues/1672
+race:g_once_impl
 
 # TSan may produce false positives for callbacks invoked from
 # non-instrumented code. Such callbacks should be listed below.
@@ -232,49 +66,3 @@ race:vips_foreign_load_jp2k_seek_source
 race:vips_foreign_load_jp2k_skip_source
 race:vips_foreign_load_png_stream
 race:vips_png_read_source
-
-# g_object_get*() is uninstrumented, but likely non-racy
-race:g_object_get
-race:g_object_get_property
-race:g_object_get_valist
-
-# using thread-local regions in generate functions is fine
-# this also catches all ->correlation, ->point, ->process_line and
-# ->scan subclass functions
-race:vips_arithmetic_gen
-race:vips_bandary_gen
-race:vips_colour_gen
-race:vips_correlation_gen
-race:vips_statistic_scan
-race:vips_point_gen
-race:vips_sdf_gen
-
-# guarded with vips__minimise_lock, so it should be fine
-race:vips_image_minimise_all
-
-# guarded with vips_cache_lock, so it should be fine
-race:vips_cache_free_cb
-
-# finalize() is only called once by a single thread, so non-racy
-race:vips_image_finalize
-
-# only called optionally when the whole program is done, so non-racy
-race:vips_shutdown
-
-# same as `race_top:vips_*_dispose` above, but matched against all
-# frames of report stacks
-race:vips_image_dispose
-race:vips_operation_dispose
-
-# thread-local state allocate/dispose functions ought to be non-racy
-race:sink_memory_thread_state_new
-race:sink_thread_state_dispose
-race:vips_sink_thread_state_new
-race:write_thread_state_new
-
-# the double-buffered output and write-behind threads are non-racy
-race:wbuffer_flush
-race:wbuffer_new
-race:wbuffer_position
-race:wbuffer_write
-race:write_free


### PR DESCRIPTION
Replaces the TSan CI workflow, which required numerous suppressions
because GLib was not built with ThreadSanitizer instrumentation.

See also: https://github.com/google/oss-fuzz/pull/15235.
Context: https://github.com/libvips/libvips/pull/4713#issuecomment-3467458167.