### PR TITLE
CI: validate user input in `/cherry-pick` commands

### DIFF
--- a/.github/utils/github-automation.py
+++ b/.github/utils/github-automation.py
@@ -17,8 +17,11 @@ from git import Repo  # type: ignore
 import github
 import os
 import re
+import string
 import sys
 from typing import List, Optional
+
+HEX_DIGITS = frozenset(string.hexdigits)
 
 
 def extract_commit_hash(arg: str):
@@ -30,7 +33,11 @@ def extract_commit_hash(arg: str):
     """
     github_prefix = "https://github.com/libvips/libvips/commit/"
     if arg.startswith(github_prefix):
-        return arg[len(github_prefix):]
+        arg = arg[len(github_prefix):]
+
+    if not HEX_DIGITS.issuperset(arg):
+        raise ValueError(f"Invalid commit hash: {arg}")
+
     return arg
 
 
@@ -300,24 +307,30 @@ class BackportWorkflow:
     def execute_command(self) -> bool:
         """
         This function reads lines from STDIN and executes the first command
-        that it finds.  The supported command is:
-        /cherry-pick< ><:> commit0 <commit1> <commit2> <...>
+        that it finds. The supported command is:
+        /cherry-pick commit0 <commit1> <commit2> <...>
         """
         for line in sys.stdin:
             line.rstrip()
-            m = re.search(r"/cherry-pick\s*:? *(.*)", line)
+            m = re.search(r"/cherry-pick +(.+)", line)
             if not m:
                 continue
 
             args = m.group(1)
 
-            arg_list = args.split()
-            commits = list(map(lambda a: extract_commit_hash(a), arg_list))
+            try:
+                arg_list = args.split()
+                commits = list(map(extract_commit_hash, arg_list))
+            except ValueError as e:
+                print(e)
+                return False
+
             return self.create_branch(commits)
 
         print("Do not understand input:")
         print(sys.stdin.readlines())
         return False
+
 
 parser = argparse.ArgumentParser()
 parser.add_argument(

--- a/.github/workflows/backport.yml
+++ b/.github/workflows/backport.yml
@@ -25,9 +25,6 @@ on:
     types:
       - opened
 
-env:
-  COMMENT_BODY: ${{ github.event.action == 'opened' && github.event.issue.body || github.event.comment.body }}
-
 jobs:
   backport-commits:
     name: Backport commits
@@ -39,7 +36,7 @@ jobs:
     if: >-
       (github.repository == 'libvips/libvips') &&
       !startswith(github.event.comment.body, '<!--IGNORE-->') &&
-      contains(github.event.action == 'opened' && github.event.issue.body || github.event.comment.body, '/cherry-pick')
+      contains(github.event.action == 'opened' && github.event.issue.body || github.event.comment.body, '/cherry-pick ')
     steps:
       - name: Fetch sources
         uses: actions/checkout@v6
@@ -53,10 +50,13 @@ jobs:
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
 
       - name: Backport commits
+        env:
+          COMMENT_BODY: ${{ github.event.action == 'opened' && github.event.issue.body || github.event.comment.body }}
+          REQUESTED_BY: ${{ (github.event.action == 'opened' && github.event.issue.user.login) || github.event.comment.user.login }}
         run: |
           printf "%s" "$COMMENT_BODY" |
           ./.github/utils/github-automation.py \
           --repo "$GITHUB_REPOSITORY" \
           --token "${{ secrets.GITHUB_TOKEN }}" \
           --issue-number ${{ github.event.issue.number }} \
-          --requested-by ${{ (github.event.action == 'opened' && github.event.issue.user.login) || github.event.comment.user.login }}
+          --requested-by "$REQUESTED_BY"


### PR DESCRIPTION
Cherry-picks these commits:
llvm/llvm-project@21df17aaaec2dd9dafd641c5dbfd96446c27921b
llvm/llvm-project@f16c0ecf2a0bc2fa9253bb73d54a8d791037d741

But performs the input validation in Python instead.