### PR TITLE
Remove `VIPS_FOREIGN_KEEP_CICP` flag

### DIFF
--- a/libvips/foreign/foreign.c
+++ b/libvips/foreign/foreign.c
@@ -1722,9 +1722,6 @@ vips_foreign_get_keep(const char *field)
 	if (vips_isprefix("gainmap", field))
 		return VIPS_FOREIGN_KEEP_GAINMAP;
 
-	if (vips_isprefix("cicp-", field))
-		return VIPS_FOREIGN_KEEP_CICP;
-
 	/* OTHER is a metadata item that:
 	 *
 	 *	- one or more savers will write to a format

--- a/libvips/include/vips/foreign.h
+++ b/libvips/include/vips/foreign.h
@@ -364,7 +364,6 @@ typedef enum /*< flags >*/ {
  * @VIPS_FOREIGN_KEEP_ICC: keep ICC metadata
  * @VIPS_FOREIGN_KEEP_OTHER: keep other metadata (e.g. PNG comments)
  * @VIPS_FOREIGN_KEEP_GAINMAP: keep the gainmap metadata
- * @VIPS_FOREIGN_KEEP_CICP: keep CICP colour metadata
  * @VIPS_FOREIGN_KEEP_ALL: keep all metadata
  *
  * Which metadata to retain.
@@ -377,15 +376,13 @@ typedef enum /*< flags >*/ {
 	VIPS_FOREIGN_KEEP_ICC = 1 << 3,
 	VIPS_FOREIGN_KEEP_OTHER = 1 << 4,
 	VIPS_FOREIGN_KEEP_GAINMAP = 1 << 5,
-	VIPS_FOREIGN_KEEP_CICP = 1 << 6,
 
 	VIPS_FOREIGN_KEEP_ALL = (VIPS_FOREIGN_KEEP_EXIF |
 		VIPS_FOREIGN_KEEP_XMP |
 		VIPS_FOREIGN_KEEP_IPTC |
 		VIPS_FOREIGN_KEEP_ICC |
 		VIPS_FOREIGN_KEEP_OTHER |
-		VIPS_FOREIGN_KEEP_GAINMAP |
-		VIPS_FOREIGN_KEEP_CICP)
+		VIPS_FOREIGN_KEEP_GAINMAP)
 } VipsForeignKeep;
 
 typedef struct _VipsForeignSave {


### PR DESCRIPTION
Treating CICP as optional metadata leads to accidental stripping. Without this compact color signaling, wide-gamut and HDR images cannot be correctly decoded, resulting in severe desaturation or incorrect contrast. Because it has minimal overhead and acts as pixel interpretation data rather than ancillary metadata, it should always be kept.

Context: https://github.com/libvips/libvips/pull/5104#discussion_r3480646781.