### PR TITLE
maplut: clamp index in complex LUT path to fix OOB read

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -31,6 +31,7 @@ date-tbd 8.19.0
 - vipsthumbnail: add '@' modifier for size to pixel count
 - dcrawload: add half-size option
 - uhdrsave: expose peak-brightness and max-content-boost parameters [dshatz]
+- maplut: clamp index in complex LUT path
 
 6/6/26 8.18.3
 

--- a/libvips/histogram/maplut.c
+++ b/libvips/histogram/maplut.c
@@ -178,10 +178,15 @@ vips_maplut_start(VipsImage *out, void *a, void *b)
 				OUT *tlut = (OUT *) maplut->table[z]; \
 \
 				for (x = 0; x < ne; x += b) { \
-					int n = p[x] * 2; \
+					unsigned int index = p[x]; \
 \
-					q[0] = tlut[n]; \
-					q[1] = tlut[n + 1]; \
+					if (index > maplut->clp) { \
+						index = maplut->clp; \
+						seq->overflow++; \
+					} \
+\
+					q[0] = tlut[index * 2]; \
+					q[1] = tlut[index * 2 + 1]; \
 					q += b * 2; \
 				} \
 			} \
@@ -273,10 +278,15 @@ vips_maplut_start(VipsImage *out, void *a, void *b)
 			VipsPel *p = VIPS_REGION_ADDR(ir, le, y); \
 \
 			for (x = 0; x < ne; x++) { \
-				int n = p[x] * 2; \
+				unsigned int index = p[x]; \
 \
-				q[0] = tlut[n]; \
-				q[1] = tlut[n + 1]; \
+				if (index > maplut->clp) { \
+					index = maplut->clp; \
+					seq->overflow++; \
+				} \
+\
+				q[0] = tlut[index * 2]; \
+				q[1] = tlut[index * 2 + 1]; \
 				q += 2; \
 			} \
 		} \
@@ -364,11 +374,16 @@ vips_maplut_start(VipsImage *out, void *a, void *b)
 			VipsPel *p = VIPS_REGION_ADDR(ir, le, y); \
 \
 			for (x = 0; x < np; x++) { \
-				int n = p[x] * 2; \
+				unsigned int n = p[x]; \
+\
+				if (n > maplut->clp) { \
+					n = maplut->clp; \
+					seq->overflow++; \
+				} \
 \
 				for (z = 0; z < maplut->nb; z++) { \
-					q[0] = tlut[z][n]; \
-					q[1] = tlut[z][n + 1]; \
+					q[0] = tlut[z][n * 2]; \
+					q[1] = tlut[z][n * 2 + 1]; \
 					q += 2; \
 				} \
 			} \

--- a/test/test-suite/test_histogram.py
+++ b/test/test-suite/test_histogram.py
@@ -79,6 +79,24 @@ class TestHistogram:
 
         assert (im - im2).abs().max() == 0.0
 
+    def test_hist_map_complex_short_lut(self):
+        # uchar index values past the end of a complex LUT must clamp to the
+        # final entry rather than reading beyond the table
+        ramp = pyvips.Image.identity().extract_area(0, 0, 16, 1)
+        index = (pyvips.Image.black(4, 4) + 200).cast("uchar")
+
+        lut = ramp.complexform(ramp)
+        out = index.maplut(lut)
+        assert out.real().avg() == 15
+        assert out.imag().avg() == 15
+
+        # also a many-band complex LUT through a one-band index
+        ramp3 = ramp.bandjoin([ramp, ramp])
+        lut3 = ramp3.complexform(ramp3)
+        out3 = index.maplut(lut3)
+        assert out3.real().avg() == 15
+        assert out3.imag().avg() == 15
+
     def test_percent(self):
         im = pyvips.Image.new_from_file(JPEG_FILE).extract_band(1)
 


### PR DESCRIPTION
maplut clamps the lookup index in every code path except the complex-LUT ones for uchar input:
- loopc, loop1c and loop1cm index tlut[p[x] * 2] straight from the pixel with no bound
- the table holds only maplut->clp + 1 entries (taken from the LUT image size), so a LUT shorter than 256 entries plus a pixel value past its length reads off the end of the table
- the matching loops for wider input types (loop1cg etc.) already clamp to clp and bump the overflow counter

Reproduced as an ASAN heap-buffer-overflow read with a 16-entry complex LUT and a uchar value of 200; clamps to the final entry after.