### PR TITLE
Fix quantizr backend returning success when quantization fails

### DIFF
--- a/libvips/foreign/quantise.c
+++ b/libvips/foreign/quantise.c
@@ -223,7 +223,7 @@ vips__quantise_image_quantize(VipsQuantiseImage *const input_image,
 	VipsQuantiseAttr *const options, VipsQuantiseResult **result_output)
 {
 	*result_output = quantizr_quantize(input_image, options);
-	return 0;
+	return *result_output != NULL ? 0 : 1;
 }
 
 VipsQuantiseError


### PR DESCRIPTION
`quantizr_quantize()` returns `NULL` on failure instead of an error code, but `vips__quantise_image_quantize()` unconditionally returned `0` (success), causing callers to dereference a `NULL` result pointer.