### PR TITLE
reducev: block the float reduce to auto-vectorise

### DIFF
--- a/libvips/resample/reducev.cpp
+++ b/libvips/resample/reducev.cpp
@@ -458,26 +458,28 @@ static void inline reducev_float_tab(VipsReducev *reducev,
 	const int l1 = lskip / sizeof(T);
 
 	/* Accumulate a block of output elements at once with the tap loop
-	 * innermost. Consecutive output elements are contiguous within each
-	 * input line, so the inner multiply-add over the block auto-vectorises.
-	 * Each element still sums its taps in the same order as the
-	 * reduce_sum() below, so the result is unchanged.
+	 * outermost. Consecutive output elements are contiguous within each
+	 * input line, so the inner multiply-add over the block can auto-vectorise,
+	 * and the per-element accumulators form independent dependency chains
+	 * for better instruction-level parallelism (ILP). Each element still
+	 * sums its taps in the same order as the reduce_sum() below, so the
+	 * result is unchanged.
 	 */
-	constexpr int block = 32;
+	constexpr int block_size = 32; // multiple of common SIMD widths, tuned
 
 	int z = 0;
-	for (; z + block <= ne; z += block) {
+	for (; z + block_size <= ne; z += block_size) {
 		/* One accumulator per output element in the block, zeroed for
 		 * each new block.
 		 */
-		double sum[block] = {};
+		double sum[block_size] = {};
 		for (int i = 0; i < n; i++) {
 			const double c = cy[i];
 			const T *restrict p = in + z + i * l1;
-			for (int k = 0; k < block; k++)
+			for (int k = 0; k < block_size; k++)
 				sum[k] += c * p[k];
 		}
-		for (int k = 0; k < block; k++)
+		for (int k = 0; k < block_size; k++)
 			out[z + k] = sum[k];
 	}
 

--- a/libvips/resample/reducev.cpp
+++ b/libvips/resample/reducev.cpp
@@ -495,8 +495,7 @@ static void inline reducev_float_tab(VipsReducev *reducev,
 
 	/* Tail: fewer than a full block.
 	 */
-	if (z < ne)
-		reducev_block<T>(out + z, in + z, ne - z, lskip, cy, n);
+	reducev_block<T>(out + z, in + z, ne - z, lskip, cy, n);
 }
 
 /* Ultra-high-quality version for double images.

--- a/libvips/resample/reducev.cpp
+++ b/libvips/resample/reducev.cpp
@@ -460,6 +460,8 @@ static void inline reduce_sum_array(T *restrict out, const T *restrict in,
 	int width, int lskip, const CT *restrict cy, int n)
 {
 	const int l1 = lskip / sizeof(T);
+
+	g_assert(width <= REDUCEV_BLOCK);
 	IT sum[REDUCEV_BLOCK] = { 0.0 };
 
 	for (int i = 0; i < n; i++) {

--- a/libvips/resample/reducev.cpp
+++ b/libvips/resample/reducev.cpp
@@ -488,12 +488,12 @@ static void inline reducev_float_tab(VipsReducev *reducev,
 
 	int z;
 
-	/* Complete blocks. Passing the constant block size lets this vectorise.
+	/* do as many complete blocks as we can
 	 */
 	for (z = 0; z + REDUCEV_BLOCK <= ne; z += REDUCEV_BLOCK)
 		reducev_block<T>(out + z, in + z, REDUCEV_BLOCK, lskip, cy, n);
 
-	/* Tail: fewer than a full block.
+	/* do the tail (fewer than a full block)
 	 */
 	reducev_block<T>(out + z, in + z, ne - z, lskip, cy, n);
 }

--- a/libvips/resample/reducev.cpp
+++ b/libvips/resample/reducev.cpp
@@ -445,6 +445,34 @@ static void inline reducev_signed_int_tab(VipsReducev *reducev,
 	}
 }
 
+/* Reduce a block of "width" output elements at once (width <= REDUCEV_BLOCK),
+ * with the tap loop outermost and the element loop innermost. Consecutive
+ * output elements are contiguous within each input line, so the inner
+ * multiply-add vectorises, and the per-element accumulators form independent
+ * dependency chains for better instruction-level parallelism (ILP). Each
+ * element sums its taps in the same order as reduce_sum(), so the result is
+ * identical.
+ */
+static constexpr int REDUCEV_BLOCK = 32; // multiple of common SIMD widths, tuned
+
+template <typename T, typename CT, typename IT = typename LongT<T>::type>
+static void inline reduce_sum_array(T *restrict out, const T *restrict in,
+	int width, int lskip, const CT *restrict cy, int n)
+{
+	const int l1 = lskip / sizeof(T);
+	IT sum[REDUCEV_BLOCK] = { 0.0 };
+
+	for (int i = 0; i < n; i++) {
+		const CT c = cy[i];
+		const T *restrict p = in + i * l1;
+		for (int k = 0; k < width; k++)
+			sum[k] += c * p[k];
+	}
+
+	for (int k = 0; k < width; k++)
+		out[k] = sum[k];
+}
+
 /* Floating-point version.
  */
 template <typename T>
@@ -455,38 +483,18 @@ static void inline reducev_float_tab(VipsReducev *reducev,
 	T *restrict out = (T *) pout;
 	const T *restrict in = (T *) pin;
 	const int n = reducev->n_point;
-	const int l1 = lskip / sizeof(T);
 
-	/* Accumulate a block of output elements at once with the tap loop
-	 * outermost. Consecutive output elements are contiguous within each
-	 * input line, so the inner multiply-add over the block can auto-vectorise,
-	 * and the per-element accumulators form independent dependency chains
-	 * for better instruction-level parallelism (ILP). Each element still
-	 * sums its taps in the same order as the reduce_sum() below, so the
-	 * result is unchanged.
+	int z;
+
+	/* Complete blocks. Passing the constant block size lets this vectorise.
 	 */
-	constexpr int block_size = 32; // multiple of common SIMD widths, tuned
+	for (z = 0; z + REDUCEV_BLOCK <= ne; z += REDUCEV_BLOCK)
+		reduce_sum_array<T>(out + z, in + z, REDUCEV_BLOCK, lskip, cy, n);
 
-	int z = 0;
-	for (; z + block_size <= ne; z += block_size) {
-		/* One accumulator per output element in the block, zeroed for
-		 * each new block.
-		 */
-		double sum[block_size] = {};
-		for (int i = 0; i < n; i++) {
-			const double c = cy[i];
-			const T *restrict p = in + z + i * l1;
-			for (int k = 0; k < block_size; k++)
-				sum[k] += c * p[k];
-		}
-		for (int k = 0; k < block_size; k++)
-			out[z + k] = sum[k];
-	}
-
-	/* Process the remaining tail elements (fewer than a full block).
+	/* Tail: fewer than a full block.
 	 */
-	for (; z < ne; z++)
-		out[z] = reduce_sum<T>(in + z, l1, cy, n);
+	if (z < ne)
+		reduce_sum_array<T>(out + z, in + z, ne - z, lskip, cy, n);
 }
 
 /* Ultra-high-quality version for double images.

--- a/libvips/resample/reducev.cpp
+++ b/libvips/resample/reducev.cpp
@@ -456,7 +456,7 @@ static void inline reducev_signed_int_tab(VipsReducev *reducev,
 static constexpr int REDUCEV_BLOCK = 32; // multiple of common SIMD widths, tuned
 
 template <typename T, typename CT, typename IT = typename LongT<T>::type>
-static void inline reduce_sum_array(T *restrict out, const T *restrict in,
+static void inline reducev_block(T *restrict out, const T *restrict in,
 	int width, int lskip, const CT *restrict cy, int n)
 {
 	const int l1 = lskip / sizeof(T);
@@ -491,12 +491,12 @@ static void inline reducev_float_tab(VipsReducev *reducev,
 	/* Complete blocks. Passing the constant block size lets this vectorise.
 	 */
 	for (z = 0; z + REDUCEV_BLOCK <= ne; z += REDUCEV_BLOCK)
-		reduce_sum_array<T>(out + z, in + z, REDUCEV_BLOCK, lskip, cy, n);
+		reducev_block<T>(out + z, in + z, REDUCEV_BLOCK, lskip, cy, n);
 
 	/* Tail: fewer than a full block.
 	 */
 	if (z < ne)
-		reduce_sum_array<T>(out + z, in + z, ne - z, lskip, cy, n);
+		reducev_block<T>(out + z, in + z, ne - z, lskip, cy, n);
 }
 
 /* Ultra-high-quality version for double images.

--- a/libvips/resample/reducev.cpp
+++ b/libvips/resample/reducev.cpp
@@ -457,7 +457,33 @@ static void inline reducev_float_tab(VipsReducev *reducev,
 	const int n = reducev->n_point;
 	const int l1 = lskip / sizeof(T);
 
-	for (int z = 0; z < ne; z++)
+	/* Accumulate a block of output elements at once with the tap loop
+	 * innermost. Consecutive output elements are contiguous within each
+	 * input line, so the inner multiply-add over the block auto-vectorises.
+	 * Each element still sums its taps in the same order as the
+	 * reduce_sum() below, so the result is unchanged.
+	 */
+	constexpr int block = 32;
+
+	int z = 0;
+	for (; z + block <= ne; z += block) {
+		/* One accumulator per output element in the block, zeroed for
+		 * each new block.
+		 */
+		double sum[block] = {};
+		for (int i = 0; i < n; i++) {
+			const double c = cy[i];
+			const T *restrict p = in + z + i * l1;
+			for (int k = 0; k < block; k++)
+				sum[k] += c * p[k];
+		}
+		for (int k = 0; k < block; k++)
+			out[z + k] = sum[k];
+	}
+
+	/* Process the remaining tail elements (fewer than a full block).
+	 */
+	for (; z < ne; z++)
 		out[z] = reduce_sum<T>(in + z, l1, cy, n);
 }
 


### PR DESCRIPTION
`reducev_float_tab` summed each output pixel's taps in a separate inner reduction, which can't be auto-vectorised. This blocks 32 contiguous output elements with the tap loop outermost, so the multiply-add auto-vectorises well and ILP (Instruction-level parallelism) is also more effective.
Taps are summed in the same order, so the output is **bit-exact**.

Affects the `FLOAT`/`COMPLEX` reduce path.
~40% faster on a float `resize` (lanczos3), and **~3x faster on the isolated `reducev` pass itself**.

`-march=native -O3` on an Apple M3 Pro (clang 21.0.0)

**Resize**:
```bash
vips gaussnoise float.v 16000 16000   # float image, so resize hits the float reduce

VIPS_CONCURRENCY=1 /usr/bin/time ./build-reducev-baseline/tools/vips resize float.v out_base.v 0.5
> 1.06 real         0.98 user         0.12 sys

VIPS_CONCURRENCY=1 /usr/bin/time ./build-reducev-branch/tools/vips resize float.v out_block.v 0.5
> 0.64 real         0.56 user         0.12 sys

sha256sum out_base.v out_block.v 
> 1d8cbf8bc662bf0ecca5ffa655af0db166d817823080ae3257fa1964649657d7  out_base.v
> 1d8cbf8bc662bf0ecca5ffa655af0db166d817823080ae3257fa1964649657d7  out_block.v
```

**Isolated `reducev`**:
```
VIPS_CONCURRENCY=1 /usr/bin/time vips reducev float.v out.v 3.0

              parent    branch   speedup
FLOAT         0.58s     0.19s    ~3.0x
```

Found with https://github.com/davebcn87/pi-autoresearch running Claude Opus 4.8. Manually verified and tuned.