### PR TITLE
jp2ksave: prevent heap buffer overflow on non-RGB images

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -12,6 +12,7 @@ tbd 8.18.3
 - hist_local: expand input by one column [kleisauke]
 - fix possible null-pointer dereference in quantizr backend [felixbuenemann]
 - jp2ksave: fix OOB read during chroma subsampling [dloebl]
+- jp2ksave: prevent heap buffer overflow on non-RGB images [dloebl]
 
 31/3/26 8.18.2
 

--- a/libvips/foreign/jp2ksave.c
+++ b/libvips/foreign/jp2ksave.c
@@ -852,6 +852,11 @@ vips_foreign_save_jp2k_build(VipsObject *object)
 	if (jp2k->subsample)
 		jp2k->save_as_ycc = TRUE;
 
+	/* Our rgb->ycc only works for exactly 3 bands.
+	 */
+	jp2k->save_as_ycc = jp2k->save_as_ycc && save->ready->Bands == 3;
+	jp2k->subsample = jp2k->subsample && jp2k->save_as_ycc;
+
 	/* Set parameters for compressor.
 	 */
 	opj_set_default_encoder_parameters(&jp2k->parameters);

--- a/libvips/foreign/jp2ksave.c
+++ b/libvips/foreign/jp2ksave.c
@@ -837,7 +837,7 @@ vips_foreign_save_jp2k_build(VipsObject *object)
 		break;
 
 	case VIPS_FOREIGN_SUBSAMPLE_ON:
-		jp2k->subsample = TRUE;
+		jp2k->subsample = save->ready->Bands == 3;
 		break;
 
 	case VIPS_FOREIGN_SUBSAMPLE_OFF:
@@ -851,11 +851,6 @@ vips_foreign_save_jp2k_build(VipsObject *object)
 
 	if (jp2k->subsample)
 		jp2k->save_as_ycc = TRUE;
-
-	/* Our rgb->ycc only works for exactly 3 bands.
-	 */
-	jp2k->save_as_ycc = jp2k->save_as_ycc && save->ready->Bands == 3;
-	jp2k->subsample = jp2k->subsample && jp2k->save_as_ycc;
 
 	/* Set parameters for compressor.
 	 */

--- a/test/test-suite/test_foreign.py
+++ b/test/test-suite/test_foreign.py
@@ -1924,6 +1924,11 @@ class TestForeign:
         im = pyvips.Image.black(22, 3, bands=3)
         im.jp2ksave_buffer(subsample_mode="on")
 
+        # regression test for heap buffer overflow with chroma subsampling
+        # on non-RGB images, see https://github.com/libvips/libvips/pull/5030
+        im = pyvips.Image.black(32, 32, bands=1)
+        im.jp2ksave_buffer(subsample_mode="on")
+
         # enabling lossless should mean a bigger buffer
         b1 = self.colour.jp2ksave_buffer(lossless=False)
         b2 = self.colour.jp2ksave_buffer(lossless=True)


### PR DESCRIPTION
Similar to #5020, there is an OOB read/write (heap buffer overflow) in the `save_as_ycc` path if the input image isn't RGB. The `Bands == 3` check that is already present in `vips__foreign_save_jp2k_compress` has to be applied to the regular `jp2ksave` build as well: https://github.com/libvips/libvips/blob/9bde113b9dd0eeae39a9c9d5b92a957490586dc7/libvips/foreign/jp2ksave.c#L1338

**Reproducer:**
```
./build-asan/tools/vips black --bands 1 out.jp2"[subsample-mode=on]" 32 32
```

```
==74562==ERROR: AddressSanitizer: heap-buffer-overflow on address 0x61a000000ac7 at pc 0x00010523b4d8 bp 0x00016bd76980 sp 0x00016bd76978
READ of size 1 at 0x61a000000ac7 thread T11
    #0 0x00010523b4d4 in vips_foreign_save_jp2k_rgb_to_ycc+0xd48 (libvips.42.dylib:arm64+0x474d4)
    #1 0x00010523d6e0 in vips_foreign_save_jp2k_write_block+0x36c (libvips.42.dylib:arm64+0x496e0)
    #2 0x000105695e6c in wbuffer_write_thread+0x134 (libvips.42.dylib:arm64+0x4a1e6c)
    #3 0x00010565c294 in vips_threadset_work+0x168 (libvips.42.dylib:arm64+0x468294)
    #4 0x00010565b230 in vips_thread_run+0x50 (libvips.42.dylib:arm64+0x467230)
    #5 0x0001048b58dc in g_thread_proxy+0x50 (libglib-2.0.0.dylib:arm64+0x558dc)
    #6 0x000105e02418 in asan_thread_start(void*)+0x4c (libclang_rt.asan_osx_dynamic.dylib:arm64e+0x3a418)
    #7 0x00018d939c04 in _pthread_start+0x84 (libsystem_pthread.dylib:arm64e+0x6c04)
    #8 0x00018d934ba4 in thread_start+0x4 (libsystem_pthread.dylib:arm64e+0x1ba4)
```