### PR TITLE
meson: require `-fsanitize=fuzzer-no-link` for libFuzzer builds

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -61,11 +61,10 @@ endif
 # libFuzzer related things
 fuzzing_engine = get_option('fuzzing_engine')
 if fuzzing_engine == 'libfuzzer'
-    if not cc.has_argument('-fsanitize=fuzzer')
-        error('fuzzing_engine libfuzzer requires "-fsanitize=fuzzer"')
+    if not cc.has_argument('-fsanitize=fuzzer-no-link')
+        error('-Dfuzzing_engine=libfuzzer requires -fsanitize=fuzzer-no-link')
     endif
-    fuzzer_args = ['-fsanitize=fuzzer-no-link', '-fsanitize=fuzzer']
-    add_project_arguments(cc.first_supported_argument(fuzzer_args), language: ['cpp', 'c'])
+    add_project_arguments('-fsanitize=fuzzer-no-link', language: ['cpp', 'c'])
 endif
 
 glib_dep = dependency('glib-2.0', version: '>=2.52')

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -289,11 +289,11 @@ option('fuzz',
   description: 'Build fuzz targets')
 
 option('fuzzing_engine',
-    type: 'combo',
-    choices : ['none', 'libfuzzer', 'oss-fuzz'],
-    value: 'none',
-    description: 'Select the fuzzing engine')
+  type: 'combo',
+  choices: ['none', 'libfuzzer', 'oss-fuzz'],
+  value: 'none',
+  description: 'Select the fuzzing engine')
 
 option('fuzzer_ldflags',
-    type: 'string',
-    description: 'Extra LDFLAGS used during linking of fuzzing binaries')
+  type: 'string',
+  description: 'Extra LDFLAGS used during linking of fuzzing binaries')


### PR DESCRIPTION
Since `-fsanitize=fuzzer-no-link` has been supported since Clang 6, checking for `-fsanitize=fuzzer` as a fallback serves no purpose.