### PR TITLE
reduceh: fix possible OOB read in Highway path

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -20,6 +20,7 @@ tbd 8.18.3
 - source: fix max/min confusion [Himanshu Anand]
 - uhdrsave: use macro to size buffer [Himanshu Anand]
 - draw_mask: fix support for packed LABQ images [lovell]
+- reduceh: fix possible OOB read in Highway path [kleisauke]
 
 31/3/26 8.18.2
 

--- a/libvips/resample/reduceh.cpp
+++ b/libvips/resample/reduceh.cpp
@@ -356,7 +356,10 @@ vips_reduceh_uchar_vector_gen(VipsRegion *out_region, void *seq,
 
 	s.left = r->left * reduceh->residual_hshrink - reduceh->hoffset;
 	s.top = r->top;
-	s.width = r->width * reduceh->residual_hshrink + reduceh->n_point;
+	/* Request one extra input pixel on the right so the Highway path can
+	 * safely process a full SIMD vector.
+	 */
+	s.width = (r->width + 1) * reduceh->residual_hshrink + reduceh->n_point;
 	s.height = r->height;
 	if (vips_region_prepare(ir, &s))
 		return -1;

--- a/test/test-suite/test_resample.py
+++ b/test/test-suite/test_resample.py
@@ -102,6 +102,14 @@ class TestResample:
                 d = abs(shr.avg() - im.avg())
                 assert d == 0
 
+        # https://github.com/libvips/libvips/issues/4864
+        if have("ppmload"):
+            im = pyvips.Image.new_from_buffer(b'P6\n2 2\n255\n'
+                                              b'\xff\x00\x00' b'\x00\xff\x00'
+                                              b'\x00\x00\xff' b'\xff\xff\x00', "")
+            im2 = im.reduceh(1.5, kernel="nearest")
+            assert im2.width == 1
+
     def test_resize(self):
         im = pyvips.Image.new_from_file(JPEG_FILE)
         im2 = im.resize(0.25)


### PR DESCRIPTION
In line with commit d55db5cfd4356e630b8d0fbe180ebf15e791a937, this affected only the nearest-neighbor resampling kernel.