### PR TITLE
test: relax tolerance for colourspace min/max comparison

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -77,10 +77,6 @@ jobs:
             mozjpeg openexr openjpeg openslide pango \
             poppler webp
 
-      - name: Workaround -march=x86-64-v3 GCC bug
-        if: runner.os == 'Linux' && matrix.build.cc == 'gcc-15'
-        run: echo "CPPFLAGS=-Wall -march=x86-64" >> $GITHUB_ENV
-
       - name: Prepare macOS environment
         if: runner.os == 'macOS'
         run: |

--- a/test/test-suite/test_colour.py
+++ b/test/test-suite/test_colour.py
@@ -21,7 +21,7 @@ class TestColour:
             for i in range(0, 4):
                 min_l = im.extract_band(i).min()
                 max_h = im.extract_band(i).max()
-                assert pytest.approx(min_l) == max_h
+                assert pytest.approx(min_l, abs=0.03) == max_h
 
             pixel = im(10, 10)
             if col == pyvips.Interpretation.SCRGB:


### PR DESCRIPTION
To account for floating-point variation introduced by FMA optimizations.

Context: https://github.com/libvips/libvips/pull/5079#issuecomment-4710936434.