### PR TITLE
archive: fix compatibility with MSVC

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -23,6 +23,7 @@ tbd 8.18.3
 - reduceh: fix possible OOB read in Highway path [kleisauke]
 - buildlut: check upper bound of x range [lovell]
 - jxl: ensure status codes are propagated [lovell]
+- archive: fix compatibility with MSVC [eunos-1128]
 
 31/3/26 8.18.2
 

--- a/libvips/foreign/archive.c
+++ b/libvips/foreign/archive.c
@@ -79,7 +79,14 @@ vips__archive_free(VipsArchive *archive)
 	VIPS_FREE(archive);
 }
 
-static ssize_t
+#if ARCHIVE_VERSION_NUMBER >= 3002000
+/* la_ssize_t requires libarchive >= v3.2.0.
+ * https://github.com/libarchive/libarchive/pull/558
+ */
+static la_ssize_t
+#else
+static __LA_SSIZE_T
+#endif
 zip_write_target_cb(struct archive *a, void *client_data,
 	const void *data, size_t length)
 {


### PR DESCRIPTION
As a possible follow-up for libvips 8.19, we could consider raising our minimum required version of libarchive to 3.2.0 (as RHEL 8 and its derivatives already provide version 3.3.3).

Context: https://github.com/conda-forge/libvips-feedstock/pull/161#discussion_r3311550250.