### PR TITLE
dcrawload add half_size

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -29,6 +29,7 @@ date-tbd 8.19.0
 - add VIPS_UHDR_TO_SCRGB
 - add uchar options to premultiply and unpremultiply [jcupitt]
 - vipsthumbnail: add '@' modifier for size to pixel count
+- dcrawload: add half-size option
 
 6/6/26 8.18.3
 

--- a/libvips/foreign/dcrawload.c
+++ b/libvips/foreign/dcrawload.c
@@ -2,6 +2,8 @@
  *
  * 15/8/25 dvdkon
  *	- handle image rotation
+ * 15/6/26
+ *	- add half_size
  */
 
 /*
@@ -66,6 +68,7 @@ typedef struct _VipsForeignLoadDcRaw {
 	VipsForeignLoad parent_object;
 
 	int bitdepth;
+	gboolean half_size;
 
 	/* LibRaw processor.
 	 */
@@ -141,6 +144,10 @@ vips_foreign_load_dcraw_open(VipsForeignLoadDcRaw *raw)
 		return -1;
 	}
 	raw->raw_processor->params.output_bps = raw->bitdepth;
+
+	/* Fast half-size decoding.
+	 */
+	raw->raw_processor->params.half_size = raw->half_size;
 
 	/* Apply camera white balance.
 	 */
@@ -473,10 +480,17 @@ vips_foreign_load_dcraw_class_init(VipsForeignLoadDcRawClass *class)
 
 	VIPS_ARG_INT(class, "bitdepth", 12,
 		_("Bit depth"),
-		_("Number of bits per pixel"),
+		_("Number of bits to decode to"),
 		VIPS_ARGUMENT_OPTIONAL_INPUT,
 		G_STRUCT_OFFSET(VipsForeignLoadDcRaw, bitdepth),
 		8, 16, 8);
+
+	VIPS_ARG_BOOL(class, "half_size", 13,
+		_("Half-size"),
+		_("Decode image at half size"),
+		VIPS_ARGUMENT_OPTIONAL_INPUT,
+		G_STRUCT_OFFSET(VipsForeignLoadDcRaw, half_size),
+		FALSE);
 
 }
 
@@ -702,8 +716,15 @@ vips_foreign_load_dcraw_buffer_init(VipsForeignLoadDcRawBuffer *buffer)
  * grayscale image suitable for further processing. It attaches XMP and ICC
  * metadata, if present.
  *
+ * Set @half_size to decode at half-size. This can be much faster, though of
+ * course the image is smaller.
+ *
+ * Set @bit_depth to control the number of bits to decode to. Either 8 or 16,
+ * default 8,
+ *
  * ::: tip "Optional arguments"
- *     * @bitdepth: `gint`, load as 8 or 16 bit data
+ *     * @bitdepth: `gint`, number of bits to decode to
+ *     * @half_size: `gboolean`, decode at half-size
  *
  * Returns: 0 on success, -1 on error.
  */
@@ -729,7 +750,8 @@ vips_dcrawload(const char *filename, VipsImage **out, ...)
  * Exactly as [ctor@Image.dcrawload], but read from a source.
  *
  * ::: tip "Optional arguments"
- *     * @bitdepth: `gint`, load as 8 or 16 bit data
+ *     * @bitdepth: `gint`, number of bits to decode to
+ *     * @half_size: `gboolean`, decode at half-size
  *
  * ::: seealso
  *     [ctor@Image.dcrawload].
@@ -759,7 +781,8 @@ vips_dcrawload_source(VipsSource *source, VipsImage **out, ...)
  * Exactly as [ctor@Image.dcrawload], but read from a buffer.
  *
  * ::: tip "Optional arguments"
- *     * @bitdepth: `gint`, load as 8 or 16 bit data
+ *     * @bitdepth: `gint`, number of bits to decode to
+ *     * @half_size: `gboolean`, decode at half-size
  *
  * ::: seealso
  *     [ctor@Image.dcrawload].


### PR DESCRIPTION
add half_size to dcrawload. This makes a half-size image quickly:

	$ time vips copy RAW_NIKON_E5700_SRGB.NEF x.jpg
	real	0m0.828s
	user	0m0.992s
	sys	0m0.259s

	$ time vips copy RAW_NIKON_E5700_SRGB.NEF[half-size] x.jpg
	real	0m0.116s
	user	0m0.280s
	sys	0m0.162s

Closes #5032