### PR TITLE
fuzz: add failing allocator fuzzer

### DIFF
--- a/fuzz/failing-alloc.c
+++ b/fuzz/failing-alloc.c
@@ -1,0 +1,45 @@
+/* Originally from HarfBuzz: https://github.com/harfbuzz/harfbuzz/blob/main/src/failing-alloc.c
+ * SPDX-License-Identifier: MIT-Modern-Variant
+ */
+
+#include <stdlib.h>
+
+/* The library's allocator calls are redirected here via -Wl,--wrap, so __real_*
+ * reaches the real (sanitizer-instrumented) allocator.
+ */
+extern void *__real_malloc(size_t size);
+extern void *__real_calloc(size_t count, size_t size);
+extern void *__real_realloc(void *ptr, size_t size);
+
+int alloc_state = 0;
+
+__attribute__((no_sanitize("integer")))
+static int
+fastrand(void)
+{
+	if (!alloc_state)
+		return 1;
+	alloc_state = (214013 * alloc_state + 2531011);
+	return (alloc_state >> 16) & 0x7FFF;
+}
+
+__attribute__((malloc, alloc_size(1)))
+void *
+__wrap_malloc(size_t size)
+{
+	return (fastrand() % 16) ? __real_malloc(size) : NULL;
+}
+
+__attribute__((malloc, alloc_size(1, 2)))
+void *
+__wrap_calloc(size_t count, size_t size)
+{
+	return (fastrand() % 16) ? __real_calloc(count, size) : NULL;
+}
+
+__attribute__((alloc_size(2)))
+void *
+__wrap_realloc(void *ptr, size_t size)
+{
+	return (fastrand() % 16) ? __real_realloc(ptr, size) : NULL;
+}

--- a/fuzz/meson.build
+++ b/fuzz/meson.build
@@ -105,6 +105,18 @@ fuzz_execs += executable('generic_buffer_with_args_fuzzer',
     link_args: fuzz_ldflags,
 )
 
+fuzz_execs += executable('vips_oom_fuzzer',
+    'vips_fuzzer.cc', 'failing-alloc.c',
+    dependencies: [libvips_dep, fuzz_deps],
+    link_args: [
+        fuzz_ldflags,
+        '-Wl,--wrap=malloc',
+        '-Wl,--wrap=calloc',
+        '-Wl,--wrap=realloc',
+    ],
+    cpp_args: '-DOOM_FUZZER',
+)
+
 executable('generate_vips_dict',
     'generate_vips_dict.c',
     dependencies: libvips_dep,

--- a/fuzz/oss_fuzz_build.sh
+++ b/fuzz/oss_fuzz_build.sh
@@ -234,7 +234,6 @@ cmake \
 cmake --build . --target install
 popd
 
-TSAN_ARGS=""
 if [ "$SANITIZER" = "undefined" ]; then
   # Allow UBSan shift errors to be recoverable to ensure our suppression rules
   # are enforced. OSS-Fuzz uses `-fno-sanitize-recover=shift` by default.
@@ -244,29 +243,42 @@ if [ "$SANITIZER" = "undefined" ]; then
   # and available in OSS-Fuzz we can re-enable the above flags instead.
   export CFLAGS+=" -fsanitize-ignorelist=$PWD/suppressions/ubsan_ignorelist.txt"
   export CXXFLAGS+=" -fsanitize-ignorelist=$PWD/suppressions/ubsan_ignorelist.txt"
-elif [ "$SANITIZER" = "thread" ]; then
-  # TSan may report false positives when callbacks cross boundaries between
-  # instrumented and non-instrumented code. To avoid this, built GLib with
-  # TSan instrumentation as well.
-  # https://github.com/google/sanitizers/wiki/threadsanitizercppmanual#non-instrumented-code
-  TSAN_ARGS="--force-fallback-for=glib -Dglib:glib_debug=disabled -Dglib:nls=disabled -Dglib:sysprof=disabled -Dglib:tests=false"
 fi
+
+# Always build GLib from source to ensure instrumentation is applied.
+# https://github.com/google/oss-fuzz/issues/6294
+# https://github.com/google/sanitizers/wiki/threadsanitizercppmanual#non-instrumented-code
+# https://github.com/google/sanitizers/wiki/MemorySanitizer#using-instrumented-libraries
+GLIB_ARGS=(
+  --force-fallback-for=glib
+  # Keep GLib shared so its allocation APIs bypass the fuzzer's -Wl,--wrap
+  # malloc/calloc/realloc hooks. Those wrappers inject NULL returns, whereas
+  # g_malloc(), g_malloc0() and g_realloc() abort rather than returning NULL.
+  -Dglib:default_library=shared
+  -Dglib:glib_debug=disabled
+  -Dglib:nls=disabled
+  -Dglib:sysprof=disabled
+  -Dglib:tests=false
+  -Dglib:b_lundef=false
+)
 
 # libvips
 # Disable building man pages, gettext po files, tools, and tests
-meson setup build --prefix=$WORK --libdir=lib --prefer-static --default-library=static --buildtype=debug $TSAN_ARGS \
+meson setup build --prefix=$WORK --libdir=lib --default-library=static --buildtype=debug "${GLIB_ARGS[@]}" \
   -Dbackend_max_links=4 -Dexamples=false -Dman=false -Dpo=false \
   -Dtests=false -Dtools=false -Dcplusplus=false -Dmodules=disabled -Dfuzz=true \
   -Dfuzzing_engine=oss-fuzz -Dfuzzer_ldflags="$LIB_FUZZING_ENGINE" \
+  -Dc_link_args="$LDFLAGS -Wl,-rpath=\$ORIGIN" \
   -Dcpp_link_args="$LDFLAGS -Wl,-rpath=\$ORIGIN/lib"
-meson install -C build --tag devel
+meson install -C build --tag runtime,devel
 
 # Copy fuzz executables to $OUT
 find build/fuzz -maxdepth 1 -executable -type f -exec cp -v '{}' $OUT \;
 
 # All shared libraries needed during fuzz target execution should be inside the $OUT/lib directory
 mkdir -p $OUT/lib
-cp $WORK/lib/*.so $OUT/lib
+cp -dv $WORK/lib/*.so* $OUT/lib
+cp -v /usr/lib/x86_64-linux-gnu/libfftw3.so.3 $OUT/lib
 
 pushd $SRC/seed-corpora
 zip -rq $OUT/seed_corpus.zip \
@@ -285,9 +297,10 @@ for fuzzer in $OUT/*_fuzzer; do
   ln -sf "seed_corpus.zip" "$OUT/${target}_seed_corpus.zip"
 done
 
-# Generate dictionary for vips_fuzzer
+# Generate dictionary for vips_fuzzer and vips_oom_fuzzer
 LD_LIBRARY_PATH="$OUT/lib" $OUT/generate_vips_dict > "$OUT/vips_fuzzer.dict"
 rm -v $OUT/generate_vips_dict
+cp -v $OUT/vips_fuzzer.dict $OUT/vips_oom_fuzzer.dict
 
 # Copy options and remaining dictionary files to $OUT
 find fuzz -name '*_fuzzer.dict' -exec cp -v '{}' $OUT \;

--- a/fuzz/vips_fuzzer.cc
+++ b/fuzz/vips_fuzzer.cc
@@ -14,6 +14,12 @@
 
 #include <vips/vips.h>
 
+#ifdef OOM_FUZZER
+/* See fuzz/failing-alloc.c
+ */
+extern "C" int alloc_state;
+#endif
+
 #define MAX_LINE_LEN 4096 // =VIPS_PATH_MAX
 #define MAX_OPTIONAL_ARGS 32
 
@@ -389,6 +395,10 @@ LLVMFuzzerTestOneInput(const guint8 *data, size_t size)
 	ctx.pending_data = data;
 	ctx.pending_size = size;
 
+#ifdef OOM_FUZZER
+	alloc_state = size;
+#endif
+
 	// Try to load an image from the remaining data.
 	if (size > 0 &&
 		((ctx.source = vips_source_new_from_memory(data, size))) &&
@@ -438,6 +448,10 @@ LLVMFuzzerTestOneInput(const guint8 *data, size_t size)
 				EvalRequiredOutput, nullptr, nullptr);
 		}
 	}
+
+#ifdef OOM_FUZZER
+	alloc_state = 0;
+#endif
 
 	// Clean up.
 	vips_object_unref_outputs(VIPS_OBJECT(operation));


### PR DESCRIPTION
Add a fuzzer that deterministically injects allocation failures. This is mostly low-hanging fruit and some allocations in dependencies (e.g. GLib) abort the process instead of returning `NULL`, which limits the approach somewhat.

Context: https://github.com/google/oss-fuzz/issues/1675.