### PR TITLE
meson: fix pkg-config generation with internal dependencies

### DIFF
--- a/cplusplus/meson.build
+++ b/cplusplus/meson.build
@@ -22,7 +22,7 @@ libvips_cpp_dep = declare_dependency(
 
 pkg.generate(
     libvips_cpp_lib,
-    requires: [ libvips_lib, glib_dep, gobject_dep ],
+    libraries: [ libvips_lib, glib_dep, gobject_dep ],
     name: 'vips-cpp',
     description: 'C++ API for vips8 image processing library',
 )

--- a/libvips/meson.build
+++ b/libvips/meson.build
@@ -36,7 +36,7 @@ libvips_dep = declare_dependency(
 
 pkg.generate(
     libvips_lib,
-    requires: [ glib_dep, gio_dep, gobject_dep ],
+    libraries: [ glib_dep, gio_dep, gobject_dep ],
     name: 'vips',
     description: 'Image processing library',
 )


### PR DESCRIPTION
Use `libraries` instead of `requires` when calling `pkg.generate()` to make the configuration succeed with internal dependencies (i.e. subprojects).

Details:
```console
libvips/meson.build:37:4: ERROR: requires argument not a string, library with pkgconfig-generated file or pkgconfig-dependency object, got <InternalDependency glib-2.0: True>
cplusplus/meson.build:23:4: ERROR: requires argument not a string, library with pkgconfig-generated file or pkgconfig-dependency object, got <InternalDependency glib-2.0: True>
```

Non-functional change, pkg-config dependencies that are part of `libraries` are automatically added to `requires`, see:
https://github.com/mesonbuild/meson/issues/6037#issuecomment-543938956
(verified locally)

Split out from #4981.