### PR TITLE
reduceh: fix missing comma in fallback shuffle table

### DIFF
--- a/libvips/resample/reduceh_hwy.cpp
+++ b/libvips/resample/reduceh_hwy.cpp
@@ -129,7 +129,7 @@ vips_reduceh_uchar_hwy(VipsPel *pout, VipsPel *pin,
 		HWY_ENDIAN_LOHI(6, -1), HWY_ENDIAN_LOHI(9, -1),
 		HWY_ENDIAN_LOHI(7, -1), HWY_ENDIAN_LOHI(10, -1),
 		HWY_ENDIAN_LOHI(8, -1), HWY_ENDIAN_LOHI(11, -1),
-		-1, -1 -1, -1
+		-1, -1, -1, -1
 	};
 
 	/*  0  1  2  3  4  5  6  7  8  9 10 11 12 13 14 15


### PR DESCRIPTION
Small correction in the `tbl3_hi` in the Highway < v1.1.0 fallback path of `reduceh_hwy.cpp`:

```c
-1, -1 -1, -1
```

But it should be this instead:
```c
-1, -1, -1, -1
```

The missing comma causes the 15 element to be an implicit `0`. I haven't tested what this caused in the output.