### PR TITLE
use uint32 for boolean_const

### DIFF
--- a/libvips/arithmetic/boolean.c
+++ b/libvips/arithmetic/boolean.c
@@ -499,7 +499,7 @@ vips_boolean_const_build(VipsObject *object)
 \
 		for (i = 0, x = 0; x < width; x++) \
 			for (b = 0; b < bands; b++, i++) \
-				q[i] = p[i] OP c[b]; \
+				q[i] = ((unsigned int) p[i]) OP c[b]; \
 	}
 
 #define FLOOPC(TYPE, OP) \
@@ -510,7 +510,7 @@ vips_boolean_const_build(VipsObject *object)
 \
 		for (i = 0, x = 0; x < width; x++) \
 			for (b = 0; b < bands; b++, i++) \
-				q[i] = ((int) p[i]) OP((int) c[b]); \
+				q[i] = ((unsigned int) p[i]) OP c[b]; \
 	}
 
 static void


### PR DESCRIPTION
Non-functional change. Use uint32 for all boolean const operations. It makes no difference, but reduces any potential confusion about sign preservation for rshift, and reduces the number of cases UBsan warns about.

See: https://github.com/libvips/libvips/issues/4960