### PR TITLE
fix: luminance scaling for uhdrsave

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -22,6 +22,7 @@ date-tbd 8.19.0
 - uhdrsave: add existing JPEG options for base image [lovell]
 - csvload: add maximum limit on column count [lovell]
 - pdfload_buffer: only search the first few bytes in is_a [violetviolinist]
+- add percent_lum: find threshold for percent of pixels by BT.709 luminance [mertalev]
 
 tbd 8.18.3
 

--- a/doc/libvips-histogram.md
+++ b/doc/libvips-histogram.md
@@ -24,6 +24,7 @@ CIELAB images, but might be useful elsewhere.
 
 * [method@Image.maplut]
 * [method@Image.percent]
+* [method@Image.percent_lum]
 * [method@Image.stdif]
 * [method@Image.hist_cum]
 * [method@Image.hist_norm]

--- a/libvips/colour/uhdr2scRGB.c
+++ b/libvips/colour/uhdr2scRGB.c
@@ -69,6 +69,11 @@ G_DEFINE_TYPE(VipsUhdr2scRGB, vips_uhdr2scRGB, VIPS_TYPE_COLOUR);
 /* Derived from the apache-licensed applyGain() method of libuhdr.
  */
 
+/* Rescale from libuhdr's linear convention (1.0 = 203 nits, the ITU-R
+ * BT.2408 SDR reference white) to scRGB (1.0 = 80 nits).
+ */
+#define UHDR_TO_SCRGB (203.0f / 80.0f)
+
 /* Monochrome gainmap, colour image. Probably the most common case.
  */
 static void
@@ -97,9 +102,9 @@ vips_uhdr2scRGB_mono(VipsUhdr2scRGB *uhdr,
 
 		float gaing = exp2(boostg);
 
-		q[0] = ((r + uhdr->offset_sdr[1]) * gaing) - uhdr->offset_hdr[1];
-		q[1] = ((g + uhdr->offset_sdr[1]) * gaing) - uhdr->offset_hdr[1];
-		q[2] = ((b + uhdr->offset_sdr[1]) * gaing) - uhdr->offset_hdr[1];
+		q[0] = (((r + uhdr->offset_sdr[1]) * gaing) - uhdr->offset_hdr[1]) * UHDR_TO_SCRGB;
+		q[1] = (((g + uhdr->offset_sdr[1]) * gaing) - uhdr->offset_hdr[1]) * UHDR_TO_SCRGB;
+		q[2] = (((b + uhdr->offset_sdr[1]) * gaing) - uhdr->offset_hdr[1]) * UHDR_TO_SCRGB;
 		q += 3;
 	}
 }
@@ -142,9 +147,9 @@ vips_uhdr2scRGB_rgb(VipsUhdr2scRGB *uhdr, VipsPel *out, VipsPel **in, int width)
 		float gaing = exp2(boostg);
 		float gainb = exp2(boostb);
 
-		q[0] = ((r + uhdr->offset_sdr[0]) * gainr) - uhdr->offset_hdr[0];
-		q[1] = ((g + uhdr->offset_sdr[1]) * gaing) - uhdr->offset_hdr[1];
-		q[2] = ((b + uhdr->offset_sdr[2]) * gainb) - uhdr->offset_hdr[2];
+		q[0] = (((r + uhdr->offset_sdr[0]) * gainr) - uhdr->offset_hdr[0]) * UHDR_TO_SCRGB;
+		q[1] = (((g + uhdr->offset_sdr[1]) * gaing) - uhdr->offset_hdr[1]) * UHDR_TO_SCRGB;
+		q[2] = (((b + uhdr->offset_sdr[2]) * gainb) - uhdr->offset_hdr[2]) * UHDR_TO_SCRGB;
 		q += 3;
 	}
 }

--- a/libvips/foreign/uhdrsave.c
+++ b/libvips/foreign/uhdrsave.c
@@ -396,8 +396,7 @@ vips_foreign_save_uhdr_set_compressed_base(VipsForeignSaveUhdr *uhdr,
 
 // save hdr
 static int
-vips_foreign_save_uhdr_hdr(VipsForeignSaveUhdr *uhdr, VipsImage *image,
-	float peak_nits)
+vips_foreign_save_uhdr_hdr(VipsForeignSaveUhdr *uhdr, VipsImage *image)
 {
 	uhdr_error_info_t error_info;
 
@@ -406,18 +405,6 @@ vips_foreign_save_uhdr_hdr(VipsForeignSaveUhdr *uhdr, VipsImage *image,
 	uhdr_enc_set_output_format(uhdr->enc, UHDR_CODEC_JPG);
 	uhdr_enc_set_gainmap_scale_factor(uhdr->enc, uhdr->gainmap_scale_factor);
 	uhdr_enc_set_using_multi_channel_gainmap(uhdr->enc, 0);
-
-	/* Tell libuhdr the actual content peak so it sizes
-	 * hdr_capacity_max correctly. Without this it defaults to
-	 * 10 000 nits (PQ maximum) which wastes gainmap precision
-	 * and under-boosts on real displays.
-	 */
-	error_info =
-		uhdr_enc_set_target_display_peak_brightness(uhdr->enc, peak_nits);
-	if (error_info.error_code) {
-		vips__uhdr_error(&error_info);
-		return -1;
-	}
 
 	// attach the gainmap, if we have one
 	if (vips_image_get_typeof(image, "gainmap-data") &&
@@ -533,14 +520,6 @@ vips_foreign_save_uhdr_build(VipsObject *object)
 		VIPS_UNREF(image);
 		image = x;
 
-		double peak_y;
-		if (vips_percent_lum(image, 99.0, &peak_y,
-				"max", 10000.0 / 80.0, NULL)) {
-			VIPS_UNREF(image);
-			return -1;
-		}
-		float peak_nits = VIPS_CLIP(203.0, peak_y * 80.0, 10000.0);
-
 		/* Rescale from scRGB (1.0 = 80 nits) to libuhdr's UHDR_CT_LINEAR
 		 * convention (1.0 = 203 nits, the ITU-R BT.2408 reference white).
 		 */
@@ -561,7 +540,7 @@ vips_foreign_save_uhdr_build(VipsObject *object)
 			image = x;
 		}
 
-		if (vips_foreign_save_uhdr_hdr(uhdr, image, peak_nits)) {
+		if (vips_foreign_save_uhdr_hdr(uhdr, image)) {
 			VIPS_UNREF(image);
 			return -1;
 		}

--- a/libvips/foreign/uhdrsave.c
+++ b/libvips/foreign/uhdrsave.c
@@ -396,7 +396,8 @@ vips_foreign_save_uhdr_set_compressed_base(VipsForeignSaveUhdr *uhdr,
 
 // save hdr
 static int
-vips_foreign_save_uhdr_hdr(VipsForeignSaveUhdr *uhdr, VipsImage *image)
+vips_foreign_save_uhdr_hdr(VipsForeignSaveUhdr *uhdr, VipsImage *image,
+	float peak_nits)
 {
 	uhdr_error_info_t error_info;
 
@@ -405,6 +406,18 @@ vips_foreign_save_uhdr_hdr(VipsForeignSaveUhdr *uhdr, VipsImage *image)
 	uhdr_enc_set_output_format(uhdr->enc, UHDR_CODEC_JPG);
 	uhdr_enc_set_gainmap_scale_factor(uhdr->enc, uhdr->gainmap_scale_factor);
 	uhdr_enc_set_using_multi_channel_gainmap(uhdr->enc, 0);
+
+	/* Tell libuhdr the actual content peak so it sizes
+	 * hdr_capacity_max correctly. Without this it defaults to
+	 * 10 000 nits (PQ maximum) which wastes gainmap precision
+	 * and under-boosts on real displays.
+	 */
+	error_info =
+		uhdr_enc_set_target_display_peak_brightness(uhdr->enc, peak_nits);
+	if (error_info.error_code) {
+		vips__uhdr_error(&error_info);
+		return -1;
+	}
 
 	// attach the gainmap, if we have one
 	if (vips_image_get_typeof(image, "gainmap-data") &&
@@ -441,6 +454,99 @@ vips_foreign_save_uhdr_sdr(VipsForeignSaveUhdr *uhdr, VipsImage *image)
 		return -1;
 	}
 
+	return 0;
+}
+
+/* 1024 bins covering [0, 130] scRGB = [0, 10400] nits, ~10 nits per bin
+ */
+#define PEAK_NITS_BINS 1024
+#define PEAK_NITS_MAX_SCRGB 130.0f
+
+typedef struct _PeakNitsAccum {
+	guint64 bins[PEAK_NITS_BINS];
+	guint64 count;
+} PeakNitsAccum;
+
+static void *
+peak_nits_start(VipsImage *image, void *a, void *b)
+{
+	return g_new0(PeakNitsAccum, 1);
+}
+
+static int
+peak_nits_scan(VipsRegion *region, void *seq, void *a, void *b, gboolean *stop)
+{
+	PeakNitsAccum *accum = (PeakNitsAccum *) seq;
+	VipsRect *r = &region->valid;
+	const int bands = region->im->Bands;
+	const float scale = (float) PEAK_NITS_BINS / PEAK_NITS_MAX_SCRGB;
+
+	for (int y = 0; y < r->height; y++) {
+		float *p = (float *) VIPS_REGION_ADDR(region, r->left, r->top + y);
+
+		for (int x = 0; x < r->width; x++) {
+			float Y = 0.2126f * p[0] + 0.7152f * p[1] + 0.0722f * p[2];
+			int bin = (int) (Y * scale);
+			bin = VIPS_CLIP(0, bin, PEAK_NITS_BINS - 1);
+			accum->bins[bin]++;
+			p += bands;
+		}
+
+		accum->count += r->width;
+	}
+
+	return 0;
+}
+
+static int
+peak_nits_stop(void *seq, void *a, void *b)
+{
+	PeakNitsAccum *thread = (PeakNitsAccum *) seq;
+	PeakNitsAccum *total = (PeakNitsAccum *) a;
+
+	for (int i = 0; i < PEAK_NITS_BINS; i++)
+		total->bins[i] += thread->bins[i];
+	total->count += thread->count;
+
+	g_free(thread);
+	return 0;
+}
+
+/* Single-pass 99th-percentile BT.709 luminance estimation.
+ *
+ * Uses luminance rather than per-channel max because out-of-gamut
+ * colours after primaries conversion can have individual channels far
+ * above the actual brightness.
+ */
+static int
+vips_foreign_save_uhdr_peak_nits(VipsImage *image, float *out)
+{
+	PeakNitsAccum accum = { { 0 }, 0 };
+
+	if (vips_image_pio_input(image))
+		return -1;
+
+	if (vips_sink(image,
+			peak_nits_start, peak_nits_scan, peak_nits_stop,
+			&accum, NULL))
+		return -1;
+
+	/* Walk histogram to find 99th percentile.
+	 */
+	guint64 target = (guint64) (accum.count * 0.99);
+	guint64 cumul = 0;
+	int bin;
+	for (bin = 0; bin < PEAK_NITS_BINS; bin++) {
+		cumul += accum.bins[bin];
+		if (cumul >= target)
+			break;
+	}
+
+	float peak_nits =
+		(bin + 0.5f) * (PEAK_NITS_MAX_SCRGB / PEAK_NITS_BINS) * 80.0f;
+	peak_nits = VIPS_CLIP(203.0f, peak_nits, 10000.0f);
+
+	*out = peak_nits;
 	return 0;
 }
 
@@ -520,6 +626,22 @@ vips_foreign_save_uhdr_build(VipsObject *object)
 		VIPS_UNREF(image);
 		image = x;
 
+		float peak_nits;
+		if (vips_foreign_save_uhdr_peak_nits(image, &peak_nits)) {
+			VIPS_UNREF(image);
+			return -1;
+		}
+
+		/* Rescale from scRGB (1.0 = 80 nits) to libuhdr's UHDR_CT_LINEAR
+		 * convention (1.0 = 203 nits, the ITU-R BT.2408 reference white).
+		 */
+		if (vips_linear1(image, &x, 80.0 / 203.0, 0.0, NULL)) {
+			VIPS_UNREF(image);
+			return -1;
+		}
+		VIPS_UNREF(image);
+		image = x;
+
 		// libuhdr needs RGBA
 		if (!vips_image_hasalpha(image)) {
 			if (vips_addalpha(image, &x, NULL)) {
@@ -530,7 +652,7 @@ vips_foreign_save_uhdr_build(VipsObject *object)
 			image = x;
 		}
 
-		if (vips_foreign_save_uhdr_hdr(uhdr, image)) {
+		if (vips_foreign_save_uhdr_hdr(uhdr, image, peak_nits)) {
 			VIPS_UNREF(image);
 			return -1;
 		}

--- a/libvips/foreign/uhdrsave.c
+++ b/libvips/foreign/uhdrsave.c
@@ -457,99 +457,6 @@ vips_foreign_save_uhdr_sdr(VipsForeignSaveUhdr *uhdr, VipsImage *image)
 	return 0;
 }
 
-/* 1024 bins covering [0, 130] scRGB = [0, 10400] nits, ~10 nits per bin
- */
-#define PEAK_NITS_BINS 1024
-#define PEAK_NITS_MAX_SCRGB 130.0f
-
-typedef struct _PeakNitsAccum {
-	guint64 bins[PEAK_NITS_BINS];
-	guint64 count;
-} PeakNitsAccum;
-
-static void *
-peak_nits_start(VipsImage *image, void *a, void *b)
-{
-	return g_new0(PeakNitsAccum, 1);
-}
-
-static int
-peak_nits_scan(VipsRegion *region, void *seq, void *a, void *b, gboolean *stop)
-{
-	PeakNitsAccum *accum = (PeakNitsAccum *) seq;
-	VipsRect *r = &region->valid;
-	const int bands = region->im->Bands;
-	const float scale = (float) PEAK_NITS_BINS / PEAK_NITS_MAX_SCRGB;
-
-	for (int y = 0; y < r->height; y++) {
-		float *p = (float *) VIPS_REGION_ADDR(region, r->left, r->top + y);
-
-		for (int x = 0; x < r->width; x++) {
-			float Y = 0.2126f * p[0] + 0.7152f * p[1] + 0.0722f * p[2];
-			int bin = (int) (Y * scale);
-			bin = VIPS_CLIP(0, bin, PEAK_NITS_BINS - 1);
-			accum->bins[bin]++;
-			p += bands;
-		}
-
-		accum->count += r->width;
-	}
-
-	return 0;
-}
-
-static int
-peak_nits_stop(void *seq, void *a, void *b)
-{
-	PeakNitsAccum *thread = (PeakNitsAccum *) seq;
-	PeakNitsAccum *total = (PeakNitsAccum *) a;
-
-	for (int i = 0; i < PEAK_NITS_BINS; i++)
-		total->bins[i] += thread->bins[i];
-	total->count += thread->count;
-
-	g_free(thread);
-	return 0;
-}
-
-/* Single-pass 99th-percentile BT.709 luminance estimation.
- *
- * Uses luminance rather than per-channel max because out-of-gamut
- * colours after primaries conversion can have individual channels far
- * above the actual brightness.
- */
-static int
-vips_foreign_save_uhdr_peak_nits(VipsImage *image, float *out)
-{
-	PeakNitsAccum accum = { { 0 }, 0 };
-
-	if (vips_image_pio_input(image))
-		return -1;
-
-	if (vips_sink(image,
-			peak_nits_start, peak_nits_scan, peak_nits_stop,
-			&accum, NULL))
-		return -1;
-
-	/* Walk histogram to find 99th percentile.
-	 */
-	guint64 target = (guint64) (accum.count * 0.99);
-	guint64 cumul = 0;
-	int bin;
-	for (bin = 0; bin < PEAK_NITS_BINS; bin++) {
-		cumul += accum.bins[bin];
-		if (cumul >= target)
-			break;
-	}
-
-	float peak_nits =
-		(bin + 0.5f) * (PEAK_NITS_MAX_SCRGB / PEAK_NITS_BINS) * 80.0f;
-	peak_nits = VIPS_CLIP(203.0f, peak_nits, 10000.0f);
-
-	*out = peak_nits;
-	return 0;
-}
-
 static int
 vips_foreign_save_uhdr_build(VipsObject *object)
 {
@@ -626,11 +533,13 @@ vips_foreign_save_uhdr_build(VipsObject *object)
 		VIPS_UNREF(image);
 		image = x;
 
-		float peak_nits;
-		if (vips_foreign_save_uhdr_peak_nits(image, &peak_nits)) {
+		double peak_y;
+		if (vips_percent_lum(image, 99.0, &peak_y,
+				"max", 10000.0 / 80.0, NULL)) {
 			VIPS_UNREF(image);
 			return -1;
 		}
+		float peak_nits = VIPS_CLIP(203.0, peak_y * 80.0, 10000.0);
 
 		/* Rescale from scRGB (1.0 = 80 nits) to libuhdr's UHDR_CT_LINEAR
 		 * convention (1.0 = 203 nits, the ITU-R BT.2408 reference white).

--- a/libvips/histogram/histogram.c
+++ b/libvips/histogram/histogram.c
@@ -224,6 +224,7 @@ vips_histogram_operation_init(void)
 	extern GType vips_maplut_get_type(void);
 	extern GType vips_case_get_type(void);
 	extern GType vips_percent_get_type(void);
+	extern GType vips_percent_lum_get_type(void);
 	extern GType vips_hist_cum_get_type(void);
 	extern GType vips_hist_norm_get_type(void);
 	extern GType vips_hist_equal_get_type(void);
@@ -237,6 +238,7 @@ vips_histogram_operation_init(void)
 	vips_maplut_get_type();
 	vips_case_get_type();
 	vips_percent_get_type();
+	vips_percent_lum_get_type();
 	vips_stdif_get_type();
 	vips_hist_cum_get_type();
 	vips_hist_norm_get_type();

--- a/libvips/histogram/meson.build
+++ b/libvips/histogram/meson.build
@@ -10,6 +10,7 @@ histogram_sources = files(
     'hist_match.c',
     'hist_local.c',
     'percent.c',
+    'percent_lum.c',
     'hist_ismonotonic.c',
     'hist_entropy.c',
     'stdif.c',

--- a/libvips/histogram/percent_lum.c
+++ b/libvips/histogram/percent_lum.c
@@ -1,0 +1,239 @@
+/* find the value at a given percentile of an image's BT.709 luminance
+ */
+
+/*
+
+	This file is part of VIPS.
+
+	VIPS is free software; you can redistribute it and/or modify
+	it under the terms of the GNU Lesser General Public License as published by
+	the Free Software Foundation; either version 2 of the License, or
+	(at your option) any later version.
+
+	This program is distributed in the hope that it will be useful,
+	but WITHOUT ANY WARRANTY; without even the implied warranty of
+	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+	GNU Lesser General Public License for more details.
+
+	You should have received a copy of the GNU Lesser General Public License
+	along with this program; if not, write to the Free Software
+	Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+	02110-1301  USA
+
+ */
+
+#ifdef HAVE_CONFIG_H
+#include <config.h>
+#endif /*HAVE_CONFIG_H*/
+#include <glib/gi18n-lib.h>
+
+#include <stdio.h>
+#include <string.h>
+
+#include <vips/vips.h>
+
+/* 1024 bins is enough to be +/- a few nits of the true value.
+ */
+#define PERCENT_LUM_BINS 1024
+
+typedef struct _VipsPercentLum {
+	VipsOperation parent_instance;
+
+	VipsImage *in;
+	double percent;
+	double max;
+	double threshold;
+
+} VipsPercentLum;
+
+typedef VipsOperationClass VipsPercentLumClass;
+
+G_DEFINE_TYPE(VipsPercentLum, vips_percent_lum, VIPS_TYPE_OPERATION);
+
+typedef struct _PercentLumAccum {
+	guint64 bins[PERCENT_LUM_BINS];
+	guint64 count;
+	float bin_scale;
+} PercentLumAccum;
+
+static void *
+vips_percent_lum_start(VipsImage *image, void *a, void *b)
+{
+	return g_new0(PercentLumAccum, 1);
+}
+
+static int
+vips_percent_lum_scan(VipsRegion *region, void *seq,
+	void *a, void *b, gboolean *stop)
+{
+	PercentLumAccum *accum = (PercentLumAccum *) seq;
+	PercentLumAccum *master = (PercentLumAccum *) a;
+	VipsRect *r = &region->valid;
+	const int bands = region->im->Bands;
+	const float scale = master->bin_scale;
+
+	for (int y = 0; y < r->height; y++) {
+		float *p = (float *)
+			VIPS_REGION_ADDR(region, r->left, r->top + y);
+
+		for (int x = 0; x < r->width; x++) {
+			float Y = 0.2126f * p[0] + 0.7152f * p[1] + 0.0722f * p[2];
+			int bin = (int) (Y * scale);
+			bin = VIPS_CLIP(0, bin, PERCENT_LUM_BINS - 1);
+			accum->bins[bin]++;
+			p += bands;
+		}
+
+		accum->count += r->width;
+	}
+
+	return 0;
+}
+
+static int
+vips_percent_lum_stop(void *seq, void *a, void *b)
+{
+	PercentLumAccum *thread = (PercentLumAccum *) seq;
+	PercentLumAccum *total = (PercentLumAccum *) a;
+
+	for (int i = 0; i < PERCENT_LUM_BINS; i++)
+		total->bins[i] += thread->bins[i];
+	total->count += thread->count;
+
+	g_free(thread);
+	return 0;
+}
+
+static int
+vips_percent_lum_build(VipsObject *object)
+{
+	VipsPercentLum *pl = (VipsPercentLum *) object;
+	PercentLumAccum accum = { { 0 }, 0, 0.0f };
+
+	if (VIPS_OBJECT_CLASS(vips_percent_lum_parent_class)->build(object))
+		return -1;
+
+	if (vips_check_uncoded(object->nickname, pl->in) ||
+		vips_check_format(object->nickname, pl->in, VIPS_FORMAT_FLOAT) ||
+		vips_check_bands_atleast(object->nickname, pl->in, 3))
+		return -1;
+
+	if (vips_image_pio_input(pl->in))
+		return -1;
+
+	accum.bin_scale = (float) (PERCENT_LUM_BINS / pl->max);
+
+	if (vips_sink(pl->in,
+			vips_percent_lum_start,
+			vips_percent_lum_scan,
+			vips_percent_lum_stop,
+			&accum, NULL))
+		return -1;
+
+	if (accum.count == 0) {
+		g_object_set(object, "threshold", 0.0, NULL);
+		return 0;
+	}
+
+	guint64 target = (guint64) (accum.count * (pl->percent / 100.0));
+	guint64 cumul = 0;
+	int bin;
+	for (bin = 0; bin < PERCENT_LUM_BINS; bin++) {
+		cumul += accum.bins[bin];
+		if (cumul >= target)
+			break;
+	}
+
+	double threshold = (bin + 0.5) * (pl->max / PERCENT_LUM_BINS);
+
+	g_object_set(object, "threshold", threshold, NULL);
+
+	return 0;
+}
+
+static void
+vips_percent_lum_class_init(VipsPercentLumClass *class)
+{
+	GObjectClass *gobject_class = G_OBJECT_CLASS(class);
+	VipsObjectClass *object_class = (VipsObjectClass *) class;
+
+	gobject_class->set_property = vips_object_set_property;
+	gobject_class->get_property = vips_object_get_property;
+
+	object_class->nickname = "percent_lum";
+	object_class->description =
+		_("find threshold for percent of pixels by BT.709 luminance");
+	object_class->build = vips_percent_lum_build;
+
+	VIPS_ARG_IMAGE(class, "in", 1,
+		_("Input"),
+		_("Input linear-light RGB float image"),
+		VIPS_ARGUMENT_REQUIRED_INPUT,
+		G_STRUCT_OFFSET(VipsPercentLum, in));
+
+	VIPS_ARG_DOUBLE(class, "percent", 2,
+		_("Percent"),
+		_("Percentile (0-100) of luminance to return"),
+		VIPS_ARGUMENT_REQUIRED_INPUT,
+		G_STRUCT_OFFSET(VipsPercentLum, percent),
+		0.0, 100.0, 99.0);
+
+	VIPS_ARG_DOUBLE(class, "threshold", 3,
+		_("Threshold"),
+		_("Luminance value at the requested percentile in input unit"),
+		VIPS_ARGUMENT_REQUIRED_OUTPUT,
+		G_STRUCT_OFFSET(VipsPercentLum, threshold),
+		-1e9, 1e9, 0.0);
+
+	VIPS_ARG_DOUBLE(class, "max", 4,
+		_("Max"),
+		_("Histogram upper bound in input unit; values above clamp to the top bin"),
+		VIPS_ARGUMENT_OPTIONAL_INPUT,
+		G_STRUCT_OFFSET(VipsPercentLum, max),
+		1e-9, 1e9, 125.0);
+}
+
+static void
+vips_percent_lum_init(VipsPercentLum *pl)
+{
+	pl->percent = 99.0;
+	pl->max = 125.0;
+}
+
+/**
+ * vips_percent_lum: (method)
+ * @in: input linear-light RGB float image
+ * @percent: percentile (0-100) of luminance to return
+ * @threshold: (out): luminance value at the percentile, in input unit
+ * @...: `NULL`-terminated list of optional named arguments
+ *
+ * Optional arguments:
+ *
+ * * @max: histogram upper bound in input unit (default 125.0)
+ *
+ * Computes BT.709 luminance over @in, builds a luminance histogram,
+ * and returns the value at the requested percentile in @threshold.
+ *
+ * The histogram is in the same unit as the input and covers `[0, max]`.
+ * For example, multiply by 80 to get nits for an scRGB (1.0 = 80 nits) input.
+ *
+ * The input must be a 3-band (or more) float image. Extra bands beyond
+ * the first three are ignored.
+ *
+ * ::: seealso
+ *     [method@Image.percent].
+ *
+ * Returns: 0 on success, -1 on error
+ */
+int
+vips_percent_lum(VipsImage *in, double percent, double *threshold, ...)
+{
+	va_list ap;
+	int result;
+
+	va_start(ap, threshold);
+	result = vips_call_split("percent_lum", ap, in, percent, threshold);
+	va_end(ap);
+
+	return result;
+}

--- a/libvips/include/vips/histogram.h
+++ b/libvips/include/vips/histogram.h
@@ -45,6 +45,9 @@ VIPS_API
 int vips_percent(VipsImage *in, double percent, int *threshold, ...)
 	G_GNUC_NULL_TERMINATED;
 VIPS_API
+int vips_percent_lum(VipsImage *in, double percent, double *threshold, ...)
+	G_GNUC_NULL_TERMINATED;
+VIPS_API
 int vips_stdif(VipsImage *in, VipsImage **out, int width, int height, ...)
 	G_GNUC_NULL_TERMINATED;
 VIPS_API

--- a/test/test-suite/test_cicp.py
+++ b/test/test-suite/test_cicp.py
@@ -399,6 +399,32 @@ class TestCICP:
         assert out.get("cicp-transfer-characteristics") == TRANSFER_PQ
         assert out.get("cicp-colour-primaries") == PRIMARIES_BT2020
 
+    # -- Ultra HDR regression tests --
+
+    @skip_if_no("uhdrsave")
+    def test_uhdr_hdr_capacity_max(self):
+        im = make_cicp_image(128, 128, 128,
+                             primaries=PRIMARIES_BT2020,
+                             transfer=TRANSFER_PQ)
+        im = im.embed(0, 0, 64, 64, extend="copy")
+        buf = im.jpegsave_buffer()
+
+        out = pyvips.Image.new_from_buffer(buf, "")
+        hdr_cap = out.get("gainmap-hdr-capacity-max")
+        assert hdr_cap < 5.0, \
+            f"hdr_capacity_max {hdr_cap:.2f} too high for ~94 nit content"
+
+    @skip_if_no("uhdrsave")
+    def test_uhdr_sdr_content_low_capacity(self):
+        im = (pyvips.Image.black(64, 64, bands=3) + [1.0, 1.0, 1.0]) \
+            .copy(interpretation="scrgb").cast("float")
+        buf = im.jpegsave_buffer()
+
+        out = pyvips.Image.new_from_buffer(buf, "")
+        hdr_cap = out.get("gainmap-hdr-capacity-max")
+        assert hdr_cap < 2.0, \
+            f"hdr_capacity_max {hdr_cap:.2f} too high for 80-nit content"
+
     # -- PNG regression tests --
 
     @skip_if_no("pngsave")

--- a/test/test-suite/test_cicp.py
+++ b/test/test-suite/test_cicp.py
@@ -399,32 +399,6 @@ class TestCICP:
         assert out.get("cicp-transfer-characteristics") == TRANSFER_PQ
         assert out.get("cicp-colour-primaries") == PRIMARIES_BT2020
 
-    # -- Ultra HDR regression tests --
-
-    @skip_if_no("uhdrsave")
-    def test_uhdr_hdr_capacity_max(self):
-        im = make_cicp_image(128, 128, 128,
-                             primaries=PRIMARIES_BT2020,
-                             transfer=TRANSFER_PQ)
-        im = im.embed(0, 0, 64, 64, extend="copy")
-        buf = im.jpegsave_buffer()
-
-        out = pyvips.Image.new_from_buffer(buf, "")
-        hdr_cap = out.get("gainmap-hdr-capacity-max")
-        assert hdr_cap < 5.0, \
-            f"hdr_capacity_max {hdr_cap:.2f} too high for ~94 nit content"
-
-    @skip_if_no("uhdrsave")
-    def test_uhdr_sdr_content_low_capacity(self):
-        im = (pyvips.Image.black(64, 64, bands=3) + [1.0, 1.0, 1.0]) \
-            .copy(interpretation="scrgb").cast("float")
-        buf = im.jpegsave_buffer()
-
-        out = pyvips.Image.new_from_buffer(buf, "")
-        hdr_cap = out.get("gainmap-hdr-capacity-max")
-        assert hdr_cap < 2.0, \
-            f"hdr_capacity_max {hdr_cap:.2f} too high for 80-nit content"
-
     # -- PNG regression tests --
 
     @skip_if_no("pngsave")

--- a/test/test-suite/test_foreign.py
+++ b/test/test-suite/test_foreign.py
@@ -471,7 +471,7 @@ class TestForeign:
         im_hdr2 = pyvips.Image.uhdrload_buffer(data).uhdr2scRGB()
         im_hdr = pyvips.Image.uhdrload(UHDR_FILE).uhdr2scRGB()
 
-        assert (im_hdr2 - im_hdr).abs().avg() < 0.05
+        assert (im_hdr2 - im_hdr).abs().avg() < 0.02
 
     @skip_if_no("uhdrsave")
     def test_uhdrsave_roundtrip_hdr(self):
@@ -479,7 +479,7 @@ class TestForeign:
         data = im.uhdrsave_buffer()
         im2 = pyvips.Image.uhdrload_buffer(data).uhdr2scRGB()
 
-        assert (im2 - im).abs().avg() < 0.1
+        assert (im2 - im).abs().avg() < 0.05
 
     @skip_if_no("uhdrsave")
     def test_uhdrsave_gainmap_scale_factor(self):

--- a/test/test-suite/test_foreign.py
+++ b/test/test-suite/test_foreign.py
@@ -471,7 +471,7 @@ class TestForeign:
         im_hdr2 = pyvips.Image.uhdrload_buffer(data).uhdr2scRGB()
         im_hdr = pyvips.Image.uhdrload(UHDR_FILE).uhdr2scRGB()
 
-        assert (im_hdr2 - im_hdr).abs().avg() < 0.02
+        assert (im_hdr2 - im_hdr).abs().avg() < 0.05
 
     @skip_if_no("uhdrsave")
     def test_uhdrsave_roundtrip_hdr(self):
@@ -479,7 +479,7 @@ class TestForeign:
         data = im.uhdrsave_buffer()
         im2 = pyvips.Image.uhdrload_buffer(data).uhdr2scRGB()
 
-        assert (im2 - im).abs().avg() < 0.05
+        assert (im2 - im).abs().avg() < 0.1
 
     @skip_if_no("uhdrsave")
     def test_uhdrsave_gainmap_scale_factor(self):


### PR DESCRIPTION
### Description

libultrahdr uses a different scaling convention from scRGB (1.0 = 203 nits rather than 1.0 = 80 nits). This PR rescales to and from 203 nits for more accurate luminance.

Additionally, libultrahdr assumes a peak of 10000 nits by default. Setting the peak to the 99th percentile luminance produces more accurate gain.

This was initially in #4928 but split out to keep the scope of changes smaller.

Resolves [this](https://github.com/libvips/libvips/pull/4954#issuecomment-4218024992) comment