### PR TITLE
OSS-Fuzz: fix build after google/libultrahdr#413

### DIFF
--- a/fuzz/oss_fuzz_build.sh
+++ b/fuzz/oss_fuzz_build.sh
@@ -230,6 +230,7 @@ cmake \
   -DBUILD_SHARED_LIBS=FALSE \
   -DUHDR_BUILD_EXAMPLES=FALSE \
   -DUHDR_MAX_DIMENSION=65500 \
+  -DUHDR_ENABLE_HEIF=FALSE \
   .
 cmake --build . --target install
 popd


### PR DESCRIPTION
See:
https://oss-fuzz-build-logs.storage.googleapis.com/log-bb241b41-1697-4f4a-ae6a-62013edfe533.txt
https://github.com/google/libultrahdr/pull/413#issuecomment-5225610727