### PR TITLE
add VIPS_UHDR_TO_SCRGB

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -26,6 +26,7 @@ date-tbd 8.19.0
 - add VIPS_MEMCPY() [kleisauke]
 - heifload: allow mif2 and mif3 "brand" images e.g. mini box [lovell]
 - add vips_scRGB2CICP [mertalev]
+- add VIPS_UHDR_TO_SCRGB
 
 6/6/26 8.18.3
 

--- a/libvips/colour/uhdr2scRGB.c
+++ b/libvips/colour/uhdr2scRGB.c
@@ -69,11 +69,6 @@ G_DEFINE_TYPE(VipsUhdr2scRGB, vips_uhdr2scRGB, VIPS_TYPE_COLOUR);
 /* Derived from the apache-licensed applyGain() method of libuhdr.
  */
 
-/* Rescale from libuhdr's linear convention (1.0 = 203 nits, the ITU-R
- * BT.2408 SDR reference white) to scRGB (1.0 = 80 nits).
- */
-#define UHDR_TO_SCRGB (203.0f / 80.0f)
-
 /* Monochrome gainmap, colour image. Probably the most common case.
  */
 static void
@@ -102,9 +97,12 @@ vips_uhdr2scRGB_mono(VipsUhdr2scRGB *uhdr,
 
 		float gaing = exp2(boostg);
 
-		q[0] = (((r + uhdr->offset_sdr[1]) * gaing) - uhdr->offset_hdr[1]) * UHDR_TO_SCRGB;
-		q[1] = (((g + uhdr->offset_sdr[1]) * gaing) - uhdr->offset_hdr[1]) * UHDR_TO_SCRGB;
-		q[2] = (((b + uhdr->offset_sdr[1]) * gaing) - uhdr->offset_hdr[1]) * UHDR_TO_SCRGB;
+		q[0] = VIPS_UHDR_TO_SCRGB *
+			(((r + uhdr->offset_sdr[1]) * gaing) - uhdr->offset_hdr[1]);
+		q[1] = VIPS_UHDR_TO_SCRGB *
+			(((g + uhdr->offset_sdr[1]) * gaing) - uhdr->offset_hdr[1]);
+		q[2] = VIPS_UHDR_TO_SCRGB *
+			(((b + uhdr->offset_sdr[1]) * gaing) - uhdr->offset_hdr[1]);
 		q += 3;
 	}
 }
@@ -147,9 +145,12 @@ vips_uhdr2scRGB_rgb(VipsUhdr2scRGB *uhdr, VipsPel *out, VipsPel **in, int width)
 		float gaing = exp2(boostg);
 		float gainb = exp2(boostb);
 
-		q[0] = (((r + uhdr->offset_sdr[0]) * gainr) - uhdr->offset_hdr[0]) * UHDR_TO_SCRGB;
-		q[1] = (((g + uhdr->offset_sdr[1]) * gaing) - uhdr->offset_hdr[1]) * UHDR_TO_SCRGB;
-		q[2] = (((b + uhdr->offset_sdr[2]) * gainb) - uhdr->offset_hdr[2]) * UHDR_TO_SCRGB;
+		q[0] = VIPS_UHDR_TO_SCRGB *
+			(((r + uhdr->offset_sdr[0]) * gainr) - uhdr->offset_hdr[0]);
+		q[1] = VIPS_UHDR_TO_SCRGB *
+			(((g + uhdr->offset_sdr[1]) * gaing) - uhdr->offset_hdr[1]);
+		q[2] = VIPS_UHDR_TO_SCRGB *
+			(((b + uhdr->offset_sdr[2]) * gainb) - uhdr->offset_hdr[2]);
 		q += 3;
 	}
 }

--- a/libvips/foreign/uhdrsave.c
+++ b/libvips/foreign/uhdrsave.c
@@ -523,7 +523,7 @@ vips_foreign_save_uhdr_build(VipsObject *object)
 		/* Rescale from scRGB (1.0 = 80 nits) to libuhdr's UHDR_CT_LINEAR
 		 * convention (1.0 = 203 nits, the ITU-R BT.2408 reference white).
 		 */
-		if (vips_linear1(image, &x, 80.0 / 203.0, 0.0, NULL)) {
+		if (vips_linear1(image, &x, 1.0 / VIPS_UHDR_TO_SCRGB, 0.0, NULL)) {
 			VIPS_UNREF(image);
 			return -1;
 		}

--- a/libvips/histogram/percent_lum.c
+++ b/libvips/histogram/percent_lum.c
@@ -73,8 +73,7 @@ vips_percent_lum_scan(VipsRegion *region, void *seq,
 	const float scale = master->bin_scale;
 
 	for (int y = 0; y < r->height; y++) {
-		float *p = (float *)
-			VIPS_REGION_ADDR(region, r->left, r->top + y);
+		float *p = (float *) VIPS_REGION_ADDR(region, r->left, r->top + y);
 
 		for (int x = 0; x < r->width; x++) {
 			float Y = 0.2126f * p[0] + 0.7152f * p[1] + 0.0722f * p[2];
@@ -124,10 +123,8 @@ vips_percent_lum_build(VipsObject *object)
 	accum.bin_scale = (float) (PERCENT_LUM_BINS / pl->max);
 
 	if (vips_sink(pl->in,
-			vips_percent_lum_start,
-			vips_percent_lum_scan,
-			vips_percent_lum_stop,
-			&accum, NULL))
+		vips_percent_lum_start, vips_percent_lum_scan, vips_percent_lum_stop,
+		&accum, NULL))
 		return -1;
 
 	if (accum.count == 0) {
@@ -143,7 +140,6 @@ vips_percent_lum_build(VipsObject *object)
 		if (cumul >= target)
 			break;
 	}
-
 	double threshold = (bin + 0.5) * (pl->max / PERCENT_LUM_BINS);
 
 	g_object_set(object, "threshold", threshold, NULL);

--- a/libvips/include/vips/colour.h
+++ b/libvips/include/vips/colour.h
@@ -93,6 +93,11 @@ extern "C" {
 #define VIPS_D3250_Y0 (100.0)
 #define VIPS_D3250_Z0 (45.8501)
 
+/* Rescale from libuhdr's linear convention (1.0 = 203 nits, the ITU-R
+ * BT.2408 SDR reference white) to scRGB (1.0 = 80 nits).
+ */
+#define VIPS_UHDR_TO_SCRGB (203.0f / 80.0f)
+
 /* Note: constants align with those defined in lcms2.h, except for
  * VIPS_INTENT_AUTO, which is libvips-specific.
  */


### PR DESCRIPTION
non-functional change

- move the 203/80 magic number into colour.h as VIPS_UHDR_TO_SCRGB
- use it in uhdr2scRGB.c and uhdrsave.c
- small formatting improvements