### PR TITLE
icc: set input interpretation for CMYK profiles

### DIFF
--- a/libvips/colour/icc_transform.c
+++ b/libvips/colour/icc_transform.c
@@ -342,6 +342,7 @@ vips_icc_build(VipsObject *object)
 
 		case cmsSigCmykData:
 		case cmsSig4colorData:
+			code->input_interpretation = VIPS_INTERPRETATION_CMYK;
 		case cmsSig5colorData:
 		case cmsSig6colorData:
 		case cmsSig7colorData:
@@ -352,7 +353,6 @@ vips_icc_build(VipsObject *object)
 		case cmsSig12colorData:
 			/* Treat as forms of CMYK.
 			 */
-			code->input_interpretation = VIPS_INTERPRETATION_CMYK;
 			vips_icc_pick_input_format(code, icc, info);
 			break;
 

--- a/libvips/colour/icc_transform.c
+++ b/libvips/colour/icc_transform.c
@@ -352,9 +352,7 @@ vips_icc_build(VipsObject *object)
 		case cmsSig12colorData:
 			/* Treat as forms of CMYK.
 			 */
-			info = vips_icc_info(
-				cmsGetColorSpace(icc->in_profile));
-
+			code->input_interpretation = VIPS_INTERPRETATION_CMYK;
 			vips_icc_pick_input_format(code, icc, info);
 			break;
 


### PR DESCRIPTION
I'm not sure why we didn't this earlier, but it seems consistent with the LAB and XYZ cases above. I think this would be useful for multiband images, e.g.:
```python
#!/usr/bin/env python3
import pyvips

# One yellow pixel
pixel = bytes([255, 255, 0, 255])
multiband = pyvips.Image.new_from_memory(pixel, 1, 1, 4, 'uchar')
#multiband = multiband.colourspace('cmyk')
srgb = multiband.icc_transform('srgb', input_profile='cmyk')
print(srgb(0, 0)) # before: [25.0, 25.0, 37.0] after: [253.0, 238.0, 0.0, 255.0]
```
(i.e. the generic multiband image would be interpreted as CMYK now)

Use of CMYK profiles with sRGB images are still blocked:
```console
$ vips icc_transform ~/zebra.jpg x.jpg srgb --input-profile=cmyk

(vips:258568): VIPS-WARNING **: 16:00:00.497: profile incompatible with image
```

Noticed this while reviewing PR #5123.