### PR TITLE
uhdrsave: use macro to size buffer

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -14,6 +14,7 @@ tbd 8.18.3
 - jp2ksave: fix OOB read during chroma subsampling [dloebl]
 - jp2ksave: prevent heap buffer overflow on non-RGB images [dloebl]
 - boolean: fix heap-buffer-overflow in lshift [dloebl]
+- uhdrsave: use macro to size buffer [Himanshu Anand]
 
 31/3/26 8.18.2
 

--- a/libvips/foreign/uhdrsave.c
+++ b/libvips/foreign/uhdrsave.c
@@ -188,7 +188,7 @@ vips_foreign_save_uhdr_set_raw_hdr(VipsForeignSaveUhdr *uhdr, VipsImage *image)
 		.w = image->Xsize,
 		.h = image->Ysize,
 		.planes[0] = (void *)
-			VIPS_ARRAY(uhdr, image->Xsize * image->Ysize * 8, VipsPel),
+			VIPS_ARRAY(uhdr, 8 * VIPS_IMAGE_N_PELS(image), VipsPel),
 		.stride[0] = image->Xsize,
 	};
 	if (!hdr_image.planes[0])


### PR DESCRIPTION
Use the correct VIPS_IMAGE_N_PELS() macro to size the buffer.

Thanks Himanshu Anand