### PR TITLE
heifsave: preserve HDR NCLX with custom ICC profiles

### DIFF
--- a/libvips/foreign/heifsave.c
+++ b/libvips/foreign/heifsave.c
@@ -379,7 +379,8 @@ vips_foreign_save_heif_write_page(VipsForeignSaveHeif *heif, int page)
 		 * write both colr boxes so the NCLX is preserved. ICC alone
 		 * cannot describe PQ or HLG.
 		 */
-		if (vips_image_get_typeof(save->ready, VIPS_META_ICC_NAME) &&
+		if ((save->profile ||
+				vips_image_get_typeof(save->ready, VIPS_META_ICC_NAME)) &&
 			(transfer_characteristics == VIPS_CICP_TRANSFER_PQ ||
 				transfer_characteristics == VIPS_CICP_TRANSFER_HLG))
 			options->save_two_colr_boxes_when_ICC_and_nclx_available = 1;

--- a/test/test-suite/test_cicp.py
+++ b/test/test-suite/test_cicp.py
@@ -590,6 +590,22 @@ class TestCICP:
         assert out.get("cicp-colour-primaries") == PRIMARIES_BT2020
 
     @skip_if_no("heifsave")
+    @pytest.mark.parametrize("transfer", [TRANSFER_PQ, TRANSFER_HLG],
+                             ids=["pq", "hlg"])
+    def test_heif_hdr_nclx_with_profile_option(self, transfer):
+        im = make_cicp_image(128, 128, 128,
+                             primaries=PRIMARIES_BT2020,
+                             transfer=transfer)
+
+        buf = im.heifsave_buffer(compression="av1",
+                                 profile=SRGB_FILE)
+        out = pyvips.Image.new_from_buffer(buf, "")
+
+        assert out.get_typeof("icc-profile-data") != 0
+        assert out.get("cicp-transfer-characteristics") == transfer
+        assert out.get("cicp-colour-primaries") == PRIMARIES_BT2020
+
+    @skip_if_no("heifsave")
     @pytest.mark.xfail(raises=pyvips.error.Error, reason="requires libheif >= 1.19.0")
     def test_heif_clli_roundtrip_keep_none(self):
         im = make_cicp_image(128, 128, 128,


### PR DESCRIPTION
## What

Preserve HDR NCLX when `heifsave(profile=...)` supplies a custom ICC profile.

libvips already asks libheif to write both ICC and NCLX `colr` boxes when an image contains an embedded ICC profile and complete PQ or HLG CICP signaling. This extends the same behavior to an ICC profile supplied through the `profile` option.

This is the focused follow-up split from #5104 during review.

## Why

When `profile=` attaches an ICC profile, libheif defaults to writing only one `colr` box. Without enabling its dual-profile option, the generated NCLX profile is omitted even though the image still contains complete HDR CICP signaling.

This makes custom output profiles behave consistently with embedded ICC profiles and avoids losing explicit PQ or HLG color signaling when attaching a custom profile.

## Test Plan

- Confirm the regression test fails on current `master` because NCLX is absent after saving with `profile=`.
- Confirm both PQ and HLG NCLX survive an AVIF save and reload with `profile=`.
- Confirm the output retains both ICC and NCLX.
- Run the full CICP and Python test suites.

Disclosure: I used an LLM to help prepare this change; I reviewed and tested it locally.
