### PR TITLE
heifload: allow mif2 and mif3 brand images

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -22,6 +22,7 @@ date-tbd 8.19.0
 - uhdrsave: add existing JPEG options for base image [lovell]
 - csvload: add maximum limit on column count [lovell]
 - pdfload_buffer: only search the first few bytes in is_a [violetviolinist]
+- heifload: allow mif2 and mif3 "brand" images e.g. mini box [lovell]
 
 tbd 8.18.3
 

--- a/libvips/foreign/heifload.c
+++ b/libvips/foreign/heifload.c
@@ -391,6 +391,8 @@ static const char *heif_magic[] = {
 	"ftyphevm", /* Multiview sequence */
 	"ftyphevs", /* Scalable sequence */
 	"ftypmif1", /* Nokia alpha_ image */
+	"ftypmif2", /* mif1 plus rref and iscl boxes */
+	"ftypmif3", /* Low-overhead mini box */
 	"ftypmsf1", /* Nokia animation image */
 	"ftypavif"	/* AV1 image format */
 };


### PR DESCRIPTION
There's an example of `ftypmif3` at [lightning_mini.heif](https://github.com/strukturag/libheif/blob/master/tests/data/lightning_mini.heif). I expect these will become popular soon, especially for icons and thumbnails as the header is much smaller.

I also added `ftypmif2` for completeness as [it appears to be supported](https://github.com/strukturag/libheif/blob/9502996a40f076391cd637867cc25a26cbf23891/libheif/api/libheif/heif_brands.h#L134-L150) upstream.