### PR TITLE
fuzz: prefer use of `__*_default_suppressions` hooks

### DIFF
--- a/fuzz/config.h
+++ b/fuzz/config.h
@@ -1,30 +1,52 @@
 #pragma once
 
-#include <unistd.h>
-
-/* Only supported since clang >= 14.0.
- */
-#if __has_attribute(disable_sanitizer_instrumentation)
-#define DISABLE_SANITIZER_INSTRUMENTATION \
-	__attribute__((disable_sanitizer_instrumentation))
-#else
-#define DISABLE_SANITIZER_INSTRUMENTATION
+// `#embed` requires C23 support. However, this file is only included when
+// building with `-Dfuzz=true`, so it ought to be safe.
+#ifdef __clang__
+#pragma clang diagnostic ignored "-Wc23-extensions"
 #endif
 
-#define DEFINE_SANITIZER_OPTS(FN, SUPP_FILE, ...) \
-	extern "C" const char * \
-	FN() DISABLE_SANITIZER_INSTRUMENTATION \
-	{ \
-		return access(SUPP_FILE, R_OK) == 0 \
-			? "suppressions=" SUPP_FILE __VA_ARGS__ \
-			: "" __VA_ARGS__; \
-	}
+extern "C" const char *
+__asan_default_suppressions()
+{
+	static const char asan_suppressions[] = {
+#embed "../suppressions/asan.supp"
+		, 0 // ensure null-terminated string
+	};
 
-#ifndef SUPPRESSIONS_DIR
-#define SUPPRESSIONS_DIR "./suppressions"
-#endif
+	return asan_suppressions;
+}
 
-DEFINE_SANITIZER_OPTS(__asan_default_options, SUPPRESSIONS_DIR "/asan.supp")
-DEFINE_SANITIZER_OPTS(__lsan_default_options, SUPPRESSIONS_DIR "/lsan.supp")
-DEFINE_SANITIZER_OPTS(__tsan_default_options, SUPPRESSIONS_DIR "/tsan.supp")
-DEFINE_SANITIZER_OPTS(__ubsan_default_options, SUPPRESSIONS_DIR "/ubsan.supp")
+extern "C" const char *
+__lsan_default_suppressions()
+{
+	static const char lsan_suppressions[] = {
+#embed "../suppressions/lsan.supp"
+		, 0
+	};
+
+	return lsan_suppressions;
+}
+
+extern "C" const char *
+__tsan_default_suppressions()
+{
+	static const char tsan_suppressions[] = {
+#embed "../suppressions/tsan.supp"
+		, 0
+	};
+
+	return tsan_suppressions;
+}
+
+// Requires https://github.com/llvm/llvm-project/pull/194862
+extern "C" const char *
+__ubsan_default_suppressions()
+{
+	static const char ubsan_suppressions[] = {
+#embed "../suppressions/ubsan.supp"
+		, 0
+	};
+
+	return ubsan_suppressions;
+}

--- a/fuzz/oss_fuzz_build.sh
+++ b/fuzz/oss_fuzz_build.sh
@@ -291,6 +291,3 @@ rm -v $OUT/generate_vips_dict
 # Copy options and remaining dictionary files to $OUT
 find fuzz -name '*_fuzzer.dict' -exec cp -v '{}' $OUT \;
 find fuzz -name '*_fuzzer.options' -exec cp -v '{}' $OUT \;
-
-# Copy sanitizer suppressions to $OUT
-cp -vr suppressions/ $OUT

--- a/fuzz/oss_fuzz_build.sh
+++ b/fuzz/oss_fuzz_build.sh
@@ -236,14 +236,17 @@ popd
 
 if [ "$SANITIZER" = "undefined" ]; then
   # Allow UBSan shift errors to be recoverable to ensure our suppression rules
-  # apply. OSS-Fuzz uses `-fno-sanitize-recover=shift` by default.
-  export CFLAGS+=" -fsanitize-recover=shift"
-  export CXXFLAGS+=" -fsanitize-recover=shift"
+  # are enforced. OSS-Fuzz uses `-fno-sanitize-recover=shift` by default.
+  #export CFLAGS+=" -fsanitize-recover=shift"
+  #export CXXFLAGS+=" -fsanitize-recover=shift"
+  # FIXME: Once PR https://github.com/llvm/llvm-project/pull/194862 is merged
+  # and available in OSS-Fuzz we can re-enable the above flags instead.
+  export CFLAGS+=" -fsanitize-ignorelist=$PWD/suppressions/ubsan_ignorelist.txt"
+  export CXXFLAGS+=" -fsanitize-ignorelist=$PWD/suppressions/ubsan_ignorelist.txt"
 fi
 
 # libvips
 # Disable building man pages, gettext po files, tools, and tests
-export CPPFLAGS+=" -DSUPPRESSIONS_DIR='\"$OUT/suppressions\"'"
 meson setup build --prefix=$WORK --libdir=lib --prefer-static --default-library=static --buildtype=debug \
   -Dbackend_max_links=4 -Dexamples=false -Dman=false -Dpo=false \
   -Dtests=false -Dtools=false -Dcplusplus=false -Dmodules=disabled -Dfuzz=true \

--- a/suppressions/ubsan_ignorelist.txt
+++ b/suppressions/ubsan_ignorelist.txt
@@ -1,0 +1,10 @@
+# Ignorelist for UndefinedBehaviorSanitizer. Turns off instrumentation of
+# particular functions or sources. Use with care. You may set location of
+# ignorelist at compile-time using `-fsanitize-ignorelist=<path>` flag.
+
+# Example usage:
+# fun:*bad_function_name*
+# src:file_with_tricky_code.cc
+
+# https://github.com/libvips/libvips/issues/4960
+src:*libvips/arithmetic/boolean.c


### PR DESCRIPTION
Works with ASan, LSan and TSan. Support for UBSan depends on:
llvm/llvm-project#194862

Context: while commit 87cd335c0024bf158b08f5717567f46af388e29b works locally and when reproducing bugs using https://google.github.io/oss-fuzz/advanced-topics/reproducing/#reproducing-bugs, it does not work in ClusterFuzz for some reason.