### PR TITLE
fix: jpegsave without uhdrsave

### DIFF
--- a/libvips/foreign/jpegsave.c
+++ b/libvips/foreign/jpegsave.c
@@ -132,6 +132,12 @@ static VipsBandFormat bandfmt_jpeg[10] = {
 	/* Promotion: */ UC, UC, UC, UC, UC, UC, UC, UC, UC, UC
 };
 
+#ifdef HAVE_UHDR
+static const gboolean have_uhdr = TRUE;
+#else
+static const gboolean have_uhdr = FALSE;
+#endif
+
 static int
 vips_foreign_save_jpeg_build(VipsObject *object)
 {
@@ -148,9 +154,10 @@ vips_foreign_save_jpeg_build(VipsObject *object)
 		jpeg->subsample_mode = jpeg->no_subsample ?
 			VIPS_FOREIGN_SUBSAMPLE_OFF : VIPS_FOREIGN_SUBSAMPLE_AUTO;
 
-	if (vips_image_get_typeof(save->ready, "gainmap-data") ||
-		save->ready->Type == VIPS_INTERPRETATION_scRGB ||
-		vips__image_is_cicp_hdr(save->ready)) {
+	if (have_uhdr &&
+		(vips_image_get_typeof(save->ready, "gainmap-data") ||
+		 save->ready->Type == VIPS_INTERPRETATION_scRGB ||
+		 vips__image_is_cicp_hdr(save->ready))) {
 		/* Pass on to uhdrsave.
 		 */
 		if (vips_uhdrsave_target(save->ready, jpeg->target,


### PR DESCRIPTION
jpegsave should not defer to uhdrsave if uhdr support is missing

Right now, if you build without uhdr support, you can trigger this error:

	$ vips copy k2.jpg x.hdr
	$ vips copy x.hdr x.jpg
	VipsOperation: class "uhdrsave_target" not found

Because jpegsave will see the HDR image and call uhdrsave.

It should not do this if uhdr support is disabled.