### PR TITLE
unpremultiply: clip out of range values

### DIFF
--- a/libvips/conversion/unpremultiply.c
+++ b/libvips/conversion/unpremultiply.c
@@ -213,8 +213,10 @@ vips_unpremultiply_gen(VipsRegion *out_region,
 				int scale = unpremultiply->scale[alpha];
 
 				int i;
-				for (i = 0; i < bands - 1; i++)
-					out[i] = (in[i] * scale + 128) >> 8;
+				for (i = 0; i < bands - 1; i++) {
+					int value = (in[i] * scale + 128) >> 8;
+					out[i] = VIPS_MIN(value, UCHAR_MAX);
+				}
 				out[i] = alpha;
 
 				in += bands;

--- a/test/test-suite/test_conversion.py
+++ b/test/test-suite/test_conversion.py
@@ -565,6 +565,12 @@ class TestConversion:
                 # differs ... don't require huge accuracy
                 assert abs(x - y) < 2
 
+        # https://github.com/libvips/libvips/issues/5182
+        # unpremultiply values above UCHAR_MAX must be clipped
+        im = (pyvips.Image.black(1, 1, bands=2) + [20, 10]).cast("uchar")
+        unpremultiplied = im.unpremultiply(uchar=True)
+        assert unpremultiplied(0, 0) == [255, 10]
+
     def test_flip(self):
         for fmt in all_formats:
             test = self.colour.cast(fmt)


### PR DESCRIPTION
Fixes a regression introduced in commit 6fcce4c.

Resolves: #5182.