### PR TITLE
Simplify PNG cICP chunk support guards

### DIFF
--- a/libvips/foreign/vipspng.c
+++ b/libvips/foreign/vipspng.c
@@ -696,7 +696,7 @@ png2vips_header(Read *read, VipsImage *out, gboolean header_only)
 
 	/* Read cICP chunk and set if present.
 	 */
-#if PNG_LIBPNG_VER >= 10645
+#ifdef PNG_cICP_SUPPORTED
 	png_byte colour_primaries;
 	png_byte transfer_characteristics;
 	png_byte matrix_coefficients;
@@ -710,7 +710,7 @@ png2vips_header(Read *read, VipsImage *out, gboolean header_only)
 		vips_image_set_int(out, "cicp-matrix-coefficients", matrix_coefficients);
 		vips_image_set_int(out, "cicp-full-range-flag", full_range_flag);
 	}
-#endif
+#endif /*PNG_cICP_SUPPORTED*/
 
 	/* Some libpng warn you to call png_set_interlace_handling(); here, but
 	 * that can actually break interlace on older libpngs.
@@ -1502,7 +1502,7 @@ write_vips(Write *write,
 			return -1;
 	}
 
-#ifdef PNG_WRITE_cICP_SUPPORTED
+#ifdef PNG_cICP_SUPPORTED
 	int colour_primaries;
 	int transfer_characteristics;
 	int matrix_coefficients;
@@ -1523,7 +1523,7 @@ write_vips(Write *write,
 			0, /* PNG pixel data is always RGB */
 			(png_byte) full_range_flag);
 	}
-#endif /*!PNG_WRITE_cICP_SUPPORTED*/
+#endif /*PNG_cICP_SUPPORTED*/
 
 	// the profile writers grab the setjmp, restore it
 	if (setjmp(png_jmpbuf(write->pPng)))


### PR DESCRIPTION
Both `png_get_cICP()` and `png_set_cICP()` are guarded with `PNG_cICP_SUPPORTED` in libpng.
https://github.com/pnggroup/libpng/blob/d1d0abeffede1cc898ddc3d0e600839cf026d749/png.h#L2005-L2017