### PR TITLE
threadpool: avoid double check

### DIFF
--- a/libvips/iofuncs/threadpool.c
+++ b/libvips/iofuncs/threadpool.c
@@ -663,13 +663,11 @@ vips_threadpool_run(VipsImage *im,
 
 		VIPS_DEBUG_MSG("vips_threadpool_run: tick\n");
 
-		if (pool->stop ||
-			pool->error)
-			break;
-
 		if (progress &&
-			progress(pool->a))
+			progress(pool->a)) {
 			pool->error = TRUE;
+			break;
+		}
 
 		if (pool->stop ||
 			pool->error)


### PR DESCRIPTION
Also exit early when `progress()` returns an error, since
`pool->stop` and `pool->error` will be made atomic later.

Split out from #5092.