### PR TITLE
Improve macOS vips concurrency detection

### DIFF
--- a/libvips/iofuncs/thread.c
+++ b/libvips/iofuncs/thread.c
@@ -56,6 +56,10 @@
 #include <windows.h>
 #endif /*G_OS_WIN32*/
 
+#ifdef __APPLE__
+#include <sys/sysctl.h>
+#endif /*__APPLE__*/
+
 /* Maximum value we allow for VIPS_CONCURRENCY. We need to stop huge values
  * killing the system.
  */
@@ -175,8 +179,24 @@ vips__concurrency_get_default(void)
 				) &&
 		(x = atoi(str)) > 0)
 		nthr = x;
-	else
+	else {
 		nthr = g_get_num_processors();
+
+#ifdef __APPLE__
+		/* On Apple Silicon, prefer the number of performance cores to
+		 * avoid scheduling work on slower efficiency cores.
+		 */
+		{
+			int pcore_count = 0;
+			size_t len = sizeof(pcore_count);
+
+			if (sysctlbyname("hw.perflevel0.logicalcpu",
+					&pcore_count, &len, NULL, 0) == 0 &&
+				pcore_count > 0)
+				nthr = pcore_count;
+		}
+#endif /*__APPLE__*/
+	}
 
 	if (nthr < 1 ||
 		nthr > MAX_THREADS) {


### PR DESCRIPTION
On Apple Silicon, use `hw.perflevel0.logicalcpu` to detect the number of performance cores and use that as the default thread count, avoiding scheduling work on slower efficiency cores.

Falls back to `g_get_num_processors()` on Intel Macs where the sysctl key does not exist.

This fixes poor performance with automatic vips concurrency detection on Apple Silicon Macs, since with the default of all cpu cores, some threads must be scheduled on slower efficiency cores (eg. M4 Pro chip has 10 performance and 4 efficiency cores).