### PR TITLE
buildlut: guard against NaN values

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -6,6 +6,7 @@ date tbd 8.18.5
 - reduceh: fix potential incorrect output with Highway < 1.1.0 [dloebl]
 - jxlsave: ensure EXIF data is freed on error [kleisauke]
 - icc_ac2rc: ensure ICC profile is closed on error [kleisauke]
+- buildlut: guard against NaN values [kleisauke]
 
 5/7/26 8.18.4
 

--- a/libvips/create/buildlut.c
+++ b/libvips/create/buildlut.c
@@ -129,7 +129,7 @@ vips_buildlut_build_init(VipsBuildlut *lut)
 
 		/* Allow for being a bit off.
 		 */
-		if (fabs(v - rint(v)) > 0.001) {
+		if (isnan(v) || fabs(v - rint(v)) > 0.001) {
 			vips_error(class->nickname,
 				_("x value row %d not an int"), y);
 			return -1;


### PR DESCRIPTION
Discovered via fuzz testing.

<details>
  <summary>Reproducer</summary>

```console
$ echo "UGYKNCA0Ci0xLjAKAACAP83MjD+aLGUAAAAAAAAAAAAAAAACAAAAb3IAAAAAAAAAAAAAAADIAAAAAAAAAAD//3qDo5CYAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAlKYrt////" | base64 -d > reproducer.pfm
$ vips buildlut reproducer.pfm x.v
=================================================================
==1681586==ERROR: AddressSanitizer: heap-buffer-overflow on address 0x7bb0807e6ac0 at pc 0x7f70873272e8 bp 0x7ffc7dbcc000 sp 0x7ffc7dbcbff8
WRITE of size 8 at 0x7bb0807e6ac0 thread T0
    #0 0x7f70873272e7 in vips_buildlut_build_create /home/kleisauke/libvips/build/../libvips/create/buildlut.c:215:43
    #1 0x7f708732562a in vips_buildlut_build /home/kleisauke/libvips/build/../libvips/create/buildlut.c:242:3
    #2 0x7f70871b97aa in vips_object_build /home/kleisauke/libvips/build/../libvips/iofuncs/object.c:372:6
    #3 0x7f708721c432 in vips_call_argv /home/kleisauke/libvips/build/../libvips/iofuncs/operation.c:1474:6
    #4 0x0000004ed1ec in main /home/kleisauke/libvips/build/../tools/vips.c:888:7
    #5 0x7f7086663680 in __libc_start_call_main (/lib64/libc.so.6+0x3680) (BuildId: 17f2e1fd905f485786f6fd6e3bede4ad737137e7)
    #6 0x7f7086663797 in __libc_start_main@GLIBC_2.2.5 (/lib64/libc.so.6+0x3797) (BuildId: 17f2e1fd905f485786f6fd6e3bede4ad737137e7)
    #7 0x000000400a94 in _start (/usr/bin/vips+0x400a94) (BuildId: c4255561945e8f3be4614581e6f80cc07148d147)

0x7bb0807e6ac0 is located 0 bytes after 48-byte region [0x7bb0807e6a90,0x7bb0807e6ac0)
allocated by thread T0 here:
    #0 0x0000004a6d1d in calloc (/usr/bin/vips+0x4a6d1d) (BuildId: c4255561945e8f3be4614581e6f80cc07148d147)
    #1 0x7f7086ae36e1 in g_malloc0 (/lib64/libglib-2.0.so.0+0x456e1) (BuildId: 6dae940c30065a166a12ab9ff52140e4d699e104)
    #2 0x7f708720931c in vips_malloc /home/kleisauke/libvips/build/../libvips/iofuncs/memory.c:160:8
    #3 0x7f7087326bd2 in vips_buildlut_build_init /home/kleisauke/libvips/build/../libvips/create/buildlut.c:165:19
    #4 0x7f70873255f7 in vips_buildlut_build /home/kleisauke/libvips/build/../libvips/create/buildlut.c:241:6
    #5 0x7f70871b97aa in vips_object_build /home/kleisauke/libvips/build/../libvips/iofuncs/object.c:372:6
    #6 0x7f708721c432 in vips_call_argv /home/kleisauke/libvips/build/../libvips/iofuncs/operation.c:1474:6
    #7 0x0000004ed1ec in main /home/kleisauke/libvips/build/../tools/vips.c:888:7
    #8 0x7f7086663680 in __libc_start_call_main (/lib64/libc.so.6+0x3680) (BuildId: 17f2e1fd905f485786f6fd6e3bede4ad737137e7)
    #9 0x7f7086663797 in __libc_start_main@GLIBC_2.2.5 (/lib64/libc.so.6+0x3797) (BuildId: 17f2e1fd905f485786f6fd6e3bede4ad737137e7)
    #10 0x000000400a94 in _start (/usr/bin/vips+0x400a94) (BuildId: c4255561945e8f3be4614581e6f80cc07148d147)

SUMMARY: AddressSanitizer: heap-buffer-overflow /home/kleisauke/libvips/build/../libvips/create/buildlut.c:215:43 in vips_buildlut_build_create
Shadow bytes around the buggy address:
  0x7bb0807e6800: fa fa 00 00 00 00 00 00 fa fa 00 00 00 00 00 00
  0x7bb0807e6880: fa fa 00 00 00 00 00 00 fa fa 00 00 00 00 00 00
  0x7bb0807e6900: fa fa 00 00 00 00 00 00 fa fa 00 00 00 00 00 fa
  0x7bb0807e6980: fa fa 00 00 00 00 00 fa fa fa fd fd fd fd fd fd
  0x7bb0807e6a00: fa fa fd fd fd fd fd fd fa fa fd fd fd fd fd fa
=>0x7bb0807e6a80: fa fa 00 00 00 00 00 00[fa]fa fa fa fa fa fa fa
  0x7bb0807e6b00: fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa
  0x7bb0807e6b80: fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa
  0x7bb0807e6c00: fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa
  0x7bb0807e6c80: fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa
  0x7bb0807e6d00: fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa
Shadow byte legend (one shadow byte represents 8 application bytes):
  Addressable:           00
  Partially addressable: 01 02 03 04 05 06 07 
  Heap left redzone:       fa
  Freed heap region:       fd
  Stack left redzone:      f1
  Stack mid redzone:       f2
  Stack right redzone:     f3
  Stack after return:      f5
  Stack use after scope:   f8
  Global redzone:          f9
  Global init order:       f6
  Poisoned by user:        f7
  Container overflow:      fc
  Array cookie:            ac
  Intra object redzone:    bb
  ASan internal:           fe
  Left alloca redzone:     ca
  Right alloca redzone:    cb
==1681586==ABORTING
Aborted                    vips buildlut reproducer.pfm x.v
```
</details>