### PR TITLE
threadpool: guard progress reporting with `allocate_lock` mutex

### DIFF
--- a/libvips/include/vips/threadpool.h
+++ b/libvips/include/vips/threadpool.h
@@ -129,8 +129,8 @@ typedef int (*VipsThreadpoolAllocateFn)(VipsThreadState *state,
  */
 typedef int (*VipsThreadpoolWorkFn)(VipsThreadState *state, void *a);
 
-/* A progress function. This is run by the main thread once for every
- * allocation. Return an error to kill computation early.
+/* A progress function. This is run single-threaded by a worker once for
+ * every work unit processed. Return an error to kill computation early.
  */
 typedef int (*VipsThreadpoolProgressFn)(void *a);
 

--- a/libvips/iofuncs/threadpool.c
+++ b/libvips/iofuncs/threadpool.c
@@ -237,13 +237,15 @@ typedef struct _VipsWorker {
 typedef struct _VipsThreadpool {
 	VipsImage *im; /* Image we are calculating */
 
-	/* Start a thread, do a unit of work (runs in parallel) and allocate
-	 * a unit of work (serial). Plus the mutex we use to serialize work
-	 * allocation.
+	/* Start a thread, allocate a unit of work (serial) and do a unit of
+	 * work (runs in parallel). Plus the mutex we use to serialize work
+	 * allocation. The same mutex is also used for @progress, which is
+	 * called once per processed work unit.
 	 */
 	VipsThreadStartFn start;
 	VipsThreadpoolAllocateFn allocate;
 	VipsThreadpoolWorkFn work;
+	VipsThreadpoolProgressFn progress;
 	GMutex allocate_lock;
 	void *a; /* User argument to start / allocate / etc. */
 
@@ -315,6 +317,18 @@ vips_worker_work_unit(VipsWorker *worker)
 		return -1;
 	}
 
+	/* Report progress of the previously processed work unit.
+	 */
+	if (worker->state &&
+		pool->progress &&
+		pool->progress(pool->a)) {
+		// TODO: pool->error is atomic after PR #5092.
+		//g_atomic_int_set(&pool->error, TRUE);
+		pool->error = TRUE;
+		g_mutex_unlock(&pool->allocate_lock);
+		return -1;
+	}
+
 	/* Has a thread been asked to exit? Volunteer if yes.
 	 */
 	if (g_atomic_int_add(&pool->exit, -1) > 0) {
@@ -382,7 +396,7 @@ vips_thread_main_loop(void *a, void *b)
 	/* Process work units! Always tick, even if we are stopping, so the
 	 * main thread will wake up for exit.
 	 */
-	int result = 0;
+	int result;
 	do {
 		VIPS_GATE_START("vips_worker_work_unit: u");
 		result = vips_worker_work_unit(worker);
@@ -583,8 +597,8 @@ vips_threadpool_new(VipsImage *im)
  * VipsThreadpoolProgressFn:
  * @a: client data
  *
- * This function is called by the main thread once for every work unit
- * processed. It can be used to give the user progress feedback.
+ * This function is run single-threaded by a worker once for every work
+ * unit processed. It can be used to give the user progress feedback.
  *
  * ::: seealso
  *     [func@threadpool_run].
@@ -611,10 +625,8 @@ vips_threadpool_new(VipsImage *im)
  * The object returned by @start must be an instance of a subclass of
  * [class@ThreadState]. Use this to communicate between @allocate and @work.
  *
- * @allocate and @start are always single-threaded (so they can write to the
- * per-pool state), whereas @work can be executed concurrently. @progress is
- * always called by
- * the main thread (ie. the thread which called [func@threadpool_run]).
+ * @start, @allocate and @progress are always single-threaded (so they can write
+ * to the per-pool state), whereas @work can be executed concurrently.
  *
  * ::: seealso
  *     [func@concurrency_set].
@@ -640,6 +652,7 @@ vips_threadpool_run(VipsImage *im,
 	pool->start = start;
 	pool->allocate = allocate;
 	pool->work = work;
+	pool->progress = progress;
 	pool->a = a;
 
 	/* Start with half of the max number of threads, then let it drift up
@@ -657,12 +670,6 @@ vips_threadpool_run(VipsImage *im,
 		vips_semaphore_down(&pool->tick);
 
 		VIPS_DEBUG_MSG("vips_threadpool_run: tick\n");
-
-		if (progress &&
-			progress(pool->a)) {
-			pool->error = TRUE;
-			break;
-		}
 
 		if (pool->stop ||
 			pool->error)

--- a/suppressions/tsan.supp
+++ b/suppressions/tsan.supp
@@ -8,12 +8,6 @@ race_top:vips_threadpool_wait
 race_top:vips_thread_main_loop
 race_top:vips_worker_work_unit
 
-# Unsynchronized write of image->time
-race_top:g_timer_elapsed
-race_top:g_timer_start
-race_top:vips_progress_add
-race_top:vips_progress_update
-
 # Unsynchronized TRUE assignment to statistic->stop
 race_top:vips_max_scan
 race_top:vips_min_scan
@@ -30,9 +24,6 @@ race_top:vips_image_set_kill
 # Unsynchronized singleton init of a local static variable
 race_top:vips_getpagesize
 race_top:vips_get_disc_threshold
-
-# Unsynchronized read of sink_base->processed
-race_top:vips_sink_base_progress
 
 # Unsynchronized read of write->buf->write_errno
 race_top:write_check_error

--- a/suppressions/valgrind.supp
+++ b/suppressions/valgrind.supp
@@ -551,13 +551,6 @@
    fun:vips_region_prepare_to
 }
 
-# unlocked read of pixels-processed-so-far, which is fine
-{
-   helgrind4
-   Helgrind:Race
-   fun:vips_sink_base_progress
-}
-
 {
    helgrind4a
    Helgrind:Race


### PR DESCRIPTION
A non-functional change in terms of that progress is still reported single-threaded for each work unit. Previously, this was done on the main thread during the semaphore tick. It now happens on a worker thread, which may affect users who expect `VipsThreadpoolProgressFn` / `vips_image_eval()` callbacks to always run on the main thread (though eval callbacks could already be invoked from worker threads in some cases, see: https://github.com/libvips/libvips/pull/5092#issuecomment-4923822692).

Split out from #5092.