### PR TITLE
cplusplus: add support for pointer args

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -48,6 +48,7 @@ date-tbd 8.19.0
 - draw_line: add draw-point optional parameter [jcupitt]
 - VipsRect: add g_autoptr cleanup
 - convi: sum using 128 bit integer, where available, before clipping [lovell]
+- cpp: add support for pointer args [kleisauke]
 
 25/8/26 8.18.6
 

--- a/cplusplus/VImage.cpp
+++ b/cplusplus/VImage.cpp
@@ -173,6 +173,7 @@ VOption::set(const char *name, double value)
 	return this;
 }
 
+// input string
 VOption *
 VOption::set(const char *name, const char *value)
 {
@@ -181,6 +182,20 @@ VOption::set(const char *name, const char *value)
 	pair->input = true;
 	g_value_init(&pair->value, G_TYPE_STRING);
 	g_value_set_string(&pair->value, value);
+	options.push_back(pair);
+
+	return this;
+}
+
+// input pointer
+VOption *
+VOption::set(const char *name, void *value)
+{
+	Pair *pair = new Pair(name);
+
+	pair->input = true;
+	g_value_init(&pair->value, G_TYPE_POINTER);
+	g_value_set_pointer(&pair->value, value);
 	options.push_back(pair);
 
 	return this;

--- a/cplusplus/examples/draw_line.cpp
+++ b/cplusplus/examples/draw_line.cpp
@@ -1,0 +1,35 @@
+/*
+ * compile with:
+ *
+ *      g++ -g -Wall draw_line.cpp `pkg-config vips-cpp --cflags --libs`
+ *
+ */
+
+#include <vips/vips8>
+#include <iostream>
+
+using namespace vips;
+
+void custom_draw(VipsImage *image, VipsPel *ink,
+	int x, int y, void *client)
+{
+	g_assert(GPOINTER_TO_INT(client) == 42);
+	std::cout << x << ' ' << y << std::endl;
+}
+
+int
+main(int argc, char **argv)
+{
+	if (vips_init(argv[0]))
+		vips_error_exit(NULL);
+
+	VImage in = VImage::black(100, 100);
+	in.draw_line({ 100 }, 0, 0, 100, 0,
+		VImage::option()
+			->set("draw-point", reinterpret_cast<void *>(custom_draw))
+			->set("client", GINT_TO_POINTER(42)));
+
+	vips_shutdown();
+
+	return 0;
+}

--- a/cplusplus/gen-operators.py
+++ b/cplusplus/gen-operators.py
@@ -37,6 +37,7 @@ gtype_to_cpp = {
     GValue.gint_type: 'int',
     GValue.gdouble_type: 'double',
     GValue.gstr_type: 'const char *',
+    GValue.gpointer_type: 'void *',
     GValue.refstr_type: 'char *',
     GValue.image_type: 'VImage',
     GValue.source_type: 'VSource',

--- a/cplusplus/include/vips/VImage8.h
+++ b/cplusplus/include/vips/VImage8.h
@@ -287,6 +287,12 @@ public:
 	set(const char *name, const char *value);
 
 	/**
+	 * Set an input pointer option.
+	 */
+	VOption *
+	set(const char *name, void *value);
+
+	/**
 	 * Set a libvips object as an option. These can be images, sources,
 	 * targets, etc.
 	 *
@@ -2946,6 +2952,11 @@ public:
 
 	/**
 	 * Draw a line on an image.
+	 *
+	 * **Optional parameters**
+	 *   - **draw_point** -- Custom point draw function, void *.
+	 *   - **client** -- Client data for the point draw function, void *.
+	 *
 	 * @param ink Color for pixels.
 	 * @param x1 Start of draw_line.
 	 * @param y1 Start of draw_line.


### PR DESCRIPTION
Needed for commit e3202151e14017c543bf2b5a2cdb20dfeb8abf01.

Note: `GValue.gpointer_type` requires PR https://github.com/libvips/pyvips/pull/1421.