### PR TITLE
heifload: fix `-Winteger-overflow` warning on 32-bit platforms

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -2,6 +2,8 @@ date tbd 8.18.4
 
 - heifload: raise security limits on references [caseywebdev]
 - tiffload: squash out read errors in openin_source_read [aleens-labs]
+- jxlsave: convert CMYK images to sRGB [DarthSim]
+- heifload: fix `-Winteger-overflow` warning on 32-bit platforms [kleisauke]
 
 6/6/26 8.18.3
 

--- a/libvips/foreign/heifload.c
+++ b/libvips/foreign/heifload.c
@@ -360,7 +360,7 @@ vips_foreign_load_heif_build(VipsObject *object)
 			heif_security_limits *limits =
 				heif_context_get_security_limits(heif->ctx);
 
-			limits->max_total_memory = 2L * 1024 * 1024 * 1024;
+			limits->max_total_memory = 2ULL * 1024 * 1024 * 1024;
 			limits->max_memory_block_size = 1024 * 1024 * 1024;
 			limits->max_items = 256;
 		}


### PR DESCRIPTION
As noticed in wasm-vips:
```console
../libvips/foreign/heifload.c:363:48: warning: overflow in expression; result is -2'147'483'648 with type 'long' [-Winteger-overflow]
  363 |                         limits->max_total_memory = 2L * 1024 * 1024 * 1024;
      |                                                    ~~~~~~~~~~~~~~~~~^~~~~~
```

Also add a missing ChangeLog entry for PR #5091.