### PR TITLE
webpsave: trigger eval callbacks on `save->ready`

### DIFF
--- a/libvips/foreign/webpsave.c
+++ b/libvips/foreign/webpsave.c
@@ -255,7 +255,7 @@ vips_foreign_save_webp_pic_init(VipsForeignSaveWebp *webp, WebPPicture *pic)
 	pic->writer = WebPMemoryWrite;
 	pic->custom_ptr = (void *) &webp->memory_writer;
 	pic->progress_hook = vips_foreign_save_webp_progress_hook;
-	pic->user_data = (void *) save->in;
+	pic->user_data = (void *) save->ready;
 
 	/* Smart subsampling needs use_argb because it is applied during
 	 * RGB to YUV conversion.


### PR DESCRIPTION
Ensure it corresponds to the image passed to `vips_sink_disc()`.

This is required for PR #5097. After that, eval callbacks failed to propagate to the image that was originally marked with `vips_image_set_progress()`.

Split out from #5092.