### PR TITLE
tiffload: squash read errors

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,6 +1,7 @@
 date tbd 8.18.4
 
 - heifload: raise security limits on references [caseywebdev]
+- tiffload: squash out read errors in openin_source_read [aleens-labs]
 
 6/6/26 8.18.3
 

--- a/libvips/foreign/tiff.c
+++ b/libvips/foreign/tiff.c
@@ -112,9 +112,10 @@ openin_source_read(thandle_t st, tdata_t data, tsize_t size)
 		gint64 bytes_read;
 
 		bytes_read = vips_source_read(source, data, size - total_read);
-		if (bytes_read == -1)
-			return -1;
-		if (bytes_read == 0)
+		/* libtiff does not allow error returns from read, so any -1s need to
+		 * be squashed out as EOF.
+		 */
+		if (bytes_read <= 0)
 			break;
 
 		total_read += bytes_read;


### PR DESCRIPTION
libtiff read handlers can't return error codes, so squash any read errors into EOF (0 byte read).

Thanks aleens-labs

closes #5089 