### PR TITLE
Fix OOB read in jp2ksave

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -10,6 +10,7 @@ tbd 8.18.3
 - image_sanity: ensure scanlines fit in INT_MAX [Niels Provos]
 - rank: expand input by one column [kleisauke]
 - hist_local: expand input by one column [kleisauke]
+- jp2ksave: fix OOB read during chroma subsampling [dloebl]
 
 31/3/26 8.18.2
 

--- a/libvips/foreign/jp2ksave.c
+++ b/libvips/foreign/jp2ksave.c
@@ -306,7 +306,8 @@ vips_foreign_save_jp2k_rgb_to_ycc(VipsRegion *region,
 	{ \
 		ACC_TYPE *acc = (ACC_TYPE *) accumulate; \
 		OUTPUT_TYPE *tq = (OUTPUT_TYPE *) q; \
-		const int n_pels = comp->dx * comp->dy; \
+		const int dy = VIPS_MIN(comp->dy, \
+			tile->height - y * comp->dy); \
 \
 		PIXEL_TYPE *tp; \
 		ACC_TYPE *ap; \
@@ -317,7 +318,7 @@ vips_foreign_save_jp2k_rgb_to_ycc(VipsRegion *region,
 			tp += n_bands; \
 		} \
 \
-		for (z = 1; z < comp->dy; z++) { \
+		for (z = 1; z < dy; z++) { \
 			tp = (PIXEL_TYPE *) (p + z * lskip); \
 			for (x = 0; x < tile->width; x++) { \
 				acc[x] += *tp; \
@@ -327,10 +328,13 @@ vips_foreign_save_jp2k_rgb_to_ycc(VipsRegion *region,
 \
 		ap = acc; \
 		for (x = 0; x < output_width; x++) { \
+			const int dx = VIPS_MIN(comp->dx, \
+				tile->width - x * comp->dx); \
+			const int n_pels = dx * dy; \
 			ACC_TYPE sum; \
 \
 			sum = 0; \
-			for (z = 0; z < comp->dx; z++) \
+			for (z = 0; z < dx; z++) \
 				sum += ap[z]; \
 \
 			tq[x] = (sum + n_pels / 2) / n_pels; \

--- a/test/test-suite/test_foreign.py
+++ b/test/test-suite/test_foreign.py
@@ -1919,6 +1919,11 @@ class TestForeign:
         b2 = self.colour.jp2ksave_buffer(subsample_mode="off")
         assert len(b2) > len(b1)
 
+        # regression test for OOB read with odd dimensions and chroma
+        # subsampling, see https://github.com/libvips/libvips/pull/5020
+        im = pyvips.Image.black(22, 3, bands=3)
+        im.jp2ksave_buffer(subsample_mode="on")
+
         # enabling lossless should mean a bigger buffer
         b1 = self.colour.jp2ksave_buffer(lossless=False)
         b2 = self.colour.jp2ksave_buffer(lossless=True)


### PR DESCRIPTION
Noticed while fuzzing with #5003 locally, there is a small OOB read in `jp2ksave`:
```
./build-asan/tools/vips black test.png 22 3 --bands 3
./build-asan/tools/vips jp2ksave test.png out.jp2 --subsample-mode on
```

```
==44563==ERROR: AddressSanitizer: heap-buffer-overflow on address 0x61700000069a at pc 0x000103c8e0a8 bp 0x00016d459990 sp 0x00016d459988
READ of size 1 at 0x61700000069a thread T6
    #0 0x000103c8e0a4 in vips_foreign_save_jp2k_unpack_subsample jp2ksave.c:379
    #1 0x000103c8c9a4 in vips_foreign_save_jp2k_write_tiles jp2ksave.c:517
    #2 0x000103c8bbc0 in vips_foreign_save_jp2k_write_block jp2ksave.c:577
    #3 0x000104109cc8 in wbuffer_write sinkdisc.c:186
    #4 0x000104109af0 in wbuffer_write_thread sinkdisc.c:211
    #5 0x0001040a8258 in vips_threadset_work threadset.c:187
    #6 0x0001040a5cb0 in vips_thread_run thread.c:112
    #7 0x000102ea18dc in g_thread_proxy+0x50 (libglib-2.0.0.dylib:arm64+0x558dc)
    #8 0x000104941d64 in asan_thread_start(void*)+0x4c (libclang_rt.asan_osx_dynamic.dylib:arm64e+0x3dd64)
    #9 0x000198b0fc04 in _pthread_start+0x84 (libsystem_pthread.dylib:arm64e+0x6c04)
    #10 0x000198b0aba4 in thread_start+0x4 (libsystem_pthread.dylib:arm64e+0x1ba4)
```

Subsampling should clamp each block to the remaining pixels, otherwise the final row/column can try to read a full `comp->dy`/`comp->dx` block past the image bounds.
libvips isn't built with JPEG2000 support in OSS Fuzz, so this wasn't found yet.