### PR TITLE
Use correct guard for `<io.h>` includes

### DIFF
--- a/libvips/iofuncs/mapfile.c
+++ b/libvips/iofuncs/mapfile.c
@@ -77,6 +77,9 @@
 #ifdef HAVE_UNISTD_H
 #include <unistd.h>
 #endif /*HAVE_UNISTD_H*/
+#ifdef HAVE_IO_H
+#include <io.h>
+#endif /*HAVE_IO_H*/
 
 #include <vips/vips.h>
 #include <vips/internal.h>
@@ -86,7 +89,6 @@
 #define S_ISREG(m) (!!(m & _S_IFREG))
 #endif
 #include <windows.h>
-#include <io.h>
 #endif /*G_OS_WIN32*/
 
 #ifdef _MSC_VER

--- a/libvips/iofuncs/source.c
+++ b/libvips/iofuncs/source.c
@@ -59,6 +59,9 @@
 #ifdef HAVE_UNISTD_H
 #include <unistd.h>
 #endif /*HAVE_UNISTD_H*/
+#ifdef HAVE_IO_H
+#include <io.h>
+#endif /*HAVE_IO_H*/
 #include <string.h>
 #include <errno.h>
 #include <sys/types.h>
@@ -66,11 +69,6 @@
 #include <fcntl.h>
 
 #include <vips/vips.h>
-
-#ifdef G_OS_WIN32
-#include <io.h>
-#endif /*G_OS_WIN32*/
-
 #include <vips/debug.h>
 #include <vips/internal.h>
 

--- a/libvips/iofuncs/target.c
+++ b/libvips/iofuncs/target.c
@@ -49,6 +49,9 @@
 #ifdef HAVE_UNISTD_H
 #include <unistd.h>
 #endif /*HAVE_UNISTD_H*/
+#ifdef HAVE_IO_H
+#include <io.h>
+#endif /*HAVE_IO_H*/
 #include <string.h>
 #include <errno.h>
 #include <sys/types.h>
@@ -56,11 +59,6 @@
 #include <fcntl.h>
 
 #include <vips/vips.h>
-
-#ifdef G_OS_WIN32
-#include <io.h>
-#endif /*G_OS_WIN32*/
-
 #include <vips/debug.h>
 #include <vips/internal.h>
 


### PR DESCRIPTION
Noticed this while reviewing PR #5170.