### PR TITLE
image: ensure `posteval` signal is emitted

### DIFF
--- a/libvips/iofuncs/image.c
+++ b/libvips/iofuncs/image.c
@@ -1577,7 +1577,7 @@ void
 vips_image_posteval(VipsImage *image)
 {
 	if (image->progress_signal &&
-		image->progress_signal->time) {
+		image->time) {
 		gint64 processed;
 
 		VIPS_DEBUG_MSG("vips_image_posteval: %p\n", image);


### PR DESCRIPTION
Fixes a regression introduced in commit 090aff0.

Found in vipsdisp (the image progress bar was never hidden because `imagewindow_posteval()` was never called).