### PR TITLE
Free sequence structs earlier

### DIFF
--- a/libvips/convolution/conva.c
+++ b/libvips/convolution/conva.c
@@ -794,6 +794,7 @@ vips_conva_stop(void *vseq, void *a, void *b)
 	VipsConvaSeq *seq = (VipsConvaSeq *) vseq;
 
 	VIPS_UNREF(seq->ir);
+	VIPS_FREE(seq);
 
 	return 0;
 }
@@ -808,7 +809,7 @@ vips_conva_start(VipsImage *out, void *a, void *b)
 
 	VipsConvaSeq *seq;
 
-	seq = VIPS_NEW(out, VipsConvaSeq);
+	seq = VIPS_NEW(NULL, VipsConvaSeq);
 	seq->conva = conva;
 	seq->ir = vips_region_new(in);
 

--- a/libvips/convolution/convasep.c
+++ b/libvips/convolution/convasep.c
@@ -359,6 +359,7 @@ vips_convasep_stop(void *vseq, void *a, void *b)
 	VIPS_FREE(seq->start);
 	VIPS_FREE(seq->end);
 	VIPS_FREE(seq->sum);
+	VIPS_FREE(seq);
 
 	return 0;
 }
@@ -373,7 +374,7 @@ vips_convasep_start(VipsImage *out, void *a, void *b)
 
 	VipsConvasepSeq *seq;
 
-	if (!(seq = VIPS_NEW(out, VipsConvasepSeq)))
+	if (!(seq = VIPS_NEW(NULL, VipsConvasepSeq)))
 		return NULL;
 
 	/* Init!

--- a/libvips/convolution/convf.c
+++ b/libvips/convolution/convf.c
@@ -130,6 +130,7 @@ vips_convf_stop(void *vseq, void *a, void *b)
 	VipsConvfSequence *seq = (VipsConvfSequence *) vseq;
 
 	VIPS_UNREF(seq->ir);
+	VIPS_FREE(seq);
 
 	return 0;
 }
@@ -143,7 +144,7 @@ vips_convf_start(VipsImage *out, void *a, void *b)
 	VipsConvf *convf = (VipsConvf *) b;
 	VipsConvfSequence *seq;
 
-	if (!(seq = VIPS_NEW(out, VipsConvfSequence)))
+	if (!(seq = VIPS_NEW(NULL, VipsConvfSequence)))
 		return NULL;
 
 	seq->convf = convf;

--- a/libvips/convolution/convi.c
+++ b/libvips/convolution/convi.c
@@ -249,6 +249,7 @@ vips_convi_stop(void *vseq, void *a, void *b)
 	VIPS_FREE(seq->t1);
 	VIPS_FREE(seq->t2);
 #endif /*HAVE_ORC*/
+	VIPS_FREE(seq);
 
 	return 0;
 }
@@ -262,7 +263,7 @@ vips_convi_start(VipsImage *out, void *a, void *b)
 	VipsConvi *convi = (VipsConvi *) b;
 	VipsConviSequence *seq;
 
-	if (!(seq = VIPS_NEW(out, VipsConviSequence)))
+	if (!(seq = VIPS_NEW(NULL, VipsConviSequence)))
 		return NULL;
 
 	seq->convi = convi;

--- a/libvips/foreign/tiff2vips.c
+++ b/libvips/foreign/tiff2vips.c
@@ -1971,7 +1971,7 @@ rtiff_seq_start(VipsImage *out, void *a, void *b)
 	Rtiff *rtiff = (Rtiff *) a;
 	RtiffSeq *seq;
 
-	if (!(seq = VIPS_NEW(out, RtiffSeq)))
+	if (!(seq = VIPS_NEW(NULL, RtiffSeq)))
 		return NULL;
 	seq->rtiff = rtiff;
 	if (!(seq->buf = vips_malloc(NULL, rtiff->header.tile_size)))
@@ -2575,6 +2575,7 @@ rtiff_seq_stop(void *vseq, void *a, void *b)
 
 	VIPS_FREE(seq->buf);
 	VIPS_FREE(seq->compressed_buf);
+	VIPS_FREE(seq);
 
 	return 0;
 }

--- a/libvips/histogram/maplut.c
+++ b/libvips/histogram/maplut.c
@@ -125,7 +125,7 @@ vips_maplut_start(VipsImage *out, void *a, void *b)
 	VipsImage *in = (VipsImage *) a;
 	VipsMaplutSequence *seq;
 
-	if (!(seq = VIPS_NEW(out, VipsMaplutSequence)))
+	if (!(seq = VIPS_NEW(NULL, VipsMaplutSequence)))
 		return NULL;
 
 	/* Init!
@@ -538,6 +538,7 @@ vips_maplut_stop(void *vseq, void *a, void *b)
 	maplut->overflow += seq->overflow;
 
 	VIPS_UNREF(seq->ir);
+	VIPS_FREE(seq);
 
 	return 0;
 }

--- a/libvips/morphology/morph.c
+++ b/libvips/morphology/morph.c
@@ -192,6 +192,7 @@ vips_morph_stop(void *vseq, void *a, void *b)
 	VIPS_FREE(seq->t1);
 	VIPS_FREE(seq->t2);
 #endif /*HAVE_ORC*/
+	VIPS_FREE(seq);
 
 	return 0;
 }
@@ -206,7 +207,7 @@ vips_morph_start(VipsImage *out, void *a, void *b)
 
 	VipsMorphSequence *seq;
 
-	if (!(seq = VIPS_NEW(out, VipsMorphSequence)))
+	if (!(seq = VIPS_NEW(NULL, VipsMorphSequence)))
 		return NULL;
 
 	/* Init!

--- a/libvips/morphology/rank.c
+++ b/libvips/morphology/rank.c
@@ -119,6 +119,7 @@ vips_rank_stop(void *vseq, void *a, void *b)
 		for (int i = 0; i < in->Bands; i++)
 			VIPS_FREE(seq->hist[i]);
 	VIPS_FREE(seq->hist);
+	VIPS_FREE(seq);
 
 	return 0;
 }
@@ -130,7 +131,7 @@ vips_rank_start(VipsImage *out, void *a, void *b)
 	VipsRank *rank = (VipsRank *) b;
 	VipsRankSequence *seq;
 
-	if (!(seq = VIPS_NEW(out, VipsRankSequence)))
+	if (!(seq = VIPS_NEW(NULL, VipsRankSequence)))
 		return NULL;
 	seq->ir = NULL;
 	seq->sort = NULL;

--- a/libvips/resample/reducev.cpp
+++ b/libvips/resample/reducev.cpp
@@ -186,6 +186,7 @@ vips_reducev_stop(void *vseq, void *a, void *b)
 	VIPS_FREE(seq->t1);
 	VIPS_FREE(seq->t2);
 #endif /*HAVE_ORC*/
+	VIPS_FREE(seq);
 
 	return 0;
 }
@@ -198,7 +199,7 @@ vips_reducev_start(VipsImage *out, void *a, void *b)
 
 	VipsReducevSequence *seq;
 
-	if (!(seq = VIPS_NEW(out, VipsReducevSequence)))
+	if (!(seq = VIPS_NEW(NULL, VipsReducevSequence)))
 		return nullptr;
 
 	/* Init!


### PR DESCRIPTION
Free the sequence structs at the end of eval, not on image dispose. This helps keep memory use down in some long-running operations.

In line with commit 3b2c77dd354720d34d4cba5fe680dfdf27720a0d.

Context: https://github.com/libvips/libvips/pull/5016#discussion_r3174165792.