### PR TITLE
Ensure scanlines fit in INT_MAX

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -7,6 +7,7 @@ tbd 8.18.3
 - foreign: guard against NULL filenames [kleisauke]
 - stdif: verify window dimensions are smaller than image [lovell]
 - dcrawload: add support for non-square pixels [jcupitt]
+- image_sanity: ensure scanlines fit in INT_MAX [Niels Provos]
 
 31/3/26 8.18.2
 

--- a/libvips/iofuncs/image.c
+++ b/libvips/iofuncs/image.c
@@ -693,6 +693,11 @@ vips_image_sanity(VipsObject *object, VipsBuf *buf)
 			sizeof_image > G_MAXSIZE - 16))
 		vips_buf_appends(buf, "dimension overflow\n");
 
+	/* And a scanline has to fit in INT_MAX.
+	 */
+	if (ls >= INT_MAX)
+		vips_buf_appends(buf, "dimension overflow\n");
+
 	/* These checks are expensive -- only do in leakcheck mode.
 	 */
 	if (vips__leak) {


### PR DESCRIPTION
Extend image sanity checks to ensure scanlines fit in INT_MAX.

Thanks Niels Provos.