### PR TITLE
Fix compilation under clang-cl on Windows

### DIFF
--- a/libvips/iofuncs/connection.c
+++ b/libvips/iofuncs/connection.c
@@ -45,6 +45,9 @@
 #ifdef HAVE_UNISTD_H
 #include <unistd.h>
 #endif /*HAVE_UNISTD_H*/
+#ifdef HAVE_IO_H
+#include <io.h>
+#endif /*HAVE_IO_H*/
 #include <string.h>
 #include <errno.h>
 #include <sys/types.h>

--- a/test/test_connections.c
+++ b/test/test_connections.c
@@ -1,12 +1,19 @@
 /* Test stream*u.
  */
 
+#ifdef HAVE_CONFIG_H
+#include <config.h>
+#endif /*HAVE_CONFIG_H*/
+
 #include <sys/types.h>
 #include <sys/stat.h>
 #include <fcntl.h>
 #ifdef HAVE_UNISTD_H
 #include <unistd.h>
 #endif /*HAVE_UNISTD_H*/
+#ifdef HAVE_IO_H
+#include <io.h>
+#endif /*HAVE_IO_H*/
 #include <string.h>
 #include <vips/vips.h>
 

--- a/tools/vipsedit.c
+++ b/tools/vipsedit.c
@@ -60,6 +60,9 @@
 #ifdef HAVE_UNISTD_H
 #include <unistd.h>
 #endif /*HAVE_UNISTD_H*/
+#ifdef HAVE_IO_H
+#include <io.h>
+#endif /*HAVE_IO_H*/
 #include <locale.h>
 
 #include <vips/vips.h>


### PR DESCRIPTION
A few translation units were missing `io.h` includes, turning what I suspect was missing declaration warnings under MSVC into compilation errors under clang-cl.