### PR TITLE
[8.16] Backport CVE-2026-2913: source: guard against length truncation (#4858)

### DIFF
--- a/libvips/iofuncs/source.c
+++ b/libvips/iofuncs/source.c
@@ -912,6 +912,12 @@ vips_source_read_to_memory(VipsSource *source)
 	g_assert(!source->header_bytes);
 	g_assert(source->length >= 0);
 
+	if (G_UNLIKELY(source->length > UINT_MAX)) {
+		vips_error(vips_connection_nick(VIPS_CONNECTION(source)),
+			"%s", _("length overflow"));
+		return -1;
+	}
+
 	if (vips_source_rewind(source))
 		return -1;
 
@@ -919,7 +925,7 @@ vips_source_read_to_memory(VipsSource *source)
 	 * directly to it.
 	 */
 	byte_array = g_byte_array_new();
-	g_byte_array_set_size(byte_array, source->length);
+	g_byte_array_set_size(byte_array, (guint) source->length);
 
 	read_position = 0;
 	q = byte_array->data;
@@ -1302,13 +1308,19 @@ vips_source_sniff_at_most(VipsSource *source,
 
 	VIPS_DEBUG_MSG("vips_source_sniff_at_most: %zd bytes\n", length);
 
+	if (G_UNLIKELY(length > UINT_MAX)) {
+		vips_error(vips_connection_nick(VIPS_CONNECTION(source)),
+			"%s", _("length overflow"));
+		return -1;
+	}
+
 	SANITY(source);
 
 	if (vips_source_test_features(source) ||
 		vips_source_rewind(source))
 		return -1;
 
-	g_byte_array_set_size(source->sniff, length);
+	g_byte_array_set_size(source->sniff, (guint) length);
 
 	read_position = 0;
 	q = source->sniff->data;


### PR DESCRIPTION
Backport of the public CVE-2026-2913 fix to `8.16`.

I cherry-picked `a56feecbe9ed` from upstream with `git cherry-pick -x`, so the original author and upstream commit reference are preserved. The change touches the affected source files.

Upstream commit: https://github.com/libvips/libvips/commit/a56feecbe9ed66521d9647ec9fbcd2546eccd7ee
CVE reference: https://nvd.nist.gov/vuln/detail/CVE-2026-2913

metadata-only conflict resolved by keeping target branch metadata file. I have not run the full project test suite locally.