### PR TITLE
thumbnail: preserve all pages when cropping multi-page images

### DIFF
--- a/libvips/resample/thumbnail.c
+++ b/libvips/resample/thumbnail.c
@@ -1012,11 +1012,20 @@ vips_thumbnail_build(VipsObject *object)
 	/* Crop after rotate so we don't need to rotate the crop box.
 	 */
 	if (thumbnail->crop != VIPS_INTERESTING_NONE) {
+		/* For multi-page (animated) images, page_height is the height
+		 * of a single frame. The image is a vertical stack of
+		 * n_loaded_pages frames each page_height tall.
+		 */
+		int page_height = vips_image_get_page_height(in);
+		gboolean is_multipage = thumbnail->n_loaded_pages > 1;
+
 		/* The image can be smaller than the target. Adjust the
-		 * arguments to vips_smartcrop().
+		 * arguments to vips_smartcrop(). For multi-page, crop_height
+		 * is relative to a single frame, not the toilet-roll Ysize.
 		 */
 		int crop_width = VIPS_MIN(thumbnail->width, in->Xsize);
-		int crop_height = VIPS_MIN(thumbnail->height, in->Ysize);
+		int crop_height = VIPS_MIN(thumbnail->height,
+			is_multipage ? page_height : in->Ysize);
 		int original_width = in->Xsize;
 		int original_height = in->Ysize;
 
@@ -1028,36 +1037,108 @@ vips_thumbnail_build(VipsObject *object)
 		double overall_hshrink = (double) rotated_input_width / in->Xsize;
 		double overall_vshrink = (double) rotated_input_height / in->Ysize;
 
+		/* If the multi-page image carries a gainmap, fall back to the
+		 * single-image crop path: that collapses the animation to one
+		 * frame (the existing pre-#2668 behaviour), but preserves the
+		 * gainmap-cropping logic below. HDR animated images are rare
+		 * and we don't want to silently mishandle the gainmap.
+		 */
+		gboolean has_gainmap = vips_image_get_typeof(in, "gainmap") != 0;
+		if (is_multipage && has_gainmap) {
+			g_info("multi-page image with gainmap: falling back to "
+				"single-frame crop (gainmap on animation is not "
+				"supported by the multi-page crop path)");
+			is_multipage = FALSE;
+		}
+
 		/* Need to copy to memory, we have to stay seq.
 		 *
 		 * FIXME ... could skip the copy if we've rotated.
 		 */
-		if (!(t[13] = vips_image_copy_memory(in)) ||
-			vips_smartcrop(t[13], &t[14], crop_width, crop_height,
-				"interesting", thumbnail->crop,
-				"interesting_x", VIPS_ROUND_UINT((double) thumbnail->interesting_x / overall_vshrink),
-				"interesting_y", VIPS_ROUND_UINT((double) thumbnail->interesting_y / overall_hshrink),
-				NULL))
+		if (!(t[13] = vips_image_copy_memory(in)))
 			return -1;
-		in = t[14];
 
-		int crop_left = -vips_image_get_xoffset(in);
-		int crop_top = -vips_image_get_yoffset(in);
+		if (is_multipage) {
+			/* Compute a shared bbox by smartcropping the first page,
+			 * then extract the same window from every page and rejoin
+			 * vertically. This keeps the animation coherent: the bbox
+			 * does not drift frame-to-frame.
+			 *
+			 * See ADR-2668 for the rationale.
+			 */
+			VipsImage *first_page;
+			VipsImage *first_cropped;
+			int n_pages = thumbnail->n_loaded_pages;
+			VipsImage **pages = (VipsImage **)
+				vips_object_local_array(object, n_pages);
+			int bbox_x, bbox_y;
+			int i;
 
-		/* Also crop the gainmap, if any.
-		 */
-		if ((gainmap = vips_image_get_gainmap(in))) {
-			double xscale = (double) gainmap->Xsize / original_width;
-			double yscale = (double) gainmap->Ysize / original_height;
+			if (vips_extract_area(t[13], &first_page,
+					0, 0, in->Xsize, page_height, NULL))
+				return -1;
+			vips_object_local(object, first_page);
 
-			if (vips_crop(gainmap, &t[16],
-					crop_left * xscale, crop_top * yscale,
-					crop_width * xscale, crop_height * yscale,
+			if (vips_smartcrop(first_page, &first_cropped,
+					crop_width, crop_height,
+					"interesting", thumbnail->crop,
+					"interesting_x", VIPS_ROUND_UINT((double) thumbnail->interesting_x / overall_vshrink),
+					"interesting_y", VIPS_ROUND_UINT((double) thumbnail->interesting_y / overall_hshrink),
 					NULL))
 				return -1;
-			g_object_unref(gainmap);
+			vips_object_local(object, first_cropped);
 
-			vips_image_set_image(in, "gainmap", t[16]);
+			bbox_x = -vips_image_get_xoffset(first_cropped);
+			bbox_y = -vips_image_get_yoffset(first_cropped);
+
+			for (i = 0; i < n_pages; i++) {
+				if (vips_extract_area(t[13], &pages[i],
+						bbox_x, i * page_height + bbox_y,
+						crop_width, crop_height, NULL))
+					return -1;
+			}
+
+			if (vips_arrayjoin(pages, &t[14], n_pages,
+					"across", 1, NULL))
+				return -1;
+			in = t[14];
+
+			/* Re-stamp page-height for the cropped result. The
+			 * resize-path set page_height to the pre-crop value
+			 * above; after vertical cropping we must update it.
+			 */
+			if (vips_copy(in, &t[18], NULL))
+				return -1;
+			in = t[18];
+			vips_image_set_int(in, VIPS_META_PAGE_HEIGHT, crop_height);
+		}
+		else {
+			if (vips_smartcrop(t[13], &t[14], crop_width, crop_height,
+					"interesting", thumbnail->crop,
+					"interesting_x", VIPS_ROUND_UINT((double) thumbnail->interesting_x / overall_vshrink),
+					"interesting_y", VIPS_ROUND_UINT((double) thumbnail->interesting_y / overall_hshrink),
+					NULL))
+				return -1;
+			in = t[14];
+
+			int crop_left = -vips_image_get_xoffset(in);
+			int crop_top = -vips_image_get_yoffset(in);
+
+			/* Also crop the gainmap, if any.
+			 */
+			if ((gainmap = vips_image_get_gainmap(in))) {
+				double xscale = (double) gainmap->Xsize / original_width;
+				double yscale = (double) gainmap->Ysize / original_height;
+
+				if (vips_crop(gainmap, &t[16],
+						crop_left * xscale, crop_top * yscale,
+						crop_width * xscale, crop_height * yscale,
+						NULL))
+					return -1;
+				g_object_unref(gainmap);
+
+				vips_image_set_image(in, "gainmap", t[16]);
+			}
 		}
 	}
 

--- a/libvips/resample/thumbnail.c
+++ b/libvips/resample/thumbnail.c
@@ -674,6 +674,41 @@ vips_thumbnail_open(VipsThumbnail *thumbnail)
 	return im;
 }
 
+/* Crop the same window from every page of an image and rejoin them into a
+ * toilet roll. Used for the image itself and for its gainmap, if it has one.
+ *
+ * left/top are relative to a page, not to the whole stack.
+ */
+static int
+vips_thumbnail_crop_pages(VipsObject *object, VipsImage *in, VipsImage **out,
+	int left, int top, int width, int height, int page_height, int n_pages)
+{
+	VipsImage **pages = (VipsImage **)
+		vips_object_local_array(object, n_pages);
+	VipsImage **t = (VipsImage **) vips_object_local_array(object, 1);
+
+	int i;
+
+	for (i = 0; i < n_pages; i++)
+		if (vips_crop(in, &pages[i],
+				left, i * page_height + top,
+				width, height, NULL))
+			return -1;
+
+	if (n_pages == 1)
+		return vips_arrayjoin(pages, out, n_pages, "across", 1, NULL);
+
+	/* Re-stamp page-height for the cropped result. Copy first so we don't
+	 * set metadata on a shared image.
+	 */
+	if (vips_arrayjoin(pages, &t[0], n_pages, "across", 1, NULL) ||
+		vips_copy(t[0], out, NULL))
+		return -1;
+	vips_image_set_int(*out, VIPS_META_PAGE_HEIGHT, height);
+
+	return 0;
+}
+
 static int
 vips_thumbnail_build(VipsObject *object)
 {
@@ -1032,10 +1067,7 @@ vips_thumbnail_build(VipsObject *object)
 
 		VipsImage *first_page;
 		VipsImage *first_cropped;
-		VipsImage **pages = (VipsImage **)
-			vips_object_local_array(object, n_pages);
 		int bbox_x, bbox_y;
-		int i;
 
 		/* Need to copy to memory, we have to stay seq.
 		 *
@@ -1065,24 +1097,11 @@ vips_thumbnail_build(VipsObject *object)
 		bbox_x = -vips_image_get_xoffset(first_cropped);
 		bbox_y = -vips_image_get_yoffset(first_cropped);
 
-		for (i = 0; i < n_pages; i++)
-			if (vips_crop(t[13], &pages[i],
-					bbox_x, i * page_height + bbox_y,
-					crop_width, crop_height, NULL))
-				return -1;
-
-		if (vips_arrayjoin(pages, &t[14], n_pages,
-				"across", 1, NULL))
+		if (vips_thumbnail_crop_pages(object, t[13], &t[14],
+				bbox_x, bbox_y, crop_width, crop_height,
+				page_height, n_pages))
 			return -1;
 		in = t[14];
-
-		if (n_pages > 1) {
-			/* Re-stamp page-height for the cropped result. */
-			if (vips_copy(in, &t[18], NULL))
-				return -1;
-			in = t[18];
-			vips_image_set_int(in, VIPS_META_PAGE_HEIGHT, crop_height);
-		}
 
 		/* Also crop the gainmap, if any. Gainmaps are single image
 		 * today, but animated HDR is coming, so treat a multi-page
@@ -1095,10 +1114,6 @@ vips_thumbnail_build(VipsObject *object)
 			int gm_n_pages = gainmap->Ysize / gm_page_height;
 			double xscale = (double) gainmap->Xsize / original_width;
 			double yscale = (double) gm_page_height / page_height;
-			int gm_crop_width = crop_width * xscale;
-			int gm_crop_height = crop_height * yscale;
-			VipsImage **gm_pages;
-			int j;
 
 			if (gm_n_pages != n_pages) {
 				g_object_unref(gainmap);
@@ -1108,29 +1123,14 @@ vips_thumbnail_build(VipsObject *object)
 				return -1;
 			}
 
-			gm_pages = (VipsImage **)
-				vips_object_local_array(object, gm_n_pages);
-
-			for (j = 0; j < gm_n_pages; j++)
-				if (vips_crop(gainmap, &gm_pages[j],
-						bbox_x * xscale,
-						j * gm_page_height + bbox_y * yscale,
-						gm_crop_width, gm_crop_height,
-						NULL)) {
-					g_object_unref(gainmap);
-					return -1;
-				}
-
-			if (vips_arrayjoin(gm_pages, &t[16], gm_n_pages,
-					"across", 1, NULL)) {
+			if (vips_thumbnail_crop_pages(object, gainmap, &t[16],
+					bbox_x * xscale, bbox_y * yscale,
+					crop_width * xscale, crop_height * yscale,
+					gm_page_height, gm_n_pages)) {
 				g_object_unref(gainmap);
 				return -1;
 			}
 			g_object_unref(gainmap);
-
-			if (gm_n_pages > 1)
-				vips_image_set_int(t[16],
-					VIPS_META_PAGE_HEIGHT, gm_crop_height);
 
 			if (vips_copy(in, &t[8], NULL))
 				return -1;

--- a/libvips/resample/thumbnail.c
+++ b/libvips/resample/thumbnail.c
@@ -674,39 +674,39 @@ vips_thumbnail_open(VipsThumbnail *thumbnail)
 	return im;
 }
 
-/* Crop the same window from every page of an image and rejoin them into a
- * toilet roll. Used for the image itself and for its gainmap, if it has one.
+/* Crop the same window from every page of an image and rejoin.
  *
  * left/top are relative to a page, not to the whole stack.
  */
-static int
-vips_thumbnail_crop_pages(VipsObject *object, VipsImage *in, VipsImage **out,
+static VipsImage *
+vips_thumbnail_crop_pages(VipsObject *object, VipsImage *in,
 	int left, int top, int width, int height, int page_height, int n_pages)
 {
-	VipsImage **pages = (VipsImage **)
-		vips_object_local_array(object, n_pages);
-	VipsImage **t = (VipsImage **) vips_object_local_array(object, 1);
+	VipsImage **pages = (VipsImage **) vips_object_local_array(object, n_pages);
 
-	int i;
+	VipsImage *out;
 
-	for (i = 0; i < n_pages; i++)
+	for (int i = 0; i < n_pages; i++)
 		if (vips_crop(in, &pages[i],
-				left, i * page_height + top,
-				width, height, NULL))
-			return -1;
+				left, i * page_height + top, width, height, NULL))
+			return NULL;
+	if (vips_arrayjoin(pages, &out, n_pages, "across", 1, NULL))
+		return NULL;
 
-	if (n_pages == 1)
-		return vips_arrayjoin(pages, out, n_pages, "across", 1, NULL);
+	if (n_pages > 1) {
+		VipsImage *t;
 
-	/* Re-stamp page-height for the cropped result. Copy first so we don't
-	 * set metadata on a shared image.
-	 */
-	if (vips_arrayjoin(pages, &t[0], n_pages, "across", 1, NULL) ||
-		vips_copy(t[0], out, NULL))
-		return -1;
-	vips_image_set_int(*out, VIPS_META_PAGE_HEIGHT, height);
+		if (vips_copy(out, &t, NULL)) {
+			g_object_unref(out);
+			return NULL;
+		}
+		g_object_unref(out);
+		out = t;
 
-	return 0;
+		vips_image_set_int(out, VIPS_META_PAGE_HEIGHT, height);
+	}
+
+	return out;
 }
 
 static int
@@ -1065,8 +1065,6 @@ vips_thumbnail_build(VipsObject *object)
 		double overall_hshrink = (double) rotated_input_width / in->Xsize;
 		double overall_vshrink = (double) rotated_input_height / in->Ysize;
 
-		VipsImage *first_page;
-		VipsImage *first_cropped;
 		int bbox_x, bbox_y;
 
 		/* Need to copy to memory, we have to stay seq.
@@ -1080,34 +1078,28 @@ vips_thumbnail_build(VipsObject *object)
 		 * apply that same window to every page (and to the gainmap, if
 		 * any) so the bbox does not drift frame-to-frame.
 		 */
-		if (vips_crop(t[13], &first_page,
+		if (vips_crop(t[13], &t[18],
 				0, 0, in->Xsize, page_height, NULL))
 			return -1;
-		vips_object_local(object, first_page);
 
-		if (vips_smartcrop(first_page, &first_cropped,
+		if (vips_smartcrop(t[18], &t[19],
 				crop_width, crop_height,
 				"interesting", thumbnail->crop,
 				"interesting_x", VIPS_ROUND_UINT((double) thumbnail->interesting_x / overall_vshrink),
 				"interesting_y", VIPS_ROUND_UINT((double) thumbnail->interesting_y / overall_hshrink),
 				NULL))
 			return -1;
-		vips_object_local(object, first_cropped);
 
-		bbox_x = -vips_image_get_xoffset(first_cropped);
-		bbox_y = -vips_image_get_yoffset(first_cropped);
+		bbox_x = -vips_image_get_xoffset(t[19]);
+		bbox_y = -vips_image_get_yoffset(t[19]);
 
-		if (vips_thumbnail_crop_pages(object, t[13], &t[14],
-				bbox_x, bbox_y, crop_width, crop_height,
-				page_height, n_pages))
+		if (!(t[14] = vips_thumbnail_crop_pages(object, t[13],
+				  bbox_x, bbox_y, crop_width, crop_height,
+				  page_height, n_pages)))
 			return -1;
 		in = t[14];
 
-		/* Also crop the gainmap, if any. Gainmaps are single image
-		 * today, but animated HDR is coming, so treat a multi-page
-		 * gainmap as a page stack like the base image. The vertical
-		 * scale is per frame: both sides are toilet rolls, so it comes
-		 * from the page heights, not the total heights.
+		/* Also crop the gainmap, if any.
 		 */
 		if ((gainmap = vips_image_get_gainmap(t[13]))) {
 			int gm_page_height = vips_image_get_page_height(gainmap);
@@ -1123,10 +1115,10 @@ vips_thumbnail_build(VipsObject *object)
 				return -1;
 			}
 
-			if (vips_thumbnail_crop_pages(object, gainmap, &t[16],
-					bbox_x * xscale, bbox_y * yscale,
-					crop_width * xscale, crop_height * yscale,
-					gm_page_height, gm_n_pages)) {
+			if (!(t[16] = vips_thumbnail_crop_pages(object, gainmap,
+					  bbox_x * xscale, bbox_y * yscale,
+					  crop_width * xscale, crop_height * yscale,
+					  gm_page_height, gm_n_pages))) {
 				g_object_unref(gainmap);
 				return -1;
 			}

--- a/libvips/resample/thumbnail.c
+++ b/libvips/resample/thumbnail.c
@@ -1063,8 +1063,6 @@ vips_thumbnail_build(VipsObject *object)
 			 * then extract the same window from every page and rejoin
 			 * vertically. This keeps the animation coherent: the bbox
 			 * does not drift frame-to-frame.
-			 *
-			 * See ADR-2668 for the rationale.
 			 */
 			VipsImage *first_page;
 			VipsImage *first_cropped;

--- a/libvips/resample/thumbnail.c
+++ b/libvips/resample/thumbnail.c
@@ -1012,20 +1012,14 @@ vips_thumbnail_build(VipsObject *object)
 	/* Crop after rotate so we don't need to rotate the crop box.
 	 */
 	if (thumbnail->crop != VIPS_INTERESTING_NONE) {
-		/* For multi-page (animated) images, page_height is the height
-		 * of a single frame. The image is a vertical stack of
-		 * n_loaded_pages frames each page_height tall.
-		 */
 		int page_height = vips_image_get_page_height(in);
-		gboolean is_multipage = thumbnail->n_loaded_pages > 1;
+		int n_pages = thumbnail->n_loaded_pages;
 
-		/* The image can be smaller than the target. Adjust the
-		 * arguments to vips_smartcrop(). For multi-page, crop_height
-		 * is relative to a single frame, not the toilet-roll Ysize.
+		/* crop_height is relative to a single frame.
 		 */
 		int crop_width = VIPS_MIN(thumbnail->width, in->Xsize);
 		int crop_height = VIPS_MIN(thumbnail->height,
-			is_multipage ? page_height : in->Ysize);
+			n_pages > 1 ? page_height : in->Ysize);
 		int original_width = in->Xsize;
 		int original_height = in->Ysize;
 
@@ -1037,19 +1031,12 @@ vips_thumbnail_build(VipsObject *object)
 		double overall_hshrink = (double) rotated_input_width / in->Xsize;
 		double overall_vshrink = (double) rotated_input_height / in->Ysize;
 
-		/* If the multi-page image carries a gainmap, fall back to the
-		 * single-image crop path: that collapses the animation to one
-		 * frame (the existing pre-#2668 behaviour), but preserves the
-		 * gainmap-cropping logic below. HDR animated images are rare
-		 * and we don't want to silently mishandle the gainmap.
-		 */
-		gboolean has_gainmap = vips_image_get_typeof(in, "gainmap") != 0;
-		if (is_multipage && has_gainmap) {
-			g_info("multi-page image with gainmap: falling back to "
-				"single-frame crop (gainmap on animation is not "
-				"supported by the multi-page crop path)");
-			is_multipage = FALSE;
-		}
+		VipsImage *first_page;
+		VipsImage *first_cropped;
+		VipsImage **pages = (VipsImage **)
+			vips_object_local_array(object, n_pages);
+		int bbox_x, bbox_y;
+		int i;
 
 		/* Need to copy to memory, we have to stay seq.
 		 *
@@ -1058,85 +1045,66 @@ vips_thumbnail_build(VipsObject *object)
 		if (!(t[13] = vips_image_copy_memory(in)))
 			return -1;
 
-		if (is_multipage) {
-			/* Compute a shared bbox by smartcropping the first page,
-			 * then extract the same window from every page and rejoin
-			 * vertically. This keeps the animation coherent: the bbox
-			 * does not drift frame-to-frame.
-			 */
-			VipsImage *first_page;
-			VipsImage *first_cropped;
-			int n_pages = thumbnail->n_loaded_pages;
-			VipsImage **pages = (VipsImage **)
-				vips_object_local_array(object, n_pages);
-			int bbox_x, bbox_y;
-			int i;
+		/* Smartcrop the first page to find a shared crop window, then
+		 * apply that same window to every page (and to the gainmap, if
+		 * any) so the bbox does not drift frame-to-frame.
+		 */
+		if (vips_crop(t[13], &first_page,
+				0, 0, in->Xsize, page_height, NULL))
+			return -1;
+		vips_object_local(object, first_page);
 
-			if (vips_extract_area(t[13], &first_page,
-					0, 0, in->Xsize, page_height, NULL))
+		if (vips_smartcrop(first_page, &first_cropped,
+				crop_width, crop_height,
+				"interesting", thumbnail->crop,
+				"interesting_x", VIPS_ROUND_UINT((double) thumbnail->interesting_x / overall_vshrink),
+				"interesting_y", VIPS_ROUND_UINT((double) thumbnail->interesting_y / overall_hshrink),
+				NULL))
+			return -1;
+		vips_object_local(object, first_cropped);
+
+		bbox_x = -vips_image_get_xoffset(first_cropped);
+		bbox_y = -vips_image_get_yoffset(first_cropped);
+
+		for (i = 0; i < n_pages; i++)
+			if (vips_crop(t[13], &pages[i],
+					bbox_x, i * page_height + bbox_y,
+					crop_width, crop_height, NULL))
 				return -1;
-			vips_object_local(object, first_page);
 
-			if (vips_smartcrop(first_page, &first_cropped,
-					crop_width, crop_height,
-					"interesting", thumbnail->crop,
-					"interesting_x", VIPS_ROUND_UINT((double) thumbnail->interesting_x / overall_vshrink),
-					"interesting_y", VIPS_ROUND_UINT((double) thumbnail->interesting_y / overall_hshrink),
-					NULL))
-				return -1;
-			vips_object_local(object, first_cropped);
+		if (vips_arrayjoin(pages, &t[14], n_pages,
+				"across", 1, NULL))
+			return -1;
+		in = t[14];
 
-			bbox_x = -vips_image_get_xoffset(first_cropped);
-			bbox_y = -vips_image_get_yoffset(first_cropped);
-
-			for (i = 0; i < n_pages; i++) {
-				if (vips_extract_area(t[13], &pages[i],
-						bbox_x, i * page_height + bbox_y,
-						crop_width, crop_height, NULL))
-					return -1;
-			}
-
-			if (vips_arrayjoin(pages, &t[14], n_pages,
-					"across", 1, NULL))
-				return -1;
-			in = t[14];
-
-			/* Re-stamp page-height for the cropped result. The
-			 * resize-path set page_height to the pre-crop value
-			 * above; after vertical cropping we must update it.
-			 */
+		if (n_pages > 1) {
+			/* Re-stamp page-height for the cropped result. */
 			if (vips_copy(in, &t[18], NULL))
 				return -1;
 			in = t[18];
 			vips_image_set_int(in, VIPS_META_PAGE_HEIGHT, crop_height);
 		}
-		else {
-			if (vips_smartcrop(t[13], &t[14], crop_width, crop_height,
-					"interesting", thumbnail->crop,
-					"interesting_x", VIPS_ROUND_UINT((double) thumbnail->interesting_x / overall_vshrink),
-					"interesting_y", VIPS_ROUND_UINT((double) thumbnail->interesting_y / overall_hshrink),
+
+		/* Also crop the gainmap, if any. A gainmap is always a single
+		 * image (UltraHDR only), so we crop it once with the same bbox
+		 * scaled to its size, never per page.
+		 */
+		if ((gainmap = vips_image_get_gainmap(t[13]))) {
+			double xscale = (double) gainmap->Xsize / original_width;
+			double yscale = (double) gainmap->Ysize / original_height;
+
+			if (vips_crop(gainmap, &t[16],
+					bbox_x * xscale, bbox_y * yscale,
+					crop_width * xscale, crop_height * yscale,
 					NULL))
 				return -1;
-			in = t[14];
+			g_object_unref(gainmap);
 
-			int crop_left = -vips_image_get_xoffset(in);
-			int crop_top = -vips_image_get_yoffset(in);
+			if (vips_copy(in, &t[8], NULL))
+				return -1;
+			in = t[8];
 
-			/* Also crop the gainmap, if any.
-			 */
-			if ((gainmap = vips_image_get_gainmap(in))) {
-				double xscale = (double) gainmap->Xsize / original_width;
-				double yscale = (double) gainmap->Ysize / original_height;
-
-				if (vips_crop(gainmap, &t[16],
-						crop_left * xscale, crop_top * yscale,
-						crop_width * xscale, crop_height * yscale,
-						NULL))
-					return -1;
-				g_object_unref(gainmap);
-
-				vips_image_set_image(in, "gainmap", t[16]);
-			}
+			vips_image_set_image(in, "gainmap", t[16]);
 		}
 	}
 

--- a/libvips/resample/thumbnail.c
+++ b/libvips/resample/thumbnail.c
@@ -1021,7 +1021,6 @@ vips_thumbnail_build(VipsObject *object)
 		int crop_height = VIPS_MIN(thumbnail->height,
 			n_pages > 1 ? page_height : in->Ysize);
 		int original_width = in->Xsize;
-		int original_height = in->Ysize;
 
 		g_info("cropping to %dx%d", crop_width, crop_height);
 
@@ -1085,20 +1084,53 @@ vips_thumbnail_build(VipsObject *object)
 			vips_image_set_int(in, VIPS_META_PAGE_HEIGHT, crop_height);
 		}
 
-		/* Also crop the gainmap, if any. A gainmap is always a single
-		 * image (UltraHDR only), so we crop it once with the same bbox
-		 * scaled to its size, never per page.
+		/* Also crop the gainmap, if any. Gainmaps are single image
+		 * today, but animated HDR is coming, so treat a multi-page
+		 * gainmap as a page stack like the base image. The vertical
+		 * scale is per frame: both sides are toilet rolls, so it comes
+		 * from the page heights, not the total heights.
 		 */
 		if ((gainmap = vips_image_get_gainmap(t[13]))) {
+			int gm_page_height = vips_image_get_page_height(gainmap);
+			int gm_n_pages = gainmap->Ysize / gm_page_height;
 			double xscale = (double) gainmap->Xsize / original_width;
-			double yscale = (double) gainmap->Ysize / original_height;
+			double yscale = (double) gm_page_height / page_height;
+			int gm_crop_width = crop_width * xscale;
+			int gm_crop_height = crop_height * yscale;
+			VipsImage **gm_pages;
+			int j;
 
-			if (vips_crop(gainmap, &t[16],
-					bbox_x * xscale, bbox_y * yscale,
-					crop_width * xscale, crop_height * yscale,
-					NULL))
+			if (gm_n_pages != n_pages) {
+				g_object_unref(gainmap);
+				vips_error("thumbnail", "%s",
+					"gainmap page count does not match "
+					"image page count");
 				return -1;
+			}
+
+			gm_pages = (VipsImage **)
+				vips_object_local_array(object, gm_n_pages);
+
+			for (j = 0; j < gm_n_pages; j++)
+				if (vips_crop(gainmap, &gm_pages[j],
+						bbox_x * xscale,
+						j * gm_page_height + bbox_y * yscale,
+						gm_crop_width, gm_crop_height,
+						NULL)) {
+					g_object_unref(gainmap);
+					return -1;
+				}
+
+			if (vips_arrayjoin(gm_pages, &t[16], gm_n_pages,
+					"across", 1, NULL)) {
+				g_object_unref(gainmap);
+				return -1;
+			}
 			g_object_unref(gainmap);
+
+			if (gm_n_pages > 1)
+				vips_image_set_int(t[16],
+					VIPS_META_PAGE_HEIGHT, gm_crop_height);
 
 			if (vips_copy(in, &t[8], NULL))
 				return -1;


### PR DESCRIPTION
Fixes #2668.

When `--crop` is set on a multi-page image (animated GIF/WebP),
`vips_thumbnail` collapses the output to a single frame.

## Reproduce

```
magick -delay 30 -size 200x200 \( xc:red xc:green xc:blue xc:yellow xc:magenta \) anim.gif
vips thumbnail "anim.gif[n=-1]" out_crop.gif 100 --crop centre
magick identify out_crop.gif | wc -l   # 1 (expected 5)
vips thumbnail "anim.gif[n=-1]" out_nocrop.gif 100
magick identify out_nocrop.gif | wc -l # 5 (no-crop path is fine)
```

Confirmed on 8.18.2 and on current master.

## Cause

The resize path already handles the toilet-roll layout (shrinks
against page height, re-stamps `page-height`). The crop path does
not: it runs `vips_smartcrop` on the full `Ysize`, which treats the
stacked pages as one tall image and returns a single window. The
remaining frames are discarded. `vips_smartcrop` is single-image by
design, so the fix belongs in the caller, not in smartcrop.

## Fix

For multi-page input: compute the crop box once on the first page,
then `extract_area` that box from every page and `arrayjoin` them
back into a toilet roll, re-stamping `page-height`. Single bbox for
all pages keeps the animation coherent rather than letting the crop
window drift per frame. Single-page input is unchanged.

## Tests

- 5-frame input + `--crop centre` → 5 frames out; each output frame
  is the solid colour of its source frame (no bleed between pages).
- Single-page output is byte-identical to before (AE=0).
- All existing `test_resample.py` cases pass.
- Verified across crop modes (centre/low/high/attention/entropy) and
  frame counts (1/2/3/5/10).
