### PR TITLE
CIFuzz: ensure `paths-ignore` filter matches all `.md` files

### DIFF
--- a/.github/workflows/cifuzz.yml
+++ b/.github/workflows/cifuzz.yml
@@ -11,7 +11,7 @@ on:
       - 'test/**'
       - 'tools/**'
       - 'ChangeLog'
-      - '*.md'
+      - '**.md'
 permissions: {}
 jobs:
   Fuzzing:


### PR DESCRIPTION
Follow-up to #5098, as noticed in #5099.