### PR TITLE
jxl: ensure status codes are propagated

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -22,6 +22,7 @@ tbd 8.18.3
 - draw_mask: fix support for packed LABQ images [lovell]
 - reduceh: fix possible OOB read in Highway path [kleisauke]
 - buildlut: check upper bound of x range [lovell]
+- jxl: ensure status codes are propagated [lovell]
 
 31/3/26 8.18.2
 

--- a/libvips/foreign/jxlload.c
+++ b/libvips/foreign/jxlload.c
@@ -250,8 +250,11 @@ vips_foreign_load_jxl_set_box_buffer(VipsForeignLoadJxl *jxl)
 
 	*jxl->box_data = new_data;
 
-	JxlDecoderSetBoxBuffer(jxl->decoder,
-		new_data + box_size, INPUT_BUFFER_SIZE);
+	if (JxlDecoderSetBoxBuffer(jxl->decoder,
+			new_data + box_size, INPUT_BUFFER_SIZE) != JXL_DEC_SUCCESS) {
+		vips_foreign_load_jxl_error(jxl, "JxlDecoderSetBoxBuffer");
+		return -1;
+	}
 
 	return 0;
 }
@@ -508,8 +511,9 @@ vips_foreign_load_jxl_process(VipsForeignLoadJxl *jxl)
 			return JXL_DEC_ERROR;
 
 		if (jxl->bytes_in_buffer)
-			JxlDecoderSetInput(jxl->decoder,
-				jxl->input_buffer, jxl->bytes_in_buffer);
+			if (JxlDecoderSetInput(jxl->decoder,
+					jxl->input_buffer, jxl->bytes_in_buffer) != JXL_DEC_SUCCESS)
+				return JXL_DEC_ERROR;
 
 		if (!bytes_read)
 			JxlDecoderCloseInput(jxl->decoder);
@@ -854,7 +858,11 @@ vips_foreign_load_jxl_header(VipsForeignLoad *load)
 
 	if (vips_foreign_load_jxl_fill_input(jxl, 0) < 0)
 		return -1;
-	JxlDecoderSetInput(jxl->decoder, jxl->input_buffer, jxl->bytes_in_buffer);
+	if (JxlDecoderSetInput(jxl->decoder,
+			jxl->input_buffer, jxl->bytes_in_buffer) != JXL_DEC_SUCCESS) {
+		vips_foreign_load_jxl_error(jxl, "JxlDecoderSetInput");
+		return -1;
+	}
 
 	jxl->frame_count = 0;
 
@@ -1061,8 +1069,11 @@ vips_foreign_load_jxl_load(VipsForeignLoad *load)
 
 	if (vips_foreign_load_jxl_fill_input(jxl, 0) < 0)
 		return -1;
-	JxlDecoderSetInput(jxl->decoder,
-		jxl->input_buffer, jxl->bytes_in_buffer);
+	if (JxlDecoderSetInput(jxl->decoder,
+			jxl->input_buffer, jxl->bytes_in_buffer) != JXL_DEC_SUCCESS) {
+		vips_foreign_load_jxl_error(jxl, "JxlDecoderSetInput");
+		return -1;
+	}
 
 	if (jxl->n > 1) {
 		if (vips_image_generate(t[0],

--- a/libvips/foreign/jxlsave.c
+++ b/libvips/foreign/jxlsave.c
@@ -154,6 +154,17 @@ typedef VipsForeignSaveClass VipsForeignSaveJxlClass;
 G_DEFINE_ABSTRACT_TYPE(VipsForeignSaveJxl, vips_foreign_save_jxl,
 	VIPS_TYPE_FOREIGN_SAVE);
 
+static void
+vips_foreign_save_jxl_error(VipsForeignSaveJxl *jxl, const char *details)
+{
+	VipsObjectClass *class = VIPS_OBJECT_GET_CLASS(jxl);
+
+	/* TODO ... libjxl seems to have no way to get error messages at the
+	 * moment.
+	 */
+	vips_error(class->nickname, "%s error", details);
+}
+
 #ifdef HAVE_LIBJXL_0_9
 static void *
 vips_foreign_save_jxl_get_buffer(void *opaque, size_t *size)
@@ -188,17 +199,21 @@ vips_foreign_save_jxl_set_finalized_position(void *opaque, uint64_t position)
 	// don't need this
 }
 
-static void
+static int
 vips_foreign_save_jxl_set_output_processor(VipsForeignSaveJxl *jxl)
 {
-	JxlEncoderSetOutputProcessor(jxl->encoder,
-		(struct JxlEncoderOutputProcessor) {
-		.opaque = jxl,
-		.get_buffer = vips_foreign_save_jxl_get_buffer,
-		.release_buffer = vips_foreign_save_jxl_output_release_buffer,
-		.seek = vips_foreign_save_jxl_seek,
-		.set_finalized_position = vips_foreign_save_jxl_set_finalized_position,
-	});
+	if (JxlEncoderSetOutputProcessor(jxl->encoder,
+			(struct JxlEncoderOutputProcessor) {
+				.opaque = jxl,
+				.get_buffer = vips_foreign_save_jxl_get_buffer,
+				.release_buffer = vips_foreign_save_jxl_output_release_buffer,
+				.seek = vips_foreign_save_jxl_seek,
+				.set_finalized_position = vips_foreign_save_jxl_set_finalized_position,
+			}) != JXL_ENC_SUCCESS) {
+		vips_foreign_save_jxl_error(jxl, "JxlEncoderSetOutputProcessor");
+		return -1;
+	}
+	return 0;
 }
 
 static void
@@ -330,17 +345,6 @@ vips_foreign_save_jxl_set_input_source(VipsForeignSaveJxl *jxl)
 	};
 }
 #endif /*defined(HAVE_LIBJXL_0_9)*/
-
-static void
-vips_foreign_save_jxl_error(VipsForeignSaveJxl *jxl, const char *details)
-{
-	VipsObjectClass *class = VIPS_OBJECT_GET_CLASS(jxl);
-
-	/* TODO ... libjxl seems to have no way to get error messages at the
-	 * moment.
-	 */
-	vips_error(class->nickname, "%s error", details);
-}
 
 #ifdef DEBUG
 static void
@@ -712,14 +716,18 @@ vips_foreign_save_jxl_save_page(VipsForeignSaveJxl *jxl,
 
 	JxlEncoderFrameSettings *frame_settings =
 		JxlEncoderFrameSettingsCreate(jxl->encoder, NULL);
-	JxlEncoderFrameSettingsSetOption(frame_settings,
-		JXL_ENC_FRAME_SETTING_DECODING_SPEED, jxl->tier);
-	JxlEncoderSetFrameDistance(frame_settings,
-		jxl->distance);
-	JxlEncoderFrameSettingsSetOption(frame_settings,
-		JXL_ENC_FRAME_SETTING_EFFORT, jxl->effort);
-	JxlEncoderSetFrameLossless(frame_settings,
-		jxl->lossless);
+	if (JxlEncoderFrameSettingsSetOption(frame_settings,
+			JXL_ENC_FRAME_SETTING_DECODING_SPEED, jxl->tier) != JXL_ENC_SUCCESS ||
+		JxlEncoderSetFrameDistance(frame_settings,
+			jxl->distance) != JXL_ENC_SUCCESS ||
+		JxlEncoderFrameSettingsSetOption(frame_settings,
+			JXL_ENC_FRAME_SETTING_EFFORT, jxl->effort) != JXL_ENC_SUCCESS ||
+		JxlEncoderSetFrameLossless(frame_settings,
+			jxl->lossless) != JXL_ENC_SUCCESS) {
+		VIPS_FREEF(g_hash_table_destroy, jxl->tile_hash);
+		vips_foreign_save_jxl_error(jxl, "JxlEncoderFrameSettings");
+		return -1;
+	}
 
 	if (jxl->info.have_animation) {
 		JxlFrameHeader header = { 0 };
@@ -729,7 +737,11 @@ vips_foreign_save_jxl_save_page(VipsForeignSaveJxl *jxl,
 		else
 			header.duration = vips_foreign_save_jxl_get_delay(jxl, n);
 
-		JxlEncoderSetFrameHeader(frame_settings, &header);
+		if (JxlEncoderSetFrameHeader(frame_settings, &header) != JXL_ENC_SUCCESS) {
+			VIPS_FREEF(g_hash_table_destroy, jxl->tile_hash);
+			vips_foreign_save_jxl_error(jxl, "JxlEncoderSetFrameHeader");
+			return -1;
+		}
 	}
 
 	if (JxlEncoderAddChunkedFrame(frame_settings,
@@ -752,7 +764,8 @@ vips_foreign_save_jxl_save_page(VipsForeignSaveJxl *jxl,
 static int
 vips_foreign_save_jxl_save(VipsForeignSaveJxl *jxl, VipsImage *in)
 {
-	vips_foreign_save_jxl_set_output_processor(jxl);
+	if (vips_foreign_save_jxl_set_output_processor(jxl))
+		return -1;
 	vips_foreign_save_jxl_set_input_source(jxl);
 
 	for (int n = 0; n < jxl->page_count; n++) {
@@ -814,18 +827,24 @@ vips_foreign_save_jxl_add_frame(VipsForeignSaveJxl *jxl)
 {
 	JxlEncoderFrameSettings *frame_settings =
 		JxlEncoderFrameSettingsCreate(jxl->encoder, NULL);
-	JxlEncoderFrameSettingsSetOption(frame_settings,
-		JXL_ENC_FRAME_SETTING_DECODING_SPEED, jxl->tier);
-	JxlEncoderSetFrameDistance(frame_settings, jxl->distance);
-	JxlEncoderFrameSettingsSetOption(frame_settings,
-		JXL_ENC_FRAME_SETTING_EFFORT, jxl->effort);
-	JxlEncoderSetFrameLossless(frame_settings, jxl->lossless);
+	if (JxlEncoderFrameSettingsSetOption(frame_settings,
+			JXL_ENC_FRAME_SETTING_DECODING_SPEED, jxl->tier) != JXL_ENC_SUCCESS ||
+		JxlEncoderSetFrameDistance(frame_settings, jxl->distance) != JXL_ENC_SUCCESS ||
+		JxlEncoderFrameSettingsSetOption(frame_settings,
+			JXL_ENC_FRAME_SETTING_EFFORT, jxl->effort) != JXL_ENC_SUCCESS ||
+		JxlEncoderSetFrameLossless(frame_settings, jxl->lossless) != JXL_ENC_SUCCESS) {
+		vips_foreign_save_jxl_error(jxl, "JxlEncoderFrameSettings");
+		return -1;
+	}
 
 #ifdef HAVE_LIBJXL_0_8
 	const JxlBitDepth bitdepth = {
 		.type = JXL_BIT_DEPTH_FROM_CODESTREAM,
 	};
-	JxlEncoderSetFrameBitDepth(frame_settings, &bitdepth);
+	if (JxlEncoderSetFrameBitDepth(frame_settings, &bitdepth) != JXL_ENC_SUCCESS) {
+		vips_foreign_save_jxl_error(jxl, "JxlEncoderSetFrameBitDepth");
+		return -1;
+	}
 #endif
 
 	if (jxl->info.have_animation) {
@@ -837,7 +856,10 @@ vips_foreign_save_jxl_add_frame(VipsForeignSaveJxl *jxl)
 			header.duration =
 				vips_foreign_save_jxl_get_delay(jxl, jxl->page_number);
 
-		JxlEncoderSetFrameHeader(frame_settings, &header);
+		if (JxlEncoderSetFrameHeader(frame_settings, &header) != JXL_ENC_SUCCESS) {
+			vips_foreign_save_jxl_error(jxl, "JxlEncoderSetFrameHeader");
+			return -1;
+		}
 	}
 
 	if (JxlEncoderAddImageFrame(frame_settings, &jxl->format,


### PR DESCRIPTION
This PR adds a few more checks to libjxl decode and encode API responses where a status code is provided.

(This was discovered whilst investigating https://issues.oss-fuzz.com/issues/517017449 but I don't think it fixes the problem.)