### PR TITLE
draw_mask: fix support for packed LABQ images

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -19,6 +19,7 @@ tbd 8.18.3
 - radload: deprecate old-style scanline read [Himanshu Anand]
 - source: fix max/min confusion [Himanshu Anand]
 - uhdrsave: use macro to size buffer [Himanshu Anand]
+- draw_mask: fix support for packed LABQ images [lovell]
 
 31/3/26 8.18.2
 

--- a/libvips/draw/draw_mask.c
+++ b/libvips/draw/draw_mask.c
@@ -145,14 +145,16 @@ vips_draw_mask_draw_labq(VipsImage *image, VipsImage *mask, VipsPel *ink,
 {
 	int width = image_clip->width;
 	int height = image_clip->height;
-	int bands = image->Bands;
+	int bands = 3;
 
 	float *lab_buffer;
+	float lab_ink[3];
 	int y;
 
 	if (!(lab_buffer = VIPS_ARRAY(NULL, width * 3, float)))
 		return -1;
 
+	vips__LabQ2Lab_vec(lab_ink, ink, 1);
 	for (y = 0; y < height; y++) {
 		VipsPel *to = VIPS_IMAGE_ADDR(image,
 			image_clip->left,
@@ -162,7 +164,7 @@ vips_draw_mask_draw_labq(VipsImage *image, VipsImage *mask, VipsPel *ink,
 			y + mask_clip->top);
 
 		vips__LabQ2Lab_vec(lab_buffer, to, width);
-		DBLEND(float, lab_buffer, (double *) ink);
+		DBLEND(float, lab_buffer, lab_ink);
 		vips__Lab2LabQ_vec(to, lab_buffer, width);
 	}
 


### PR DESCRIPTION
The `DBLEND` macro uses LAB so the ink needs to be in the same format. Tested using the `failing_vips_resize_8bit.tif` image from https://github.com/libvips/libvips/issues/1499.