### PR TITLE
heif: preserve CLLI signaling

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -36,6 +36,7 @@ date-tbd 8.19.0
 - project: add combine option [jcupitt]
 - reducev: auto-vectorise the vertical reduce for all band formats, up to ~3x faster [dloebl]
 - icc: fix black output when transforming float images [lancylot2004]
+- heifload, heifsave: preserve CLLI signaling [gregbenz]
 
 6/6/26 8.18.3
 

--- a/libvips/colour/CICP2scRGB.c
+++ b/libvips/colour/CICP2scRGB.c
@@ -445,13 +445,15 @@ vips_CICP2scRGB_build(VipsObject *object)
 	if (VIPS_OBJECT_CLASS(vips_CICP2scRGB_parent_class)->build(object))
 		return -1;
 
-	/* Strip CICP metadata from the output - it no longer describes
-	 * the pixel values after linearization to scRGB.
+	/* Strip CICP and dependent HDR signalling from the output - it no longer
+	 * describes the pixel values after linearization to scRGB.
 	 */
 	vips_image_remove(colour->out, "cicp-colour-primaries");
 	vips_image_remove(colour->out, "cicp-transfer-characteristics");
 	vips_image_remove(colour->out, "cicp-matrix-coefficients");
 	vips_image_remove(colour->out, "cicp-full-range-flag");
+	vips_image_remove(colour->out, "clli-max-content-light-level");
+	vips_image_remove(colour->out, "clli-max-frame-average-light-level");
 
 	return 0;
 }

--- a/libvips/colour/CICP2scRGB.c
+++ b/libvips/colour/CICP2scRGB.c
@@ -445,7 +445,7 @@ vips_CICP2scRGB_build(VipsObject *object)
 	if (VIPS_OBJECT_CLASS(vips_CICP2scRGB_parent_class)->build(object))
 		return -1;
 
-	/* Strip CICP and dependent HDR signalling from the output - it no longer
+	/* Strip CICP and CLLI signalling from the output - it no longer
 	 * describes the pixel values after linearization to scRGB.
 	 */
 	vips_image_remove(colour->out, "cicp-colour-primaries");

--- a/libvips/colour/scRGB2CICP.c
+++ b/libvips/colour/scRGB2CICP.c
@@ -439,6 +439,8 @@ vips_scRGB2CICP_build(VipsObject *object)
 	vips_image_set_int(colour->out,
 		"cicp-matrix-coefficients", cicp->matrix_coefficients);
 	vips_image_set_int(colour->out, "cicp-full-range-flag", 1);
+	vips_image_remove(colour->out, "clli-max-content-light-level");
+	vips_image_remove(colour->out, "clli-max-frame-average-light-level");
 
 	return 0;
 }

--- a/libvips/foreign/heifload.c
+++ b/libvips/foreign/heifload.c
@@ -573,7 +573,7 @@ vips_foreign_load_heif_set_page(VipsForeignLoadHeif *heif,
 }
 
 static gboolean
-vips_foreign_load_heif_get_cicp_current(VipsForeignLoadHeif *heif,
+vips_foreign_load_heif_get_cicp(VipsForeignLoadHeif *heif,
 	VipsHeifCicp *cicp)
 {
 	struct heif_error error;
@@ -597,43 +597,9 @@ vips_foreign_load_heif_get_cicp_current(VipsForeignLoadHeif *heif,
 	return FALSE;
 }
 
-static int
-vips_foreign_load_heif_set_cicp_metadata(VipsForeignLoadHeif *heif,
-	VipsImage *out)
-{
-	VipsHeifCicp cicp;
-
-	if (vips_foreign_load_heif_set_page(heif, heif->page, FALSE))
-		return -1;
-
-	if (vips_foreign_load_heif_get_cicp_current(heif, &cicp)) {
-#ifdef DEBUG
-		printf("\tnclx->color_primaries: %d\n", cicp.colour_primaries);
-		printf("\tnclx->transfer_characteristics: %d\n",
-			cicp.transfer_characteristics);
-		printf("\tnclx->matrix_coefficients: %d\n",
-			cicp.matrix_coefficients);
-		printf("\tnclx->full_range_flag: %d\n", cicp.full_range_flag);
-#endif
-
-		g_info("heifload: setting CICP from nclx");
-
-		vips_image_set_int(out, "cicp-colour-primaries",
-			cicp.colour_primaries);
-		vips_image_set_int(out, "cicp-transfer-characteristics",
-			cicp.transfer_characteristics);
-		vips_image_set_int(out, "cicp-matrix-coefficients",
-			cicp.matrix_coefficients);
-		vips_image_set_int(out, "cicp-full-range-flag",
-			cicp.full_range_flag);
-	}
-
-	return 0;
-}
-
 #ifdef HAVE_HEIF_CONTENT_LIGHT_LEVEL
 static gboolean
-vips_foreign_load_heif_get_clli_current(VipsForeignLoadHeif *heif,
+vips_foreign_load_heif_get_clli(VipsForeignLoadHeif *heif,
 	VipsHeifClli *clli)
 {
 	heif_content_light_level content_light_level;
@@ -649,27 +615,6 @@ vips_foreign_load_heif_get_clli_current(VipsForeignLoadHeif *heif,
 	}
 
 	return FALSE;
-}
-
-static int
-vips_foreign_load_heif_set_clli_metadata(VipsForeignLoadHeif *heif,
-	VipsImage *out)
-{
-	VipsHeifClli clli;
-
-	if (vips_foreign_load_heif_set_page(heif, heif->page, FALSE))
-		return -1;
-
-	if (vips_foreign_load_heif_get_clli_current(heif, &clli)) {
-		g_info("heifload: setting CLLI from content light level");
-
-		vips_image_set_int(out, "clli-max-content-light-level",
-			clli.max_content_light_level);
-		vips_image_set_int(out, "clli-max-frame-average-light-level",
-			clli.max_frame_average_light_level);
-	}
-
-	return 0;
 }
 #endif /*HAVE_HEIF_CONTENT_LIGHT_LEVEL*/
 
@@ -846,19 +791,42 @@ vips_foreign_load_heif_set_header(VipsForeignLoadHeif *heif, VipsImage *out)
 		vips_image_set_blob(out, VIPS_META_ICC_NAME,
 			(VipsCallbackFn) vips_area_free_cb, data, length);
 	}
+
 	/* Always try to fetch the NCLX profile, even when ICC is present.
 	 * CICP takes priority over ICC for colour interpretation.
 	 */
-	if (vips_foreign_load_heif_set_cicp_metadata(heif, out))
-		return -1;
+	VipsHeifCicp cicp;
+	if (vips_foreign_load_heif_get_cicp(heif, &cicp)) {
+#ifdef DEBUG
+		printf("\tnclx->color_primaries: %d\n", cicp.colour_primaries);
+		printf("\tnclx->transfer_characteristics: %d\n",
+			cicp.transfer_characteristics);
+		printf("\tnclx->matrix_coefficients: %d\n",
+			cicp.matrix_coefficients);
+		printf("\tnclx->full_range_flag: %d\n", cicp.full_range_flag);
+#endif
+
+		g_info("heifload: setting CICP from nclx");
+
+		vips_image_set_int(out, "cicp-colour-primaries",
+			cicp.colour_primaries);
+		vips_image_set_int(out, "cicp-transfer-characteristics",
+			cicp.transfer_characteristics);
+		vips_image_set_int(out, "cicp-matrix-coefficients",
+			cicp.matrix_coefficients);
+		vips_image_set_int(out, "cicp-full-range-flag",
+			cicp.full_range_flag);
+	}
 
 #ifdef HAVE_HEIF_CONTENT_LIGHT_LEVEL
-	if (vips_image_get_typeof(out, "cicp-colour-primaries") &&
-		vips_image_get_typeof(out, "cicp-transfer-characteristics") &&
-		vips_image_get_typeof(out, "cicp-matrix-coefficients") &&
-		vips_image_get_typeof(out, "cicp-full-range-flag")) {
-		if (vips_foreign_load_heif_set_clli_metadata(heif, out))
-			return -1;
+	VipsHeifClli clli;
+	if (vips_foreign_load_heif_get_clli(heif, &clli)) {
+		g_info("heifload: setting CLLI from content light level");
+
+		vips_image_set_int(out, "clli-max-content-light-level",
+			clli.max_content_light_level);
+		vips_image_set_int(out, "clli-max-frame-average-light-level",
+			clli.max_frame_average_light_level);
 	}
 #endif
 

--- a/libvips/foreign/heifload.c
+++ b/libvips/foreign/heifload.c
@@ -211,6 +211,20 @@ typedef struct _VipsForeignLoadHeif {
 
 } VipsForeignLoadHeif;
 
+typedef struct {
+	int colour_primaries;
+	int transfer_characteristics;
+	int matrix_coefficients;
+	int full_range_flag;
+} VipsHeifCicp;
+
+#ifdef HAVE_HEIF_CONTENT_LIGHT_LEVEL
+typedef struct {
+	int max_content_light_level;
+	int max_frame_average_light_level;
+} VipsHeifClli;
+#endif
+
 #ifdef HAVE_HEIF_INIT
 static void *
 vips__heif_init_once(void *client)
@@ -558,6 +572,107 @@ vips_foreign_load_heif_set_page(VipsForeignLoadHeif *heif,
 	return 0;
 }
 
+static gboolean
+vips_foreign_load_heif_get_cicp_current(VipsForeignLoadHeif *heif,
+	VipsHeifCicp *cicp)
+{
+	struct heif_error error;
+	struct heif_color_profile_nclx *nclx = NULL;
+
+	error = heif_image_handle_get_nclx_color_profile(heif->handle, &nclx);
+	if (error.code == 0 && nclx) {
+		cicp->colour_primaries = nclx->color_primaries;
+		cicp->transfer_characteristics = nclx->transfer_characteristics;
+		cicp->matrix_coefficients = nclx->matrix_coefficients;
+		cicp->full_range_flag = nclx->full_range_flag;
+
+		heif_nclx_color_profile_free(nclx);
+
+		return TRUE;
+	}
+
+	if (nclx)
+		heif_nclx_color_profile_free(nclx);
+
+	return FALSE;
+}
+
+static int
+vips_foreign_load_heif_set_cicp_metadata(VipsForeignLoadHeif *heif,
+	VipsImage *out)
+{
+	VipsHeifCicp cicp;
+
+	if (vips_foreign_load_heif_set_page(heif, heif->page, FALSE))
+		return -1;
+
+	if (vips_foreign_load_heif_get_cicp_current(heif, &cicp)) {
+#ifdef DEBUG
+		printf("\tnclx->color_primaries: %d\n", cicp.colour_primaries);
+		printf("\tnclx->transfer_characteristics: %d\n",
+			cicp.transfer_characteristics);
+		printf("\tnclx->matrix_coefficients: %d\n",
+			cicp.matrix_coefficients);
+		printf("\tnclx->full_range_flag: %d\n", cicp.full_range_flag);
+#endif
+
+		g_info("heifload: setting CICP from nclx");
+
+		vips_image_set_int(out, "cicp-colour-primaries",
+			cicp.colour_primaries);
+		vips_image_set_int(out, "cicp-transfer-characteristics",
+			cicp.transfer_characteristics);
+		vips_image_set_int(out, "cicp-matrix-coefficients",
+			cicp.matrix_coefficients);
+		vips_image_set_int(out, "cicp-full-range-flag",
+			cicp.full_range_flag);
+	}
+
+	return 0;
+}
+
+#ifdef HAVE_HEIF_CONTENT_LIGHT_LEVEL
+static gboolean
+vips_foreign_load_heif_get_clli_current(VipsForeignLoadHeif *heif,
+	VipsHeifClli *clli)
+{
+	heif_content_light_level content_light_level;
+
+	if (heif_image_handle_get_content_light_level(heif->handle,
+			&content_light_level)) {
+		clli->max_content_light_level =
+			content_light_level.max_content_light_level;
+		clli->max_frame_average_light_level =
+			content_light_level.max_pic_average_light_level;
+
+		return TRUE;
+	}
+
+	return FALSE;
+}
+
+static int
+vips_foreign_load_heif_set_clli_metadata(VipsForeignLoadHeif *heif,
+	VipsImage *out)
+{
+	VipsHeifClli clli;
+
+	if (vips_foreign_load_heif_set_page(heif, heif->page, FALSE))
+		return -1;
+
+	if (vips_foreign_load_heif_get_clli_current(heif, &clli)) {
+		g_info("heifload: setting CLLI from content light level");
+
+		vips_image_set_int(out, "clli-max-content-light-level",
+			clli.max_content_light_level);
+		vips_image_set_int(out, "clli-max-frame-average-light-level",
+			clli.max_frame_average_light_level);
+	}
+
+	return 0;
+}
+#endif /*HAVE_HEIF_CONTENT_LIGHT_LEVEL*/
+
 static int
 vips_foreign_load_heif_set_header(VipsForeignLoadHeif *heif, VipsImage *out)
 {
@@ -734,34 +849,18 @@ vips_foreign_load_heif_set_header(VipsForeignLoadHeif *heif, VipsImage *out)
 	/* Always try to fetch the NCLX profile, even when ICC is present.
 	 * CICP takes priority over ICC for colour interpretation.
 	 */
-	{
-		struct heif_color_profile_nclx *nclx = NULL;
+	if (vips_foreign_load_heif_set_cicp_metadata(heif, out))
+		return -1;
 
-		error = heif_image_handle_get_nclx_color_profile(heif->handle, &nclx);
-		if (error.code == 0 && nclx) {
-#ifdef DEBUG
-			printf("\tnclx: %p\n", nclx);
-			printf("\tnclx->color_primaries: %d\n", nclx->color_primaries);
-			printf("\tnclx->transfer_characteristics: %d\n", nclx->transfer_characteristics);
-			printf("\tnclx->matrix_coefficients: %d\n", nclx->matrix_coefficients);
-			printf("\tnclx->full_range_flag: %d\n", nclx->full_range_flag);
-#endif
-
-			g_info("heifload: setting CICP from nclx");
-
-			vips_image_set_int(out, "cicp-colour-primaries",
-				nclx->color_primaries);
-			vips_image_set_int(out, "cicp-transfer-characteristics",
-				nclx->transfer_characteristics);
-			vips_image_set_int(out, "cicp-matrix-coefficients",
-				nclx->matrix_coefficients);
-			vips_image_set_int(out, "cicp-full-range-flag",
-				nclx->full_range_flag);
-		}
-
-		if (nclx)
-			heif_nclx_color_profile_free(nclx);
+#ifdef HAVE_HEIF_CONTENT_LIGHT_LEVEL
+	if (vips_image_get_typeof(out, "cicp-colour-primaries") &&
+		vips_image_get_typeof(out, "cicp-transfer-characteristics") &&
+		vips_image_get_typeof(out, "cicp-matrix-coefficients") &&
+		vips_image_get_typeof(out, "cicp-full-range-flag")) {
+		if (vips_foreign_load_heif_set_clli_metadata(heif, out))
+			return -1;
 	}
+#endif
 
 	vips_image_set_int(out, "heif-primary", heif->primary_page);
 	vips_image_set_int(out, VIPS_META_N_PAGES, heif->n_top);

--- a/libvips/foreign/heifload.c
+++ b/libvips/foreign/heifload.c
@@ -211,20 +211,6 @@ typedef struct _VipsForeignLoadHeif {
 
 } VipsForeignLoadHeif;
 
-typedef struct {
-	int colour_primaries;
-	int transfer_characteristics;
-	int matrix_coefficients;
-	int full_range_flag;
-} VipsHeifCicp;
-
-#ifdef HAVE_HEIF_CONTENT_LIGHT_LEVEL
-typedef struct {
-	int max_content_light_level;
-	int max_frame_average_light_level;
-} VipsHeifClli;
-#endif
-
 #ifdef HAVE_HEIF_INIT
 static void *
 vips__heif_init_once(void *client)
@@ -574,17 +560,18 @@ vips_foreign_load_heif_set_page(VipsForeignLoadHeif *heif,
 
 static gboolean
 vips_foreign_load_heif_get_cicp(VipsForeignLoadHeif *heif,
-	VipsHeifCicp *cicp)
+	int *colour_primaries, int *transfer_characteristics,
+	int *matrix_coefficients, int *full_range_flag)
 {
 	struct heif_error error;
 	struct heif_color_profile_nclx *nclx = NULL;
 
 	error = heif_image_handle_get_nclx_color_profile(heif->handle, &nclx);
 	if (error.code == 0 && nclx) {
-		cicp->colour_primaries = nclx->color_primaries;
-		cicp->transfer_characteristics = nclx->transfer_characteristics;
-		cicp->matrix_coefficients = nclx->matrix_coefficients;
-		cicp->full_range_flag = nclx->full_range_flag;
+		*colour_primaries = nclx->color_primaries;
+		*transfer_characteristics = nclx->transfer_characteristics;
+		*matrix_coefficients = nclx->matrix_coefficients;
+		*full_range_flag = nclx->full_range_flag;
 
 		heif_nclx_color_profile_free(nclx);
 
@@ -596,27 +583,6 @@ vips_foreign_load_heif_get_cicp(VipsForeignLoadHeif *heif,
 
 	return FALSE;
 }
-
-#ifdef HAVE_HEIF_CONTENT_LIGHT_LEVEL
-static gboolean
-vips_foreign_load_heif_get_clli(VipsForeignLoadHeif *heif,
-	VipsHeifClli *clli)
-{
-	heif_content_light_level content_light_level;
-
-	if (heif_image_handle_get_content_light_level(heif->handle,
-			&content_light_level)) {
-		clli->max_content_light_level =
-			content_light_level.max_content_light_level;
-		clli->max_frame_average_light_level =
-			content_light_level.max_pic_average_light_level;
-
-		return TRUE;
-	}
-
-	return FALSE;
-}
-#endif /*HAVE_HEIF_CONTENT_LIGHT_LEVEL*/
 
 static int
 vips_foreign_load_heif_set_header(VipsForeignLoadHeif *heif, VipsImage *out)
@@ -792,41 +758,48 @@ vips_foreign_load_heif_set_header(VipsForeignLoadHeif *heif, VipsImage *out)
 			(VipsCallbackFn) vips_area_free_cb, data, length);
 	}
 
+	int colour_primaries;
+	int transfer_characteristics;
+	int matrix_coefficients;
+	int full_range_flag;
+
 	/* Always try to fetch the NCLX profile, even when ICC is present.
 	 * CICP takes priority over ICC for colour interpretation.
 	 */
-	VipsHeifCicp cicp;
-	if (vips_foreign_load_heif_get_cicp(heif, &cicp)) {
+	if (vips_foreign_load_heif_get_cicp(heif,
+			&colour_primaries, &transfer_characteristics,
+			&matrix_coefficients, &full_range_flag)) {
 #ifdef DEBUG
-		printf("\tnclx->color_primaries: %d\n", cicp.colour_primaries);
+		printf("\tnclx->color_primaries: %d\n", colour_primaries);
 		printf("\tnclx->transfer_characteristics: %d\n",
-			cicp.transfer_characteristics);
+			transfer_characteristics);
 		printf("\tnclx->matrix_coefficients: %d\n",
-			cicp.matrix_coefficients);
-		printf("\tnclx->full_range_flag: %d\n", cicp.full_range_flag);
+			matrix_coefficients);
+		printf("\tnclx->full_range_flag: %d\n", full_range_flag);
 #endif
 
 		g_info("heifload: setting CICP from nclx");
 
 		vips_image_set_int(out, "cicp-colour-primaries",
-			cicp.colour_primaries);
+			colour_primaries);
 		vips_image_set_int(out, "cicp-transfer-characteristics",
-			cicp.transfer_characteristics);
+			transfer_characteristics);
 		vips_image_set_int(out, "cicp-matrix-coefficients",
-			cicp.matrix_coefficients);
+			matrix_coefficients);
 		vips_image_set_int(out, "cicp-full-range-flag",
-			cicp.full_range_flag);
+			full_range_flag);
 	}
 
 #ifdef HAVE_HEIF_CONTENT_LIGHT_LEVEL
-	VipsHeifClli clli;
-	if (vips_foreign_load_heif_get_clli(heif, &clli)) {
+	heif_content_light_level clli;
+
+	if (heif_image_handle_get_content_light_level(heif->handle, &clli)) {
 		g_info("heifload: setting CLLI from content light level");
 
 		vips_image_set_int(out, "clli-max-content-light-level",
 			clli.max_content_light_level);
 		vips_image_set_int(out, "clli-max-frame-average-light-level",
-			clli.max_frame_average_light_level);
+			clli.max_pic_average_light_level);
 	}
 #endif
 

--- a/libvips/foreign/heifsave.c
+++ b/libvips/foreign/heifsave.c
@@ -411,25 +411,12 @@ vips_foreign_save_heif_write_page(VipsForeignSaveHeif *heif, int page)
 	options->image_orientation = vips_image_get_orientation(save->ready);
 #endif
 
-#if defined(HAVE_HEIF_CONTENT_LIGHT_LEVEL) && \
-	defined(HAVE_HEIF_ENCODING_OPTIONS_OUTPUT_NCLX_PROFILE)
-	{
-		int colour_primaries;
-		int transfer_characteristics;
-		int matrix_coefficients;
-		int full_range_flag;
-		heif_content_light_level content_light_level;
+#ifdef HAVE_HEIF_CONTENT_LIGHT_LEVEL
+	heif_content_light_level content_light_level;
 
-		if (vips_foreign_save_heif_get_cicp(save->ready,
-				&colour_primaries, &transfer_characteristics,
-				&matrix_coefficients, &full_range_flag) &&
-			vips_foreign_save_heif_get_clli(save->ready,
-				&content_light_level))
-			heif_image_set_content_light_level(heif->img,
-				&content_light_level);
-	}
-#endif /*HAVE_HEIF_CONTENT_LIGHT_LEVEL &&
-	HAVE_HEIF_ENCODING_OPTIONS_OUTPUT_NCLX_PROFILE*/
+	if (vips_foreign_save_heif_get_clli(save->ready, &content_light_level))
+		heif_image_set_content_light_level(heif->img, &content_light_level);
+#endif /*HAVE_HEIF_CONTENT_LIGHT_LEVEL*/
 
 #ifdef DEBUG
 	GTimer *timer = g_timer_new();

--- a/libvips/foreign/heifsave.c
+++ b/libvips/foreign/heifsave.c
@@ -411,10 +411,10 @@ vips_foreign_save_heif_write_page(VipsForeignSaveHeif *heif, int page)
 #endif
 
 #ifdef HAVE_HEIF_CONTENT_LIGHT_LEVEL
-	heif_content_light_level content_light_level;
+	heif_content_light_level clli;
 
-	if (vips_foreign_save_heif_get_clli(save->ready, &content_light_level))
-		heif_image_set_content_light_level(heif->img, &content_light_level);
+	if (vips_foreign_save_heif_get_clli(save->ready, &clli))
+		heif_image_set_content_light_level(heif->img, &clli);
 #endif /*HAVE_HEIF_CONTENT_LIGHT_LEVEL*/
 
 #ifdef DEBUG

--- a/libvips/foreign/heifsave.c
+++ b/libvips/foreign/heifsave.c
@@ -379,8 +379,7 @@ vips_foreign_save_heif_write_page(VipsForeignSaveHeif *heif, int page)
 		 * write both colr boxes so the NCLX is preserved. ICC alone
 		 * cannot describe PQ or HLG.
 		 */
-		if ((save->profile ||
-				vips_image_get_typeof(save->ready, VIPS_META_ICC_NAME)) &&
+		if (vips_image_get_typeof(save->ready, VIPS_META_ICC_NAME) &&
 			(transfer_characteristics == VIPS_CICP_TRANSFER_PQ ||
 				transfer_characteristics == VIPS_CICP_TRANSFER_HLG))
 			options->save_two_colr_boxes_when_ICC_and_nclx_available = 1;

--- a/libvips/foreign/heifsave.c
+++ b/libvips/foreign/heifsave.c
@@ -267,6 +267,65 @@ vips_foreign_save_heif_add_orig_icc(VipsForeignSaveHeif *heif)
 	return 0;
 }
 
+#ifdef HAVE_HEIF_ENCODING_OPTIONS_OUTPUT_NCLX_PROFILE
+static gboolean
+vips_foreign_save_heif_get_cicp(VipsImage *image,
+	int *colour_primaries, int *transfer_characteristics,
+	int *matrix_coefficients, int *full_range_flag)
+{
+	if (!vips_image_get_typeof(image, "cicp-colour-primaries") ||
+		!vips_image_get_typeof(image, "cicp-transfer-characteristics") ||
+		!vips_image_get_typeof(image, "cicp-matrix-coefficients") ||
+		!vips_image_get_typeof(image, "cicp-full-range-flag"))
+		return FALSE;
+
+	if (vips_image_get_int(image, "cicp-colour-primaries",
+			colour_primaries) ||
+		vips_image_get_int(image, "cicp-transfer-characteristics",
+			transfer_characteristics) ||
+		vips_image_get_int(image, "cicp-matrix-coefficients",
+			matrix_coefficients) ||
+		vips_image_get_int(image, "cicp-full-range-flag",
+			full_range_flag))
+		return FALSE;
+
+	return TRUE;
+}
+#endif /*HAVE_HEIF_ENCODING_OPTIONS_OUTPUT_NCLX_PROFILE*/
+
+#ifdef HAVE_HEIF_CONTENT_LIGHT_LEVEL
+static gboolean
+vips_foreign_save_heif_get_clli(VipsImage *image,
+	heif_content_light_level *content_light_level)
+{
+	int max_content_light_level;
+	int max_frame_average_light_level;
+
+	if (!vips_image_get_typeof(image, "clli-max-content-light-level") ||
+		!vips_image_get_typeof(image, "clli-max-frame-average-light-level"))
+		return FALSE;
+
+	if (vips_image_get_int(image, "clli-max-content-light-level",
+			&max_content_light_level) ||
+		vips_image_get_int(image, "clli-max-frame-average-light-level",
+			&max_frame_average_light_level))
+		return FALSE;
+
+	if (max_content_light_level < 0 ||
+		max_content_light_level > 65535 ||
+		max_frame_average_light_level < 0 ||
+		max_frame_average_light_level > 65535)
+		return FALSE;
+
+	content_light_level->max_content_light_level =
+		max_content_light_level;
+	content_light_level->max_pic_average_light_level =
+		max_frame_average_light_level;
+
+	return TRUE;
+}
+#endif /*HAVE_HEIF_CONTENT_LIGHT_LEVEL*/
+
 static int
 vips_foreign_save_heif_write_page(VipsForeignSaveHeif *heif, int page)
 {
@@ -299,15 +358,9 @@ vips_foreign_save_heif_write_page(VipsForeignSaveHeif *heif, int page)
 	int matrix_coefficients;
 	int full_range_flag;
 
-	if (vips_image_get_typeof(save->ready, "cicp-colour-primaries") &&
-		!vips_image_get_int(save->ready, "cicp-colour-primaries",
-			&colour_primaries) &&
-		!vips_image_get_int(save->ready, "cicp-transfer-characteristics",
-			&transfer_characteristics) &&
-		!vips_image_get_int(save->ready, "cicp-matrix-coefficients",
-			&matrix_coefficients) &&
-		!vips_image_get_int(save->ready, "cicp-full-range-flag",
-			&full_range_flag)) {
+	if (vips_foreign_save_heif_get_cicp(save->ready,
+			&colour_primaries, &transfer_characteristics,
+			&matrix_coefficients, &full_range_flag)) {
 
 		if (!(nclx = heif_nclx_color_profile_alloc())) {
 			heif_encoding_options_free(options);
@@ -326,7 +379,8 @@ vips_foreign_save_heif_write_page(VipsForeignSaveHeif *heif, int page)
 		 * write both colr boxes so the NCLX is preserved. ICC alone
 		 * cannot describe PQ or HLG.
 		 */
-		if (vips_image_get_typeof(save->ready, VIPS_META_ICC_NAME) &&
+		if ((save->profile ||
+				vips_image_get_typeof(save->ready, VIPS_META_ICC_NAME)) &&
 			(transfer_characteristics == VIPS_CICP_TRANSFER_PQ ||
 				transfer_characteristics == VIPS_CICP_TRANSFER_HLG))
 			options->save_two_colr_boxes_when_ICC_and_nclx_available = 1;
@@ -356,6 +410,26 @@ vips_foreign_save_heif_write_page(VipsForeignSaveHeif *heif, int page)
 	 */
 	options->image_orientation = vips_image_get_orientation(save->ready);
 #endif
+
+#if defined(HAVE_HEIF_CONTENT_LIGHT_LEVEL) && \
+	defined(HAVE_HEIF_ENCODING_OPTIONS_OUTPUT_NCLX_PROFILE)
+	{
+		int colour_primaries;
+		int transfer_characteristics;
+		int matrix_coefficients;
+		int full_range_flag;
+		heif_content_light_level content_light_level;
+
+		if (vips_foreign_save_heif_get_cicp(save->ready,
+				&colour_primaries, &transfer_characteristics,
+				&matrix_coefficients, &full_range_flag) &&
+			vips_foreign_save_heif_get_clli(save->ready,
+				&content_light_level))
+			heif_image_set_content_light_level(heif->img,
+				&content_light_level);
+	}
+#endif /*HAVE_HEIF_CONTENT_LIGHT_LEVEL &&
+	HAVE_HEIF_ENCODING_OPTIONS_OUTPUT_NCLX_PROFILE*/
 
 #ifdef DEBUG
 	GTimer *timer = g_timer_new();

--- a/meson.build
+++ b/meson.build
@@ -547,6 +547,9 @@ if libheif_dep.found()
     cfg_var.set('HAVE_HEIF_GET_DISABLED_SECURITY_LIMITS', cpp.has_function('heif_get_disabled_security_limits', prefix: '#include <libheif/heif.h>', dependencies: libheif_dep))
     # heif_security_limits.max_total_memory added in 1.20.0
     cfg_var.set('HAVE_HEIF_MAX_TOTAL_MEMORY', cpp.has_member('struct heif_security_limits', 'max_total_memory', prefix: '#include <libheif/heif.h>', dependencies: libheif_dep))
+    cfg_var.set('HAVE_HEIF_CONTENT_LIGHT_LEVEL',
+        cpp.has_function('heif_image_handle_get_content_light_level', prefix: '#include <libheif/heif.h>', dependencies: libheif_dep) and
+        cpp.has_function('heif_image_set_content_light_level', prefix: '#include <libheif/heif.h>', dependencies: libheif_dep))
 endif
 
 libjxl_dep = dependency('libjxl', version: '>=0.7', required: get_option('jpeg-xl'))

--- a/meson.build
+++ b/meson.build
@@ -545,11 +545,13 @@ if libheif_dep.found()
     cfg_var.set('HAVE_HEIF_ERROR_SUCCESS', libheif_dep.version().version_compare('>=1.17.0'))
     # heif_get_disabled_security_limits added in 1.19.0
     cfg_var.set('HAVE_HEIF_GET_DISABLED_SECURITY_LIMITS', cpp.has_function('heif_get_disabled_security_limits', prefix: '#include <libheif/heif.h>', dependencies: libheif_dep))
+    # heif_image_set_content_light_level added in 1.15.0
+    # heif_image_handle_get_content_light_level added in 1.19.0
+    cfg_var.set('HAVE_HEIF_CONTENT_LIGHT_LEVEL',
+                cpp.has_function('heif_image_handle_get_content_light_level', prefix : '#include <libheif/heif.h>', dependencies : libheif_dep) and
+                cpp.has_function('heif_image_set_content_light_level', prefix : '#include <libheif/heif.h>', dependencies : libheif_dep))
     # heif_security_limits.max_total_memory added in 1.20.0
     cfg_var.set('HAVE_HEIF_MAX_TOTAL_MEMORY', cpp.has_member('struct heif_security_limits', 'max_total_memory', prefix: '#include <libheif/heif.h>', dependencies: libheif_dep))
-    cfg_var.set('HAVE_HEIF_CONTENT_LIGHT_LEVEL',
-        cpp.has_function('heif_image_handle_get_content_light_level', prefix: '#include <libheif/heif.h>', dependencies: libheif_dep) and
-        cpp.has_function('heif_image_set_content_light_level', prefix: '#include <libheif/heif.h>', dependencies: libheif_dep))
 endif
 
 libjxl_dep = dependency('libjxl', version: '>=0.7', required: get_option('jpeg-xl'))

--- a/meson.build
+++ b/meson.build
@@ -548,8 +548,8 @@ if libheif_dep.found()
     # heif_image_set_content_light_level added in 1.15.0
     # heif_image_handle_get_content_light_level added in 1.19.0
     cfg_var.set('HAVE_HEIF_CONTENT_LIGHT_LEVEL',
-                cpp.has_function('heif_image_handle_get_content_light_level', prefix : '#include <libheif/heif.h>', dependencies : libheif_dep) and
-                cpp.has_function('heif_image_set_content_light_level', prefix : '#include <libheif/heif.h>', dependencies : libheif_dep))
+                cpp.has_function('heif_image_handle_get_content_light_level', prefix: '#include <libheif/heif.h>', dependencies: libheif_dep) and
+                cpp.has_function('heif_image_set_content_light_level', prefix: '#include <libheif/heif.h>', dependencies: libheif_dep))
     # heif_security_limits.max_total_memory added in 1.20.0
     cfg_var.set('HAVE_HEIF_MAX_TOTAL_MEMORY', cpp.has_member('struct heif_security_limits', 'max_total_memory', prefix: '#include <libheif/heif.h>', dependencies: libheif_dep))
 endif

--- a/test/test-suite/test_cicp.py
+++ b/test/test-suite/test_cicp.py
@@ -1,7 +1,5 @@
 # vim: set fileencoding=utf-8 :
 
-import subprocess
-
 import pytest
 
 import pyvips
@@ -46,29 +44,6 @@ def add_clli(im, max_content_light_level=1624,
     )
 
     return im
-
-
-def have_libheif_clli():
-    try:
-        version = subprocess.check_output(
-            ["pkg-config", "--modversion", "libheif"],
-            stderr=subprocess.DEVNULL,
-            text=True
-        ).strip()
-    except (OSError, subprocess.CalledProcessError):
-        return False
-
-    parts = []
-    for part in version.split(".")[:3]:
-        try:
-            parts.append(int(part))
-        except ValueError:
-            break
-
-    while len(parts) < 3:
-        parts.append(0)
-
-    return tuple(parts) >= (1, 23, 0)
 
 
 # CICP transfer characteristic codes
@@ -359,10 +334,10 @@ class TestCICP:
     @skip_if_no("scRGB2CICP")
     def test_scRGB2CICP_strips_clli_metadata(self):
         im = pyvips.Image.black(1, 1, bands=3).copy(interpretation="scrgb") \
-            + [0.5, 0.5, 0.5]
+             + [0.5, 0.5, 0.5]
         add_clli(im)
         result = im.scRGB2CICP(colour_primaries=PRIMARIES_BT2020,
-                                transfer_characteristics=TRANSFER_PQ)
+                               transfer_characteristics=TRANSFER_PQ)
         assert result.get("cicp-colour-primaries") == PRIMARIES_BT2020
         assert result.get("cicp-transfer-characteristics") == TRANSFER_PQ
         assert result.get_typeof("clli-max-content-light-level") == 0
@@ -511,7 +486,7 @@ class TestCICP:
                              primaries=PRIMARIES_DISPLAY_P3,
                              transfer=TRANSFER_PQ)
         buf = im.heifsave_buffer(compression="av1",
-                                  subsample_mode="on")
+                                 subsample_mode="on")
         out = pyvips.Image.new_from_buffer(buf, "")
         assert out.get("cicp-matrix-coefficients") == 0
 
@@ -621,17 +596,15 @@ class TestCICP:
                              transfer=TRANSFER_PQ)
 
         buf = im.heifsave_buffer(compression="av1",
-                                  profile=SRGB_FILE)
+                                 profile=SRGB_FILE)
         out = pyvips.Image.new_from_buffer(buf, "")
 
         assert out.get("cicp-transfer-characteristics") == TRANSFER_PQ
         assert out.get("cicp-colour-primaries") == PRIMARIES_BT2020
 
     @skip_if_no("heifsave")
+    @pytest.mark.xfail(raises=pyvips.error.Error, reason="requires libheif >= 1.19.0")
     def test_heif_clli_roundtrip_keep_none(self):
-        if not have_libheif_clli():
-            pytest.skip("libheif lacks CLLI API")
-
         im = make_cicp_image(128, 128, 128,
                              primaries=PRIMARIES_BT2020,
                              transfer=TRANSFER_PQ)
@@ -642,35 +615,8 @@ class TestCICP:
         assert out.get("clli-max-frame-average-light-level") == 182
 
     @skip_if_no("heifsave")
-    def test_heif_multipage_first_page_cicp_clli_roundtrip(self):
-        if not have_libheif_clli():
-            pytest.skip("libheif lacks CLLI API")
-
-        page = make_cicp_image(128, 128, 128,
-                               primaries=PRIMARIES_BT2020,
-                               transfer=TRANSFER_PQ)
-        im = page.join(page, "vertical")
-        im.set_type(pyvips.GValue.gint_type, "page-height", 1)
-        im.set_type(pyvips.GValue.gint_type,
-                    "cicp-colour-primaries", PRIMARIES_BT2020)
-        im.set_type(pyvips.GValue.gint_type,
-                    "cicp-transfer-characteristics", TRANSFER_PQ)
-        im.set_type(pyvips.GValue.gint_type, "cicp-matrix-coefficients", 0)
-        im.set_type(pyvips.GValue.gint_type, "cicp-full-range-flag", 1)
-        add_clli(im)
-
-        buf = im.heifsave_buffer(compression="av1", keep="none")
-        out = pyvips.Image.new_from_buffer(buf, "", n=2)
-        assert out.get("cicp-colour-primaries") == PRIMARIES_BT2020
-        assert out.get("cicp-transfer-characteristics") == TRANSFER_PQ
-        assert out.get("clli-max-content-light-level") == 1624
-        assert out.get("clli-max-frame-average-light-level") == 182
-
-    @skip_if_no("heifsave")
+    @pytest.mark.xfail(raises=pyvips.error.Error, reason="requires libheif >= 1.19.0")
     def test_heif_clli_invalid_values_not_written(self):
-        if not have_libheif_clli():
-            pytest.skip("libheif lacks CLLI API")
-
         im = make_cicp_image(128, 128, 128,
                              primaries=PRIMARIES_BT2020,
                              transfer=TRANSFER_PQ)
@@ -681,27 +627,13 @@ class TestCICP:
         assert out.get_typeof("clli-max-frame-average-light-level") == 0
 
     @skip_if_no("heifsave")
+    @pytest.mark.xfail(raises=pyvips.error.Error, reason="requires libheif >= 1.19.0")
     def test_heif_clli_partial_values_not_written(self):
-        if not have_libheif_clli():
-            pytest.skip("libheif lacks CLLI API")
-
         im = make_cicp_image(128, 128, 128,
                              primaries=PRIMARIES_BT2020,
                              transfer=TRANSFER_PQ)
         im.set_type(pyvips.GValue.gint_type,
                     "clli-max-content-light-level", 1624)
-        buf = im.heifsave_buffer(compression="av1")
-        out = pyvips.Image.new_from_buffer(buf, "")
-        assert out.get_typeof("clli-max-content-light-level") == 0
-        assert out.get_typeof("clli-max-frame-average-light-level") == 0
-
-    @skip_if_no("heifsave")
-    def test_heif_clli_without_cicp_not_written(self):
-        if not have_libheif_clli():
-            pytest.skip("libheif lacks CLLI API")
-
-        im = pyvips.Image.black(128, 128, bands=3)
-        add_clli(im)
         buf = im.heifsave_buffer(compression="av1")
         out = pyvips.Image.new_from_buffer(buf, "")
         assert out.get_typeof("clli-max-content-light-level") == 0

--- a/test/test-suite/test_cicp.py
+++ b/test/test-suite/test_cicp.py
@@ -590,24 +590,21 @@ class TestCICP:
         assert out.get("cicp-colour-primaries") == PRIMARIES_BT2020
 
     @skip_if_no("heifsave")
-    def test_heif_hdr_nclx_with_profile_option(self):
-        im = make_cicp_image(128, 128, 128,
-                             primaries=PRIMARIES_BT2020,
-                             transfer=TRANSFER_PQ)
-
-        buf = im.heifsave_buffer(compression="av1",
-                                 profile=SRGB_FILE)
-        out = pyvips.Image.new_from_buffer(buf, "")
-
-        assert out.get("cicp-transfer-characteristics") == TRANSFER_PQ
-        assert out.get("cicp-colour-primaries") == PRIMARIES_BT2020
-
-    @skip_if_no("heifsave")
     @pytest.mark.xfail(raises=pyvips.error.Error, reason="requires libheif >= 1.19.0")
     def test_heif_clli_roundtrip_keep_none(self):
         im = make_cicp_image(128, 128, 128,
                              primaries=PRIMARIES_BT2020,
                              transfer=TRANSFER_PQ)
+        add_clli(im)
+        buf = im.heifsave_buffer(compression="av1", keep="none")
+        out = pyvips.Image.new_from_buffer(buf, "")
+        assert out.get("clli-max-content-light-level") == 1624
+        assert out.get("clli-max-frame-average-light-level") == 182
+
+    @skip_if_no("heifsave")
+    @pytest.mark.xfail(raises=pyvips.error.Error, reason="requires libheif >= 1.19.0")
+    def test_heif_clli_roundtrip_without_input_cicp(self):
+        im = pyvips.Image.black(128, 128, bands=3)
         add_clli(im)
         buf = im.heifsave_buffer(compression="av1", keep="none")
         out = pyvips.Image.new_from_buffer(buf, "")

--- a/test/test-suite/test_cicp.py
+++ b/test/test-suite/test_cicp.py
@@ -561,7 +561,7 @@ class TestCICP:
                              transfer=TRANSFER_PQ, mc=6,
                              width=64, height=64)
         buf = im.heifsave_buffer(compression="av1",
-                                  subsample_mode="on")
+                                 subsample_mode="on")
         out = pyvips.Image.new_from_buffer(buf, "")
         assert out.get("cicp-colour-primaries") == PRIMARIES_DISPLAY_P3
         assert out.get("cicp-transfer-characteristics") == TRANSFER_PQ

--- a/test/test-suite/test_cicp.py
+++ b/test/test-suite/test_cicp.py
@@ -1,18 +1,23 @@
 # vim: set fileencoding=utf-8 :
 
+import subprocess
+
 import pytest
 
 import pyvips
 from helpers import *
 
 
-def make_cicp_image(r, g, b, primaries=1, transfer=1, mc=0, fmt="uchar"):
-    """Create a 1x1 CICP-tagged image with given pixel values."""
+def make_cicp_image(r, g, b, primaries=1, transfer=1, mc=0, fmt="uchar",
+                    width=1, height=1):
+    """Create a CICP-tagged image with given pixel values."""
 
     if fmt == "uchar":
-        im = (pyvips.Image.black(1, 1, bands=3) + [r, g, b]).cast("uchar")
+        im = (pyvips.Image.black(width, height, bands=3) +
+              [r, g, b]).cast("uchar")
     elif fmt == "ushort":
-        im = (pyvips.Image.black(1, 1, bands=3) + [r, g, b]).cast("ushort")
+        im = (pyvips.Image.black(width, height, bands=3) +
+              [r, g, b]).cast("ushort")
     else:
         raise ValueError(f"unsupported format: {fmt}")
 
@@ -25,6 +30,45 @@ def make_cicp_image(r, g, b, primaries=1, transfer=1, mc=0, fmt="uchar"):
     im.set_type(pyvips.GValue.gint_type, "cicp-full-range-flag", 1)
 
     return im
+
+
+def add_clli(im, max_content_light_level=1624,
+             max_frame_average_light_level=182):
+    im.set_type(
+        pyvips.GValue.gint_type,
+        "clli-max-content-light-level",
+        max_content_light_level
+    )
+    im.set_type(
+        pyvips.GValue.gint_type,
+        "clli-max-frame-average-light-level",
+        max_frame_average_light_level
+    )
+
+    return im
+
+
+def have_libheif_clli():
+    try:
+        version = subprocess.check_output(
+            ["pkg-config", "--modversion", "libheif"],
+            stderr=subprocess.DEVNULL,
+            text=True
+        ).strip()
+    except (OSError, subprocess.CalledProcessError):
+        return False
+
+    parts = []
+    for part in version.split(".")[:3]:
+        try:
+            parts.append(int(part))
+        except ValueError:
+            break
+
+    while len(parts) < 3:
+        parts.append(0)
+
+    return tuple(parts) >= (1, 23, 0)
 
 
 # CICP transfer characteristic codes
@@ -223,6 +267,19 @@ class TestCICP:
         assert result.interpretation == "scrgb"
         assert result.bands == 3
 
+    def test_CICP2scRGB_strips_cicp_clli_metadata(self):
+        im = make_cicp_image(128, 128, 128,
+                             primaries=PRIMARIES_BT2020,
+                             transfer=TRANSFER_PQ)
+        add_clli(im)
+        result = im.CICP2scRGB()
+        assert result.get_typeof("cicp-colour-primaries") == 0
+        assert result.get_typeof("cicp-transfer-characteristics") == 0
+        assert result.get_typeof("cicp-matrix-coefficients") == 0
+        assert result.get_typeof("cicp-full-range-flag") == 0
+        assert result.get_typeof("clli-max-content-light-level") == 0
+        assert result.get_typeof("clli-max-frame-average-light-level") == 0
+
     @skip_if_no("scRGB2CICP")
     @pytest.mark.parametrize("transfer,name,cases,tolerance", TRANSFER_CASES,
                              ids=[c[1] for c in TRANSFER_CASES])
@@ -298,6 +355,18 @@ class TestCICP:
         assert result.get("cicp-transfer-characteristics") == TRANSFER_PQ
         assert result.get("cicp-matrix-coefficients") == 0
         assert result.get("cicp-full-range-flag") == 1
+
+    @skip_if_no("scRGB2CICP")
+    def test_scRGB2CICP_strips_clli_metadata(self):
+        im = pyvips.Image.black(1, 1, bands=3).copy(interpretation="scrgb") \
+            + [0.5, 0.5, 0.5]
+        add_clli(im)
+        result = im.scRGB2CICP(colour_primaries=PRIMARIES_BT2020,
+                                transfer_characteristics=TRANSFER_PQ)
+        assert result.get("cicp-colour-primaries") == PRIMARIES_BT2020
+        assert result.get("cicp-transfer-characteristics") == TRANSFER_PQ
+        assert result.get_typeof("clli-max-content-light-level") == 0
+        assert result.get_typeof("clli-max-frame-average-light-level") == 0
 
     @skip_if_no("scRGB2CICP")
     def test_scRGB2CICP_ushort_roundtrip(self):
@@ -441,8 +510,10 @@ class TestCICP:
         im = make_cicp_image(128, 100, 80,
                              primaries=PRIMARIES_DISPLAY_P3,
                              transfer=TRANSFER_PQ)
-        buf = im.heifsave_buffer(compression="av1")
-        assert len(buf) > 0
+        buf = im.heifsave_buffer(compression="av1",
+                                  subsample_mode="on")
+        out = pyvips.Image.new_from_buffer(buf, "")
+        assert out.get("cicp-matrix-coefficients") == 0
 
     @skip_if_no("heifsave")
     def test_heif_cicp_ushort_pixel_roundtrip(self):
@@ -482,6 +553,24 @@ class TestCICP:
         assert out.get("cicp-full-range-flag") == 1
 
     @skip_if_no("heifsave")
+    @pytest.mark.parametrize("save_options", [
+        {"keep": "none"},
+        {"strip": True},
+        {"keep": "icc"},
+        {"keep": pyvips.ForeignKeep.ICC | pyvips.ForeignKeep.GAINMAP},
+    ], ids=["keep-none", "strip", "keep-icc", "keep-icc-gainmap"])
+    def test_heif_cicp_nclx_kept_for_colour_signalling(self, save_options):
+        im = make_cicp_image(128, 128, 128,
+                             primaries=PRIMARIES_BT2020,
+                             transfer=TRANSFER_PQ)
+        buf = im.heifsave_buffer(compression="av1", **save_options)
+        out = pyvips.Image.new_from_buffer(buf, "")
+        assert out.get("cicp-colour-primaries") == PRIMARIES_BT2020
+        assert out.get("cicp-transfer-characteristics") == TRANSFER_PQ
+        assert out.get("cicp-matrix-coefficients") == 0
+        assert out.get("cicp-full-range-flag") == 1
+
+    @skip_if_no("heifsave")
     def test_heif_cicp_matrix_coefficients_preserved(self):
         im = make_cicp_image(128, 128, 128,
                              primaries=PRIMARIES_DISPLAY_P3,
@@ -489,6 +578,20 @@ class TestCICP:
         buf = im.heifsave_buffer(compression="av1")
         out = pyvips.Image.new_from_buffer(buf, "")
         assert out.get("cicp-matrix-coefficients") == 6
+
+    @skip_if_no("heifsave")
+    def test_heif_cicp_matrix_coefficients_preserved_with_subsample(self):
+        im = make_cicp_image(128, 128, 128,
+                             primaries=PRIMARIES_DISPLAY_P3,
+                             transfer=TRANSFER_PQ, mc=6,
+                             width=64, height=64)
+        buf = im.heifsave_buffer(compression="av1",
+                                  subsample_mode="on")
+        out = pyvips.Image.new_from_buffer(buf, "")
+        assert out.get("cicp-colour-primaries") == PRIMARIES_DISPLAY_P3
+        assert out.get("cicp-transfer-characteristics") == TRANSFER_PQ
+        assert out.get("cicp-matrix-coefficients") == 6
+        assert out.get("cicp-full-range-flag") == 1
 
     @skip_if_no("heifsave")
     def test_heif_hdr_nclx_with_icc(self):
@@ -511,6 +614,99 @@ class TestCICP:
         assert out.get("cicp-transfer-characteristics") == TRANSFER_PQ
         assert out.get("cicp-colour-primaries") == PRIMARIES_BT2020
 
+    @skip_if_no("heifsave")
+    def test_heif_hdr_nclx_with_profile_option(self):
+        im = make_cicp_image(128, 128, 128,
+                             primaries=PRIMARIES_BT2020,
+                             transfer=TRANSFER_PQ)
+
+        buf = im.heifsave_buffer(compression="av1",
+                                  profile=SRGB_FILE)
+        out = pyvips.Image.new_from_buffer(buf, "")
+
+        assert out.get("cicp-transfer-characteristics") == TRANSFER_PQ
+        assert out.get("cicp-colour-primaries") == PRIMARIES_BT2020
+
+    @skip_if_no("heifsave")
+    def test_heif_clli_roundtrip_keep_none(self):
+        if not have_libheif_clli():
+            pytest.skip("libheif lacks CLLI API")
+
+        im = make_cicp_image(128, 128, 128,
+                             primaries=PRIMARIES_BT2020,
+                             transfer=TRANSFER_PQ)
+        add_clli(im)
+        buf = im.heifsave_buffer(compression="av1", keep="none")
+        out = pyvips.Image.new_from_buffer(buf, "")
+        assert out.get("clli-max-content-light-level") == 1624
+        assert out.get("clli-max-frame-average-light-level") == 182
+
+    @skip_if_no("heifsave")
+    def test_heif_multipage_first_page_cicp_clli_roundtrip(self):
+        if not have_libheif_clli():
+            pytest.skip("libheif lacks CLLI API")
+
+        page = make_cicp_image(128, 128, 128,
+                               primaries=PRIMARIES_BT2020,
+                               transfer=TRANSFER_PQ)
+        im = page.join(page, "vertical")
+        im.set_type(pyvips.GValue.gint_type, "page-height", 1)
+        im.set_type(pyvips.GValue.gint_type,
+                    "cicp-colour-primaries", PRIMARIES_BT2020)
+        im.set_type(pyvips.GValue.gint_type,
+                    "cicp-transfer-characteristics", TRANSFER_PQ)
+        im.set_type(pyvips.GValue.gint_type, "cicp-matrix-coefficients", 0)
+        im.set_type(pyvips.GValue.gint_type, "cicp-full-range-flag", 1)
+        add_clli(im)
+
+        buf = im.heifsave_buffer(compression="av1", keep="none")
+        out = pyvips.Image.new_from_buffer(buf, "", n=2)
+        assert out.get("cicp-colour-primaries") == PRIMARIES_BT2020
+        assert out.get("cicp-transfer-characteristics") == TRANSFER_PQ
+        assert out.get("clli-max-content-light-level") == 1624
+        assert out.get("clli-max-frame-average-light-level") == 182
+
+    @skip_if_no("heifsave")
+    def test_heif_clli_invalid_values_not_written(self):
+        if not have_libheif_clli():
+            pytest.skip("libheif lacks CLLI API")
+
+        im = make_cicp_image(128, 128, 128,
+                             primaries=PRIMARIES_BT2020,
+                             transfer=TRANSFER_PQ)
+        add_clli(im, max_content_light_level=70000)
+        buf = im.heifsave_buffer(compression="av1")
+        out = pyvips.Image.new_from_buffer(buf, "")
+        assert out.get_typeof("clli-max-content-light-level") == 0
+        assert out.get_typeof("clli-max-frame-average-light-level") == 0
+
+    @skip_if_no("heifsave")
+    def test_heif_clli_partial_values_not_written(self):
+        if not have_libheif_clli():
+            pytest.skip("libheif lacks CLLI API")
+
+        im = make_cicp_image(128, 128, 128,
+                             primaries=PRIMARIES_BT2020,
+                             transfer=TRANSFER_PQ)
+        im.set_type(pyvips.GValue.gint_type,
+                    "clli-max-content-light-level", 1624)
+        buf = im.heifsave_buffer(compression="av1")
+        out = pyvips.Image.new_from_buffer(buf, "")
+        assert out.get_typeof("clli-max-content-light-level") == 0
+        assert out.get_typeof("clli-max-frame-average-light-level") == 0
+
+    @skip_if_no("heifsave")
+    def test_heif_clli_without_cicp_not_written(self):
+        if not have_libheif_clli():
+            pytest.skip("libheif lacks CLLI API")
+
+        im = pyvips.Image.black(128, 128, bands=3)
+        add_clli(im)
+        buf = im.heifsave_buffer(compression="av1")
+        out = pyvips.Image.new_from_buffer(buf, "")
+        assert out.get_typeof("clli-max-content-light-level") == 0
+        assert out.get_typeof("clli-max-frame-average-light-level") == 0
+
     # -- PNG regression tests --
 
     @skip_if_no("pngsave")
@@ -528,4 +724,3 @@ class TestCICP:
         if out.get_typeof("cicp-colour-primaries"):
             assert out.get("cicp-colour-primaries") == PRIMARIES_DISPLAY_P3
             assert out.get("cicp-transfer-characteristics") == TRANSFER_PQ
-


### PR DESCRIPTION
## What

HEIF/AVIF images can carry CLLI (Content Light Level Information), which records MaxCLL and MaxFALL for HDR content.

This PR preserves complete CLLI pairs through HEIF/AVIF load and save, including when ancillary metadata is stripped. libvips copies existing values; it does not synthesize or recompute them.

## Why

CLLI provides content light-level information that displays and tone-mapping systems can use when adapting HDR content. libvips currently loses this signaling during HEIF/AVIF transcoding.

## Details

- Detect the typed libheif CLLI load/save APIs at build time.
- Load and save CLLI when both values are present and within the unsigned 16-bit range.
- Preserve CLLI whether or not the input image has CICP metadata, including with `keep=none`.
- Omit missing, partial, or out-of-range CLLI values.
- Remove stale CLLI after explicit CICP/scRGB color transformations.
- Add no new public option or keep flag.

## Test Plan

- CLLI round-trips with `keep=none`.
- CLLI round-trips when the input has no CICP metadata.
- Missing, partial, and out-of-range CLLI values are not written.
- Explicit CICP/scRGB transformations remove stale CLLI.
- CLLI tests use `xfail` when libheif lacks the required APIs.

Local verification:

- `git diff --check`
- `python3 -m py_compile test/test-suite/test_cicp.py`
- Meson configure and compile
- Targeted CICP/HEIF tests with CLLI-capable libheif
- Manual 50% HDR AVIF resize confirming CLLI survives `keep=none`
