### PR TITLE
heif: use struct tag for heif_content_light_level (fix build on libheif 1.19.x)

### DIFF
--- a/libvips/foreign/heifload.c
+++ b/libvips/foreign/heifload.c
@@ -791,7 +791,7 @@ vips_foreign_load_heif_set_header(VipsForeignLoadHeif *heif, VipsImage *out)
 	}
 
 #ifdef HAVE_HEIF_CONTENT_LIGHT_LEVEL
-	heif_content_light_level clli;
+	struct heif_content_light_level clli;
 
 	if (heif_image_handle_get_content_light_level(heif->handle, &clli)) {
 		g_info("heifload: setting CLLI from content light level");

--- a/libvips/foreign/heifsave.c
+++ b/libvips/foreign/heifsave.c
@@ -296,7 +296,7 @@ vips_foreign_save_heif_get_cicp(VipsImage *image,
 #ifdef HAVE_HEIF_CONTENT_LIGHT_LEVEL
 static gboolean
 vips_foreign_save_heif_get_clli(VipsImage *image,
-	heif_content_light_level *content_light_level)
+	struct heif_content_light_level *content_light_level)
 {
 	int max_content_light_level;
 	int max_frame_average_light_level;
@@ -412,7 +412,7 @@ vips_foreign_save_heif_write_page(VipsForeignSaveHeif *heif, int page)
 #endif
 
 #ifdef HAVE_HEIF_CONTENT_LIGHT_LEVEL
-	heif_content_light_level clli;
+	struct heif_content_light_level clli;
 
 	if (vips_foreign_save_heif_get_clli(save->ready, &clli))
 		heif_image_set_content_light_level(heif->img, &clli);


### PR DESCRIPTION

The CLLI support added in #5104 declares variables and a parameter with the bare
type name `heif_content_light_level`. libheif only added that typedef in 1.20.0
(`heif_color.h`); in the 1.19.x series the type is available solely as the struct
tag (`struct heif_content_light_level`, `heif.h`), and libheif's own accessors
take `struct heif_content_light_level *`.

`HAVE_HEIF_CONTENT_LIGHT_LEVEL` is set from function presence
(`heif_image_handle_get_content_light_level`, added in 1.19.0), so on libheif
1.19.x the block is compiled in but fails to build in C — the bare name is not a
type without the `struct` keyword. Builds against libheif < 1.19 compile the
block out, and ≥ 1.20 have the typedef, so only the 1.19.x window breaks (e.g.
Debian trixie ships libheif 1.19.8).

Use the struct tag, which is valid on both 1.19.x and 1.20+ and in C and C++.
This keeps the feature enabled on 1.19.x rather than gating it off, since the
accessor functions are present there.

Fixes #5189.
