### PR TITLE
heifload: tighten restrictions on heif memory use

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -13,6 +13,7 @@ tbd 8.18.3
 - fix possible null-pointer dereference in quantizr backend [felixbuenemann]
 - jp2ksave: fix OOB read during chroma subsampling [dloebl]
 - jp2ksave: prevent heap buffer overflow on non-RGB images [dloebl]
+- heifload: tighten limits on memory use [nprovos]
 
 31/3/26 8.18.2
 

--- a/ChangeLog
+++ b/ChangeLog
@@ -13,7 +13,7 @@ tbd 8.18.3
 - fix possible null-pointer dereference in quantizr backend [felixbuenemann]
 - jp2ksave: fix OOB read during chroma subsampling [dloebl]
 - jp2ksave: prevent heap buffer overflow on non-RGB images [dloebl]
-- heifload: tighten limits on memory use [nprovos]
+- heifload: tighten limits on memory use [provos]
 
 31/3/26 8.18.2
 

--- a/libvips/foreign/heifload.c
+++ b/libvips/foreign/heifload.c
@@ -356,9 +356,14 @@ vips_foreign_load_heif_build(VipsObject *object)
 		heif_context_set_maximum_image_size_limit(heif->ctx,
 			heif->unlimited ? USHRT_MAX : 0x4000);
 #ifdef HAVE_HEIF_MAX_TOTAL_MEMORY
-		if (!heif->unlimited)
-			heif_context_get_security_limits(heif->ctx)
-				->max_total_memory = 2UL * 1024 * 1024 * 1024;
+		if (!heif->unlimited) {
+			heif_security_limits *limits =
+				heif_context_get_security_limits(heif->ctx);
+
+			limits->max_total_memory = 2L * 1024 * 1024 * 1024;
+			limits->max_memory_block_size = 1024 * 1024 * 1024;
+			limits->max_items = 16;
+		}
 #endif /* HAVE_HEIF_MAX_TOTAL_MEMORY */
 #ifdef HAVE_HEIF_GET_DISABLED_SECURITY_LIMITS
 		if (heif->unlimited)
@@ -554,6 +559,7 @@ vips_foreign_load_heif_set_page(VipsForeignLoadHeif *heif,
 static int
 vips_foreign_load_heif_set_header(VipsForeignLoadHeif *heif, VipsImage *out)
 {
+	VipsObjectClass *class = VIPS_OBJECT_GET_CLASS(heif);
 	VipsForeignLoad *load = (VipsForeignLoad *) heif;
 
 	int bands;
@@ -614,6 +620,11 @@ vips_foreign_load_heif_set_header(VipsForeignLoadHeif *heif, VipsImage *out)
 
 		if (!length)
 			continue;
+		if (!heif->unlimited &&
+			length > 64 * 1024 * 1024) {
+			vips_error(class->nickname, "%s", _("metadata block too large"));
+			return -1;
+		}
 		if (!(data = VIPS_ARRAY(NULL, length, unsigned char)))
 			return -1;
 		error = heif_image_handle_get_metadata(heif->handle, id[i], data);


### PR DESCRIPTION
Tighten up the limits on heifload memory use. These new limits are still loose enough to allow a 16k x 16k pixel image to load successfully.

With this test image (32k x 32k pixels, don't click to view, right click and download instead):

https://upload.wikimedia.org/wikipedia/commons/d/d7/Giovanni_Bellini_-_Saint_Francis_in_the_Desert_-_Google_Art_Project.jpg

I can run:

```
$ # the largest avif we allow
$ vips crop st-francis.jpg st-francis.avif 0 0 16384 16384
$ ls -l st-francis.avif 
-rw-r--r-- 1 john john 24918121 May  8 14:15 st-francis.avif
$ /usr/bin/time -f %M:%e vips copy st-francis.avif x.jpg
2831204:4.63
$
```

So it loads in 280mb of memory and without triggering a security limit.

Thanks @provos !