### PR TITLE
dcrawload: add preview jpegs

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -29,6 +29,7 @@ date-tbd 8.19.0
 - add VIPS_UHDR_TO_SCRGB
 - add uchar options to premultiply and unpremultiply [jcupitt]
 - vipsthumbnail: add '@' modifier for size to pixel count
+- dcrawload: attach preview jpeg as metadata
 
 6/6/26 8.18.3
 

--- a/libvips/foreign/dcrawload.c
+++ b/libvips/foreign/dcrawload.c
@@ -350,6 +350,11 @@ vips_foreign_load_dcraw_set_metadata(VipsForeignLoadDcRaw *raw,
 		vips_image_set_blob_copy(image, "jpeg-thumbnail-data",
 			raw->raw_processor->thumbnail.thumb,
 			raw->raw_processor->thumbnail.tlength);
+
+		// old deprecated name for compat
+		vips_image_set_blob_copy(image, "raw-thumbnail-data",
+			raw->raw_processor->thumbnail.thumb,
+			raw->raw_processor->thumbnail.tlength);
 	}
 
 	if (preview_index != -1 &&

--- a/libvips/foreign/dcrawload.c
+++ b/libvips/foreign/dcrawload.c
@@ -2,6 +2,8 @@
  *
  * 15/8/25 dvdkon
  *	- handle image rotation
+ * 15/6/26
+ *	- add raw-preview-data, the largest embedded preview jpeg
  */
 
 /*
@@ -273,45 +275,61 @@ vips_foreign_load_dcraw_set_metadata(VipsForeignLoadDcRaw *raw,
 	vips_image_set_int(image, VIPS_META_ORIENTATION, orientation);
 
 #if LIBRAW_COMPILE_CHECK_VERSION_NOTLESS(0, 21)
-	/* Search the available thumbnails for the largest that's smaller than
-	 * the main image and has a known type.
+	/* Search the available thumbnails for a thumbnail and a preview.
+	 *
+	 * thumbnail: largest that's under 1mb
+	 * preview: as large as possible
+	 *
+	 * both must be jpg, have the same number of bands as the main image, be 8
+	 * bit.
 	 */
-	libraw_image_sizes_t *sizes = &raw->raw_processor->sizes;
 	libraw_thumbnail_list_t *thumbs_list = &raw->raw_processor->thumbs_list;
 
 	int thumb_index;
+	int preview_index;
 
 	thumb_index = -1;
+	preview_index = -1;
 	for (int i = 0; i < thumbs_list->thumbcount; i++) {
-		libraw_thumbnail_item_t *best = thumb_index == -1 ?
-			NULL : &thumbs_list->thumblist[thumb_index];
 		libraw_thumbnail_item_t *this = &thumbs_list->thumblist[i];
+
+#ifdef DEBUG
+		printf("dcrawload: thumb %d, width = %d, height = %d, format = %d\n",
+				i, this->twidth, this->twidth, this->tformat);
+#endif /*DEBUG*/
 
 		// only support JPEG thumbnails for now
 		if (this->tformat != LIBRAW_INTERNAL_THUMBNAIL_JPEG)
 			continue;
 
-		// useless thumbnails the same size as the main image are very
-		// common
-		if (this->twidth >= sizes->iwidth &&
-			this->theight >= sizes->iheight)
-			continue;
-
 		// must be 8-bit, must match the main image in bands
 		int bpp = this->tmisc & ((1 << 5) - 1);
-		int bands = this->tmisc >> 5;
+		int this_bands = this->tmisc >> 5 > 1 ? 3 : 1;
+		int image_bands = raw->raw_processor->idata.colors > 1 ? 3 : 1;
 		if (bpp != 8 ||
-			bands != raw->raw_processor->idata.colors)
+			this_bands != image_bands)
 			continue;
 
-		// size must be sane (under 1mb).
-		if (this->tlength > 1024 * 1024)
-			continue;
+		// thumbnails must be under 1mb
+		if (this->tlength < 1024 * 1024) {
+			libraw_thumbnail_item_t *thumb = thumb_index == -1 ?
+				NULL : &thumbs_list->thumblist[thumb_index];
 
-		if (!best ||
-			this->twidth > best->twidth ||
-			this->theight > best->theight)
-			thumb_index = i;
+			if (!thumb ||
+				this->twidth > thumb->twidth ||
+				this->theight > thumb->theight)
+				thumb_index = i;
+		}
+
+		// preview is just the largest
+		libraw_thumbnail_item_t *preview = preview_index == -1 ?
+			NULL : &thumbs_list->thumblist[preview_index];
+
+		if (!preview ||
+			this->twidth > preview->twidth ||
+			this->theight > preview->theight)
+			preview_index = i;
+
 	}
 
 	if (thumb_index != -1) {
@@ -323,10 +341,26 @@ vips_foreign_load_dcraw_set_metadata(VipsForeignLoadDcRaw *raw,
 			return -1;
 		}
 
-		vips_image_set_blob_copy(image, "raw-thumbnail-data",
+		vips_image_set_blob_copy(image, "jpeg-thumbnail-data",
 			raw->raw_processor->thumbnail.thumb,
 			raw->raw_processor->thumbnail.tlength);
 	}
+
+	if (preview_index != -1 &&
+		preview_index != thumb_index) {
+		int result;
+		result = libraw_unpack_thumb_ex(raw->raw_processor, preview_index);
+		if (result != LIBRAW_SUCCESS) {
+			vips_foreign_load_dcraw_error(raw,
+				_("unable to unpack preview"), result);
+			return -1;
+		}
+
+		vips_image_set_blob_copy(image, "jpeg-preview-data",
+			raw->raw_processor->thumbnail.thumb,
+			raw->raw_processor->thumbnail.tlength);
+	}
+
 #endif /*LIBRAW_COMPILE_CHECK_VERSION_NOTLESS(0, 21)*/
 
 	return 0;
@@ -701,6 +735,9 @@ vips_foreign_load_dcraw_buffer_init(VipsForeignLoadDcRawBuffer *buffer)
  * The loader applies demosaicing and basic processing to produce an RGB or
  * grayscale image suitable for further processing. It attaches XMP and ICC
  * metadata, if present.
+ *
+ * The loader will search for embedded, JPEG-encoded thumbnail and preview
+ * images, attaching them as `jpeg-thumbnail-data` and `jpeg-preview-data`.
  *
  * ::: tip "Optional arguments"
  *     * @bitdepth: `gint`, load as 8 or 16 bit data

--- a/libvips/iofuncs/header.c
+++ b/libvips/iofuncs/header.c
@@ -1571,6 +1571,7 @@ static const char *vips_image_header_deprecated[] = {
 	"gif-delay",
 	"gif-loop",
 	"palette-bit-depth",
+	"raw-thumbnail-data",
 	"heif-bitdepth"
 };
 


### PR DESCRIPTION
And rename `raw-thumbnail-data` as `jpeg-thumbnail-data`.

	$ vipsheader -f jpeg-thumbnail-data RAW_NIKON_E5700_SRGB.NEF | base64 -d > x.jpg
	$ vipsheader -f jpeg-preview-data RAW_NIKON_E5700_SRGB.NEF | base64 -d > x.jpg

closes #5026