### PR TITLE
fix: undeprecate old-style radload

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -16,6 +16,7 @@
 - heifload: tighten limits on memory use [provos]
 - boolean: fix heap-buffer-overflow in lshift [dloebl]
 - magickload: check animation height [Himanshu Anand]
+- source: fix max/min confusion [Himanshu Anand]
 - uhdrsave: use macro to size buffer [Himanshu Anand]
 - draw_mask: fix support for packed LABQ images [lovell]
 - reduceh: fix possible OOB read in Highway path [kleisauke]

--- a/ChangeLog
+++ b/ChangeLog
@@ -16,8 +16,6 @@
 - heifload: tighten limits on memory use [provos]
 - boolean: fix heap-buffer-overflow in lshift [dloebl]
 - magickload: check animation height [Himanshu Anand]
-- radload: deprecate old-style scanline read [Himanshu Anand]
-- source: fix max/min confusion [Himanshu Anand]
 - uhdrsave: use macro to size buffer [Himanshu Anand]
 - draw_mask: fix support for packed LABQ images [lovell]
 - reduceh: fix possible OOB read in Highway path [kleisauke]

--- a/libvips/foreign/radiance.c
+++ b/libvips/foreign/radiance.c
@@ -361,12 +361,11 @@ getheader(VipsSbuf *sbuf, gethfunc *f, void *p)
 	return 0;
 }
 
-/* Read a single scanline, encoded in the old style.
+/* Read a single scanline, encoded in the old style, or unencoded.
  */
 static int
 scanline_read_old(VipsSbuf *sbuf, COLR *scanline, int width)
 {
-#ifdef ENABLE_DEPRECATED
 	int rshift = 0;
 	COLR *q = scanline;
 	int n = width;
@@ -411,12 +410,6 @@ scanline_read_old(VipsSbuf *sbuf, COLR *scanline, int width)
 	}
 
 	return 0;
-#else /*!ENABLE_DEPRECATED*/
-	/* Old-style radiance read is deprecated.
-	 */
-	vips_error("rad2vips", "%s", _("deprecated old-style RAD scanline"));
-	return -1;
-#endif /*ENABLE_DEPRECATED*/
 }
 
 /* Read a single encoded scanline.


### PR DESCRIPTION
This path was used for uncompressed scanlines too.

See https://github.com/libvips/libvips/issues/5065