### PR TITLE
Fix potential heap-buffer-overflow writes in boolean lshift

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -13,6 +13,7 @@ tbd 8.18.3
 - fix possible null-pointer dereference in quantizr backend [felixbuenemann]
 - jp2ksave: fix OOB read during chroma subsampling [dloebl]
 - jp2ksave: prevent heap buffer overflow on non-RGB images [dloebl]
+- boolean: fix heap-buffer-overflow in lshift [dloebl]
 
 31/3/26 8.18.2
 

--- a/libvips/arithmetic/boolean.c
+++ b/libvips/arithmetic/boolean.c
@@ -163,7 +163,7 @@ vips_boolean_build(VipsObject *object)
 	{ \
 		TYPE *restrict left = (TYPE *) in[0]; \
 		TYPE *restrict right = (TYPE *) in[1]; \
-		int *restrict q = (int *) out; \
+		TYPE *restrict q = (TYPE *) out; \
 \
 		for (x = 0; x < sz; x++) \
 			q[x] = FN(left[x], right[x]); \


### PR DESCRIPTION
Found with #5031
There are potential OOB writes in the `boolean lshift`. The output pointer was incorrectly cast to `int *` regardless of the output format, which can cause OOB writes for `VIPS_FORMAT_CHAR` and `VIPS_FORMAT_SHORT`.

**Reproducer:**
```
./build/tools/vips black test.png 32 32 && \
./build/tools/vips cast test.png in.v char && \
./build/tools/vips boolean in.v in.v out.v lshift
``` 
`build` must be configured with `-Db_sanitize=address`:

```
==27948==ERROR: AddressSanitizer: heap-buffer-overflow on address 0x6160000104a7 at pc 0x0001058356dc bp 0x00016b3ce650 sp 0x00016b3ce648
WRITE of size 64 at 0x6160000104a7 thread T1
    #0 0x0001058356d8 in vips_boolean_buffer boolean.c:203
    #1 0x000105827a98 in vips_arithmetic_gen arithmetic.c:421
    #2 0x000105b5810c in vips_region_generate region.c:1614
    #3 0x000105b57e88 in vips_region_prepare region.c:1682
    #4 0x0001059c91ac in vips_copy_gen copy.c:140
    #5 0x000105b5810c in vips_region_generate region.c:1614
    #6 0x000105b57e88 in vips_region_prepare region.c:1682
    #7 0x000105b0e95c in vips_image_write_gen image.c:2619
    #8 0x000105b589c8 in vips_region_prepare_to_generate region.c:1737
    #9 0x000105b58644 in vips_region_prepare_to region.c
    #10 0x000105b21220 in wbuffer_work_fn sinkdisc.c:438
    #11 0x000105aeacb8 in vips_thread_main_loop threadpool.c:393
    #12 0x000105ae9274 in vips_threadset_work threadset.c:187
    #13 0x000105ae8254 in vips_thread_run thread.c:112
    #14 0x000104c718dc in g_thread_proxy+0x50 (libglib-2.0.0.dylib:arm64+0x558dc)
    #15 0x000106272418 in asan_thread_start(void*)+0x4c (libclang_rt.asan_osx_dynamic.dylib:arm64e+0x3a418)
    #16 0x00018d939c04 in _pthread_start+0x84 (libsystem_pthread.dylib:arm64e+0x6c04)
    #17 0x00018d934ba4 in thread_start+0x4 (libsystem_pthread.dylib:arm64e+0x1ba4)
```