### PR TITLE
CI: validate `author_association` in `/cherry-pick` commands

### DIFF
--- a/.github/workflows/backport.yml
+++ b/.github/workflows/backport.yml
@@ -36,7 +36,8 @@ jobs:
     if: >-
       (github.repository == 'libvips/libvips') &&
       !startswith(github.event.comment.body, '<!--IGNORE-->') &&
-      contains(github.event.action == 'opened' && github.event.issue.body || github.event.comment.body, '/cherry-pick ')
+      contains(github.event.comment.body || github.event.issue.body, '/cherry-pick ') &&
+      contains(fromJSON('["OWNER", "MEMBER", "COLLABORATOR"]'), github.event.comment.author_association || github.event.issue.author_association)
     steps:
       - name: Fetch sources
         uses: actions/checkout@v6
@@ -51,8 +52,8 @@ jobs:
 
       - name: Backport commits
         env:
-          COMMENT_BODY: ${{ github.event.action == 'opened' && github.event.issue.body || github.event.comment.body }}
-          REQUESTED_BY: ${{ (github.event.action == 'opened' && github.event.issue.user.login) || github.event.comment.user.login }}
+          COMMENT_BODY: ${{ github.event.comment.body || github.event.issue.body }}
+          REQUESTED_BY: ${{ github.event.comment.user.login || github.event.issue.user.login }}
         run: |
           printf "%s" "$COMMENT_BODY" |
           ./.github/utils/github-automation.py \


### PR DESCRIPTION
Restrict the `/cherry-pick` command to users with an `author_association` of `OWNER`, `MEMBER` or `COLLABORATOR`. Without this check, the `/cherry-pick` command could succeed for external users on older issues or PRs that have a milestone attached.

Also simplify the event handling by using comment fields first (`github.event.comment`) and falling back to issue fields (`github.event.issue`), without checking if `github.event.action` is `opened`.

Follow up to: #5134.