### PR TITLE
colour: fix hue wrap-around in dE00 and CMC2LCh

### DIFF
--- a/libvips/colour/UCS2LCh.c
+++ b/libvips/colour/UCS2LCh.c
@@ -206,7 +206,7 @@ vips_col_Chcmc2h(float C, float hcmc)
 	known = VIPS_CLIP(0, known, 359);
 
 	return hI[r][known] +
-		(hI[r][(known + 1) % 360] - hI[r][known]) * (hcmc - known);
+		(hI[r][known + 1] - hI[r][known]) * (hcmc - known);
 }
 
 static void *

--- a/libvips/colour/dE00.c
+++ b/libvips/colour/dE00.c
@@ -133,9 +133,16 @@ vips_col_dE00(float L1, float a1, float b1,
 	 */
 	double Ldb = (L1d + L2d) / 2;
 	double Cdb = (C1d + C2d) / 2;
-	double hdb = fabs(h1d - h2d) < 180
-		? (h1d + h2d) / 2
-		: fabs(h1d + h2d - 360) / 2;
+
+	/* Mean hue, see Sharma eq. (14). 180 belongs to the unwrapped case.
+	 */
+	double hdb = h1d + h2d;
+	if (fabs(h1d - h2d) <= 180)
+		hdb /= 2;
+	else if (hdb < 360)
+		hdb = (hdb + 360) / 2;
+	else
+		hdb = (hdb - 360) / 2;
 
 	/* dtheta, RC
 	 */
@@ -160,11 +167,13 @@ vips_col_dE00(float L1, float a1, float b1,
 	double SC = 1 + 0.045 * Cdb;
 	double SH = 1 + 0.015 * Cdb * T;
 
-	/* hue difference ... careful!
+	/* Hue difference, see Sharma eq. (10), in our 1 - 2 orientation.
 	 */
-	double dhd = fabs(h1d - h2d) < 180
-		? h1d - h2d
-		: 360 - (h1d - h2d);
+	double dhd = h1d - h2d;
+	if (dhd > 180)
+		dhd -= 360;
+	else if (dhd < -180)
+		dhd += 360;
 
 	/* dLd, dCd dHd
 	 */

--- a/test/test-suite/test_colour.py
+++ b/test/test-suite/test_colour.py
@@ -206,6 +206,19 @@ class TestColour:
         assert result < 6
         assert pytest.approx(alpha, 0.001) == 42.0
 
+    def test_CMC_hue_round_trip(self):
+        # hues in the last degree came back near 0, since the inverse hue
+        # table was interpolated against entry 0 rather than entry 360
+        hues = [340, 350, 355, 358, 359, 359.5, 359.9]
+        rows = [[50.0, 40.0, h] for h in hues]
+
+        lch = pyvips.Interpretation.LCH
+        im = line_image(rows, lch)
+        back = im.colourspace(pyvips.Interpretation.CMC).colourspace(lch)
+
+        for i, h in enumerate(hues):
+            assert pytest.approx(back(i, 0)[2], abs=0.1) == h
+
     @skip_if_no("icc_import")
     def test_icc(self):
         test = pyvips.Image.new_from_file(JPEG_FILE)

--- a/test/test-suite/test_colour.py
+++ b/test/test-suite/test_colour.py
@@ -5,6 +5,14 @@ import pyvips
 from helpers import *
 
 
+def line_image(rows, interpretation):
+    """Make a width x 1 three band float image from a list of triples."""
+    bands = [pyvips.Image.new_from_array([[row[i] for row in rows]])
+             for i in range(3)]
+    im = bands[0].bandjoin(bands[1:]).cast(pyvips.BandFormat.FLOAT)
+    return im.copy(interpretation=interpretation)
+
+
 class TestColour:
     def test_colourspace(self):
         # mid-grey in Lab ... put 42 in the extra band, it should be copied
@@ -98,6 +106,79 @@ class TestColour:
         result, alpha = difference(10, 10)
         assert pytest.approx(result, 0.001) == 30.238
         assert pytest.approx(alpha, 0.001) == 42.0
+
+    def test_dE00_sharma(self):
+        # test data from Sharma, Wu and Dalal, "The CIEDE2000 color-difference
+        # formula: implementation notes, supplementary test data, and
+        # mathematical observations", Color Res. Appl. 30(1) 2005, table 1
+        #
+        # L1, a1, b1, L2, a2, b2, dE00
+        sharma = [
+            [50.0000, 2.6772, -79.7751, 50.0000, 0.0000, -82.7485, 2.0425],
+            [50.0000, 3.1571, -77.2803, 50.0000, 0.0000, -82.7485, 2.8615],
+            [50.0000, 2.8361, -74.0200, 50.0000, 0.0000, -82.7485, 3.4412],
+            [50.0000, -1.3802, -84.2814, 50.0000, 0.0000, -82.7485, 1.0000],
+            [50.0000, -1.1848, -84.8006, 50.0000, 0.0000, -82.7485, 1.0000],
+            [50.0000, -0.9009, -85.5211, 50.0000, 0.0000, -82.7485, 1.0000],
+            [50.0000, 0.0000, 0.0000, 50.0000, -1.0000, 2.0000, 2.3669],
+            [50.0000, -1.0000, 2.0000, 50.0000, 0.0000, 0.0000, 2.3669],
+            [50.0000, 2.4900, -0.0010, 50.0000, -2.4900, 0.0009, 7.1792],
+            [50.0000, 2.4900, -0.0010, 50.0000, -2.4900, 0.0010, 7.1792],
+            [50.0000, 2.4900, -0.0010, 50.0000, -2.4900, 0.0011, 7.2195],
+            [50.0000, 2.4900, -0.0010, 50.0000, -2.4900, 0.0012, 7.2195],
+            [50.0000, -0.0010, 2.4900, 50.0000, 0.0009, -2.4900, 4.8045],
+            [50.0000, -0.0010, 2.4900, 50.0000, 0.0010, -2.4900, 4.8045],
+            [50.0000, -0.0010, 2.4900, 50.0000, 0.0011, -2.4900, 4.7461],
+            [50.0000, 2.5000, 0.0000, 50.0000, 0.0000, -2.5000, 4.3065],
+            [50.0000, 2.5000, 0.0000, 73.0000, 25.0000, -18.0000, 27.1492],
+            [50.0000, 2.5000, 0.0000, 61.0000, -5.0000, 29.0000, 22.8977],
+            [50.0000, 2.5000, 0.0000, 56.0000, -27.0000, -3.0000, 31.9030],
+            [50.0000, 2.5000, 0.0000, 58.0000, 24.0000, 15.0000, 19.4535],
+            [50.0000, 2.5000, 0.0000, 50.0000, 3.1736, 0.5854, 1.0000],
+            [50.0000, 2.5000, 0.0000, 50.0000, 3.2972, 0.0000, 1.0000],
+            [50.0000, 2.5000, 0.0000, 50.0000, 1.8634, 0.5757, 1.0000],
+            [50.0000, 2.5000, 0.0000, 50.0000, 3.2592, 0.3350, 1.0000],
+            [60.2574, -34.0099, 36.2677, 60.4626, -34.1751, 39.4387, 1.2644],
+            [63.0109, -31.0961, -5.8663, 62.8187, -29.7946, -4.0864, 1.2630],
+            [61.2901, 3.7196, -5.3901, 61.4292, 2.2480, -4.9620, 1.8731],
+            [35.0831, -44.1164, 3.7933, 35.0232, -40.0716, 1.5901, 1.8645],
+            [22.7233, 20.0904, -46.6940, 23.0331, 14.9730, -42.5619, 2.0373],
+            [36.4612, 47.8580, 18.3852, 36.2715, 50.5065, 21.2231, 1.4146],
+            [90.8027, -2.0831, 1.4410, 91.1528, -1.6435, 0.0447, 1.4441],
+            [90.9257, -0.5406, -0.9208, 88.6381, -0.8985, -0.7239, 1.5381],
+            [6.7747, -0.2908, -2.4247, 5.8714, -0.0985, -2.2286, 0.6377],
+            [2.0776, 0.0795, -1.1350, 0.9033, -0.0636, -0.5514, 0.9082],
+        ]
+
+        # pairs 10 and 14 have h1' and h2' exactly 180 apart, where dE00
+        # jumps. In double precision they land one ulp either side of the
+        # boundary: 10 the documented way, 14 not, giving 4.7461 instead
+        del sharma[13]
+
+        lab = pyvips.Interpretation.LAB
+        reference = line_image([row[0:3] for row in sharma], lab)
+        sample = line_image([row[3:6] for row in sharma], lab)
+
+        difference = reference.dE00(sample)
+        for i, row in enumerate(sharma):
+            assert pytest.approx(difference(i, 0)[0], abs=0.001) == row[6]
+
+        # two more cases, computed from the published formula and checked
+        # against an independent implementation: the first has h1' and h2'
+        # exactly 180 apart, so the branch is not picked by rounding, the
+        # second sits just inside the 180 limit in the blue region, where R_T
+        # is large and the sign of dH' shows up
+        extra = [
+            [50.0, 0.0, 25.0, 50.0, 0.0, -25.0, 36.5813],
+            [50.0, -31.0, 8.0, 50.0, 60.0, -16.0, 43.7673],
+        ]
+
+        reference = line_image([row[0:3] for row in extra], lab)
+        sample = line_image([row[3:6] for row in extra], lab)
+
+        difference = reference.dE00(sample)
+        for i, row in enumerate(extra):
+            assert pytest.approx(difference(i, 0)[0], abs=0.001) == row[6]
 
     def test_dE76(self):
         # put 42 in the extra band, it should be copied unmodified


### PR DESCRIPTION
Two hue wrap-around bugs in `libvips/colour`, found checking `dE00` against the published CIEDE2000 test data.

**`vips_col_dE00()` gets the 0/360 hue wrap wrong three ways.** The wrapped mean hue is `fabs(h1' + h2' - 360) / 2`, which is `180 - (h1' + h2') / 2` when the sum is below 360 rather than the `180 + (h1' + h2') / 2` the formula asks for; the branch tests `|dh'| < 180` when the boundary belongs to the unwrapped case; and the wrapped `dh'` is `360 - (h1' - h2')`, right magnitude but inverted relative to `dL'` and `dC'`, so the `R_T dC' dH'` term comes out with the wrong sign. Now written as Sharma eq. (10) and (14).

Master matches 30 of the 34 published pairs (Sharma, Wu and Dalal, Color Res. Appl. 30(1) 2005), this branch matches 33. Over 300k random sRGB pairs, 9.0% of master's results are off by more than 0.1 dE00, 3.0% by more than 5, worst case 17.8. Pure red vs pure blue: 58.30 on master, 52.88 correct.

Pair 14 still fails and is unchanged here. `h1'` and `h2'` are exactly 180 apart there, which is where dE00 is discontinuous, and in double precision they land one ulp on the wrapped side; pair 10 is the same case and happens to land the other way. Anything I tried just moved the knife edge, so the test skips 14 and pins the same situation with a pair whose hues come out exact (`a' = 0`, so `h'` is exactly 90 and 270).

**`vips_col_Chcmc2h()` indexes the wrong entry at the top of the hue table.** It interpolates towards `hI[r][(known + 1) % 360]`, but the table has 361 entries and `known` is clipped to 359, so the modulo only ever fires at the end of the range, where it picks up entry 0 (hue ~0) instead of entry 360. Hues in the last degree came back from CMC near zero: `h = 359.5` at `C = 40` round tripped to 161.8. `vips_col_Lcmc2L()` and `vips_col_Ccmc2C()` alongside it index `known + 1` with no modulo.

Tests are the 34 pair table and a CMC hue round trip in `test_colour.py`, both red before and green after. The rest of `test/test-suite` is unchanged (3 failures here on master as well, libexif and libpng related). The published values were cross-checked against an independent implementation of eq. (2)-(24) and against `skimage.color.deltaE_ciede2000`; all three agree on all 34 pairs. No API change, so no ChangeLog entry.

This work was done with AI assistance under my direction; I have verified every change myself and am accountable for it.
