### PR TITLE
vips_target_finish: drop the two params it no longer takes

### DIFF
--- a/libvips/deprecated/rename.c
+++ b/libvips/deprecated/rename.c
@@ -912,8 +912,6 @@ vips_cache_operation_lookup(VipsOperation *operation)
 /**
  * vips_target_finish:
  * @target: target to operate on
- * @buffer: bytes to write
- * @length: length of @buffer in bytes
  *
  * Deprecated in favour of vips_target_end().
  */


### PR DESCRIPTION
The block still describes the old signature, the function has taken only the target since it became a wrapper around `vips_target_end()`.
