### PR TITLE
CIFuzz: add `paths-ignore` filter

### DIFF
--- a/.github/workflows/cifuzz.yml
+++ b/.github/workflows/cifuzz.yml
@@ -1,5 +1,17 @@
 name: CIFuzz
-on: [pull_request]
+on:
+  pull_request:
+    paths-ignore:
+      - 'completions/**'
+      - 'cplusplus/**'
+      - 'doc/**'
+      - 'examples/**'
+      - 'man/**'
+      - 'po/**'
+      - 'test/**'
+      - 'tools/**'
+      - 'ChangeLog'
+      - '*.md'
 permissions: {}
 jobs:
   Fuzzing:


### PR DESCRIPTION
Avoids unnecessary CI runs (e.g. when only doc files are changed).

See:
https://google.github.io/oss-fuzz/getting-started/continuous-integration/#branches-and-paths
https://docs.github.com/en/actions/reference/workflows-and-actions/workflow-syntax#example-excluding-paths

As an aside, I noticed that CIFuzz doesn't work on commits in forks, see for example this changeset:
https://github.com/libvips/libvips/compare/master...kleisauke:tsan-test
(I was really confused by this, so hopefully this helps others as well)