### PR TITLE
Fix `-Wmaybe-uninitialized` warnings

### DIFF
--- a/libvips/conversion/bandjoin.c
+++ b/libvips/conversion/bandjoin.c
@@ -387,13 +387,11 @@ vips_bandjoin_const_build(VipsObject *object)
 	VipsBandary *bandary = (VipsBandary *) object;
 	VipsBandjoinConst *bandjoin = (VipsBandjoinConst *) object;
 
-	double *c;
-	int n;
-
 	if (bandjoin->c &&
 		bandjoin->in) {
-		c = vips_array_double_get(bandjoin->c, &n);
+		int n;
 
+		(void) vips_array_double_get(bandjoin->c, &n);
 		if (n == 0)
 			return vips_bandary_copy(bandary);
 		else {
@@ -410,9 +408,11 @@ vips_bandjoin_const_build(VipsObject *object)
 	if (VIPS_OBJECT_CLASS(vips_bandjoin_const_parent_class)->build(object))
 		return -1;
 
+	int n;
+	double *c = vips_array_double_get(bandjoin->c, &n);
 	if (!(bandjoin->c_ready = vips__vector_to_pels(class->nickname,
-			  n, bandary->ready[0]->BandFmt, bandary->ready[0]->Coding,
-			  c, NULL, n)))
+			n, bandary->ready[0]->BandFmt, bandary->ready[0]->Coding,
+			c, NULL, n)))
 		return -1;
 
 	return 0;

--- a/libvips/iofuncs/image.c
+++ b/libvips/iofuncs/image.c
@@ -683,19 +683,17 @@ vips_image_sanity(VipsObject *object, VipsBuf *buf)
 	 * whether the VIPS_IMAGE_SIZEOF_PEL(), VIPS_IMAGE_SIZEOF_LINE()
 	 * and VIPS_IMAGE_SIZEOF_IMAGE() macros can be safely used.
 	 *
+	 * A scanline (i.e. `es * bands * width`) has to fit in INT_MAX.
+	 *
 	 * Also ensure that vips_tracked_malloc(VIPS_IMAGE_SIZEOF_IMAGE(image))
 	 * can be called safely for setbuf types.
 	 */
 	if (!g_uint64_checked_mul(&ps, es, image->Bands) ||
 		!g_uint64_checked_mul(&ls, ps, image->Xsize) ||
+		ls >= INT_MAX ||
 		!g_uint64_checked_mul(&sizeof_image, ls, image->Ysize) ||
 		(image->dtype == VIPS_IMAGE_SETBUF &&
 			sizeof_image > G_MAXSIZE - 16))
-		vips_buf_appends(buf, "dimension overflow\n");
-
-	/* And a scanline has to fit in INT_MAX.
-	 */
-	if (ls >= INT_MAX)
 		vips_buf_appends(buf, "dimension overflow\n");
 
 	/* These checks are expensive -- only do in leakcheck mode.


### PR DESCRIPTION
Trivial backport of 883ca43c430b70bd527dd8047cf7edea2ad091eb to [`8.18`](https://github.com/libvips/libvips/tree/8.18), along with a fix for a compiler warning introduced in c72f50927413cd2451837d9813f954bc5d88f548.

```console
[1/42] Compiling C object libvips/conversion/libconversion.a.p/bandjoin.c.o
../libvips/conversion/bandjoin.c: In function ‘vips_bandjoin_const_build’:
../libvips/conversion/bandjoin.c:413:35: warning: ‘c’ may be used uninitialized [-Wmaybe-uninitialized]
  413 |         if (!(bandjoin->c_ready = vips__vector_to_pels(class->nickname,
      |                                   ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
  414 |                           n, bandary->ready[0]->BandFmt, bandary->ready[0]->Coding,
      |                           ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
  415 |                           c, NULL, n)))
      |                           ~~~~~~~~~~~
../libvips/conversion/bandjoin.c:390:17: note: ‘c’ was declared here
  390 |         double *c;
      |                 ^
[2/42] Compiling C object libvips/iofuncs/libiofuncs.a.p/image.c.o
../libvips/iofuncs/image.c: In function ‘vips_image_sanity’:
../libvips/iofuncs/image.c:698:12: warning: ‘ls’ may be used uninitialized [-Wmaybe-uninitialized]
  698 |         if (ls >= INT_MAX)
      |            ^
../libvips/iofuncs/image.c:660:25: note: ‘ls’ was declared here
  660 |         guint64 es, ps, ls, sizeof_image;
      |                         ^~
```

Note: rebase merge, don't squash.