### PR TITLE
invert: prevent integer overflow for 32-bit signed input

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -43,6 +43,7 @@ date-tbd 8.19.0
 - pngload, pngsave: read and write cLLI metadata [gregbenz]
 - foreign: trim excess bands to the largest size the saver supports [Socialpranker]
 - update toolchain requirement to C11 [kleisauke]
+- invert: prevent integer overflow for 32-bit signed TIFF input [lovell]
 
 3/8/26 8.18.5
 

--- a/libvips/arithmetic/invert.c
+++ b/libvips/arithmetic/invert.c
@@ -83,7 +83,7 @@ G_DEFINE_TYPE(VipsInvert, vips_invert, VIPS_TYPE_UNARY);
 		TYPE *restrict q = (TYPE *) out; \
 \
 		for (x = 0; x < sz; x++) \
-			q[x] = -1 * p[x]; \
+			q[x] = -1L * p[x]; \
 	}
 
 #define LOOPC(TYPE) \


### PR DESCRIPTION
Fixes https://issues.oss-fuzz.com/issues/514267255