### PR TITLE
stdif: verify window dimensions are smaller than image

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -5,6 +5,7 @@ tbd 8.18.3
 - edge: ensure parent object is built [lovell]
 - object: guard against invalid interpolators [kleisauke]
 - foreign: guard against NULL filenames [kleisauke]
+- stdif: verify window dimensions are smaller than image [lovell]
 
 31/3/26 8.18.2
 

--- a/libvips/histogram/stdif.c
+++ b/libvips/histogram/stdif.c
@@ -99,7 +99,7 @@ vips_stdif_generate(VipsRegion *out_region,
 	VipsImage *in = (VipsImage *) a;
 	VipsStdif *stdif = (VipsStdif *) b;
 	int bands = in->Bands;
-	int npel = stdif->width * stdif->width;
+	int npel = stdif->width * stdif->height;
 
 	VipsRect irect;
 	int y;
@@ -231,8 +231,8 @@ vips_stdif_build(VipsObject *object)
 	if (vips_check_format(class->nickname, in, VIPS_FORMAT_UCHAR))
 		return -1;
 
-	if (stdif->width > in->Xsize ||
-		stdif->height > in->Ysize) {
+	if (stdif->width >= in->Xsize ||
+		stdif->height >= in->Ysize) {
 		vips_error(class->nickname, "%s", _("window too large"));
 		return -1;
 	}


### PR DESCRIPTION
Fixes https://issues.oss-fuzz.com/issues/503995698

Also fixes pixel count calculation for non-square windows (spotted whilst investigating).