### PR TITLE
dcrawload: move other loaders ahead of dcrawload

### DIFF
--- a/libvips/foreign/dcrawload.c
+++ b/libvips/foreign/dcrawload.c
@@ -468,8 +468,8 @@ vips_foreign_load_dcraw_class_init(VipsForeignLoadDcRawClass *class)
 
 	operation_class->flags |= VIPS_OPERATION_UNTRUSTED;
 
-	/* We need to be ahead of JPEG and TIFF, since many cameras use those
-	 * formats as containers. We are slow to open, but we only test the
+	/* We need to be ahead of TIFF, since many cameras use that
+	 * format as a container. We are slow to open, but we only test the
 	 * filename suffix, so that's fine.
 	 */
 	foreign_class->priority = 100;

--- a/libvips/foreign/heifload.c
+++ b/libvips/foreign/heifload.c
@@ -1105,6 +1105,7 @@ vips_foreign_load_heif_class_init(VipsForeignLoadHeifClass *class)
 {
 	GObjectClass *gobject_class = G_OBJECT_CLASS(class);
 	VipsObjectClass *object_class = (VipsObjectClass *) class;
+	VipsForeignClass *foreign_class = (VipsForeignClass *) class;
 	VipsForeignLoadClass *load_class = (VipsForeignLoadClass *) class;
 
 	vips__heif_init();
@@ -1116,6 +1117,10 @@ vips_foreign_load_heif_class_init(VipsForeignLoadHeifClass *class)
 	object_class->nickname = "heifload_base";
 	object_class->description = _("load a HEIF image");
 	object_class->build = vips_foreign_load_heif_build;
+
+	/* Our is_a() is a cheap ISOBMFF brand check, so high priority.
+	 */
+	foreign_class->priority = 150;
 
 	load_class->get_flags = vips_foreign_load_heif_get_flags;
 	load_class->header = vips_foreign_load_heif_header;

--- a/libvips/foreign/jpegload.c
+++ b/libvips/foreign/jpegload.c
@@ -177,7 +177,7 @@ vips_foreign_load_jpeg_class_init(VipsForeignLoadJpegClass *class)
 
 	/* We are fast at is_a(), so high priority.
 	 */
-	foreign_class->priority = 50;
+	foreign_class->priority = 150;
 
 	load_class->get_flags_filename = vips_foreign_load_jpeg_get_flags_filename;
 	load_class->get_flags = vips_foreign_load_jpeg_get_flags;

--- a/libvips/foreign/openslideload.c
+++ b/libvips/foreign/openslideload.c
@@ -985,7 +985,7 @@ vips_foreign_load_openslide_class_init(VipsForeignLoadOpenslideClass *class)
 	 * We need to be ahead of JPEG, since MRXS images are also
 	 * JPEGs.
 	 */
-	foreign_class->priority = 100;
+	foreign_class->priority = 152;
 
 	/* openslide is not fuzzed too heavily.
 	 */

--- a/libvips/foreign/uhdrload.c
+++ b/libvips/foreign/uhdrload.c
@@ -601,7 +601,7 @@ vips_foreign_load_uhdr_class_init(VipsForeignLoadUhdrClass *class)
 
 	/* We need to be higher priority than jpegload.
 	 */
-	foreign_class->priority = 100;
+	foreign_class->priority = 151;
 
 	load_class->get_flags = vips_foreign_load_uhdr_get_flags;
 	load_class->header = vips_foreign_load_uhdr_header;


### PR DESCRIPTION
### Description

Since dcrawload matches on filename, there's a chance of false positives when an image has the wrong extension. This PR moves jpegload and heifload ahead of it since they have strict `is_a` implementations that should take priority if they match. tiffload is intentionally still lower since RAW images can look like TIFFs, so the file extension is actually a more reliable disambiguation there.

I was initially going to change `dcrawload`'s priority, but realized tiffload and jpegload share the same priority and heifload had a lower priority than tiffload, so raising jpegload and heifload is what I landed on.

Fixes #5124