### PR TITLE
Fix `-Wunused-but-set-variable` warning

### DIFF
--- a/libvips/iofuncs/generate.c
+++ b/libvips/iofuncs/generate.c
@@ -278,14 +278,8 @@ vips__demand_hint_array(VipsImage *image,
 {
 	VipsDemandStyle hint = (VipsDemandStyle) int_hint;
 
-	int i, len, nany;
+	int i, len;
 	VipsDemandStyle set_hint;
-
-	/* How many input images are there? And how many are ANY?
-	 */
-	for (i = 0, len = 0, nany = 0; in[i]; i++, len++)
-		if (in[i]->dhint == VIPS_DEMAND_STYLE_ANY)
-			nany++;
 
 	/* Find the most restrictive of all the hints available to us.
 	 *
@@ -296,7 +290,7 @@ vips__demand_hint_array(VipsImage *image,
 	 * FATSTRIP.
 	 */
 	set_hint = hint;
-	for (i = 0; i < len; i++)
+	for (i = 0, len = 0; in[i]; i++, len++)
 		set_hint = (VipsDemandStyle)
 			VIPS_MIN((int) set_hint, (int) in[i]->dhint);
 


### PR DESCRIPTION
Introduced in GCC 16.
https://gcc.gnu.org/gcc-16/porting_to.html#changes-to-wunused

```console
[1/19] Compiling C object libvips/iofuncs/libiofuncs.a.p/generate.c.o
../libvips/iofuncs/generate.c: In function ‘vips__demand_hint_array’:
../libvips/iofuncs/generate.c:281:21: warning: variable ‘nany’ set but not used [-Wunused-but-set-variable=]
  281 |         int i, len, nany;
      |                     ^~~~
```