### PR TITLE
ppmload: fix get_flags return code

### DIFF
--- a/libvips/foreign/ppmload.c
+++ b/libvips/foreign/ppmload.c
@@ -403,7 +403,7 @@ vips_foreign_load_ppm_get_flags(VipsForeignLoad *load)
 	VipsForeignFlags flags;
 
 	if (vips_foreign_load_ppm_parse_header(ppm))
-		return -1;
+		return 0;
 
 	flags = 0;
 


### PR DESCRIPTION
Fixes a regression introduced in commit abb668e.

<details>
  <summary>Reproducer</summary>

```console
$ printf 'P5\n0 1\n65536\n' > invalid_header.ppm
$ printf '\x7F\xFF\xFF\xFF%.0s' >> invalid_header.ppm
$ vipsheader invalid_header.ppm

(vipsheader:169688): VIPS-WARNING **: 10:28:16.193: VIPS_FOREIGN_PARTIAL and VIPS_FOREIGN_SEQUENTIAL both set -- using SEQUENTIAL

(vipsheader:169688): GLib-GObject-CRITICAL **: 10:28:16.193: value "((VipsForeignFlags) VIPS_FOREIGN_BIGENDIAN | VIPS_FOREIGN_SEQUENTIAL | 4294967288)" of type 'VipsForeignFlags' is invalid or out of range for property 'flags' of type 'VipsForeignFlags'
vipsheader: ppmload: bad image dimensions
ppmload: bad magic number
```
</details>
