### PR TITLE
raise security limits for heifload

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,7 @@
+date tbd 8.18.4
+
+- heifload: raise security limits on references [caseywebdev]
+
 6/6/26 8.18.3
 
 - invertlut: verify input mask positions [lovell]

--- a/libvips/foreign/heifload.c
+++ b/libvips/foreign/heifload.c
@@ -362,7 +362,7 @@ vips_foreign_load_heif_build(VipsObject *object)
 
 			limits->max_total_memory = 2L * 1024 * 1024 * 1024;
 			limits->max_memory_block_size = 1024 * 1024 * 1024;
-			limits->max_items = 16;
+			limits->max_items = 64;
 		}
 #endif /* HAVE_HEIF_MAX_TOTAL_MEMORY */
 #ifdef HAVE_HEIF_GET_DISABLED_SECURITY_LIMITS

--- a/meson.build
+++ b/meson.build
@@ -1,5 +1,5 @@
 project('vips', 'c', 'cpp',
-    version: '8.18.3',
+    version: '8.18.4',
     meson_version: '>=0.55',
     default_options: [
         # this is what glib uses (one of our required deps), so we use it too
@@ -23,7 +23,7 @@ version_patch = version_parts[2]
 # binary interface changed: increment current, reset revision to 0
 #   binary interface changes backwards compatible?: increment age
 #   binary interface changes not backwards compatible?: reset age to 0
-library_revision = 3
+library_revision = 4
 library_current = 62
 library_age = 20
 library_version = '@0@.@1@.@2@'.format(library_current - library_age, library_age, library_revision)


### PR DESCRIPTION
Raise the number of allowed references from 16 to 64. This lets ordinary iphone photos pass security checks.

Also bump version to 8.18.4.

Referring issue:

https://github.com/libvips/libvips/pull/5034#issuecomment-4681459132