### PR TITLE
Remove ChangeLog entry for backported change

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -38,7 +38,6 @@ date-tbd 8.19.0
 - icc: fix black output when transforming float images [lancylot2004]
 - heifload, heifsave: preserve CLLI signaling [gregbenz]
 - foreign: trim excess bands to the largest size the saver supports [Socialpranker]
-- jp2kload: support palette images [Socialpranker]
 
 6/6/26 8.18.3
 


### PR DESCRIPTION
Commit b65e453 was backported to 8.18 as d4a34a7. Therefore, remove this ChangeLog entry from 8.19.