### PR TITLE
pdfload_buffer: only search first 32 bytes

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -21,6 +21,7 @@ date-tbd 8.19.0
   [Starbix] [mertalev]
 - uhdrsave: add existing JPEG options for base image [lovell]
 - csvload: add maximum limit on column count [lovell]
+- pdfload_buffer: only search the first few bytes in is_a [violetviolinist]
 
 tbd 8.18.3
 

--- a/libvips/foreign/magick.c
+++ b/libvips/foreign/magick.c
@@ -362,7 +362,7 @@ magick_ismagick(const unsigned char *bytes, size_t length)
 	 */
 	return !magick_block(bytes, length) &&
 		(magick_sniff(bytes, length) ||
-		GetImageMagick(bytes, length, format));
+		 GetImageMagick(bytes, length, format));
 }
 
 int

--- a/libvips/foreign/pdf.c
+++ b/libvips/foreign/pdf.c
@@ -51,21 +51,6 @@ const char *vips__pdf_suffs[] = {
 	NULL
 };
 
-gboolean
-vips__pdf_is_a_buffer(const void *buf, size_t len)
-{
-	const char *str = (const char *) buf;
-
-	if (len < 4)
-		return FALSE;
-
-	for (size_t i = 0; i < len - 4; i++)
-		if (vips_isprefix("%PDF", str + i))
-			return TRUE;
-
-	return FALSE;
-}
-
 /* PDF v2 allows for offset headers, ie. there may be any number of
  * characters of padding before the "%PDF" file marker. These can be
  * arbitrary printer control characters, whitespace, etc.
@@ -73,10 +58,23 @@ vips__pdf_is_a_buffer(const void *buf, size_t len)
  * In practice, the amount of padding is usually small (less than 32
  * bytes).
  *
- * Another strategy is to look for "%EOF" in the final 1k of the file, but of
- * course that won't work well for streamed data.
+ * Another strategy would be to look for "%EOF" in the final 1k of the file,
+ * but of course that wouldn't work for streamed data.
  */
 #define MAX_OFFSET (32)
+
+gboolean
+vips__pdf_is_a_buffer(const void *buf, size_t len)
+{
+	const char *str = (const char *) buf;
+
+	if (len >= 4)
+		for (size_t i = 0; i < VIPS_MIN(MAX_OFFSET, len - 4); i++)
+			if (vips_isprefix("%PDF", str + i))
+				return TRUE;
+
+	return FALSE;
+}
 
 gboolean
 vips__pdf_is_a_file(const char *filename)

--- a/libvips/histogram/percent.c
+++ b/libvips/histogram/percent.c
@@ -138,8 +138,8 @@ vips_percent_init(VipsPercent *percent)
  * @threshold: (out): output threshold value
  * @...: `NULL`-terminated list of optional named arguments
  *
- * [method@Image.percent] returns (through the @threshold parameter) the threshold
- * below which there are @percent values of @in. For example:
+ * [method@Image.percent] returns (through the @threshold parameter) the
+ * threshold below which there are @percent values of @in. For example:
  *
  * ```bash
  * $ vips percent k2.jpg 90


### PR DESCRIPTION
The `is_a` detector for pdf buffer load was being passed and then searching the whole input buffer for the `%PDF` marker. This could lead to binary files being incorrectly recognised as PDF.

Closes: https://github.com/libvips/libvips/issues/4885

Thanks @violetviolinist