### PR TITLE
shrinkv: multiply by 1/vshrink in float FAVG to match shrinkh

### DIFF
--- a/libvips/resample/shrinkv.c
+++ b/libvips/resample/shrinkv.c
@@ -259,9 +259,10 @@ vips_shrinkv_add_line(VipsShrinkv *shrink, VipsShrinkvSequence *seq,
 	{ \
 		double *restrict sum = (double *) seq->sum + sz * y; \
 		TYPE *restrict q = (TYPE *) out; \
+		const double inv_vshrink = 1.0 / shrink->vshrink; \
 \
 		for (int x = 0; x < sz; x++) \
-			q[x] = sum[x] / shrink->vshrink; \
+			q[x] = sum[x] * inv_vshrink; \
 	}
 
 /* Average the line of sums to out.


### PR DESCRIPTION
Brings `shrinkv`'s float average path in line with the `shrinkh` float path from #5077, which already multiplies by the reciprocal instead of dividing per pixel:

https://github.com/libvips/libvips/blob/f8be485a187e1bb64902194bed288adfaa22766f/libvips/resample/shrinkh.c#L140

`FAVG` now computes `1.0 / vshrink` once and multiplies (applies to FLOAT, DOUBLE, COMPLEX, DPCOMPLEX). Avoids a DIV in the loop.