### PR TITLE
heifsave: add "smart_subsample" option

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -10,6 +10,7 @@ date-tbd 8.19.0
 - add VIPS_UNLIMITED, --vips-unlimited, vips_unlimited_get()/_set() to
   disable DoS checks
 - better centre sampling on resize upscale [chcunningham]
+- heifsave: add `chroma_downsampling` option [chcunningham]
 - conversion: non-separable blending modes added [kstanikviacbs]
 - dECMC: fix incorrect results [jcupitt]
 - jxlsave: add `interlace` option [mertalev]

--- a/ChangeLog
+++ b/ChangeLog
@@ -10,7 +10,7 @@ date-tbd 8.19.0
 - add VIPS_UNLIMITED, --vips-unlimited, vips_unlimited_get()/_set() to
   disable DoS checks
 - better centre sampling on resize upscale [chcunningham]
-- heifsave: add `chroma_downsampling` option [chcunningham]
+- heifsave: add `smart_subsample` option [chcunningham]
 - conversion: non-separable blending modes added [kstanikviacbs]
 - dECMC: fix incorrect results [jcupitt]
 - jxlsave: add `interlace` option [mertalev]

--- a/libvips/foreign/foreign.c
+++ b/libvips/foreign/foreign.c
@@ -2396,6 +2396,10 @@ vips_heifload_source(VipsSource *source, VipsImage **out, ...)
  * Use @tune to pass a set of tuning parameters to the encoder, see the
  * libheif documentation.
  *
+ * Use @chroma_downsampling to force a chroma downsampling algorithm (for
+ * example sharp YUV) when writing 4:2:0; the default leaves the choice to
+ * libheif.
+ *
  * ::: tip "Optional arguments"
  *     * @Q: `gint`, quality factor
  *     * @bitdepth: `gint`, set write bit depth to 8, 10, or 12 bits
@@ -2406,6 +2410,8 @@ vips_heifload_source(VipsSource *source, VipsImage **out, ...)
  *     * @subsample_mode: [enum@ForeignSubsample], chroma subsampling mode
  *     * @encoder: [enum@ForeignHeifEncoder], select encoder to use
  *     * @tune: `gchararray`, encoder tuning parameters
+ *     * @chroma_downsampling: [enum@ForeignHeifChromaDownsampling], chroma
+ *       downsampling algorithm
  *
  * ::: seealso
  *     [method@Image.write_to_file], [ctor@Image.heifload].
@@ -2448,6 +2454,8 @@ vips_heifsave(VipsImage *in, const char *filename, ...)
  *     * @subsample_mode: [enum@ForeignSubsample], chroma subsampling mode
  *     * @encoder: [enum@ForeignHeifEncoder], select encoder to use
  *     * @tune: `gchararray`, encoder tuning parameters
+ *     * @chroma_downsampling: [enum@ForeignHeifChromaDownsampling], chroma
+ *       downsampling algorithm
  *
  * ::: seealso
  *     [method@Image.heifsave], [method@Image.write_to_file].
@@ -2500,6 +2508,8 @@ vips_heifsave_buffer(VipsImage *in, void **buf, size_t *len, ...)
  *     * @subsample_mode: [enum@ForeignSubsample], chroma subsampling mode
  *     * @encoder: [enum@ForeignHeifEncoder], select encoder to use
  *     * @tune: `gchararray`, encoder tuning parameters
+ *     * @chroma_downsampling: [enum@ForeignHeifChromaDownsampling], chroma
+ *       downsampling algorithm
  *
  * ::: seealso
  *     [method@Image.heifsave], [method@Image.write_to_target].

--- a/libvips/foreign/foreign.c
+++ b/libvips/foreign/foreign.c
@@ -2396,9 +2396,9 @@ vips_heifload_source(VipsSource *source, VipsImage **out, ...)
  * Use @tune to pass a set of tuning parameters to the encoder, see the
  * libheif documentation.
  *
- * Use @chroma_downsampling to force a chroma downsampling algorithm (for
- * example sharp YUV) when writing 4:2:0; the default leaves the choice to
- * libheif.
+ * Set @smart_subsample to enable high quality chroma subsampling. This routes
+ * 4:2:0 chroma downsampling through libsharpyuv, so it needs libheif 1.16 or
+ * later, built with that library. It has no effect on 4:4:4 output.
  *
  * ::: tip "Optional arguments"
  *     * @Q: `gint`, quality factor
@@ -2410,8 +2410,7 @@ vips_heifload_source(VipsSource *source, VipsImage **out, ...)
  *     * @subsample_mode: [enum@ForeignSubsample], chroma subsampling mode
  *     * @encoder: [enum@ForeignHeifEncoder], select encoder to use
  *     * @tune: `gchararray`, encoder tuning parameters
- *     * @chroma_downsampling: [enum@ForeignHeifChromaDownsampling], chroma
- *       downsampling algorithm
+ *     * @smart_subsample: `gboolean`, enables high quality chroma subsampling
  *
  * ::: seealso
  *     [method@Image.write_to_file], [ctor@Image.heifload].
@@ -2454,8 +2453,7 @@ vips_heifsave(VipsImage *in, const char *filename, ...)
  *     * @subsample_mode: [enum@ForeignSubsample], chroma subsampling mode
  *     * @encoder: [enum@ForeignHeifEncoder], select encoder to use
  *     * @tune: `gchararray`, encoder tuning parameters
- *     * @chroma_downsampling: [enum@ForeignHeifChromaDownsampling], chroma
- *       downsampling algorithm
+ *     * @smart_subsample: `gboolean`, enables high quality chroma subsampling
  *
  * ::: seealso
  *     [method@Image.heifsave], [method@Image.write_to_file].
@@ -2508,8 +2506,7 @@ vips_heifsave_buffer(VipsImage *in, void **buf, size_t *len, ...)
  *     * @subsample_mode: [enum@ForeignSubsample], chroma subsampling mode
  *     * @encoder: [enum@ForeignHeifEncoder], select encoder to use
  *     * @tune: `gchararray`, encoder tuning parameters
- *     * @chroma_downsampling: [enum@ForeignHeifChromaDownsampling], chroma
- *       downsampling algorithm
+ *     * @smart_subsample: `gboolean`, enables high quality chroma subsampling
  *
  * ::: seealso
  *     [method@Image.heifsave], [method@Image.write_to_target].

--- a/libvips/foreign/heifsave.c
+++ b/libvips/foreign/heifsave.c
@@ -136,6 +136,10 @@ typedef struct _VipsForeignSaveHeif {
 	 */
 	const char *tune;
 
+	/* Chroma downsampling algorithm.
+	 */
+	VipsForeignHeifChromaDownsampling chroma_downsampling;
+
 } VipsForeignSaveHeif;
 
 typedef VipsForeignSaveClass VipsForeignSaveHeifClass;
@@ -416,6 +420,39 @@ vips_foreign_save_heif_write_page(VipsForeignSaveHeif *heif, int page)
 	if (vips_foreign_save_heif_get_clli(save->ready, &clli))
 		heif_image_set_content_light_level(heif->img, &clli);
 #endif /*HAVE_HEIF_CONTENT_LIGHT_LEVEL*/
+
+#ifdef HAVE_HEIF_ENCODING_OPTIONS_COLOR_CONVERSION_OPTIONS
+	/* AUTO leaves libheif's pipeline search to pick the algorithm. Any other
+	 * value forces that algorithm; the force flag is required, since without
+	 * it libheif's search picks the cheapest op regardless of preference.
+	 */
+	if (heif->chroma_downsampling != VIPS_FOREIGN_HEIF_CHROMA_DOWNSAMPLING_AUTO) {
+		enum heif_chroma_downsampling_algorithm algorithm =
+			heif_chroma_downsampling_average;
+
+		switch (heif->chroma_downsampling) {
+		case VIPS_FOREIGN_HEIF_CHROMA_DOWNSAMPLING_NEAREST:
+			algorithm = heif_chroma_downsampling_nearest_neighbor;
+			break;
+
+		case VIPS_FOREIGN_HEIF_CHROMA_DOWNSAMPLING_AVERAGE:
+			algorithm = heif_chroma_downsampling_average;
+			break;
+
+		case VIPS_FOREIGN_HEIF_CHROMA_DOWNSAMPLING_SHARP:
+			algorithm = heif_chroma_downsampling_sharp_yuv;
+			break;
+
+		default:
+			break;
+		}
+
+		options->color_conversion_options
+			.preferred_chroma_downsampling_algorithm = algorithm;
+		options->color_conversion_options
+			.only_use_preferred_chroma_algorithm = TRUE;
+	}
+#endif /*HAVE_HEIF_ENCODING_OPTIONS_COLOR_CONVERSION_OPTIONS*/
 
 #ifdef DEBUG
 	GTimer *timer = g_timer_new();
@@ -956,6 +993,14 @@ vips_foreign_save_heif_class_init(VipsForeignSaveHeifClass *class)
 		G_STRUCT_OFFSET(VipsForeignSaveHeif, tune),
 		NULL);
 
+	VIPS_ARG_ENUM(class, "chroma_downsampling", 20,
+		_("Chroma downsampling"),
+		_("Chroma downsampling algorithm"),
+		VIPS_ARGUMENT_OPTIONAL_INPUT,
+		G_STRUCT_OFFSET(VipsForeignSaveHeif, chroma_downsampling),
+		VIPS_TYPE_FOREIGN_HEIF_CHROMA_DOWNSAMPLING,
+		VIPS_FOREIGN_HEIF_CHROMA_DOWNSAMPLING_AUTO);
+
 }
 
 static void
@@ -967,6 +1012,7 @@ vips_foreign_save_heif_init(VipsForeignSaveHeif *heif)
 	heif->compression = VIPS_FOREIGN_HEIF_COMPRESSION_HEVC;
 	heif->effort = 4;
 	heif->subsample_mode = VIPS_FOREIGN_SUBSAMPLE_AUTO;
+	heif->chroma_downsampling = VIPS_FOREIGN_HEIF_CHROMA_DOWNSAMPLING_AUTO;
 
 	/* Deprecated.
 	 */

--- a/libvips/foreign/heifsave.c
+++ b/libvips/foreign/heifsave.c
@@ -136,9 +136,9 @@ typedef struct _VipsForeignSaveHeif {
 	 */
 	const char *tune;
 
-	/* Chroma downsampling algorithm.
+	/* Enable smart chroma subsampling.
 	 */
-	VipsForeignHeifChromaDownsampling chroma_downsampling;
+	gboolean smart_subsample;
 
 } VipsForeignSaveHeif;
 
@@ -421,38 +421,24 @@ vips_foreign_save_heif_write_page(VipsForeignSaveHeif *heif, int page)
 		heif_image_set_content_light_level(heif->img, &clli);
 #endif /*HAVE_HEIF_CONTENT_LIGHT_LEVEL*/
 
-#ifdef HAVE_HEIF_ENCODING_OPTIONS_COLOR_CONVERSION_OPTIONS
-	/* AUTO leaves libheif's pipeline search to pick the algorithm. Any other
-	 * value forces that algorithm; the force flag is required, since without
-	 * it libheif's search picks the cheapest op regardless of preference.
+	/* Use sharp YUV for chroma downsampling, if requested.
 	 */
-	if (heif->chroma_downsampling != VIPS_FOREIGN_HEIF_CHROMA_DOWNSAMPLING_AUTO) {
-		enum heif_chroma_downsampling_algorithm algorithm =
-			heif_chroma_downsampling_average;
+	if (heif->smart_subsample) {
+#ifdef HAVE_HEIF_ENCODING_OPTIONS_COLOR_CONVERSION_OPTIONS
+		/* Sharp YUV has to be forced: without the force flag libheif's
+		 * pipeline search picks the cheapest conversion regardless of the
+		 * preference, which for RGB input is nearest-neighbour.
+		 */
+		struct heif_color_conversion_options *cc_options =
+			&options->color_conversion_options;
 
-		switch (heif->chroma_downsampling) {
-		case VIPS_FOREIGN_HEIF_CHROMA_DOWNSAMPLING_NEAREST:
-			algorithm = heif_chroma_downsampling_nearest_neighbor;
-			break;
-
-		case VIPS_FOREIGN_HEIF_CHROMA_DOWNSAMPLING_AVERAGE:
-			algorithm = heif_chroma_downsampling_average;
-			break;
-
-		case VIPS_FOREIGN_HEIF_CHROMA_DOWNSAMPLING_SHARP:
-			algorithm = heif_chroma_downsampling_sharp_yuv;
-			break;
-
-		default:
-			break;
-		}
-
-		options->color_conversion_options
-			.preferred_chroma_downsampling_algorithm = algorithm;
-		options->color_conversion_options
-			.only_use_preferred_chroma_algorithm = TRUE;
-	}
+		cc_options->preferred_chroma_downsampling_algorithm =
+			heif_chroma_downsampling_sharp_yuv;
+		cc_options->only_use_preferred_chroma_algorithm = 1;
+#else  /*!HAVE_HEIF_ENCODING_OPTIONS_COLOR_CONVERSION_OPTIONS*/
+		g_warning("libheif >= 1.16.0 required for smart_subsample");
 #endif /*HAVE_HEIF_ENCODING_OPTIONS_COLOR_CONVERSION_OPTIONS*/
+	}
 
 #ifdef DEBUG
 	GTimer *timer = g_timer_new();
@@ -993,14 +979,12 @@ vips_foreign_save_heif_class_init(VipsForeignSaveHeifClass *class)
 		G_STRUCT_OFFSET(VipsForeignSaveHeif, tune),
 		NULL);
 
-	VIPS_ARG_ENUM(class, "chroma_downsampling", 20,
-		_("Chroma downsampling"),
-		_("Chroma downsampling algorithm"),
+	VIPS_ARG_BOOL(class, "smart_subsample", 20,
+		_("Smart subsampling"),
+		_("Enable high quality chroma subsampling"),
 		VIPS_ARGUMENT_OPTIONAL_INPUT,
-		G_STRUCT_OFFSET(VipsForeignSaveHeif, chroma_downsampling),
-		VIPS_TYPE_FOREIGN_HEIF_CHROMA_DOWNSAMPLING,
-		VIPS_FOREIGN_HEIF_CHROMA_DOWNSAMPLING_AUTO);
-
+		G_STRUCT_OFFSET(VipsForeignSaveHeif, smart_subsample),
+		FALSE);
 }
 
 static void
@@ -1012,7 +996,6 @@ vips_foreign_save_heif_init(VipsForeignSaveHeif *heif)
 	heif->compression = VIPS_FOREIGN_HEIF_COMPRESSION_HEVC;
 	heif->effort = 4;
 	heif->subsample_mode = VIPS_FOREIGN_SUBSAMPLE_AUTO;
-	heif->chroma_downsampling = VIPS_FOREIGN_HEIF_CHROMA_DOWNSAMPLING_AUTO;
 
 	/* Deprecated.
 	 */

--- a/libvips/foreign/heifsave.c
+++ b/libvips/foreign/heifsave.c
@@ -436,7 +436,7 @@ vips_foreign_save_heif_write_page(VipsForeignSaveHeif *heif, int page)
 			heif_chroma_downsampling_sharp_yuv;
 		cc_options->only_use_preferred_chroma_algorithm = 1;
 #else  /*!HAVE_HEIF_ENCODING_OPTIONS_COLOR_CONVERSION_OPTIONS*/
-		g_warning("libheif >= 1.16.0 required for smart_subsample");
+		g_warning("ignoring smart_subsample (requires libheif >= v1.16.0)");
 #endif /*HAVE_HEIF_ENCODING_OPTIONS_COLOR_CONVERSION_OPTIONS*/
 	}
 

--- a/libvips/include/vips/foreign.h
+++ b/libvips/include/vips/foreign.h
@@ -1101,6 +1101,27 @@ typedef enum {
 	VIPS_FOREIGN_HEIF_ENCODER_LAST	/*< skip >*/
 } VipsForeignHeifEncoder;
 
+/**
+ * VipsForeignHeifChromaDownsampling:
+ * @VIPS_FOREIGN_HEIF_CHROMA_DOWNSAMPLING_AUTO: let libheif choose (default)
+ * @VIPS_FOREIGN_HEIF_CHROMA_DOWNSAMPLING_NEAREST: nearest-neighbour
+ * @VIPS_FOREIGN_HEIF_CHROMA_DOWNSAMPLING_AVERAGE: averaging
+ * @VIPS_FOREIGN_HEIF_CHROMA_DOWNSAMPLING_SHARP: sharp YUV (libsharpyuv)
+ *
+ * The chroma downsampling algorithm to use when writing 4:2:0.
+ *
+ * @VIPS_FOREIGN_HEIF_CHROMA_DOWNSAMPLING_AUTO leaves the choice to libheif,
+ * which selects an algorithm from its internal pipeline search. The other
+ * values force libheif to use that specific algorithm.
+ */
+typedef enum {
+	VIPS_FOREIGN_HEIF_CHROMA_DOWNSAMPLING_AUTO,
+	VIPS_FOREIGN_HEIF_CHROMA_DOWNSAMPLING_NEAREST,
+	VIPS_FOREIGN_HEIF_CHROMA_DOWNSAMPLING_AVERAGE,
+	VIPS_FOREIGN_HEIF_CHROMA_DOWNSAMPLING_SHARP,
+	VIPS_FOREIGN_HEIF_CHROMA_DOWNSAMPLING_LAST	/*< skip >*/
+} VipsForeignHeifChromaDownsampling;
+
 #ifdef __cplusplus
 }
 #endif /*__cplusplus*/

--- a/libvips/include/vips/foreign.h
+++ b/libvips/include/vips/foreign.h
@@ -1101,27 +1101,6 @@ typedef enum {
 	VIPS_FOREIGN_HEIF_ENCODER_LAST	/*< skip >*/
 } VipsForeignHeifEncoder;
 
-/**
- * VipsForeignHeifChromaDownsampling:
- * @VIPS_FOREIGN_HEIF_CHROMA_DOWNSAMPLING_AUTO: let libheif choose (default)
- * @VIPS_FOREIGN_HEIF_CHROMA_DOWNSAMPLING_NEAREST: nearest-neighbour
- * @VIPS_FOREIGN_HEIF_CHROMA_DOWNSAMPLING_AVERAGE: averaging
- * @VIPS_FOREIGN_HEIF_CHROMA_DOWNSAMPLING_SHARP: sharp YUV (libsharpyuv)
- *
- * The chroma downsampling algorithm to use when writing 4:2:0.
- *
- * @VIPS_FOREIGN_HEIF_CHROMA_DOWNSAMPLING_AUTO leaves the choice to libheif,
- * which selects an algorithm from its internal pipeline search. The other
- * values force libheif to use that specific algorithm.
- */
-typedef enum {
-	VIPS_FOREIGN_HEIF_CHROMA_DOWNSAMPLING_AUTO,
-	VIPS_FOREIGN_HEIF_CHROMA_DOWNSAMPLING_NEAREST,
-	VIPS_FOREIGN_HEIF_CHROMA_DOWNSAMPLING_AVERAGE,
-	VIPS_FOREIGN_HEIF_CHROMA_DOWNSAMPLING_SHARP,
-	VIPS_FOREIGN_HEIF_CHROMA_DOWNSAMPLING_LAST	/*< skip >*/
-} VipsForeignHeifChromaDownsampling;
-
 #ifdef __cplusplus
 }
 #endif /*__cplusplus*/

--- a/meson.build
+++ b/meson.build
@@ -551,6 +551,8 @@ if libheif_dep.found()
                 cpp.has_function('heif_image_set_content_light_level', prefix: '#include <libheif/heif.h>', dependencies: libheif_dep))
     # heif_security_limits.max_total_memory added in 1.20.0
     cfg_var.set('HAVE_HEIF_MAX_TOTAL_MEMORY', cpp.has_member('struct heif_security_limits', 'max_total_memory', prefix: '#include <libheif/heif.h>', dependencies: libheif_dep))
+    # heif_encoding_options.color_conversion_options added in 1.16.0
+    cfg_var.set('HAVE_HEIF_ENCODING_OPTIONS_COLOR_CONVERSION_OPTIONS', cpp.has_member('struct heif_encoding_options', 'color_conversion_options', prefix: '#include <libheif/heif.h>', dependencies: libheif_dep))
 endif
 
 libjxl_dep = dependency('libjxl', version: '>=0.7', required: get_option('jpeg-xl'))

--- a/test/test-suite/test_foreign.py
+++ b/test/test-suite/test_foreign.py
@@ -1869,31 +1869,11 @@ class TestForeign:
         plain = self.colour.heifsave_buffer(compression="av1")
         assert len(plain) > 10000
 
-        # FALSE is the default, so this just checks the option is there
-        off = self.colour.heifsave_buffer(compression="av1",
-                                          smart_subsample=False)
-        assert len(off) > 10000
-
-        # smart_subsample routes chroma downsampling through libsharpyuv, so
-        # the save fails on a libheif built without it
-        try:
-            sharp = self.colour.heifsave_buffer(compression="av1",
-                                                smart_subsample=True)
-        except pyvips.error.Error:
-            pytest.skip("libheif built without libsharpyuv")
-
+        # smart_subsample routes 4:2:0 chroma downsampling through libsharpyuv
+        sharp = self.colour.heifsave_buffer(compression="av1",
+                                            smart_subsample=True)
         assert len(sharp) > 10000
-
-        # libheif before 1.16.0 has no chroma downsampling control, so the
-        # option is compiled out and both bitstreams match
-        if sharp == plain:
-            pytest.skip("libheif too old for chroma downsampling control")
-
-        # 4:4:4 does no chroma downsampling, so the flag is harmless there
-        buf = self.colour.heifsave_buffer(compression="av1",
-                                          subsample_mode="off",
-                                          smart_subsample=True)
-        assert len(buf) > 10000
+        assert sharp != plain
 
     @skip_if_no("heifsave")
     @pytest.mark.xfail(raises=pyvips.error.Error, reason="requires libheif built with patent-encumbered HEVC dependencies")

--- a/test/test-suite/test_foreign.py
+++ b/test/test-suite/test_foreign.py
@@ -1865,26 +1865,35 @@ class TestForeign:
         assert len(buf) > 10000
 
     @skip_if_no("heifsave")
-    def test_avifsave_chroma_downsampling(self):
-        # each chroma downsampling nick should be accepted and encode
-        for algorithm in ["auto", "nearest", "average"]:
-            buf = self.colour.heifsave_buffer(compression="av1",
-                                              chroma_downsampling=algorithm)
-            assert len(buf) > 10000
+    def test_avifsave_smart_subsample(self):
+        plain = self.colour.heifsave_buffer(compression="av1")
+        assert len(plain) > 10000
 
-        # sharp additionally requires libheif built with libsharpyuv, so
-        # tolerate a forced-sharp error on builds that lack it
+        # FALSE is the default, so this just checks the option is there
+        off = self.colour.heifsave_buffer(compression="av1",
+                                          smart_subsample=False)
+        assert len(off) > 10000
+
+        # smart_subsample routes chroma downsampling through libsharpyuv, so
+        # the save fails on a libheif built without it
         try:
-            buf = self.colour.heifsave_buffer(compression="av1",
-                                              chroma_downsampling="sharp")
-            assert len(buf) > 10000
+            sharp = self.colour.heifsave_buffer(compression="av1",
+                                                smart_subsample=True)
         except pyvips.error.Error:
-            pass
+            pytest.skip("libheif built without libsharpyuv")
 
-        # an unknown nick must be rejected rather than silently ignored
-        with pytest.raises(pyvips.error.Error):
-            self.colour.heifsave_buffer(compression="av1",
-                                        chroma_downsampling="banana")
+        assert len(sharp) > 10000
+
+        # libheif before 1.16.0 has no chroma downsampling control, so the
+        # option is compiled out and both bitstreams match
+        if sharp == plain:
+            pytest.skip("libheif too old for chroma downsampling control")
+
+        # 4:4:4 does no chroma downsampling, so the flag is harmless there
+        buf = self.colour.heifsave_buffer(compression="av1",
+                                          subsample_mode="off",
+                                          smart_subsample=True)
+        assert len(buf) > 10000
 
     @skip_if_no("heifsave")
     @pytest.mark.xfail(raises=pyvips.error.Error, reason="requires libheif built with patent-encumbered HEVC dependencies")

--- a/test/test-suite/test_foreign.py
+++ b/test/test-suite/test_foreign.py
@@ -1865,6 +1865,28 @@ class TestForeign:
         assert len(buf) > 10000
 
     @skip_if_no("heifsave")
+    def test_avifsave_chroma_downsampling(self):
+        # each chroma downsampling nick should be accepted and encode
+        for algorithm in ["auto", "nearest", "average"]:
+            buf = self.colour.heifsave_buffer(compression="av1",
+                                              chroma_downsampling=algorithm)
+            assert len(buf) > 10000
+
+        # sharp additionally requires libheif built with libsharpyuv, so
+        # tolerate a forced-sharp error on builds that lack it
+        try:
+            buf = self.colour.heifsave_buffer(compression="av1",
+                                              chroma_downsampling="sharp")
+            assert len(buf) > 10000
+        except pyvips.error.Error:
+            pass
+
+        # an unknown nick must be rejected rather than silently ignored
+        with pytest.raises(pyvips.error.Error):
+            self.colour.heifsave_buffer(compression="av1",
+                                        chroma_downsampling="banana")
+
+    @skip_if_no("heifsave")
     @pytest.mark.xfail(raises=pyvips.error.Error, reason="requires libheif built with patent-encumbered HEVC dependencies")
     def test_heicsave_16_to_12(self):
         rgb16 = self.colour.colourspace("rgb16")


### PR DESCRIPTION
Expose libheif's chroma downsampling algorithm as an enum: auto / nearest / average / sharp.

Default value of `auto` leaves libheif's colour conversion options unchanged. The other values (`nearest`, `average`, `sharp`) force their specified algorithm by setting only_use_preferred_chroma_algorithm.

Guarded with HAVE_HEIF_ENCODING_OPTIONS_COLOR_CONVERSION_OPTIONS, since color_conversion_options was added in libheif 1.16.0.