### PR TITLE
convi: sum using 128 bit integer where available

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -46,6 +46,7 @@ date-tbd 8.19.0
 - invert: prevent integer overflow for 32-bit signed TIFF input [lovell]
 - draw_line: add draw-point optional parameter [jcupitt]
 - VipsRect: add g_autoptr cleanup
+- convi: sum using 128 bit integer, where available, before clipping [lovell]
 
 3/8/26 8.18.5
 

--- a/libvips/convolution/convi.c
+++ b/libvips/convolution/convi.c
@@ -129,6 +129,12 @@
 
 #include "pconvolution.h"
 
+#ifdef __SIZEOF_INT128__
+#define VIPS_CONVI_INT128 __int128
+#else
+#define VIPS_CONVI_INT128 int64_t
+#endif
+
 #ifdef HAVE_ORC
 #include <orc/orc.h>
 
@@ -702,7 +708,7 @@ vips_convi_gen_vector(VipsRegion *out_region,
 		int *restrict offsets = seq->offsets; \
 \
 		for (x = 0; x < sz; x++) { \
-			int64_t sum; \
+			VIPS_CONVI_INT128 sum; \
 			int i; \
 \
 			sum = 0; \


### PR DESCRIPTION
Uses the `__int128` extension type provided by gcc and clang on 64-bit platforms.

https://stackoverflow.com/questions/63029428/why-is-int128-t-faster-than-long-long-on-x86-64-gcc suggests this approach might be slightly faster too.

Fixes https://issues.oss-fuzz.com/issues/550629907