### PR TITLE
docs: add Rust binding (vips-rs) to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,7 @@ Full bindings are available for:
 | Elixir | [vix](https://github.com/akash-akya/vix) |
 | Java | [vips-ffm](https://github.com/lopcode/vips-ffm) |
 | Nim | [libvips-nim](https://github.com/openpeeps/libvips-nim) |
+| Rust | [vips-rs](https://github.com/houseme/vips-rs) |
 
 libvips is used as an image processing engine by:
 


### PR DESCRIPTION
## Summary

Adds the community Rust binding [vips-rs](https://github.com/houseme/vips-rs) to the language bindings table in `README.md`.

| Language | Binding |
|---|---|
| Rust | [vips-rs](https://github.com/houseme/vips-rs) |

- Crate: [`vips` on crates.io](https://crates.io/crates/vips)
- Docs: https://docs.rs/vips
- Repository: https://github.com/houseme/vips-rs

## Checklist

- [x] Documentation only (README bindings table)
- [x] Matches existing binding table format (GitHub link for community bindings)
