### PR TITLE
IM_FREEF: fix error with glib 2.43+

### DIFF
--- a/libvips/include/vips/vips7compat.h
+++ b/libvips/include/vips/vips7compat.h
@@ -424,7 +424,7 @@ int im_cache(IMAGE *in, IMAGE *out, int width, int height, int max);
 	G_STMT_START \
 	{ \
 		if (S) { \
-			(void) F((S)); \
+			(void) (F((S))); \
 			(S) = 0; \
 		} \
 	} \


### PR DESCRIPTION
the same fix we made for VIPS_FREEF a while ago