### PR TITLE
Backport of the public CVE-2026-3147 fix to `8.16`.  I cherry-picked `b3ab458a25e0` from upstream with `git cherry-pick -x`, so the original author and upstream commit reference are preserved. The change touches the affected source files.  Upstream commit: https://github.com/libvips/libvips/commit/b3ab458a25e0e261cbd1788474bbc763f7435780 CVE reference: https://nvd.nist.gov/vuln/detail/CVE-2026-3147  metadata-only conflict resolved by keeping target branch metadata file. I have not run the full project test suite locally.

### DIFF
--- a/libvips/foreign/csvload.c
+++ b/libvips/foreign/csvload.c
@@ -121,6 +121,13 @@ vips_foreign_load_csv_build(VipsObject *object)
 	int i;
 	const char *p;
 
+	if (!g_str_is_ascii(csv->whitespace) ||
+		!g_str_is_ascii(csv->separator)) {
+		vips_error("csvload", "%s",
+			_("whitespace and separator must be ASCII"));
+		return -1;
+	}
+
 	if (!(csv->sbuf = vips_sbuf_new_from_source(csv->source)))
 		return -1;
 


### PR DESCRIPTION
Backport of the public CVE-2026-3147 fix to `8.16`.

I cherry-picked `b3ab458a25e0` from upstream with `git cherry-pick -x`, so the original author and upstream commit reference are preserved. The change touches the affected source files.

Upstream commit: https://github.com/libvips/libvips/commit/b3ab458a25e0e261cbd1788474bbc763f7435780
CVE reference: https://nvd.nist.gov/vuln/detail/CVE-2026-3147

metadata-only conflict resolved by keeping target branch metadata file. I have not run the full project test suite locally.