### PR TITLE
add vips_chain_fuzzer

### DIFF
--- a/fuzz/meson.build
+++ b/fuzz/meson.build
@@ -19,7 +19,8 @@ fuzz_progs = [
     'thumbnail_fuzzer',
     'smartcrop_fuzzer',
     'mosaic_fuzzer',
-    'vips_fuzzer'
+    'vips_fuzzer',
+    'vips_chain_fuzzer'
 ]
 
 if libjpeg_dep.found()

--- a/fuzz/oss_fuzz_build.sh
+++ b/fuzz/oss_fuzz_build.sh
@@ -284,8 +284,10 @@ for fuzzer in $OUT/*_fuzzer; do
   ln -sf "seed_corpus.zip" "$OUT/${target}_seed_corpus.zip"
 done
 
-# Generate dictionary for vips_fuzzer
+# Generate dictionary for vips_fuzzer (also shared with vips_chain_fuzzer,
+# which uses the same op-name / argument / enum vocabulary).
 LD_LIBRARY_PATH="$OUT/lib" $OUT/generate_vips_dict > "$OUT/vips_fuzzer.dict"
+cp -v "$OUT/vips_fuzzer.dict" "$OUT/vips_chain_fuzzer.dict"
 rm -v $OUT/generate_vips_dict
 
 # Copy options and remaining dictionary files to $OUT

--- a/fuzz/vips_chain_fuzzer.cc
+++ b/fuzz/vips_chain_fuzzer.cc
@@ -1,0 +1,359 @@
+/* Fuzz chains of libvips operations.
+ *
+ * Like vips_fuzzer but applies up to MAX_CHAIN_LEN operations in sequence,
+ * piping the first image output of each op into the next op's input image.
+ * This exercises pipeline construction, intermediate VipsImage state, and
+ * combinations of ops that single-op fuzzers cannot reach. Operations that
+ * do not produce an image output (e.g. min, avg, save ops) leave the
+ * pipeline image unchanged so subsequent ops can still consume it.
+ *
+ * Input format:
+ *   Line 1: optional [option_string] for the initial source-from-memory load
+ *   Repeated up to MAX_CHAIN_LEN times:
+ *     Line: operation name (must be a known op nickname; otherwise the chain
+ *       ends and remaining bytes become image data)
+ *     Lines: required non-image argument strings, one per line
+ *     Lines: optional arguments as "--name=value", one per line
+ *   Remaining bytes: raw image data fed to vips_image_new_from_source
+ */
+
+#include "config.h"
+
+#include "vips_fuzzer_common.h"
+
+#define MAX_CHAIN_LEN 8
+/* Cap intermediate image dimensions so an early enlarge op cannot make
+ * downstream ops slow or OOM-prone.
+ */
+#define MAX_CHAIN_IMAGE_DIM 1000
+#define MAX_CHAIN_IMAGE_BANDS 16
+
+extern "C" int
+LLVMFuzzerInitialize(int *argc, char ***argv)
+{
+	if (VIPS_INIT(*argv[0]))
+		return -1;
+
+	vips_concurrency_set(1);
+	vips_cache_set_max(0);
+
+	FuzzApplyBlocklist();
+
+	return 0;
+}
+
+typedef struct _OpSpec {
+	VipsOperation *op;
+	char **string_args;
+	int n_string_args;
+	char *opt_names[MAX_OPTIONAL_ARGS];
+	char *opt_values[MAX_OPTIONAL_ARGS];
+	int n_optional;
+} OpSpec;
+
+static void
+op_spec_clear(OpSpec *spec)
+{
+	if (spec->op) {
+		g_object_unref(spec->op);
+		spec->op = nullptr;
+	}
+	for (int j = 0; j < spec->n_string_args; j++)
+		g_free(spec->string_args[j]);
+	g_free(spec->string_args);
+	spec->string_args = nullptr;
+	spec->n_string_args = 0;
+	for (int j = 0; j < spec->n_optional; j++) {
+		g_free(spec->opt_names[j]);
+		g_free(spec->opt_values[j]);
+	}
+	spec->n_optional = 0;
+}
+
+/* Capture the first image output of an op (taking a ref) so we can chain
+ * it into the next op. Subsequent image outputs are force-evaluated and
+ * dropped.
+ */
+typedef struct _CaptureCtx {
+	VipsImage *captured;
+} CaptureCtx;
+
+static void *
+CaptureFirstImageOutput(VipsObject *object,
+	GParamSpec *pspec,
+	VipsArgumentClass *argument_class,
+	VipsArgumentInstance *argument_instance,
+	void *a, void *b)
+{
+	CaptureCtx *cctx = static_cast<CaptureCtx *>(a);
+	GType type = G_PARAM_SPEC_VALUE_TYPE(pspec);
+
+	if (!(argument_class->flags & VIPS_ARGUMENT_REQUIRED) ||
+		!(argument_class->flags & VIPS_ARGUMENT_CONSTRUCT) ||
+		!(argument_class->flags & VIPS_ARGUMENT_OUTPUT) ||
+		(argument_class->flags & VIPS_ARGUMENT_DEPRECATED))
+		return nullptr;
+
+	if (!g_type_is_a(type, VIPS_TYPE_IMAGE))
+		return nullptr;
+
+	VipsImage *out;
+	const char *name = g_param_spec_get_name(pspec);
+	g_object_get(object, name, &out, nullptr);
+	if (!out)
+		return nullptr;
+
+	if (cctx->captured == nullptr) {
+		cctx->captured = out;
+	}
+	else {
+		// We already kept the first one; force-eval and unref this.
+		if (out->Xsize <= MAX_CHAIN_IMAGE_DIM &&
+			out->Ysize <= MAX_CHAIN_IMAGE_DIM &&
+			out->Bands <= MAX_CHAIN_IMAGE_BANDS) {
+			double d;
+			(void) vips_min(out, &d, nullptr);
+		}
+		g_object_unref(out);
+	}
+
+	return nullptr;
+}
+
+/* Parse one op block: opname, required string args, then a run of
+ * "--name=value" lines. Returns TRUE if the spec is fully populated and
+ * the op was created. Returns FALSE if no more ops can be parsed (the
+ * caller should treat (data, size) as image data).
+ *
+ * On a partial parse failure (e.g. ran out of lines mid-required-args)
+ * we drop what we read and return FALSE so the chain ends cleanly.
+ */
+static gboolean
+parse_op_block(OpSpec *spec, const guint8 **data, size_t *size)
+{
+	const guint8 *save_data = *data;
+	size_t save_size = *size;
+	char *opname = FuzzExtractLine(data, size);
+	if (!opname)
+		return FALSE;
+
+	VipsOperation *op = vips_operation_new(opname);
+	g_free(opname);
+	if (!op) {
+		// Not a valid op; restore so trailing bytes remain intact.
+		*data = save_data;
+		*size = save_size;
+		return FALSE;
+	}
+
+	VipsOperationFlags flags = vips_operation_get_flags(op);
+	if ((flags & VIPS_OPERATION_DEPRECATED) ||
+		(flags & VIPS_OPERATION_BLOCKED)) {
+		g_object_unref(op);
+		// Restore so trailing image bytes are preserved.
+		*data = save_data;
+		*size = save_size;
+		return FALSE;
+	}
+
+	spec->op = op;
+
+	int n_str = 0;
+	vips_argument_map(VIPS_OBJECT(op),
+		FuzzCountStringArgs, &n_str, nullptr);
+	spec->n_string_args = n_str;
+	spec->string_args = g_new0(char *, VIPS_MAX(n_str, 1));
+
+	for (int j = 0; j < n_str; j++) {
+		spec->string_args[j] = FuzzExtractLine(data, size);
+		if (!spec->string_args[j]) {
+			op_spec_clear(spec);
+			return FALSE;
+		}
+	}
+
+	while (spec->n_optional < MAX_OPTIONAL_ARGS) {
+		const guint8 *od = *data;
+		size_t os = *size;
+		char *line = FuzzExtractLine(data, size);
+		if (!line)
+			break;
+		if (line[0] != '-' || line[1] != '-') {
+			// Not an optional arg -- put it back so the next op
+			// (or the image data) sees it.
+			g_free(line);
+			*data = od;
+			*size = os;
+			break;
+		}
+		char *eq = strchr(line + 2, '=');
+		if (eq) {
+			*eq = '\0';
+			spec->opt_names[spec->n_optional] = g_strdup(line + 2);
+			spec->opt_values[spec->n_optional] = g_strdup(eq + 1);
+			spec->n_optional++;
+		}
+		g_free(line);
+	}
+
+	return TRUE;
+}
+
+extern "C" int
+LLVMFuzzerTestOneInput(const guint8 *data, size_t size)
+{
+	FuzzCtx ctx = {};
+	OpSpec chain[MAX_CHAIN_LEN] = {};
+	int n_ops = 0;
+
+	// Optional [option_string] for the initial image load.
+	char *option_string;
+	{
+		const guint8 *save_data = data;
+		size_t save_size = size;
+		char *line = FuzzExtractLine(&data, &size);
+		if (line && line[0] == '[') {
+			option_string = line;
+		}
+		else {
+			g_free(line);
+			data = save_data;
+			size = save_size;
+			option_string = g_strdup("");
+		}
+	}
+
+	// Parse the op chain.
+	for (int i = 0; i < MAX_CHAIN_LEN; i++) {
+		if (!parse_op_block(&chain[i], &data, &size))
+			break;
+		n_ops = i + 1;
+	}
+
+	// What's left is the initial image bytes.
+	ctx.pending_data = data;
+	ctx.pending_size = size;
+
+	if (size > 0 &&
+		((ctx.source = vips_source_new_from_memory(data, size))) &&
+		(!(ctx.image = vips_image_new_from_source(ctx.source,
+			option_string, "access", VIPS_ACCESS_RANDOM, nullptr)))) {
+		g_object_unref(ctx.source);
+		ctx.source = nullptr;
+	}
+
+	if (ctx.image &&
+		(ctx.image->Xsize > 100 ||
+			ctx.image->Ysize > 100 ||
+			ctx.image->Bands > 4)) {
+		g_object_unref(ctx.image);
+		ctx.image = nullptr;
+		g_object_unref(ctx.source);
+		ctx.source = nullptr;
+	}
+
+	// Run the chain.
+	for (int i = 0; i < n_ops; i++) {
+		OpSpec *spec = &chain[i];
+		VipsOperation *op = spec->op;
+
+		// Reset the per-op string arg cursor in ctx but keep
+		// source/image/files persistent across the chain.
+		ctx.string_args = spec->string_args;
+		ctx.n_string_args = spec->n_string_args;
+		ctx.string_idx = 0;
+		ctx.failed = FALSE;
+
+		vips_argument_map(VIPS_OBJECT(op),
+			FuzzSetRequiredInput, &ctx, nullptr);
+
+		for (int j = 0; j < spec->n_optional; j++) {
+			VipsArgumentFlags af =
+				vips_object_get_argument_flags(VIPS_OBJECT(op),
+					spec->opt_names[j]);
+			if ((af & VIPS_ARGUMENT_REQUIRED) ||
+				!(af & VIPS_ARGUMENT_CONSTRUCT) ||
+				!(af & VIPS_ARGUMENT_INPUT) ||
+				(af & VIPS_ARGUMENT_DEPRECATED))
+				continue;
+			vips_object_set_argument_from_string(VIPS_OBJECT(op),
+				spec->opt_names[j], spec->opt_values[j]);
+		}
+
+		CaptureCtx cctx = {};
+		gboolean built = FALSE;
+		if (!ctx.failed &&
+			!vips_object_build(VIPS_OBJECT(op))) {
+			built = TRUE;
+			vips_argument_map(VIPS_OBJECT(op),
+				CaptureFirstImageOutput, &cctx, nullptr);
+		}
+
+		// Detach references the op holds on its outputs; we own
+		// `cctx.captured` via g_object_get already.
+		vips_object_unref_outputs(VIPS_OBJECT(op));
+
+		// We're done with the op; the spec keeps no other handle.
+		g_object_unref(op);
+		spec->op = nullptr;
+
+		if (cctx.captured) {
+			VipsImage *next_image = cctx.captured;
+
+			gboolean ok = next_image->Xsize <= MAX_CHAIN_IMAGE_DIM &&
+				next_image->Ysize <= MAX_CHAIN_IMAGE_DIM &&
+				next_image->Bands <= MAX_CHAIN_IMAGE_BANDS;
+			if (ok) {
+				double d;
+				if (vips_min(next_image, &d, nullptr))
+					ok = FALSE;
+			}
+
+			if (ok) {
+				if (ctx.image)
+					g_object_unref(ctx.image);
+				ctx.image = next_image;
+			}
+			else {
+				g_object_unref(next_image);
+				// Halt the chain; subsequent ops would either
+				// inherit a too-big image or a stale one.
+				ctx.string_args = nullptr;
+				ctx.n_string_args = 0;
+				break;
+			}
+		}
+		else if (built) {
+			// Op built but produced no image output (e.g. min,
+			// avg, a save op). Leave ctx.image alone so the next
+			// op can still consume it.
+		}
+
+		ctx.string_args = nullptr;
+		ctx.n_string_args = 0;
+	}
+
+	// Cleanup. op_spec_clear unrefs any op left behind by an early break.
+	for (int i = 0; i < n_ops; i++)
+		op_spec_clear(&chain[i]);
+
+	if (ctx.image)
+		g_object_unref(ctx.image);
+	if (ctx.source)
+		g_object_unref(ctx.source);
+
+	g_free(option_string);
+
+	if (ctx.output_filename) {
+		g_unlink(ctx.output_filename);
+		g_free(ctx.output_filename);
+	}
+	if (ctx.input_filename) {
+		g_unlink(ctx.input_filename);
+		g_free(ctx.input_filename);
+	}
+
+	vips_error_clear();
+
+	return 0;
+}

--- a/fuzz/vips_fuzzer.cc
+++ b/fuzz/vips_fuzzer.cc
@@ -12,10 +12,7 @@
 
 #include "config.h"
 
-#include <vips/vips.h>
-
-#define MAX_LINE_LEN 4096 // =VIPS_PATH_MAX
-#define MAX_OPTIONAL_ARGS 32
+#include "vips_fuzzer_common.h"
 
 extern "C" int
 LLVMFuzzerInitialize(int *argc, char ***argv)
@@ -26,226 +23,9 @@ LLVMFuzzerInitialize(int *argc, char ***argv)
 	vips_concurrency_set(1);
 	vips_cache_set_max(0);
 
-	const char *blocklist[] = {
-		/* Avoid possible timeout errors, e.g.:
-		 * $ vips fractsurf x.v 9999 9999 3
-		 * $ vips worley x.v 9999 9999
-		 * is likely taking more than 60 seconds.
-		 */
-		"VipsWorley",
-		"VipsFractsurf",
-		/* Block matrixprint and {jpeg,webp}save_mime to prevent image data
-		 * from being written to stdout and cluttering the output.
-		 */
-		"VipsForeignPrintMatrix",
-		"VipsForeignSaveJpegMime",
-		"VipsForeignSaveWebpMime",
-		/* dzsave writes a .dzi sidecar and a _files/ tile directory
-		 * alongside the primary path; a single g_unlink can't clean
-		 * that up, so the tmpdir would grow each iteration.
-		 */
-		"VipsForeignSaveDzFile",
-	};
-	for (const char *operation : blocklist)
-		vips_operation_block_set(operation, TRUE);
+	FuzzApplyBlocklist();
 
 	return 0;
-}
-
-static char *
-ExtractLine(const guint8 **data, size_t *size)
-{
-	const guint8 *end;
-
-	if (*size == 0)
-		return nullptr;
-
-	end = static_cast<const guint8 *>(
-		memchr(*data, '\n', VIPS_MIN(*size, MAX_LINE_LEN)));
-	if (end == nullptr)
-		return nullptr;
-
-	size_t n = end - *data;
-	char *line = g_strndup(reinterpret_cast<const char *>(*data), n);
-	*data += n + 1;
-	*size -= n + 1;
-
-	return line;
-}
-
-// Context passed through vips_argument_map callbacks.
-typedef struct _FuzzCtx {
-	VipsSource *source; // Input source, may be NULL
-	VipsImage *image;	// Input image, may be NULL
-	char **string_args; // Pre-parsed string arguments
-	int n_string_args;
-	int string_idx; // Next string argument to consume
-	gboolean failed;
-	const guint8 *pending_data; // Bytes to lazily write to input_filename
-	size_t pending_size;
-	char *input_filename;  // /tmp path holding the raw fuzz bytes, or NULL
-	gboolean input_written; // TRUE if input_filename was written ok
-	gboolean input_tried;	// TRUE once we've tried to materialise input
-	char *output_filename; // /tmp path handed to save ops, or NULL
-} FuzzCtx;
-
-// Lazily write the pending fuzz bytes to a unique /tmp file. Returns the
-// path, or NULL if size is zero or the write failed.
-static const char *
-EnsureInputFile(FuzzCtx *ctx)
-{
-	if (ctx->input_written)
-		return ctx->input_filename;
-	if (ctx->input_tried)
-		return nullptr;
-	ctx->input_tried = TRUE;
-
-	if (ctx->pending_size == 0)
-		return nullptr;
-
-	ctx->input_filename = vips__temp_name("%s");
-	if (!ctx->input_filename)
-		return nullptr;
-	if (!g_file_set_contents(ctx->input_filename,
-			reinterpret_cast<const char *>(ctx->pending_data),
-			ctx->pending_size, nullptr))
-		return nullptr;
-
-	ctx->input_written = TRUE;
-	return ctx->input_filename;
-}
-
-/* Count how many required input arguments need a string value (i.e. are
- * not image, array-of-images, source, target, or blob).
- */
-static void *
-CountStringArgs(VipsObject *object,
-	GParamSpec *pspec,
-	VipsArgumentClass *argument_class,
-	VipsArgumentInstance *argument_instance,
-	void *a, void *b)
-{
-	int *count = static_cast<int *>(a);
-	GType type = G_PARAM_SPEC_VALUE_TYPE(pspec);
-
-	if (!(argument_class->flags & VIPS_ARGUMENT_REQUIRED) ||
-		!(argument_class->flags & VIPS_ARGUMENT_CONSTRUCT) ||
-		!(argument_class->flags & VIPS_ARGUMENT_INPUT) ||
-		(argument_class->flags & VIPS_ARGUMENT_DEPRECATED))
-		return nullptr;
-
-	if (!g_type_is_a(type, VIPS_TYPE_IMAGE) &&
-		!g_type_is_a(type, VIPS_TYPE_ARRAY_IMAGE) &&
-		!g_type_is_a(type, VIPS_TYPE_SOURCE) &&
-		!g_type_is_a(type, VIPS_TYPE_TARGET) &&
-		!g_type_is_a(type, VIPS_TYPE_BLOB))
-		(*count)++;
-
-	return nullptr;
-}
-
-// Set all required input arguments from the fuzz context.
-static void *
-SetRequiredInput(VipsObject *object,
-	GParamSpec *pspec,
-	VipsArgumentClass *argument_class,
-	VipsArgumentInstance *argument_instance,
-	void *a, void *b)
-{
-	FuzzCtx *ctx = static_cast<FuzzCtx *>(a);
-	const char *name = g_param_spec_get_name(pspec);
-	GType type = G_PARAM_SPEC_VALUE_TYPE(pspec);
-
-	if (!(argument_class->flags & VIPS_ARGUMENT_REQUIRED) ||
-		!(argument_class->flags & VIPS_ARGUMENT_CONSTRUCT) ||
-		!(argument_class->flags & VIPS_ARGUMENT_INPUT) ||
-		(argument_class->flags & VIPS_ARGUMENT_DEPRECATED))
-		return nullptr;
-
-	if (g_type_is_a(type, VIPS_TYPE_IMAGE)) {
-		if (!ctx->image) {
-			ctx->failed = TRUE;
-			return pspec;
-		}
-		g_object_set(object, name, ctx->image, nullptr);
-	}
-	else if (g_type_is_a(type, VIPS_TYPE_ARRAY_IMAGE)) {
-		if (!ctx->image) {
-			ctx->failed = TRUE;
-			return pspec;
-		}
-		VipsArrayImage *array = vips_array_image_new(&ctx->image, 1);
-		g_object_set(object, name, array, nullptr);
-		vips_area_unref(VIPS_AREA(array));
-	}
-	else if (g_type_is_a(type, VIPS_TYPE_SOURCE)) {
-		if (!ctx->source) {
-			ctx->failed = TRUE;
-			return pspec;
-		}
-		g_object_set(object, name, ctx->source, nullptr);
-	}
-	else if (g_type_is_a(type, VIPS_TYPE_TARGET)) {
-		VipsTarget *target = vips_target_new_to_memory();
-		if (!target) {
-			ctx->failed = TRUE;
-			return pspec;
-		}
-		g_object_set(object, name, target, nullptr);
-		g_object_unref(target);
-	}
-	else if (g_type_is_a(type, VIPS_TYPE_BLOB)) {
-		if (!ctx->source) {
-			ctx->failed = TRUE;
-			return pspec;
-		}
-		g_object_set(object, name, ctx->source->blob, nullptr);
-	}
-	else {
-		if (ctx->string_idx >= ctx->n_string_args) {
-			ctx->failed = TRUE;
-			return pspec;
-		}
-		const char *value = ctx->string_args[ctx->string_idx++];
-
-		/* Never let fuzzer-controlled strings reach the filesystem via
-		 * a filename arg. Route loads at our fuzz-data temp file and
-		 * saves at a unique /tmp output file we'll unlink afterwards.
-		 * The temp files are materialised lazily so ops that don't
-		 * touch a filename pay no IO cost.
-		 */
-		if (strcmp(name, "filename") == 0) {
-			GType self_type = G_TYPE_FROM_INSTANCE(object);
-			GType foreign_save = g_type_from_name("VipsForeignSave");
-			GType foreign_load = g_type_from_name("VipsForeignLoad");
-
-			if (foreign_save &&
-				g_type_is_a(self_type, foreign_save)) {
-				if (!ctx->output_filename)
-					ctx->output_filename =
-						vips__temp_name("%s");
-				value = ctx->output_filename
-					? ctx->output_filename
-					: "/dev/null";
-			}
-			else if (foreign_load &&
-				g_type_is_a(self_type, foreign_load)) {
-				const char *path = EnsureInputFile(ctx);
-				value = path ? path : "/dev/null";
-			}
-			else {
-				value = "/dev/null";
-			}
-		}
-
-		if (vips_object_set_argument_from_string(object, name,
-				value)) {
-			ctx->failed = TRUE;
-			return pspec;
-		}
-	}
-
-	return nullptr;
 }
 
 // Force evaluation of required output images.
@@ -295,7 +75,7 @@ LLVMFuzzerTestOneInput(const guint8 *data, size_t size)
 	int i;
 
 	// Extract the operation name from the first line.
-	op_name = ExtractLine(&data, &size);
+	op_name = FuzzExtractLine(&data, &size);
 	if (!op_name)
 		return 0;
 
@@ -320,12 +100,12 @@ LLVMFuzzerTestOneInput(const guint8 *data, size_t size)
 
 	// Count how many string-valued required input args we need.
 	vips_argument_map(VIPS_OBJECT(operation),
-		CountStringArgs, &ctx.n_string_args, nullptr);
+		FuzzCountStringArgs, &ctx.n_string_args, nullptr);
 
 	// Parse that many lines from the fuzzer data.
 	ctx.string_args = g_new0(char *, VIPS_MAX(ctx.n_string_args, 1));
 	for (i = 0; i < ctx.n_string_args; i++) {
-		ctx.string_args[i] = ExtractLine(&data, &size);
+		ctx.string_args[i] = FuzzExtractLine(&data, &size);
 		if (!ctx.string_args[i]) {
 			for (int j = 0; j < i; j++)
 				g_free(ctx.string_args[j]);
@@ -338,7 +118,7 @@ LLVMFuzzerTestOneInput(const guint8 *data, size_t size)
 	// Get the option_string from the input
 	const guint8 *save_data = data;
 	size_t save_size = size;
-	char *line = ExtractLine(&data, &size);
+	char *line = FuzzExtractLine(&data, &size);
 	char *option_string;
 	if (line && line[0] == '[') {
 		option_string = line;
@@ -359,7 +139,7 @@ LLVMFuzzerTestOneInput(const guint8 *data, size_t size)
 		// Peek at the next line without consuming it.
 		const guint8 *save_data = data;
 		size_t save_size = size;
-		char *line = ExtractLine(&data, &size);
+		char *line = FuzzExtractLine(&data, &size);
 
 		if (!line)
 			break;
@@ -384,7 +164,7 @@ LLVMFuzzerTestOneInput(const guint8 *data, size_t size)
 		g_free(line);
 	}
 
-	// Stash the remaining bytes so EnsureInputFile() can lazily
+	// Stash the remaining bytes so FuzzEnsureInputFile() can lazily
 	// materialise them to a /tmp file if a load op actually needs one.
 	ctx.pending_data = data;
 	ctx.pending_size = size;
@@ -412,7 +192,7 @@ LLVMFuzzerTestOneInput(const guint8 *data, size_t size)
 
 	// Set all required input arguments.
 	vips_argument_map(VIPS_OBJECT(operation),
-		SetRequiredInput, &ctx, nullptr);
+		FuzzSetRequiredInput, &ctx, nullptr);
 
 	// Set optional arguments (ignore failures).
 	for (i = 0; i < n_optional; i++) {

--- a/fuzz/vips_fuzzer_common.h
+++ b/fuzz/vips_fuzzer_common.h
@@ -1,0 +1,246 @@
+/* Helpers shared by vips_fuzzer.cc and vips_chain_fuzzer.cc.
+ *
+ * Includes the FuzzCtx context, line-based input parsing, lazy /tmp file
+ * materialisation for filename args, and the argument_map callbacks that
+ * count and set required inputs.
+ */
+
+#pragma once
+
+#include <vips/vips.h>
+
+#define MAX_LINE_LEN 4096 // =VIPS_PATH_MAX
+#define MAX_OPTIONAL_ARGS 32
+
+// Context passed through vips_argument_map callbacks.
+typedef struct _FuzzCtx {
+	VipsSource *source; // Input source, may be NULL
+	VipsImage *image;	// Input image, may be NULL
+	char **string_args; // Pre-parsed string arguments
+	int n_string_args;
+	int string_idx; // Next string argument to consume
+	gboolean failed;
+	const guint8 *pending_data; // Bytes to lazily write to input_filename
+	size_t pending_size;
+	char *input_filename;  // /tmp path holding the raw fuzz bytes, or NULL
+	gboolean input_written; // TRUE if input_filename was written ok
+	gboolean input_tried;	// TRUE once we've tried to materialise input
+	char *output_filename; // /tmp path handed to save ops, or NULL
+} FuzzCtx;
+
+static inline char *
+FuzzExtractLine(const guint8 **data, size_t *size)
+{
+	const guint8 *end;
+
+	if (*size == 0)
+		return nullptr;
+
+	end = static_cast<const guint8 *>(
+		memchr(*data, '\n', VIPS_MIN(*size, MAX_LINE_LEN)));
+	if (end == nullptr)
+		return nullptr;
+
+	size_t n = end - *data;
+	char *line = g_strndup(reinterpret_cast<const char *>(*data), n);
+	*data += n + 1;
+	*size -= n + 1;
+
+	return line;
+}
+
+// Lazily write the pending fuzz bytes to a unique /tmp file. Returns the
+// path, or NULL if size is zero or the write failed.
+static inline const char *
+FuzzEnsureInputFile(FuzzCtx *ctx)
+{
+	if (ctx->input_written)
+		return ctx->input_filename;
+	if (ctx->input_tried)
+		return nullptr;
+	ctx->input_tried = TRUE;
+
+	if (ctx->pending_size == 0)
+		return nullptr;
+
+	ctx->input_filename = vips__temp_name("%s");
+	if (!ctx->input_filename)
+		return nullptr;
+	if (!g_file_set_contents(ctx->input_filename,
+			reinterpret_cast<const char *>(ctx->pending_data),
+			ctx->pending_size, nullptr))
+		return nullptr;
+
+	ctx->input_written = TRUE;
+	return ctx->input_filename;
+}
+
+/* Count how many required input arguments need a string value (i.e. are
+ * not image, array-of-images, source, target, or blob).
+ */
+static inline void *
+FuzzCountStringArgs(VipsObject *object,
+	GParamSpec *pspec,
+	VipsArgumentClass *argument_class,
+	VipsArgumentInstance *argument_instance,
+	void *a, void *b)
+{
+	int *count = static_cast<int *>(a);
+	GType type = G_PARAM_SPEC_VALUE_TYPE(pspec);
+
+	if (!(argument_class->flags & VIPS_ARGUMENT_REQUIRED) ||
+		!(argument_class->flags & VIPS_ARGUMENT_CONSTRUCT) ||
+		!(argument_class->flags & VIPS_ARGUMENT_INPUT) ||
+		(argument_class->flags & VIPS_ARGUMENT_DEPRECATED))
+		return nullptr;
+
+	if (!g_type_is_a(type, VIPS_TYPE_IMAGE) &&
+		!g_type_is_a(type, VIPS_TYPE_ARRAY_IMAGE) &&
+		!g_type_is_a(type, VIPS_TYPE_SOURCE) &&
+		!g_type_is_a(type, VIPS_TYPE_TARGET) &&
+		!g_type_is_a(type, VIPS_TYPE_BLOB))
+		(*count)++;
+
+	return nullptr;
+}
+
+// Set all required input arguments from the fuzz context.
+static inline void *
+FuzzSetRequiredInput(VipsObject *object,
+	GParamSpec *pspec,
+	VipsArgumentClass *argument_class,
+	VipsArgumentInstance *argument_instance,
+	void *a, void *b)
+{
+	FuzzCtx *ctx = static_cast<FuzzCtx *>(a);
+	const char *name = g_param_spec_get_name(pspec);
+	GType type = G_PARAM_SPEC_VALUE_TYPE(pspec);
+
+	if (!(argument_class->flags & VIPS_ARGUMENT_REQUIRED) ||
+		!(argument_class->flags & VIPS_ARGUMENT_CONSTRUCT) ||
+		!(argument_class->flags & VIPS_ARGUMENT_INPUT) ||
+		(argument_class->flags & VIPS_ARGUMENT_DEPRECATED))
+		return nullptr;
+
+	if (g_type_is_a(type, VIPS_TYPE_IMAGE)) {
+		if (!ctx->image) {
+			ctx->failed = TRUE;
+			return pspec;
+		}
+		g_object_set(object, name, ctx->image, nullptr);
+	}
+	else if (g_type_is_a(type, VIPS_TYPE_ARRAY_IMAGE)) {
+		if (!ctx->image) {
+			ctx->failed = TRUE;
+			return pspec;
+		}
+		VipsArrayImage *array = vips_array_image_new(&ctx->image, 1);
+		g_object_set(object, name, array, nullptr);
+		vips_area_unref(VIPS_AREA(array));
+	}
+	else if (g_type_is_a(type, VIPS_TYPE_SOURCE)) {
+		if (!ctx->source) {
+			ctx->failed = TRUE;
+			return pspec;
+		}
+		g_object_set(object, name, ctx->source, nullptr);
+	}
+	else if (g_type_is_a(type, VIPS_TYPE_TARGET)) {
+		VipsTarget *target = vips_target_new_to_memory();
+		if (!target) {
+			ctx->failed = TRUE;
+			return pspec;
+		}
+		g_object_set(object, name, target, nullptr);
+		g_object_unref(target);
+	}
+	else if (g_type_is_a(type, VIPS_TYPE_BLOB)) {
+		if (!ctx->source) {
+			ctx->failed = TRUE;
+			return pspec;
+		}
+		g_object_set(object, name, ctx->source->blob, nullptr);
+	}
+	else {
+		if (ctx->string_idx >= ctx->n_string_args) {
+			ctx->failed = TRUE;
+			return pspec;
+		}
+		const char *value = ctx->string_args[ctx->string_idx++];
+
+		/* Never let fuzzer-controlled strings reach the filesystem via
+		 * a filename arg. Route loads at our fuzz-data temp file and
+		 * saves at a unique /tmp output file we'll unlink afterwards.
+		 * The temp files are materialised lazily so ops that don't
+		 * touch a filename pay no IO cost.
+		 */
+		if (strcmp(name, "filename") == 0) {
+			GType self_type = G_TYPE_FROM_INSTANCE(object);
+			GType foreign_save = g_type_from_name("VipsForeignSave");
+			GType foreign_load = g_type_from_name("VipsForeignLoad");
+
+			if (foreign_save &&
+				g_type_is_a(self_type, foreign_save)) {
+				if (!ctx->output_filename)
+					ctx->output_filename =
+						vips__temp_name("%s");
+				value = ctx->output_filename
+					? ctx->output_filename
+					: "/dev/null";
+			}
+			else if (foreign_load &&
+				g_type_is_a(self_type, foreign_load)) {
+				const char *path = FuzzEnsureInputFile(ctx);
+				value = path ? path : "/dev/null";
+			}
+			else {
+				value = "/dev/null";
+			}
+		}
+
+		if (vips_object_set_argument_from_string(object, name,
+				value)) {
+			ctx->failed = TRUE;
+			return pspec;
+		}
+	}
+
+	return nullptr;
+}
+
+/* Apply the standard fuzz-target blocklist:
+ *   - timeout-prone create-from-scratch ops (worley, fractsurf)
+ *   - ops that write images to stdout
+ *   - dzsave's tile sidecar that g_unlink can't clean up
+ *   - vips_system, which spawns external commands
+ */
+static inline void
+FuzzApplyBlocklist(void)
+{
+	const char *blocklist[] = {
+		/* Avoid possible timeout errors, e.g.:
+		 * $ vips fractsurf x.v 9999 9999 3
+		 * $ vips worley x.v 9999 9999
+		 * is likely taking more than 60 seconds.
+		 */
+		"VipsWorley",
+		"VipsFractsurf",
+		/* Block matrixprint and {jpeg,webp}save_mime to prevent image data
+		 * from being written to stdout and cluttering the output.
+		 */
+		"VipsForeignPrintMatrix",
+		"VipsForeignSaveJpegMime",
+		"VipsForeignSaveWebpMime",
+		/* dzsave writes a .dzi sidecar and a _files/ tile directory
+		 * alongside the primary path; a single g_unlink can't clean
+		 * that up, so the tmpdir would grow each iteration.
+		 */
+		"VipsForeignSaveDzFile",
+		/* vips_system spawns external commands; never let fuzzer-
+		 * controlled strings reach a shell.
+		 */
+		"VipsSystem",
+	};
+	for (const char *operation : blocklist)
+		vips_operation_block_set(operation, TRUE);
+}


### PR DESCRIPTION
A fuzz target that allows vips operations to be chained. Can be useful to discover even more exotic crashes and push coverage even further.
This will probably stay a draft for a while - there are more edge cases that can cause false-positives.

**ToDo:**
- [ ] Explore structure aware fuzzing
- [ ] Handle edge cases more gracefully to avoid false-positives
- [ ] Add a seed corpus for the `vips_chain_fuzzer`