### PR TITLE
Update toolchain requirement to C11

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -41,6 +41,7 @@ date-tbd 8.19.0
 - heifload, heifsave: preserve CLLI signaling [gregbenz]
 - pngload, pngsave: read and write cLLI metadata [gregbenz]
 - foreign: trim excess bands to the largest size the saver supports [Socialpranker]
+- update toolchain requirement to C11 [kleisauke]
 
 3/8/26 8.18.5
 

--- a/meson.build
+++ b/meson.build
@@ -3,7 +3,7 @@ project('vips', 'c', 'cpp',
     meson_version: '>=0.55',
     default_options: [
         # this is what glib uses (one of our required deps), so we use it too
-        'c_std=gnu99',
+        'c_std=gnu11',
         # we use some C++14 features
         'cpp_std=c++14',
         # do a release (optimised) build by default


### PR DESCRIPTION
GLib 2.89.2 updated its toolchain requirement to C11 in https://gitlab.gnome.org/GNOME/glib/-/merge_requests/3574, so let's do the same. This would fix a lot of noisy `-Wtypedef-redefinition` warnings when building with Clang, see e.g.:
https://github.com/lovell/sharp-libvips/actions/runs/30836350475/job/91762528607#step:4:9239
https://github.com/kleisauke/wasm-vips/actions/runs/30895159808/job/91946196579#step:5:8412