### PR TITLE
object: guard against non-input arguments

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -4,6 +4,7 @@ date tbd 8.18.4
 - tiffload: squash out read errors in openin_source_read [aleens-labs]
 - jxlsave: convert CMYK images to sRGB [DarthSim]
 - heifload: fix `-Winteger-overflow` warning on 32-bit platforms [kleisauke]
+- object: guard against non-input arguments [kleisauke]
 
 6/6/26 8.18.3
 

--- a/libvips/iofuncs/object.c
+++ b/libvips/iofuncs/object.c
@@ -1871,9 +1871,15 @@ vips_object_set_argument_from_string(VipsObject *object,
 			&pspec, &argument_class, &argument_instance))
 		return -1;
 
-	otype = G_PARAM_SPEC_VALUE_TYPE(pspec);
+	/* Only allow input args.
+	 */
+	if (!(argument_class->flags & VIPS_ARGUMENT_INPUT)) {
+		vips_error(class->nickname,
+			_("unable to set '%s'"), name);
+		return -1;
+	}
 
-	g_assert(argument_class->flags & VIPS_ARGUMENT_INPUT);
+	otype = G_PARAM_SPEC_VALUE_TYPE(pspec);
 
 	if (g_type_is_a(otype, VIPS_TYPE_IMAGE)) {
 		VipsImage *out;


### PR DESCRIPTION
Before:
```console
$ vips copy x.jpg[out=/dev/null] x2.jpg
**
VIPS:ERROR:../libvips/iofuncs/object.c:1876:vips_object_set_argument_from_string: assertion failed: (argument_class->flags & VIPS_ARGUMENT_INPUT)
Bail out! VIPS:ERROR:../libvips/iofuncs/object.c:1876:vips_object_set_argument_from_string: assertion failed: (argument_class->flags & VIPS_ARGUMENT_INPUT)
Aborted                    (core dumped) vips copy x.jpg[out=/dev/null] x2.jpg
```
(assertion failure only happens in debug builds)

After:
```console
$ vips copy x.jpg[out=/dev/null] x2.jpg
jpegload: unable to set 'out'
memory: high-water mark 0 bytes
error buffer: jpegload: unable to set 'out'
```

Fixes: https://issues.oss-fuzz.com/issues/494127572.