### PR TITLE
dzsave: check cancellation on `save->ready`

### DIFF
--- a/libvips/foreign/dzsave.c
+++ b/libvips/foreign/dzsave.c
@@ -1376,7 +1376,7 @@ image_strip_work(VipsThreadState *state, void *a)
 	/* killed is checked by sink_disc, but that's only once per strip, and
 	 * they can be huge. Check per output tile as well.
 	 */
-	if (vips_image_iskilled(save->in))
+	if (vips_image_iskilled(save->ready))
 		return -1;
 
 	/* We may be outside the real pixels.
@@ -1605,7 +1605,7 @@ direct_strip_work(VipsThreadState *state, void *a)
 	/* killed is checked by sink_disc, but that's only once per strip, and
 	 * they can be huge. Check per output tile as well.
 	 */
-	if (vips_image_iskilled(save->in))
+	if (vips_image_iskilled(save->ready))
 		return -1;
 
 	/* We may be outside the real pixels.


### PR DESCRIPTION
Split out from #5092.

Probably also required for PR #5097, but still need to verify this.